### PR TITLE
o/state: change notice Before filter to BeforeOrAt

### DIFF
--- a/overlord/state/notices.go
+++ b/overlord/state/notices.go
@@ -426,7 +426,7 @@ func (f *NoticeFilter) matches(n *Notice) bool {
 	if !f.After.IsZero() && !n.lastRepeated.After(f.After) {
 		return false
 	}
-	if !f.BeforeOrAt.IsZero() && f.BeforeOrAt.Before(n.lastRepeated) {
+	if !f.BeforeOrAt.IsZero() && n.lastRepeated.After(f.BeforeOrAt) {
 		// XXX: there's a chance for a notice which would otherwise be included
 		// to be omitted here, if it is repeated after the BeforeOrAt timestamp.
 		// For example, if a notice is first recorded between the After and


### PR DESCRIPTION
A `Before` notice filter was introduced in #15601 to allow querying for notices before a given timestamp. The intent was (in the future) to allow multiple notice backends to be queried in parallel, and then when one returned a notice, re-query all backends for any notices with a timestamp before the returned notice's last-repeated timestamp. But the problem is that then that notice is itself omitted, since it does not occur before its own timestamp.

To simplify things for this intended use-case, this commit changes the `Before` filter into a `BeforeOrAt` filter, which matches notices with a last-repeated timestamp which is before or equal to the `BeforeOrAt` timestamp.

This is a follow-up to #15601 which should also be ported to pebble along with it. Marking as 2.71 since this is small and I'd like it to be in the same release as #15601.