### PR TITLE
tests: use test-snapd-curl snap since curl in 25.10 has a strict apparmor profile

### DIFF
--- a/tests/main/snap-session-agent-service-control/task.yaml
+++ b/tests/main/snap-session-agent-service-control/task.yaml
@@ -22,11 +22,8 @@ prepare: |
         touch agent-was-enabled
     fi
 
-    # ensure curl is available (needed for e.g. core18)
-    if ! command -v curl; then
-        snap install --devmode --edge test-snapd-curl
-        snap alias test-snapd-curl.curl curl
-    fi
+    snap install --devmode --edge test-snapd-curl
+    snap alias test-snapd-curl.curl curl
 
     tests.session -u test prepare
 

--- a/tests/main/snap-session-agent-socket-activation/task.yaml
+++ b/tests/main/snap-session-agent-socket-activation/task.yaml
@@ -27,11 +27,8 @@ prepare: |
         touch agent-was-enabled
     fi
 
-    # ensure curl is available (needed for e.g. core18)
-    if ! command -v curl; then
-        snap install --devmode --edge test-snapd-curl
-        snap alias test-snapd-curl.curl curl
-    fi
+    snap install --devmode --edge test-snapd-curl
+    snap alias test-snapd-curl.curl curl
 
     tests.session -u test prepare
 


### PR DESCRIPTION
The apparmor profile in 25.10 is currently blocking access to unix sockets that live anywhere outside of $HOME. Using the snap allows us to get around that.