### PR TITLE
daemon,overlord: use notice manager and query from daemon

### DIFF
--- a/daemon/api_notices.go
+++ b/daemon/api_notices.go
@@ -125,9 +125,7 @@ func getNotices(c *Command, r *http.Request, user *auth.UserState) Response {
 		return BadRequest("invalid timeout: %v", err)
 	}
 
-	st := c.d.overlord.State()
-	st.Lock()
-	defer st.Unlock()
+	noticeMgr := c.d.overlord.NoticeManager()
 
 	var notices []*state.Notice
 
@@ -138,7 +136,7 @@ func getNotices(c *Command, r *http.Request, user *auth.UserState) Response {
 		ctx, cancel := context.WithTimeout(c.d.tomb.Context(r.Context()), timeout)
 		defer cancel()
 
-		notices, err = st.WaitNotices(ctx, filter)
+		notices, err = noticeMgr.WaitNotices(ctx, filter)
 		if errors.Is(err, context.Canceled) {
 			return InternalError("request canceled")
 		}
@@ -149,7 +147,7 @@ func getNotices(c *Command, r *http.Request, user *auth.UserState) Response {
 		}
 	} else {
 		// No timeout given, fetch currently-available notices
-		notices = st.Notices(filter)
+		notices = noticeMgr.Notices(filter)
 	}
 
 	if notices == nil {
@@ -167,7 +165,7 @@ func uidFromRequest(r *http.Request) (uint32, error) {
 	return cred.Uid, nil
 }
 
-// Construct the user IDs filter which will be passed to state.Notices.
+// Construct the user IDs filter which will be passed to noticeMgr.Notices.
 // Must only be called if the query user ID argument is set.
 func sanitizeNoticeUserIDFilter(queryUserID []string) (*uint32, error) {
 	userIDStrs := strutil.MultiCommaSeparatedList(queryUserID)
@@ -185,7 +183,7 @@ func sanitizeNoticeUserIDFilter(queryUserID []string) (*uint32, error) {
 	return &userID, nil
 }
 
-// Construct the types filter which will be passed to state.Notices.
+// Construct the types filter which will be passed to noticeMgr.Notices.
 func sanitizeNoticeTypesFilter(queryTypes []string, r *http.Request) ([]state.NoticeType, error) {
 	typeStrs := strutil.MultiCommaSeparatedList(queryTypes)
 	alreadySeen := make(map[state.NoticeType]bool, len(typeStrs))
@@ -319,10 +317,8 @@ func getNotice(c *Command, r *http.Request, user *auth.UserState) Response {
 		return Forbidden("cannot determine UID of request, so cannot retrieve notice")
 	}
 	noticeID := muxVars(r)["id"]
-	st := c.d.overlord.State()
-	st.Lock()
-	defer st.Unlock()
-	notice := st.Notice(noticeID)
+	noticeMgr := c.d.overlord.NoticeManager()
+	notice := noticeMgr.Notice(noticeID)
 	if notice == nil {
 		return NotFound("cannot find notice with id %q", noticeID)
 	}

--- a/daemon/api_notices.go
+++ b/daemon/api_notices.go
@@ -125,6 +125,9 @@ func getNotices(c *Command, r *http.Request, user *auth.UserState) Response {
 		return BadRequest("invalid timeout: %v", err)
 	}
 
+	// State lock is not required to get or use the notice manager. The notice
+	// manager will decide whether it's necessary to query the state for
+	// notices, and if so, it is responsible for acquiring the state lock.
 	noticeMgr := c.d.overlord.NoticeManager()
 
 	var notices []*state.Notice

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -699,7 +699,7 @@ func (o *Overlord) SnapshotManager() *snapshotstate.SnapshotManager {
 }
 
 // NoticeManager returns the notice manager responsible for mediating requests
-// for notice across all notice backends.
+// for notices across all notice backends.
 func (o *Overlord) NoticeManager() *notices.NoticeManager {
 	return o.noticeMgr
 }

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -47,6 +47,7 @@ import (
 	"github.com/snapcore/snapd/overlord/healthstate"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/ifacestate"
+	"github.com/snapcore/snapd/overlord/notices"
 	"github.com/snapcore/snapd/overlord/patch"
 	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/servicestate"
@@ -115,6 +116,7 @@ type Overlord struct {
 	cmdMgr     *cmdstate.CommandManager
 	shotMgr    *snapshotstate.SnapshotManager
 	fdeMgr     *fdestate.FDEManager
+	noticeMgr  *notices.NoticeManager
 	// proxyConf mediates the http proxy config
 	proxyConf func(req *http.Request) (*url.URL, error)
 }
@@ -136,6 +138,8 @@ func New(restartHandler restart.Handler) (*Overlord, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	o.noticeMgr = notices.NewNoticeManager(s)
 
 	o.stateEng = NewStateEngine(s)
 	o.runner = state.NewTaskRunner(s)
@@ -692,6 +696,12 @@ func (o *Overlord) FDEManager() *fdestate.FDEManager {
 // SnapshotManager returns the manager responsible for snapshots.
 func (o *Overlord) SnapshotManager() *snapshotstate.SnapshotManager {
 	return o.shotMgr
+}
+
+// NoticeManager returns the notice manager responsible for mediating requests
+// for notice across all notice backends.
+func (o *Overlord) NoticeManager() *notices.NoticeManager {
+	return o.noticeMgr
 }
 
 // Mock creates an Overlord without any managers and with a backend


### PR DESCRIPTION
~~This PR is based on #15673, only the final commit(s) are relevant.~~

Initialize a new `NoticeManager` after state is loaded from disk, and expose it under a new `NoticeManager()` method on the overlord.
    
Then, for the notices endpoints which query existing notices, switch from querying notices directly from state, and instead query via the overlord's notice manager.
    
The goal of this is that if there is an API request for notices which is satisfied by notice backends outside of state, then there is no need to acquire state lock in order to process that notices request, and the notice manager can instead only query the relevant notice backends.

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-35275