### PR TITLE
overlord/fdestate: warn of inconsistent primary key or policy counter

### DIFF
--- a/overlord/fdestate/backend/export_test.go
+++ b/overlord/fdestate/backend/export_test.go
@@ -47,3 +47,11 @@ func MockBootIsResealNeeded(f func(pbc boot.PredictableBootChains, bootChainsFil
 		bootIsResealNeeded = old
 	}
 }
+
+func MockSecbootPCRPolicyCounterHandles(f func(uk secboot.UpdatedKeys) []uint32) (restore func()) {
+	old := secbootPCRPolicyCounterHandles
+	secbootPCRPolicyCounterHandles = f
+	return func() {
+		secbootPCRPolicyCounterHandles = old
+	}
+}

--- a/overlord/fdestate/backend/reseal.go
+++ b/overlord/fdestate/backend/reseal.go
@@ -72,6 +72,18 @@ func MockSecbootGetPrimaryKey(f func(devices []string, fallbackKeyFiles []string
 	}
 }
 
+func secbootPCRPolicyCounterHandlesImpl(uk secboot.UpdatedKeys) []uint32 {
+	return uk.PCRPolicyCounterHandles()
+}
+
+var secbootPCRPolicyCounterHandles = secbootPCRPolicyCounterHandlesImpl
+
+// RoleInfo is an extract of fdestate.KeyslotRoleInfo
+type RoleInfo struct {
+	PrimaryKeyID                   int
+	TPM2PCRPolicyRevocationCounter uint32
+}
+
 // SealingParameters contains the parameters that may be used for
 // sealing.  It should be the same as
 // fdestate.KeyslotRoleParameters. However we cannot import it. See
@@ -147,12 +159,17 @@ type EncryptedContainer interface {
 type FDEStateManager interface {
 	// Update will update the sealing parameters for a give role.
 	Update(role string, containerRole string, parameters *SealingParameters) error
-	// Get returns the current parameters for a given role. If parameters exist for that role, it will return nil without error.
+	// Get returns the current parameters for a given role as well as policy counter and primary key id. If role exists but there is no parameters, it will return nil parameters without error.
 	Get(role string, containerRole string) (parameters *SealingParameters, err error)
+	// RoleInfo
+	RoleInfo(role string) (info *RoleInfo, err error)
 	// Unlock notifies the manager that the state can be unlocked and returns a function to relock it.
 	Unlock() (relock func())
 	// GetEncryptedContainers returns the list of encrypted disks for the device
 	GetEncryptedContainers() ([]EncryptedContainer, error)
+	// VerifyPrimaryKeyAgainstState verifies that a raw primary key matches
+	// the digest of primary key indexed by its state ID.
+	VerifyPrimaryKeyAgainstState(primaryKeyID int, primaryKey []byte) bool
 }
 
 // comparableModel is just a representation of secboot.ModelForSealing
@@ -254,11 +271,17 @@ func doReseal(manager FDEStateManager, rootdir string, hintExpectFDEHook bool, i
 		return nil
 	}
 
-	var allResealedKeys secboot.UpdatedKeys
+	foundPrimaryKeys := make(map[int][]byte)
+
+	allResealedKeys := make(map[int]secboot.UpdatedKeys)
 	resealKey := func(key secboot.KeyDataLocation, role string, containerRole string) error {
 		parameters := newParameters.find(role, containerRole, "all")
 		if parameters == nil {
 			return fmt.Errorf("internal error: not container role for %s/%s", role, containerRole)
+		}
+		roleInfo, err := manager.RoleInfo(role)
+		if err != nil {
+			return err
 		}
 
 		getTpmPCRProfile := func() ([]byte, error) {
@@ -271,6 +294,14 @@ func doReseal(manager FDEStateManager, rootdir string, hintExpectFDEHook bool, i
 			return parameters.TpmPCRProfile, nil
 		}
 
+		verifyPrimaryKey := func(primaryKey []byte) {
+			if !manager.VerifyPrimaryKeyAgainstState(roleInfo.PrimaryKeyID, primaryKey) {
+				logger.Noticef("WARNING: primary key is not matching the FDE state")
+			} else {
+				foundPrimaryKeys[roleInfo.PrimaryKeyID] = primaryKey
+			}
+		}
+
 		rkp := &secboot.ResealKeyParams{
 			// Because the save disk might be opened with
 			// an old plainkey, there might not be any
@@ -279,6 +310,7 @@ func doReseal(manager FDEStateManager, rootdir string, hintExpectFDEHook bool, i
 			// devices.
 			PrimaryKeyDevices:       devices,
 			FallbackPrimaryKeyFiles: fallbackPrimaryKeyFiles,
+			VerifyPrimaryKey:        verifyPrimaryKey,
 			BootModes:               parameters.BootModes,
 			Models:                  parameters.Models,
 			GetTpmPCRProfile:        getTpmPCRProfile,
@@ -290,9 +322,14 @@ func doReseal(manager FDEStateManager, rootdir string, hintExpectFDEHook bool, i
 			revokeOldKeys = false
 			return err
 		}
-		if revokeOldKeys {
-			allResealedKeys = append(allResealedKeys, resealedKeys...)
+
+		for _, policyCounter := range secbootPCRPolicyCounterHandles(resealedKeys) {
+			if policyCounter != roleInfo.TPM2PCRPolicyRevocationCounter {
+				logger.Noticef("WARNING: policy counter handle %v is not matching the FDE state", policyCounter)
+			}
 		}
+
+		allResealedKeys[roleInfo.PrimaryKeyID] = append(allResealedKeys[roleInfo.PrimaryKeyID], resealedKeys...)
 
 		return nil
 	}
@@ -303,7 +340,6 @@ func doReseal(manager FDEStateManager, rootdir string, hintExpectFDEHook bool, i
 		switch container.ContainerRole() {
 		case "system-data":
 			defaultLegacyKey, hasDefaultLegacyKey := legacyKeys["default"]
-
 			runKey := secboot.KeyDataLocation{
 				DevicePath: container.DevPath(),
 				SlotName:   "default",
@@ -347,12 +383,14 @@ func doReseal(manager FDEStateManager, rootdir string, hintExpectFDEHook bool, i
 	}
 
 	if revokeOldKeys {
-		primaryKey, err := secbootGetPrimaryKey(devices, fallbackPrimaryKeyFiles)
-		if err != nil {
-			return err
-		}
-		if err := secbootRevokeOldKeys(&allResealedKeys, primaryKey); err != nil {
-			return fmt.Errorf("cannot revoke older keys: %v", err)
+		for primaryKeyID, oldKeys := range allResealedKeys {
+			primaryKey, hasPrimaryKey := foundPrimaryKeys[primaryKeyID]
+			if !hasPrimaryKey {
+				return fmt.Errorf("Missing primary key")
+			}
+			if err := secbootRevokeOldKeys(&oldKeys, primaryKey); err != nil {
+				return fmt.Errorf("cannot revoke older keys: %v", err)
+			}
 		}
 	}
 

--- a/overlord/fdestate/backend/reseal_test.go
+++ b/overlord/fdestate/backend/reseal_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/snapcore/snapd/bootloader/bootloadertest"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget/device"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/fdestate/backend"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/testutil"
@@ -136,6 +137,8 @@ type fakeState struct {
 	isUnlocked          bool
 	hasUnlocked         int
 	EncryptedContainers []backend.EncryptedContainer
+	brokenPrimaryKey    bool
+	policyCounterHandle uint32
 }
 
 func (fs *fakeState) Update(role string, containerRole string, params *backend.SealingParameters) error {
@@ -160,6 +163,18 @@ func (fs *fakeState) Get(role string, containerRole string) (params *backend.Sea
 	return p, nil
 }
 
+func (fs *fakeState) RoleInfo(role string) (info *backend.RoleInfo, err error) {
+	info = &backend.RoleInfo{
+		PrimaryKeyID:                   0,
+		TPM2PCRPolicyRevocationCounter: fs.policyCounterHandle,
+	}
+	return info, nil
+}
+
+func (fs *fakeState) VerifyPrimaryKeyAgainstState(primaryKeyID int, primaryKey []byte) bool {
+	return !fs.brokenPrimaryKey
+}
+
 func (fs *fakeState) Unlock() (relock func()) {
 	fs.isUnlocked = true
 	fs.hasUnlocked++
@@ -179,7 +194,18 @@ type fakeSealedKey struct {
 	num int
 }
 
-func (s *resealTestSuite) testTPMResealHappy(c *C, revokeOldKeys bool, missingRunParams bool, missingRecoverParams bool, onClassic bool) {
+type tpmResealHappyCase struct {
+	revokeOldKeys             bool
+	missingRunParams          bool
+	missingRecoverParams      bool
+	onClassic                 bool
+	brokenPrimaryKey          bool
+	brokenRevocationCounter   bool
+	multipleRevocationCounter bool
+	noPrimaryKey              bool
+}
+
+func (s *resealTestSuite) testTPMResealHappy(c *C, tc tpmResealHappyCase) {
 	bl := bootloadertest.Mock("trusted", "").WithTrustedAssets()
 	bootloader.Force(bl)
 	defer bootloader.Force(nil)
@@ -221,11 +247,11 @@ func (s *resealTestSuite) testTPMResealHappy(c *C, revokeOldKeys bool, missingRu
 		bootIsResealNeededCalls++
 		switch bootIsResealNeededCalls {
 		case 1:
-			if missingRunParams {
+			if tc.missingRunParams {
 				return false, 0, nil
 			}
 		case 2:
-			if missingRecoverParams {
+			if tc.missingRecoverParams {
 				return false, 0, nil
 			}
 		}
@@ -234,7 +260,7 @@ func (s *resealTestSuite) testTPMResealHappy(c *C, revokeOldKeys bool, missingRu
 	})()
 
 	var model *asserts.Model
-	if onClassic {
+	if tc.onClassic {
 		model = boottest.MakeMockClassicWithModesModel()
 	} else {
 		model = boottest.MakeMockUC20Model()
@@ -360,14 +386,14 @@ func (s *resealTestSuite) testTPMResealHappy(c *C, revokeOldKeys bool, missingRu
 	restore := backend.MockSecbootBuildPCRProtectionProfile(func(modelParams []*secboot.SealKeyModelParams, allowInsufficientDmaProtection bool) (secboot.SerializedPCRProfile, error) {
 		buildProfileCalls++
 
-		c.Check(allowInsufficientDmaProtection, Equals, !onClassic)
+		c.Check(allowInsufficientDmaProtection, Equals, !tc.onClassic)
 
 		c.Assert(modelParams, HasLen, 1)
 		mp := modelParams[0]
 		c.Check(mp.Model.Model(), Equals, model.Model())
 		switch buildProfileCalls {
 		case 1:
-			if !missingRunParams {
+			if !tc.missingRunParams {
 				c.Check(mp.EFILoadChains, DeepEquals, []*secboot.LoadChain{
 					secboot.NewLoadChain(shimBf,
 						secboot.NewLoadChain(assetBf,
@@ -411,6 +437,9 @@ func (s *resealTestSuite) testTPMResealHappy(c *C, revokeOldKeys bool, missingRu
 		c.Logf("key: %v", key)
 
 		tpmPCRProfile, profileErr := params.GetTpmPCRProfile()
+		if !tc.noPrimaryKey {
+			params.VerifyPrimaryKey([]byte{1,2,3,4})
+		}
 
 		switch resealCalls {
 		case 1:
@@ -420,7 +449,7 @@ func (s *resealTestSuite) testTPMResealHappy(c *C, revokeOldKeys bool, missingRu
 				SlotName:   "default",
 				KeyFile:    filepath.Join(s.rootdir, "run/mnt/ubuntu-boot/device/fde/ubuntu-data.sealed-key"),
 			})
-			if missingRunParams {
+			if tc.missingRunParams {
 				c.Assert(profileErr, NotNil)
 				return nil, profileErr
 			}
@@ -433,7 +462,7 @@ func (s *resealTestSuite) testTPMResealHappy(c *C, revokeOldKeys bool, missingRu
 				SlotName:   "default-fallback",
 				KeyFile:    filepath.Join(s.rootdir, "run/mnt/ubuntu-seed/device/fde/ubuntu-data.recovery.sealed-key"),
 			})
-			if missingRecoverParams {
+			if tc.missingRecoverParams {
 				c.Assert(profileErr, NotNil)
 				return nil, profileErr
 			}
@@ -446,7 +475,7 @@ func (s *resealTestSuite) testTPMResealHappy(c *C, revokeOldKeys bool, missingRu
 				SlotName:   "default-fallback",
 				KeyFile:    filepath.Join(s.rootdir, "run/mnt/ubuntu-seed/device/fde/ubuntu-save.recovery.sealed-key"),
 			})
-			if missingRecoverParams {
+			if tc.missingRecoverParams {
 				c.Assert(profileErr, NotNil)
 				return nil, profileErr
 			}
@@ -459,7 +488,14 @@ func (s *resealTestSuite) testTPMResealHappy(c *C, revokeOldKeys bool, missingRu
 	})
 	defer restore()
 
-	myState := &fakeState{}
+	myState := &fakeState{
+		brokenPrimaryKey:    tc.brokenPrimaryKey,
+		policyCounterHandle: 42,
+	}
+	if tc.brokenRevocationCounter {
+		myState.policyCounterHandle = 43
+	}
+
 	myState.EncryptedContainers = []backend.EncryptedContainer{
 		&encryptedContainer{
 			uuid:          "123",
@@ -479,7 +515,7 @@ func (s *resealTestSuite) testTPMResealHappy(c *C, revokeOldKeys bool, missingRu
 	}
 
 	defer backend.MockSecbootRevokeOldKeys(func(uk *secboot.UpdatedKeys, primaryKey []byte) error {
-		if !revokeOldKeys {
+		if !tc.revokeOldKeys {
 			c.Errorf("unexpected call")
 			return fmt.Errorf("unexpected call")
 		}
@@ -503,9 +539,40 @@ func (s *resealTestSuite) testTPMResealHappy(c *C, revokeOldKeys bool, missingRu
 		return []byte{1, 2, 3, 4}, nil
 	})()
 
-	opts := boot.ResealKeyToModeenvOptions{ExpectReseal: true, RevokeOldKeys: revokeOldKeys}
+	backend.MockSecbootPCRPolicyCounterHandles(func(uk secboot.UpdatedKeys) []uint32 {
+		if tc.multipleRevocationCounter {
+			return []uint32{41, 42}
+		} else {
+			return []uint32{42}
+		}
+	})
+
+	loggerBuf, restore := logger.MockLogger()
+	defer restore()
+
+	opts := boot.ResealKeyToModeenvOptions{ExpectReseal: true, RevokeOldKeys: tc.revokeOldKeys}
 	err := backend.ResealKeyForBootChains(myState, device.SealingMethodTPM, s.rootdir, &boot.ResealKeyForBootChainsParams{BootChains: bootChains, Options: opts})
+	if tc.noPrimaryKey && tc.revokeOldKeys {
+		c.Assert(err, ErrorMatches, `Missing primary key`)
+		return
+	}
 	c.Assert(err, IsNil)
+
+	if tc.brokenPrimaryKey {
+		c.Check(loggerBuf.String(), testutil.Contains, "WARNING: primary key is not matching the FDE state")
+	} else {
+		c.Check(loggerBuf.String(), Not(testutil.Contains), "WARNING: primary key is not matching the FDE state")
+	}
+	if tc.brokenRevocationCounter {
+		c.Check(loggerBuf.String(), testutil.Contains, "WARNING: policy counter handle 42 is not matching the FDE state")
+	} else {
+		c.Check(loggerBuf.String(), Not(testutil.Contains), "WARNING: policy counter handle .* is not matching the FDE state")
+	}
+	if tc.multipleRevocationCounter {
+		c.Check(loggerBuf.String(), testutil.Contains, "WARNING: policy counter handle 41 is not matching the FDE state")
+	} else {
+		c.Check(loggerBuf.String(), Not(testutil.Contains), "WARNING: policy counter handle .* is not matching the FDE state")
+	}
 
 	c.Assert(bootIsResealNeededCalls, Equals, 2)
 
@@ -513,65 +580,106 @@ func (s *resealTestSuite) testTPMResealHappy(c *C, revokeOldKeys bool, missingRu
 
 	pbc, cnt, err := boot.ReadBootChains(filepath.Join(dirs.SnapFDEDir, "boot-chains"))
 	c.Assert(err, IsNil)
-	if !missingRunParams {
+	if !tc.missingRunParams {
 		c.Assert(cnt, Equals, 1)
 		c.Check(pbc, DeepEquals, boot.ToPredictableBootChains(removeKernelBootFiles(append(bootChains.RunModeBootChains, bootChains.RecoveryBootChainsForRunKey...))))
 	}
 
 	recoveryPbc, cnt, err := boot.ReadBootChains(filepath.Join(dirs.SnapFDEDir, "recovery-boot-chains"))
 	c.Assert(err, IsNil)
-	if !missingRecoverParams {
+	if !tc.missingRecoverParams {
 		c.Check(recoveryPbc, DeepEquals, boot.ToPredictableBootChains(removeKernelBootFiles(bootChains.RecoveryBootChains)))
 		c.Assert(cnt, Equals, 1)
 	}
 }
 
 func (s *resealTestSuite) TestTPMResealHappy(c *C) {
-	const revokeOldKeys = false
-	const missingRunParams = false
-	const missingRecoverParams = false
-	const onClassic = true
-	s.testTPMResealHappy(c, revokeOldKeys, missingRunParams, missingRecoverParams, onClassic)
+	tc := tpmResealHappyCase{
+		onClassic: true,
+	}
+	s.testTPMResealHappy(c, tc)
 }
 
 func (s *resealTestSuite) TestTPMResealHappyCore(c *C) {
-	const revokeOldKeys = false
-	const missingRunParams = false
-	const missingRecoverParams = false
-	const onClassic = false
-	s.testTPMResealHappy(c, revokeOldKeys, missingRunParams, missingRecoverParams, onClassic)
+	tc := tpmResealHappyCase{}
+	s.testTPMResealHappy(c, tc)
 }
 
 func (s *resealTestSuite) TestTPMResealHappyRevoke(c *C) {
-	const revokeOldKeys = true
-	const missingRunParams = false
-	const missingRecoverParams = false
-	const onClassic = true
-	s.testTPMResealHappy(c, revokeOldKeys, missingRunParams, missingRecoverParams, onClassic)
+	tc := tpmResealHappyCase{
+		onClassic:     true,
+		revokeOldKeys: true,
+	}
+	s.testTPMResealHappy(c, tc)
 }
 
 func (s *resealTestSuite) TestTPMResealHappyRevokeMissingRunParams(c *C) {
-	const revokeOldKeys = true
-	const missingRunParams = true
-	const missingRecoverParams = false
-	const onClassic = true
-	s.testTPMResealHappy(c, revokeOldKeys, missingRunParams, missingRecoverParams, onClassic)
+	tc := tpmResealHappyCase{
+		onClassic:        true,
+		revokeOldKeys:    true,
+		missingRunParams: true,
+	}
+	s.testTPMResealHappy(c, tc)
 }
 
 func (s *resealTestSuite) TestTPMResealHappyRevokeMissingRecoverParams(c *C) {
-	const revokeOldKeys = true
-	const missingRunParams = false
-	const missingRecoverParams = true
-	const onClassic = true
-	s.testTPMResealHappy(c, revokeOldKeys, missingRunParams, missingRecoverParams, onClassic)
+	tc := tpmResealHappyCase{
+		onClassic:            true,
+		revokeOldKeys:        true,
+		missingRecoverParams: true,
+	}
+	s.testTPMResealHappy(c, tc)
 }
 
 func (s *resealTestSuite) TestTPMResealHappyRevokeMissingParams(c *C) {
-	const revokeOldKeys = true
-	const missingRunParams = true
-	const missingRecoverParams = true
-	const onClassic = true
-	s.testTPMResealHappy(c, revokeOldKeys, missingRunParams, missingRecoverParams, onClassic)
+	tc := tpmResealHappyCase{
+		onClassic:            true,
+		revokeOldKeys:        true,
+		missingRunParams:     true,
+		missingRecoverParams: true,
+	}
+	s.testTPMResealHappy(c, tc)
+}
+
+func (s *resealTestSuite) TestTPMResealHappyBrokenPrimaryKey(c *C) {
+	tc := tpmResealHappyCase{
+		onClassic:        true,
+		brokenPrimaryKey: true,
+	}
+	s.testTPMResealHappy(c, tc)
+}
+
+func (s *resealTestSuite) TestTPMResealHappyNoPrimaryKey(c *C) {
+	tc := tpmResealHappyCase{
+		onClassic:    true,
+		noPrimaryKey: true,
+	}
+	s.testTPMResealHappy(c, tc)
+}
+
+func (s *resealTestSuite) TestTPMResealHappyNoPrimaryKeyRevoke(c *C) {
+	tc := tpmResealHappyCase{
+		onClassic:     true,
+		revokeOldKeys: true,
+		noPrimaryKey:  true,
+	}
+	s.testTPMResealHappy(c, tc)
+}
+
+func (s *resealTestSuite) TestTPMResealHappyBrokenRevocationCounter(c *C) {
+	tc := tpmResealHappyCase{
+		onClassic:               true,
+		brokenRevocationCounter: true,
+	}
+	s.testTPMResealHappy(c, tc)
+}
+
+func (s *resealTestSuite) TestTPMResealHappyMultiplePolicyCounters(c *C) {
+	tc := tpmResealHappyCase{
+		onClassic:                 true,
+		multipleRevocationCounter: true,
+	}
+	s.testTPMResealHappy(c, tc)
 }
 
 func (s *resealTestSuite) TestResealKeyForBootchainsWithSystemFallback(c *C) {

--- a/overlord/fdestate/export_test.go
+++ b/overlord/fdestate/export_test.go
@@ -53,6 +53,7 @@ var (
 
 	CheckFDEChangeConflict            = checkFDEChangeConflict
 	CheckFDEParametersChangeConflicts = checkFDEParametersChangeConflicts
+
 )
 
 type ExternalOperation = externalOperation

--- a/overlord/fdestate/fdemgr_test.go
+++ b/overlord/fdestate/fdemgr_test.go
@@ -23,6 +23,7 @@ package fdestate_test
 import (
 	"bytes"
 	"crypto"
+	"crypto/hmac"
 	"errors"
 	"fmt"
 	"os"
@@ -601,43 +602,67 @@ func (s *fdeMgrSuite) TestGetParameters(c *C) {
 		&mockModel{"other"},
 	}
 
-	err := manager.UpdateParameters("recover", "something", []string{"recover"}, models, secboot.SerializedPCRProfile(`serialized-profile-recover`))
+	// Let's insert special values for primary and counter handles
+	var fdeSt fdestate.FdeState
+	err := st.Get("fde", &fdeSt)
+	c.Assert(err, IsNil)
+	runRole := fdeSt.KeyslotRoles["run"]
+	runRole.PrimaryKeyID = 1
+	runRole.TPM2PCRPolicyRevocationCounter = 2
+	fdeSt.KeyslotRoles["run"] = runRole
+	recoverRole := fdeSt.KeyslotRoles["recover"]
+	recoverRole.PrimaryKeyID = 3
+	recoverRole.TPM2PCRPolicyRevocationCounter = 4
+	fdeSt.KeyslotRoles["recover"] = recoverRole
+	s.st.Set("fde", fdeSt)
+
+	err = manager.UpdateParameters("recover", "something", []string{"recover"}, models, secboot.SerializedPCRProfile(`serialized-profile-recover`))
 	c.Assert(err, IsNil)
 	err = manager.UpdateParameters("recover", "all", []string{"recover-all"}, models, secboot.SerializedPCRProfile(`serialized-profile-recover-all`))
 	c.Assert(err, IsNil)
 	err = manager.UpdateParameters("run", "something", []string{"run"}, models, secboot.SerializedPCRProfile(`serialized-profile-run`))
 	c.Assert(err, IsNil)
 
-	hasParameters, foundRunModes, foundModels, foundPCRProfile, err := manager.GetParameters("recover", "something")
+	params, err := manager.GetParameters("recover", "something")
 	c.Assert(err, IsNil)
-	c.Check(hasParameters, Equals, true)
-	c.Check(foundRunModes, DeepEquals, []string{"recover"})
-	c.Assert(foundModels, HasLen, 2)
-	c.Check(foundModels[0].Model(), Equals, "mock-model")
-	c.Check(foundModels[1].Model(), Equals, "other")
-	c.Check(foundPCRProfile, DeepEquals, []byte(`serialized-profile-recover`))
+	c.Assert(params, NotNil)
+	c.Check(params.BootModes, DeepEquals, []string{"recover"})
+	c.Assert(params.Models, HasLen, 2)
+	c.Check(params.Models[0].Model(), Equals, "mock-model")
+	c.Check(params.Models[1].Model(), Equals, "other")
+	c.Check(params.TpmPCRProfile, DeepEquals, []byte(`serialized-profile-recover`))
+	info, err := manager.GetRoleInfo("recover")
+	c.Assert(err, IsNil)
+	c.Assert(info, NotNil)
+	c.Check(info.PrimaryKeyID, Equals, 3)
+	c.Check(info.TPM2PCRPolicyRevocationCounter, Equals, uint32(4))
 
-	hasParameters, foundRunModes, foundModels, foundPCRProfile, err = manager.GetParameters("recover", "something-that-is-not-specific")
+	params, err = manager.GetParameters("recover", "something-that-is-not-specific")
 	c.Assert(err, IsNil)
-	c.Check(hasParameters, Equals, true)
-	c.Check(foundRunModes, DeepEquals, []string{"recover-all"})
-	c.Assert(foundModels, HasLen, 2)
-	c.Check(foundModels[0].Model(), Equals, "mock-model")
-	c.Check(foundModels[1].Model(), Equals, "other")
-	c.Check(foundPCRProfile, DeepEquals, []byte(`serialized-profile-recover-all`))
+	c.Assert(params, NotNil)
+	c.Check(params.BootModes, DeepEquals, []string{"recover-all"})
+	c.Assert(params.Models, HasLen, 2)
+	c.Check(params.Models[0].Model(), Equals, "mock-model")
+	c.Check(params.Models[1].Model(), Equals, "other")
+	c.Check(params.TpmPCRProfile, DeepEquals, []byte(`serialized-profile-recover-all`))
 
-	hasParameters, foundRunModes, foundModels, foundPCRProfile, err = manager.GetParameters("run", "something")
+	params, err = manager.GetParameters("run", "something")
 	c.Assert(err, IsNil)
-	c.Check(hasParameters, Equals, true)
-	c.Check(foundRunModes, DeepEquals, []string{"run"})
-	c.Assert(foundModels, HasLen, 2)
-	c.Check(foundModels[0].Model(), Equals, "mock-model")
-	c.Check(foundModels[1].Model(), Equals, "other")
-	c.Check(foundPCRProfile, DeepEquals, []byte(`serialized-profile-run`))
+	c.Assert(params, NotNil)
+	c.Check(params.BootModes, DeepEquals, []string{"run"})
+	c.Assert(params.Models, HasLen, 2)
+	c.Check(params.Models[0].Model(), Equals, "mock-model")
+	c.Check(params.Models[1].Model(), Equals, "other")
+	c.Check(params.TpmPCRProfile, DeepEquals, []byte(`serialized-profile-run`))
+	info, err = manager.GetRoleInfo("run")
+	c.Assert(err, IsNil)
+	c.Assert(info, NotNil)
+	c.Check(info.PrimaryKeyID, Equals, 1)
+	c.Check(info.TPM2PCRPolicyRevocationCounter, Equals, uint32(2))
 
-	hasParameters, _, _, _, err = manager.GetParameters("run", "something-that-is-not-specific")
+	params, err = manager.GetParameters("run", "something-that-is-not-specific")
 	c.Assert(err, IsNil)
-	c.Check(hasParameters, Equals, false)
+	c.Check(params, IsNil)
 }
 
 func (s *fdeMgrSuite) TestGetEncryptedContainers(c *C) {
@@ -1341,4 +1366,34 @@ func (s *fdeMgrSuite) TestAddPlatformKeysTaskAffectedSnaps(c *C) {
 	snaps, err := snapstate.SnapsAffectedByTask(tsk)
 	c.Assert(err, IsNil)
 	c.Assert(snaps, DeepEquals, []string{"pc", "pc-kernel", "core20"})
+}
+
+func (s *fdeMgrSuite) TestManagerVerifyPrimaryKey(c *C) {
+	st := s.st
+	onClassic := true
+	mgr := s.startedManager(c, onClassic)
+
+	salt := []byte{1, 2, 3, 4}
+	primaryKey := []byte{5, 6, 7, 8}
+
+	h := hmac.New(crypto.Hash(crypto.SHA256).New, salt[:])
+	h.Write(primaryKey)
+	digest := h.Sum(nil)
+
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	var fdeSt fdestate.FdeState
+	err := st.Get("fde", &fdeSt)
+	c.Assert(err, IsNil)
+	fdeSt.PrimaryKeys[1] = fdestate.PrimaryKeyInfo{fdestate.KeyDigest{
+		Algorithm: secboot.HashAlg(crypto.SHA256),
+		Salt: salt,
+		Digest: digest,
+	}}
+	st.Set("fde", &fdeSt)
+
+	c.Assert(mgr.VerifyPrimaryKeyAgainstState(1, primaryKey), Equals, true)
+	c.Assert(mgr.VerifyPrimaryKeyAgainstState(1, []byte{2, 2, 2, 2}), Equals, false)
+	c.Assert(mgr.VerifyPrimaryKeyAgainstState(2, primaryKey), Equals, false)
 }

--- a/overlord/fdestate/fdestate.go
+++ b/overlord/fdestate/fdestate.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/gadget/device"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/fdestate/backend"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/secboot"
@@ -323,28 +324,45 @@ func updateParameters(st *state.State, role string, containerRole string, bootMo
 	return nil
 }
 
-func (s *FdeState) getParameters(role string, containerRole string) (hasParamters bool, bootModes []string, models []secboot.ModelForSealing, tpmPCRProfile []byte, err error) {
-	roleInfo, hasRole := s.KeyslotRoles[role]
+func (s *FdeState) getParameters(role string, containerRole string) (roleParams *backend.SealingParameters, err error) {
+	info, hasRole := s.KeyslotRoles[role]
 	if !hasRole {
-		return false, nil, nil, nil, fmt.Errorf("cannot find keyslot role %s", role)
+		return nil, fmt.Errorf("cannot find keyslot role %s", role)
 	}
 
-	if roleInfo.Parameters == nil {
-		return false, nil, nil, nil, nil
+	if info.Parameters == nil {
+		return nil, nil
 	}
-	parameters, hasContainerRole := roleInfo.Parameters[containerRole]
+	parameters, hasContainerRole := info.Parameters[containerRole]
 	if !hasContainerRole {
-		parameters, hasContainerRole = roleInfo.Parameters["all"]
+		parameters, hasContainerRole = info.Parameters["all"]
 	}
 	if !hasContainerRole {
-		return false, nil, nil, nil, nil
+		return nil, nil
+	}
+
+	roleParams = &backend.SealingParameters{
+		BootModes:     parameters.BootModes,
+		TpmPCRProfile: parameters.TPM2PCRProfile,
 	}
 
 	for _, model := range parameters.Models {
-		models = append(models, model)
+		roleParams.Models = append(roleParams.Models, model)
 	}
 
-	return true, parameters.BootModes, models, parameters.TPM2PCRProfile, nil
+	return roleParams, nil
+}
+
+func (s *FdeState) getRoleInfo(role string) (roleInfo *backend.RoleInfo, err error) {
+	info, hasRole := s.KeyslotRoles[role]
+	if !hasRole {
+		return nil, fmt.Errorf("cannot find keyslot role %s", role)
+	}
+	roleInfo = &backend.RoleInfo{
+		PrimaryKeyID:                   info.PrimaryKeyID,
+		TPM2PCRPolicyRevocationCounter: info.TPM2PCRPolicyRevocationCounter,
+	}
+	return roleInfo, nil
 }
 
 func withFdeState(st *state.State, op func(fdeSt *FdeState) (modified bool, err error)) error {

--- a/overlord/fdestate/handlers.go
+++ b/overlord/fdestate/handlers.go
@@ -330,16 +330,16 @@ func (m *FDEManager) doAddPlatformKeys(t *state.Task, _ *tomb.Tomb) (err error) 
 			return fmt.Errorf("internal error: cannot load FDE state parameters: %v", err)
 		}
 
-		hasParameters, _, _, pcrProfile, err := m.GetParameters(role, ref.ContainerRole)
+		roleParams, err := m.GetParameters(role, ref.ContainerRole)
 		if err != nil {
 			return err
 		}
-		if !hasParameters {
+		if roleParams == nil {
 			return fmt.Errorf("internal error: cannot find parameters (key role: %s, container role: %s)", role, ref.ContainerRole)
 		}
 
 		params := secboot.ProtectKeyParams{
-			PCRProfile:             pcrProfile,
+			PCRProfile:             roleParams.TpmPCRProfile,
 			PCRPolicyCounterHandle: fdeKeyslotRoles[role].TPM2PCRPolicyRevocationCounter,
 			KeyRole:                role,
 			VolumesAuth:            volumesAuth,

--- a/secboot/export_sb_test.go
+++ b/secboot/export_sb_test.go
@@ -557,7 +557,7 @@ func NewKeyData(kd *sb.KeyData) KeyData {
 	return &keyData{kd: kd}
 }
 
-func MockResealKeysWithFDESetupHook(f func(keys []KeyDataLocation, primaryKeyDevices []string, fallbackPrimaryKeyFiles []string, models []ModelForSealing, bootModes []string) error) (restore func()) {
+func MockResealKeysWithFDESetupHook(f func(keys []KeyDataLocation, primaryKeyDevices []string, fallbackPrimaryKeyFiles []string, verifyPrimaryKey func([]byte), models []ModelForSealing, bootModes []string) error) (restore func()) {
 	return testutil.Mock(&resealKeysWithFDESetupHook, f)
 }
 
@@ -567,4 +567,8 @@ func MockResealKeysWithTPM(f func(params *resealKeysWithTPMParams, newPCRPolicyV
 
 func MockSbKeyDataPlatformName(f func(d *sb.KeyData) string) (restore func()) {
 	return testutil.Mock(&sbKeyDataPlatformName, f)
+}
+
+func MockSbPCRPolicyCounterHandle(f func(skd *sb_tpm2.SealedKeyData) tpm2.Handle) (restore func()) {
+	return testutil.Mock(&sbPCRPolicyCounterHandle, f)
 }

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -308,6 +308,7 @@ type ResealKeyParams struct {
 	// FallbackPrimaryKeyFiles is the list of files that might contain
 	// the primary key.
 	FallbackPrimaryKeyFiles []string
+	VerifyPrimaryKey func([]byte)
 	// The allowed boot modes (run, recover, factory-reset)
 	BootModes []string
 	// The allowed models

--- a/secboot/secboot_hooks.go
+++ b/secboot/secboot_hooks.go
@@ -224,7 +224,7 @@ var setAuthorizedBootModesOnHooksKeydata = setAuthorizedBootModesOnHooksKeydataI
 
 // resealKeysWithFDESetupHookImpl updates hook based keydatas for given
 // files with a specific list of models
-func resealKeysWithFDESetupHookImpl(keys []KeyDataLocation, primaryKeyDevices []string, fallbackPrimaryKeyFiles []string, models []ModelForSealing, bootModes []string) error {
+func resealKeysWithFDESetupHookImpl(keys []KeyDataLocation, primaryKeyDevices []string, fallbackPrimaryKeyFiles []string, verifyPrimaryKey func([]byte), models []ModelForSealing, bootModes []string) error {
 	var sbModels []sb.SnapModel
 	for _, model := range models {
 		sbModels = append(sbModels, model)
@@ -264,6 +264,7 @@ func resealKeysWithFDESetupHookImpl(keys []KeyDataLocation, primaryKeyDevices []
 			if err != nil {
 				return err
 			}
+			verifyPrimaryKey(pk)
 			primaryKey = pk
 		}
 		if keyData.Generation() == 1 {

--- a/secboot/secboot_sb.go
+++ b/secboot/secboot_sb.go
@@ -740,6 +740,9 @@ func ResealKey(key KeyDataLocation, params *ResealKeyParams) (UpdatedKeys, error
 		if err != nil {
 			return nil, err
 		}
+		if params.VerifyPrimaryKey != nil {
+			params.VerifyPrimaryKey(primaryKey)
+		}
 		pcrProfile, err := params.GetTpmPCRProfile()
 		if err != nil {
 			return nil, err
@@ -754,7 +757,7 @@ func ResealKey(key KeyDataLocation, params *ResealKeyParams) (UpdatedKeys, error
 		return resealKeysWithTPM(keyParams, params.NewPCRPolicyVersion)
 
 	case hookResealKind:
-		err = resealKeysWithFDESetupHook([]KeyDataLocation{key}, params.PrimaryKeyDevices, params.FallbackPrimaryKeyFiles, params.Models, params.BootModes)
+		err = resealKeysWithFDESetupHook([]KeyDataLocation{key}, params.PrimaryKeyDevices, params.FallbackPrimaryKeyFiles, params.VerifyPrimaryKey, params.Models, params.BootModes)
 		return nil, err
 
 	case noResealKind:

--- a/secboot/secboot_sb_test.go
+++ b/secboot/secboot_sb_test.go
@@ -1541,12 +1541,12 @@ func (s *secbootSuite) TestResealKeysWithTPM(c *C) {
 				c.Check(keyFile, Not(testutil.FilePresent))
 				c.Check(keyFile2, Not(testutil.FilePresent))
 			}
-			if !tc.revoke {
+			if tc.oldKeyFiles {
 				c.Check(sealedKeysRequested, Equals, 0)
 				c.Check(updatedKeys, IsNil)
 			} else {
 				c.Check(sealedKeysRequested, Equals, 2)
-				c.Assert(updatedKeys, HasLen, 2)
+				c.Check(updatedKeys, HasLen, 2)
 			}
 		} else {
 			c.Assert(err, ErrorMatches, tc.expectedErr, Commentf("%v", tc))
@@ -3403,7 +3403,7 @@ func (s *secbootSuite) TestResealKeysWithFDESetupHookV1(c *C) {
 		return nil, fmt.Errorf("unexpected call")
 	})()
 
-	err = secboot.ResealKeysWithFDESetupHook([]secboot.KeyDataLocation{key1Location}, nil, nil, []secboot.ModelForSealing{m}, []string{"run"})
+	err = secboot.ResealKeysWithFDESetupHook([]secboot.KeyDataLocation{key1Location}, nil, nil, func([]byte) {}, []secboot.ModelForSealing{m}, []string{"run"})
 	c.Assert(err, IsNil)
 
 	// Nothing should have happened. But we make sure that they key is still there untouched.
@@ -3446,7 +3446,7 @@ func (s *secbootSuite) TestResealKeysWithFDESetupHookV2(c *C) {
 		return auxKey, nil
 	})()
 
-	err = secboot.ResealKeysWithFDESetupHook([]secboot.KeyDataLocation{key1Location}, []string{"/dev/foo"}, nil, []secboot.ModelForSealing{m}, []string{"run"})
+	err = secboot.ResealKeysWithFDESetupHook([]secboot.KeyDataLocation{key1Location}, []string{"/dev/foo"}, nil, func([]byte) {}, []secboot.ModelForSealing{m}, []string{"run"})
 	c.Assert(err, IsNil)
 
 	afterReader, err := sb.NewFileKeyDataReader(key1Fn)
@@ -3537,7 +3537,7 @@ func (s *secbootSuite) TestResealKeysWithFDESetupHook(c *C) {
 		return primaryKey, nil
 	})()
 
-	err = secboot.ResealKeysWithFDESetupHook([]secboot.KeyDataLocation{key1Location}, []string{"/dev/foo"}, nil, []secboot.ModelForSealing{newModel}, []string{"some-mode"})
+	err = secboot.ResealKeysWithFDESetupHook([]secboot.KeyDataLocation{key1Location}, []string{"/dev/foo"}, nil, func([]byte) {}, []secboot.ModelForSealing{newModel}, []string{"some-mode"})
 	c.Assert(err, IsNil)
 	c.Check(modelSet, Equals, 1)
 	c.Check(bootModesSet, Equals, 1)
@@ -3613,7 +3613,7 @@ func (s *secbootSuite) TestResealKeysWithFDESetupHookFromFile(c *C) {
 		return primaryKey, nil
 	})()
 
-	err = secboot.ResealKeysWithFDESetupHook([]secboot.KeyDataLocation{key1Location}, []string{"/dev/foo"}, nil, []secboot.ModelForSealing{newModel}, []string{"some-mode"})
+	err = secboot.ResealKeysWithFDESetupHook([]secboot.KeyDataLocation{key1Location}, []string{"/dev/foo"}, nil, func([]byte) {}, []secboot.ModelForSealing{newModel}, []string{"some-mode"})
 	c.Assert(err, IsNil)
 	c.Check(modelSet, Equals, 1)
 	c.Check(bootModesSet, Equals, 1)
@@ -4974,7 +4974,7 @@ func (s *secbootSuite) TestResealKeyHook(c *C) {
 	})()
 
 	resealKeysWithTPMCalled := 0
-	defer secboot.MockResealKeysWithFDESetupHook(func(keys []secboot.KeyDataLocation, primaryKeyDevices []string, fallbackPrimaryKeyFiles []string, models []secboot.ModelForSealing, bootModes []string) error {
+	defer secboot.MockResealKeysWithFDESetupHook(func(keys []secboot.KeyDataLocation, primaryKeyDevices []string, fallbackPrimaryKeyFiles []string, verifyPrimaryKey func([]byte), models []secboot.ModelForSealing, bootModes []string) error {
 		resealKeysWithTPMCalled++
 		c.Check(primaryKeyDevices, DeepEquals, []string{"/dev/foo", "/dev/bar"})
 		c.Check(fallbackPrimaryKeyFiles, DeepEquals, []string{"/some/file", "/some/other/key"})
@@ -5034,7 +5034,7 @@ func (s *secbootSuite) TestResealKeyHookV2(c *C) {
 	})()
 
 	resealKeysWithTPMCalled := 0
-	defer secboot.MockResealKeysWithFDESetupHook(func(keys []secboot.KeyDataLocation, primaryKeyDevices []string, fallbackPrimaryKeyFiles []string, models []secboot.ModelForSealing, bootModes []string) error {
+	defer secboot.MockResealKeysWithFDESetupHook(func(keys []secboot.KeyDataLocation, primaryKeyDevices []string, fallbackPrimaryKeyFiles []string, verifyPrimaryKey func([]byte), models []secboot.ModelForSealing, bootModes []string) error {
 		resealKeysWithTPMCalled++
 		c.Check(primaryKeyDevices, DeepEquals, []string{"/dev/foo", "/dev/bar"})
 		c.Check(fallbackPrimaryKeyFiles, DeepEquals, []string{"/some/file", "/some/other/key"})
@@ -5176,4 +5176,36 @@ func (s *secbootSuite) TestResealKeyAllOtherPlatforms(c *C) {
 		}
 
 	}
+}
+
+type fakeUnwrappableWrappedSealedKeyData struct {
+	unique int
+}
+
+func (f *fakeUnwrappableWrappedSealedKeyData) Unwrap() *sb_tpm2.SealedKeyData {
+	return nil
+}
+
+func (s *secbootSuite) TestUpdatedKeysPCRPolicyCounterHandles(c *C) {
+	calls := 0
+	callReturns := []uint32{42, 51, 42}
+	defer secboot.MockSbPCRPolicyCounterHandle(func(skd *sb_tpm2.SealedKeyData) tpm2.Handle {
+		calls += 1
+		return tpm2.Handle(callReturns[calls-1])
+	})()
+
+	key1 := &fakeUnwrappableWrappedSealedKeyData{1}
+	key2 := &fakeUnwrappableWrappedSealedKeyData{2}
+	key3 := &fakeUnwrappableWrappedSealedKeyData{3}
+	keys := secboot.UpdatedKeys([]secboot.MaybeSealedKeyData{key1, key2, key3})
+
+	handles := keys.PCRPolicyCounterHandles()
+	c.Assert(handles, HasLen, 2)
+	switch handles[0] {
+	case 42:
+		c.Check(handles[1], Equals, uint32(51))
+	case 51:
+		c.Check(handles[1], Equals, uint32(42))
+	}
+	c.Check(calls, Equals, 3)
 }

--- a/tests/nested/manual/core-broken-fde-state/task.yaml
+++ b/tests/nested/manual/core-broken-fde-state/task.yaml
@@ -1,0 +1,57 @@
+summary: Verify that inconsistent FDE state generates warning on reseal
+
+details: |
+    When the primary key digests or the revocation counter handles
+    from the FDE state do not match what we get from resealing, we
+    should at least warn about it in the logs.
+
+systems:
+  - -ubuntu-1*
+  - -ubuntu-20*
+  - -ubuntu-22*
+
+prepare: |
+    tests.nested build-image core
+    tests.nested create-vm core
+
+    unsquashfs -d pc-kernel "$(tests.nested get assets-path)"/pc-kernel*.snap
+    quiet apt install -y systemd-boot-efi systemd-ukify
+
+    objcopy -O binary -j .initrd pc-kernel/kernel.efi initrd.img
+    objcopy -O binary -j .linux pc-kernel/kernel.efi linux
+
+    /usr/lib/systemd/ukify build --linux=linux --initrd=initrd.img --section=.spread:test --output=pc-kernel/kernel.efi
+
+    KEY_NAME=$(tests.nested download snakeoil-key)
+    SNAKEOIL_KEY="$PWD/$KEY_NAME.key"
+    SNAKEOIL_CERT="$PWD/$KEY_NAME.pem"
+    tests.nested secboot-sign file "$PWD/pc-kernel/kernel.efi" "$SNAKEOIL_KEY" "$SNAKEOIL_CERT"
+
+    snap pack pc-kernel --filename=new-pc-kernel.snap
+    remote.push new-pc-kernel.snap
+
+execute: |
+    remote.exec "sudo snap wait system seed.loaded"
+
+    remote.exec "sudo systemctl stop snapd.socket snapd.service"
+
+    remote.exec "sudo journalctl -u snapd.service" >snapd.before.log
+    NOMATCH "WARNING: primary key is not matching the FDE state" <snapd.before.log
+    NOMATCH "WARNING: policy counter handle .* is not matching the FDE state" <snapd.before.log
+
+    remote.exec "sudo cat /var/lib/snapd/state.json" >state.json
+
+    gojq '.data.fde."primary-keys"."0".digest.digest = "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAK"' <state.json |
+      gojq '(.data.fde."keyslot-roles".[]|."tpm2-pcr-policy-revocation-counter")=42'>broken-state.json
+
+    remote.push broken-state.json
+
+    remote.exec "sudo cp broken-state.json /var/lib/snapd/state.json"
+
+    remote.exec "sudo systemctl start snapd.socket snapd.service"
+
+    # Note installing a kernel snap reboots. So we need to inhibit it
+    # until we captured the journal.
+    remote.exec "sudo systemd-inhibit bash -c 'snap install --dangerous new-pc-kernel.snap; journalctl -u snapd.service'" >snapd.log
+    MATCH "WARNING: primary key is not matching the FDE state" <snapd.log
+    MATCH "WARNING: policy counter handle .* is not matching the FDE state" <snapd.log


### PR DESCRIPTION
When resealing keys, this verifies that the primary key or policy counter handle match what we currently have in the FDE state.
