### PR TITLE
daemon, o/install: prevent usage of FDE APIs on incorrect systems

### DIFF
--- a/daemon/api_system_recovery_keys.go
+++ b/daemon/api_system_recovery_keys.go
@@ -54,7 +54,7 @@ func newRecoveryKeyAPISupported(st *state.State) (bool, error) {
 		return true, nil
 	}
 
-	supported, err := install.PreinstallCheckSupported(deviceCtx.Model())
+	supported, err := install.CheckHybridPluckyRelease(deviceCtx.Model())
 	if err != nil {
 		return false, err
 	}

--- a/daemon/api_system_recovery_keys.go
+++ b/daemon/api_system_recovery_keys.go
@@ -43,7 +43,7 @@ var systemRecoveryKeysCmd = &Command{
 // FDE/recovery key APIs.
 //
 // TODO: usage of this function and the routes we support should be reviewed for
-// core26
+// UC 26
 func newRecoveryKeyAPISupported(st *state.State) (bool, error) {
 	deviceCtx, err := snapstate.DeviceCtx(st, nil, nil)
 

--- a/daemon/api_system_recovery_keys.go
+++ b/daemon/api_system_recovery_keys.go
@@ -80,7 +80,7 @@ func getSystemRecoveryKeys(c *Command, r *http.Request, user *auth.UserState) Re
 
 	// systems that support the new APIs should use those
 	if supported {
-		return BadRequest("this action is not supported on this system")
+		return BadRequest("this action is not supported on 25.10+ classic systems")
 	}
 
 	keys, err := c.d.overlord.DeviceManager().EnsureRecoveryKeys()
@@ -127,7 +127,7 @@ func postSystemRecoveryKeys(c *Command, r *http.Request, user *auth.UserState) R
 
 	// systems that support the new APIs should use those
 	if supported {
-		return BadRequest("this action is not supported on this system")
+		return BadRequest("this action is not supported on 25.10+ classic systems")
 	}
 
 	err = deviceManagerRemoveRecoveryKeys(c.d.overlord.DeviceManager())

--- a/daemon/api_system_recovery_keys.go
+++ b/daemon/api_system_recovery_keys.go
@@ -21,6 +21,7 @@ package daemon
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 
 	"github.com/snapcore/snapd/overlord/auth"
@@ -44,25 +45,28 @@ var systemRecoveryKeysCmd = &Command{
 //
 // TODO: usage of this function and the routes we support should be reviewed for
 // UC 26
-func newRecoveryKeyAPISupported(st *state.State) (bool, error) {
+func newRecoveryKeyAPISupported(st *state.State) (bool, Response) {
 	deviceCtx, err := snapstate.DeviceCtx(st, nil, nil)
 
 	// TODO: if we don't yet have a model, assume that it should be supported?
 	// is that the right thing to do? unsure if this is a realistic scenario,
 	// but it does happen in tests
 	if err != nil {
-		return true, nil
+		if errors.Is(err, state.ErrNoState) {
+			return false, BadRequest("cannot use this API prior to device having a model")
+		}
+		return false, InternalError(err.Error())
 	}
 
 	supported, err := install.CheckHybridPluckyRelease(deviceCtx.Model())
 	if err != nil {
-		return false, err
+		return false, InternalError(err.Error())
 	}
 
 	return supported, nil
 }
 
-func newRecoveryKeyAPISupportedLocking(st *state.State) (bool, error) {
+func newRecoveryKeyAPISupportedLocking(st *state.State) (bool, Response) {
 	st.Lock()
 	defer st.Unlock()
 	return newRecoveryKeyAPISupported(st)
@@ -73,9 +77,9 @@ func getSystemRecoveryKeys(c *Command, r *http.Request, user *auth.UserState) Re
 	st.Lock()
 	defer st.Unlock()
 
-	supported, err := newRecoveryKeyAPISupported(st)
-	if err != nil {
-		return InternalError(err.Error())
+	supported, respErr := newRecoveryKeyAPISupported(st)
+	if respErr != nil {
+		return respErr
 	}
 
 	// systems that support the new APIs should use those
@@ -120,9 +124,9 @@ func postSystemRecoveryKeys(c *Command, r *http.Request, user *auth.UserState) R
 	st.Lock()
 	defer st.Unlock()
 
-	supported, err := newRecoveryKeyAPISupported(st)
-	if err != nil {
-		return InternalError(err.Error())
+	supported, respErr := newRecoveryKeyAPISupported(st)
+	if respErr != nil {
+		return respErr
 	}
 
 	// systems that support the new APIs should use those
@@ -130,7 +134,7 @@ func postSystemRecoveryKeys(c *Command, r *http.Request, user *auth.UserState) R
 		return BadRequest("this action is not supported on 25.10+ classic systems")
 	}
 
-	err = deviceManagerRemoveRecoveryKeys(c.d.overlord.DeviceManager())
+	err := deviceManagerRemoveRecoveryKeys(c.d.overlord.DeviceManager())
 	if err != nil {
 		return InternalError(err.Error())
 	}

--- a/daemon/api_system_recovery_keys.go
+++ b/daemon/api_system_recovery_keys.go
@@ -66,7 +66,7 @@ func newRecoveryKeyAPISupported(st *state.State) (bool, *apiError) {
 	return supported, nil
 }
 
-func newRecoveryKeyAPISupportedLocking(st *state.State) (bool, Response) {
+func newRecoveryKeyAPISupportedLocking(st *state.State) (bool, *apiError) {
 	st.Lock()
 	defer st.Unlock()
 	return newRecoveryKeyAPISupported(st)

--- a/daemon/api_system_recovery_keys.go
+++ b/daemon/api_system_recovery_keys.go
@@ -45,7 +45,7 @@ var systemRecoveryKeysCmd = &Command{
 //
 // TODO: usage of this function and the routes we support should be reviewed for
 // UC 26
-func newRecoveryKeyAPISupported(st *state.State) (bool, Response) {
+func newRecoveryKeyAPISupported(st *state.State) (bool, *apiError) {
 	deviceCtx, err := snapstate.DeviceCtx(st, nil, nil)
 
 	// TODO: if we don't yet have a model, assume that it should be supported?

--- a/daemon/api_system_recovery_keys_test.go
+++ b/daemon/api_system_recovery_keys_test.go
@@ -207,7 +207,7 @@ func (s *recoveryKeysSuite) TestGetSystemRecoveryKeysFailsOnHybrid(c *C) {
 
 	rspe := s.errorReq(c, req, nil, actionIsExpected)
 	c.Check(rspe.Status, Equals, 400)
-	c.Check(rspe.Message, Equals, "this action is not supported on this system")
+	c.Check(rspe.Message, Equals, "this action is not supported on 25.10+ classic systems")
 }
 
 func (s *recoveryKeysSuite) TestPostSystemRecoveryKeysFailsOnHybrid(c *C) {
@@ -247,5 +247,5 @@ func (s *recoveryKeysSuite) TestPostSystemRecoveryKeysFailsOnHybrid(c *C) {
 
 	rspe := s.errorReq(c, req, nil, actionIsExpected)
 	c.Check(rspe.Status, Equals, 400)
-	c.Check(rspe.Message, Equals, "this action is not supported on this system")
+	c.Check(rspe.Message, Equals, "this action is not supported on 25.10+ classic systems")
 }

--- a/daemon/api_system_volumes.go
+++ b/daemon/api_system_volumes.go
@@ -132,6 +132,15 @@ func structureInfoFromVolumeStructure(structure *devicestate.VolumeStructureWith
 }
 
 func getSystemVolumes(c *Command, r *http.Request, user *auth.UserState) Response {
+	supported, err := newRecoveryKeyAPISupportedLocking(c.d.overlord.State())
+	if err != nil {
+		return InternalError(err.Error())
+	}
+
+	if !supported {
+		return BadRequest("this action is not supported on this system")
+	}
+
 	opts, err := parseSystemVolumesOptionsFromURL(r.URL.Query())
 	if err != nil {
 		return BadRequest(err.Error())
@@ -201,8 +210,16 @@ type systemVolumesActionRequest struct {
 }
 
 func postSystemVolumesAction(c *Command, r *http.Request, user *auth.UserState) Response {
-	contentType := r.Header.Get("Content-Type")
+	supported, err := newRecoveryKeyAPISupportedLocking(c.d.overlord.State())
+	if err != nil {
+		return InternalError(err.Error())
+	}
 
+	if !supported {
+		return BadRequest("this action is not supported on this system")
+	}
+
+	contentType := r.Header.Get("Content-Type")
 	switch contentType {
 	case "application/json":
 		return postSystemVolumesActionJSON(c, r)

--- a/daemon/api_system_volumes.go
+++ b/daemon/api_system_volumes.go
@@ -132,9 +132,9 @@ func structureInfoFromVolumeStructure(structure *devicestate.VolumeStructureWith
 }
 
 func getSystemVolumes(c *Command, r *http.Request, user *auth.UserState) Response {
-	supported, err := newRecoveryKeyAPISupportedLocking(c.d.overlord.State())
-	if err != nil {
-		return InternalError(err.Error())
+	supported, respErr := newRecoveryKeyAPISupportedLocking(c.d.overlord.State())
+	if respErr != nil {
+		return respErr
 	}
 
 	if !supported {
@@ -210,9 +210,9 @@ type systemVolumesActionRequest struct {
 }
 
 func postSystemVolumesAction(c *Command, r *http.Request, user *auth.UserState) Response {
-	supported, err := newRecoveryKeyAPISupportedLocking(c.d.overlord.State())
-	if err != nil {
-		return InternalError(err.Error())
+	supported, respErr := newRecoveryKeyAPISupportedLocking(c.d.overlord.State())
+	if respErr != nil {
+		return respErr
 	}
 
 	if !supported {

--- a/daemon/api_system_volumes_test.go
+++ b/daemon/api_system_volumes_test.go
@@ -36,8 +36,11 @@ import (
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/fdestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/secboot/keys"
+	"github.com/snapcore/snapd/snap/snaptest"
 )
 
 type systemVolumesSuite struct {
@@ -72,8 +75,38 @@ func (s *systemVolumesSuite) SetUpTest(c *C) {
 	}
 }
 
+func (s *systemVolumesSuite) mockHybridSystem() {
+	restore := release.MockReleaseInfo(&release.OS{
+		ID:        "ubuntu",
+		VersionID: "25.10",
+	})
+	s.AddCleanup(restore)
+
+	model := s.Brands.Model("can0nical", "pc-new", map[string]any{
+		"classic":      "true",
+		"distribution": "ubuntu",
+		"architecture": "amd64",
+		"base":         "core24",
+		"snaps": []any{
+			map[string]any{
+				"name": "pc-kernel",
+				"id":   snaptest.AssertedSnapID("pc-kernel"),
+				"type": "kernel",
+			},
+			map[string]any{
+				"name": "pc",
+				"id":   snaptest.AssertedSnapID("pc"),
+				"type": "gadget",
+			},
+		},
+	})
+	restore = snapstatetest.MockDeviceModel(model)
+	s.AddCleanup(restore)
+}
+
 func (s *systemVolumesSuite) TestSystemVolumesBadContentType(c *C) {
 	s.daemon(c)
+	s.mockHybridSystem()
 
 	body := strings.NewReader(`{"action": "blah"}`)
 	req, err := http.NewRequest("POST", "/v2/system-volumes", body)
@@ -86,6 +119,7 @@ func (s *systemVolumesSuite) TestSystemVolumesBadContentType(c *C) {
 
 func (s *systemVolumesSuite) TestSystemVolumesBogusAction(c *C) {
 	s.daemon(c)
+	s.mockHybridSystem()
 
 	body := strings.NewReader(`{"action": "blah"}`)
 	req, err := http.NewRequest("POST", "/v2/system-volumes", body)
@@ -104,6 +138,7 @@ func (s *systemVolumesSuite) TestSystemVolumesActionGenerateRecoveryKey(c *C) {
 	}
 
 	s.daemon(c)
+	s.mockHybridSystem()
 
 	called := 0
 	s.AddCleanup(daemon.MockFdeMgrGenerateRecoveryKey(func(fdemgr *fdestate.FDEManager) (rkey keys.RecoveryKey, keyID string, err error) {
@@ -134,6 +169,7 @@ func (s *systemVolumesSuite) TestSystemVolumesActionCheckRecoveryKey(c *C) {
 	}
 
 	d := s.daemon(c)
+	s.mockHybridSystem()
 
 	called := 0
 	s.AddCleanup(daemon.MockFdeMgrCheckRecoveryKey(func(fdemgr *fdestate.FDEManager, rkey keys.RecoveryKey, containerRoles []string) (err error) {
@@ -168,6 +204,7 @@ func (s *systemVolumesSuite) TestSystemVolumesActionCheckRecoveryKeyMissingKey(c
 	}
 
 	s.daemon(c)
+	s.mockHybridSystem()
 
 	body := strings.NewReader(`{"action": "check-recovery-key"}`)
 	req, err := http.NewRequest("POST", "/v2/system-volumes", body)
@@ -185,6 +222,7 @@ func (s *systemVolumesSuite) TestSystemVolumesActionCheckRecoveryKeyBadRecoveryK
 	}
 
 	s.daemon(c)
+	s.mockHybridSystem()
 
 	called := 0
 	s.AddCleanup(daemon.MockFdeMgrCheckRecoveryKey(func(fdemgr *fdestate.FDEManager, rkey keys.RecoveryKey, containerRoles []string) (err error) {
@@ -211,6 +249,7 @@ func (s *systemVolumesSuite) TestSystemVolumesActionCheckRecoveryKeyError(c *C) 
 	}
 
 	s.daemon(c)
+	s.mockHybridSystem()
 
 	called := 0
 	s.AddCleanup(daemon.MockFdeMgrCheckRecoveryKey(func(fdemgr *fdestate.FDEManager, rkey keys.RecoveryKey, containerRoles []string) (err error) {
@@ -233,6 +272,7 @@ func (s *systemVolumesSuite) TestSystemVolumesActionCheckRecoveryKeyError(c *C) 
 
 func (s *systemVolumesSuite) TestSystemVolumesActionReplaceRecoveryKey(c *C) {
 	d := s.daemon(c)
+	s.mockHybridSystem()
 	st := d.Overlord().State()
 
 	d.Overlord().Loop()
@@ -279,6 +319,7 @@ func (s *systemVolumesSuite) TestSystemVolumesActionReplaceRecoveryKey(c *C) {
 
 func (s *systemVolumesSuite) TestSystemVolumesActionReplaceRecoveryKeyError(c *C) {
 	s.daemon(c)
+	s.mockHybridSystem()
 
 	var mockErr error
 	s.AddCleanup(daemon.MockFdestateReplaceRecoveryKey(func(st *state.State, recoveryKeyID string, keyslots []fdestate.KeyslotRef) (*state.TaskSet, error) {
@@ -313,6 +354,7 @@ func (s *systemVolumesSuite) TestSystemVolumesActionReplaceRecoveryKeyError(c *C
 
 func (s *systemVolumesSuite) TestSystemVolumesActionReplaceRecoveryKeyMissingKeyID(c *C) {
 	s.daemon(c)
+	s.mockHybridSystem()
 
 	body := strings.NewReader(`{"action": "replace-recovery-key"}`)
 	req, err := http.NewRequest("POST", "/v2/system-volumes", body)
@@ -326,6 +368,7 @@ func (s *systemVolumesSuite) TestSystemVolumesActionReplaceRecoveryKeyMissingKey
 
 func (s *systemVolumesSuite) TestSystemVolumesActionChangePassphrase(c *C) {
 	d := s.daemon(c)
+	s.mockHybridSystem()
 	st := d.Overlord().State()
 
 	d.Overlord().Loop()
@@ -369,6 +412,7 @@ func (s *systemVolumesSuite) TestSystemVolumesActionChangePassphrase(c *C) {
 
 func (s *systemVolumesSuite) TestSystemVolumesActionChangePassphraseMissingOldPassphrase(c *C) {
 	s.daemon(c)
+	s.mockHybridSystem()
 
 	body := strings.NewReader(`{"action": "change-passphrase", "new-passphrase": "new"}`)
 	req, err := http.NewRequest("POST", "/v2/system-volumes", body)
@@ -385,6 +429,7 @@ func (s *systemVolumesSuite) TestSystemVolumesActionChangePassphraseMissingOldPa
 // This test should intentionally fail when resetting passphrase as root is implemented.
 func (s *systemVolumesSuite) TestSystemVolumesActionChangePassphraseMissingOldPassphraseAsRoot(c *C) {
 	s.daemon(c)
+	s.mockHybridSystem()
 
 	body := strings.NewReader(`{"action": "change-passphrase", "new-passphrase": "new"}`)
 	req, err := http.NewRequest("POST", "/v2/system-volumes", body)
@@ -400,6 +445,7 @@ func (s *systemVolumesSuite) TestSystemVolumesActionChangePassphraseMissingOldPa
 
 func (s *systemVolumesSuite) TestSystemVolumesActionChangePassphraseMissingNewPassphrase(c *C) {
 	s.daemon(c)
+	s.mockHybridSystem()
 
 	body := strings.NewReader(`{"action": "change-passphrase", "old-passphrase": "old"}`)
 	req, err := http.NewRequest("POST", "/v2/system-volumes", body)
@@ -413,6 +459,7 @@ func (s *systemVolumesSuite) TestSystemVolumesActionChangePassphraseMissingNewPa
 
 func (s *systemVolumesSuite) TestSystemVolumesActionChangePassphraseChangeAuthError(c *C) {
 	s.daemon(c)
+	s.mockHybridSystem()
 
 	var mockErr error
 	s.AddCleanup(daemon.MockFdestateChangeAuth(func(st *state.State, authMode device.AuthMode, old, new string, keyslotRefs []fdestate.KeyslotRef) (*state.TaskSet, error) {
@@ -482,6 +529,7 @@ func (k *mockKeyData) WriteTokenAtomic(devicePath, slotName string) error {
 
 func (s *systemVolumesSuite) testSystemVolumesGet(c *C, query string, expectedResult any) {
 	d := s.daemon(c)
+	s.mockHybridSystem()
 
 	s.AddCleanup(daemon.MockDevicestateGetVolumeStructuresWithKeyslots(func(st *state.State) ([]devicestate.VolumeStructureWithKeyslots, error) {
 		// check state is locked
@@ -601,6 +649,7 @@ func (s *systemVolumesSuite) TestSystemVolumesGetContainerRole(c *C) {
 
 func (s *systemVolumesSuite) TestSystemVolumesGetQueryConflictError(c *C) {
 	s.daemon(c)
+	s.mockHybridSystem()
 
 	req, err := http.NewRequest("GET", "/v2/system-volumes?by-container-role=true&container-role=mbr", nil)
 	c.Assert(err, IsNil)
@@ -612,6 +661,7 @@ func (s *systemVolumesSuite) TestSystemVolumesGetQueryConflictError(c *C) {
 
 func (s *systemVolumesSuite) TestSystemVolumesGetQueryByContainerRoleError(c *C) {
 	s.daemon(c)
+	s.mockHybridSystem()
 
 	req, err := http.NewRequest("GET", "/v2/system-volumes?by-container-role=ok", nil)
 	c.Assert(err, IsNil)
@@ -623,6 +673,7 @@ func (s *systemVolumesSuite) TestSystemVolumesGetQueryByContainerRoleError(c *C)
 
 func (s *systemVolumesSuite) TestSystemVolumesGetGadgetError(c *C) {
 	s.daemon(c)
+	s.mockHybridSystem()
 
 	s.AddCleanup(daemon.MockDevicestateGetVolumeStructuresWithKeyslots(func(st *state.State) ([]devicestate.VolumeStructureWithKeyslots, error) {
 		return nil, errors.New("boom!")
@@ -638,6 +689,7 @@ func (s *systemVolumesSuite) TestSystemVolumesGetGadgetError(c *C) {
 
 func (s *systemVolumesSuite) TestSystemVolumesActionCheckPassphrase(c *C) {
 	s.daemon(c)
+	s.mockHybridSystem()
 
 	// just mock values for output matching
 	const expectedEntropy = uint32(10)
@@ -677,6 +729,7 @@ func (s *systemVolumesSuite) TestSystemVolumesActionCheckPassphrase(c *C) {
 
 func (s *systemVolumesSuite) TestSystemVolumesActionCheckPassphraseError(c *C) {
 	s.daemon(c)
+	s.mockHybridSystem()
 
 	// just mock values for output matching
 	const expectedEntropy = uint32(10)
@@ -741,6 +794,7 @@ func (s *systemVolumesSuite) TestSystemVolumesActionCheckPassphraseError(c *C) {
 
 func (s *systemVolumesSuite) TestSystemVolumesActionCheckPIN(c *C) {
 	s.daemon(c)
+	s.mockHybridSystem()
 
 	// just mock values for output matching
 	const expectedEntropy = uint32(10)
@@ -780,6 +834,7 @@ func (s *systemVolumesSuite) TestSystemVolumesActionCheckPIN(c *C) {
 
 func (s *systemVolumesSuite) TestSystemVolumesActionCheckPINError(c *C) {
 	s.daemon(c)
+	s.mockHybridSystem()
 
 	// just mock values for output matching
 	const expectedEntropy = uint32(10)
@@ -840,4 +895,29 @@ func (s *systemVolumesSuite) TestSystemVolumesActionCheckPINError(c *C) {
 		c.Check(rspe.Message, Matches, tc.expectedErrMsg)
 		c.Check(rspe.Value, DeepEquals, tc.expectedErrValue)
 	}
+}
+
+func (s *systemVolumesSuite) TestPostSystemVolumesUnsupportedSystem(c *C) {
+	s.daemon(c)
+
+	body := strings.NewReader(`{"action": "generate-recovery-key"}`)
+	req, err := http.NewRequest("POST", "/v2/system-volumes", body)
+	c.Assert(err, IsNil)
+	req.Header.Add("Content-Type", "application/json")
+
+	rsp := s.errorReq(c, req, nil, actionIsExpected)
+	c.Assert(rsp.Status, Equals, 400)
+	c.Assert(rsp.Message, Equals, "this action is not supported on this system")
+}
+
+func (s *systemVolumesSuite) TestGetSystemVolumesUnsupportedSystem(c *C) {
+	s.daemon(c)
+
+	req, err := http.NewRequest("POST", "/v2/system-volumes", nil)
+	c.Assert(err, IsNil)
+	req.Header.Add("Content-Type", "application/json")
+
+	rsp := s.errorReq(c, req, nil, actionIsExpected)
+	c.Assert(rsp.Status, Equals, 400)
+	c.Assert(rsp.Message, Equals, "this action is not supported on this system")
 }

--- a/daemon/api_systems.go
+++ b/daemon/api_systems.go
@@ -352,15 +352,6 @@ func postSystemActionInstall(c *Command, systemLabel string, req *systemActionRe
 		ensureStateSoon(st)
 		return AsyncResponse(nil, chg.ID())
 	case client.InstallStepGenerateRecoveryKey:
-		supported, err := newRecoveryKeyAPISupported(st)
-		if err != nil {
-			return InternalError(err.Error())
-		}
-
-		if !supported {
-			return BadRequest("this action is not supported on this system")
-		}
-
 		rkey, err := devicestateGeneratePreInstallRecoveryKey(st, systemLabel)
 		if err != nil {
 			return BadRequest("cannot generate recovery key for %q: %v", systemLabel, err)

--- a/daemon/api_systems.go
+++ b/daemon/api_systems.go
@@ -272,11 +272,6 @@ func postSystemsActionJSON(c *Command, r *http.Request) Response {
 		return BadRequest("extra content found in request body")
 	}
 
-	supported, err := newRecoveryKeyAPISupportedLocking(c.d.overlord.State())
-	if err != nil {
-		return InternalError(err.Error())
-	}
-
 	switch req.Action {
 	case "do":
 		return postSystemActionDo(c, systemLabel, &req)
@@ -292,14 +287,8 @@ func postSystemsActionJSON(c *Command, r *http.Request) Response {
 	case "remove":
 		return postSystemActionRemove(c, systemLabel)
 	case "check-passphrase":
-		if !supported {
-			return BadRequest("this action is not supported on this system")
-		}
 		return postSystemActionCheckPassphrase(c, systemLabel, &req)
 	case "check-pin":
-		if !supported {
-			return BadRequest("this action is not supported on this system")
-		}
 		return postSystemActionCheckPIN(c, systemLabel, &req)
 	default:
 		return BadRequest("unsupported action %q", req.Action)

--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -1432,17 +1432,6 @@ func (s *systemsSuite) TestSystemInstallActionGenerateRecoveryKeyError(c *check.
 	c.Check(rsp.Message, check.Equals, `cannot generate recovery key for "20250529": boom!`)
 }
 
-func (s *systemsSuite) TestSystemInstallActionGenerateRecoveryKeyErrorUnsupportedSystem(c *check.C) {
-	s.daemon(c)
-
-	req, err := http.NewRequest("POST", "/v2/systems/20250529", strings.NewReader(`{"action": "install", "step": "generate-recovery-key"}`))
-	c.Assert(err, check.IsNil)
-
-	rsp := s.errorReq(c, req, nil, actionIsExpected)
-	c.Check(rsp.Status, check.Equals, 400)
-	c.Check(rsp.Message, check.Equals, `this action is not supported on this system`)
-}
-
 func (s *systemsSuite) TestSystemInstallActionGeneratesTasks(c *check.C) {
 	d := s.daemon(c)
 	st := d.Overlord().State()

--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -1832,19 +1832,6 @@ func (s *systemsSuite) TestSystemActionCheckPINError(c *check.C) {
 	}
 }
 
-func (s *systemsSuite) TestSystemActionsUnsupportedOnNonHybrid(c *check.C) {
-	s.daemon(c)
-	for _, action := range []string{"check-pin", "check-passphrase"} {
-		body := fmt.Sprintf(`{"action": "%s"}`, action)
-		req, err := http.NewRequest("POST", "/v2/systems/20250122", strings.NewReader(body))
-		c.Assert(err, check.IsNil)
-
-		rsp := s.errorReq(c, req, nil, actionIsExpected)
-		c.Assert(rsp.Status, check.Equals, 400)
-		c.Assert(rsp.Message, check.Equals, "this action is not supported on this system")
-	}
-}
-
 func (s *systemsSuite) TestSystemActionCheckPassphraseOrPINCacheEncryptionInfo(c *check.C) {
 	if !secboot.WithSecbootSupport {
 		c.Skip("secboot is not available")

--- a/overlord/install/export_test.go
+++ b/overlord/install/export_test.go
@@ -28,7 +28,6 @@ import (
 
 var (
 	EncryptionAvailabilityCheck    = encryptionAvailabilityCheck
-	PreinstallCheckSupported       = preinstallCheckSupported
 	OrderedCurrentBootImages       = orderedCurrentBootImages
 	OrderedCurrentBootImagesHybrid = orderedCurrentBootImagesHybrid
 	CheckFDEFeatures               = checkFDEFeatures

--- a/overlord/install/export_test.go
+++ b/overlord/install/export_test.go
@@ -27,10 +27,11 @@ import (
 )
 
 var (
-	EncryptionAvailabilityCheck    = encryptionAvailabilityCheck
-	OrderedCurrentBootImages       = orderedCurrentBootImages
-	OrderedCurrentBootImagesHybrid = orderedCurrentBootImagesHybrid
-	CheckFDEFeatures               = checkFDEFeatures
+	EncryptionAvailabilityCheck             = encryptionAvailabilityCheck
+	OrderedCurrentBootImages                = orderedCurrentBootImages
+	OrderedCurrentBootImagesHybrid          = orderedCurrentBootImagesHybrid
+	CheckFDEFeatures                        = checkFDEFeatures
+	PreinstallCheckSupportedWithEnvFallback = preinstallCheckSupportedWithEnvFallback
 )
 
 func MockPreinstallCheckTimeout(tm time.Duration) (restore func()) {

--- a/overlord/install/install.go
+++ b/overlord/install/install.go
@@ -317,7 +317,7 @@ func GetEncryptionSupportInfo(model *asserts.Model, tpmMode secboot.TPMProvision
 }
 
 func encryptionAvailabilityCheck(model *asserts.Model, tpmMode secboot.TPMProvisionMode) (string, []secboot.PreinstallErrorDetails, error) {
-	supported, err := preinstallCheckSupported(model)
+	supported, err := PreinstallCheckSupported(model)
 	if err != nil {
 		return "", nil, fmt.Errorf("cannot confirm preinstall check support: %v", err)
 	}
@@ -356,7 +356,7 @@ func encryptionAvailabilityCheck(model *asserts.Model, tpmMode secboot.TPMProvis
 	return "", nil, nil
 }
 
-var preinstallCheckSupported = func(model *asserts.Model) (bool, error) {
+func PreinstallCheckSupported(model *asserts.Model) (bool, error) {
 	//TODO:FDEM: This temporary fallback must be removed before release of snapd 2.71
 	if osutil.GetenvBool("SNAPD_DISABLE_PREINSTALL_CHECK") {
 		logger.Noticef(`preinstall check disabled by environment variable "SNAPD_DISABLE_PREINSTALL_CHECK"`)

--- a/overlord/install/install_test.go
+++ b/overlord/install/install_test.go
@@ -493,7 +493,7 @@ func (s *installSuite) TestPreinstallCheckSupported(c *C) {
 			defer os.Unsetenv("SNAPD_DISABLE_PREINSTALL_CHECK")
 		}
 
-		supported, err := install.PreinstallCheckSupported(modelMock)
+		supported, err := install.PreinstallCheckSupportedWithEnvFallback(modelMock)
 
 		if tc.expectedError != "" {
 			c.Assert(err, ErrorMatches, tc.expectedError)

--- a/tests/nested/manual/passphrase-support-on-hybrid/task.yaml
+++ b/tests/nested/manual/passphrase-support-on-hybrid/task.yaml
@@ -8,18 +8,18 @@ systems: [-ubuntu-1*, -ubuntu-20*, -ubuntu-22*]
 
 environment:
   # Defaults
-  MODEL_VERSION: "2404"
-  GADGET_VERSION: classic-24.04
-  KERNEL_VERSION: "24"
+  MODEL_VERSION: "2510"
+  GADGET_VERSION: "classic-25.10"
+  KERNEL_VERSION: "25.10"
   KDF_TYPE: default
+
+  MODEL_VERSION/2404: "2404"
+  GADGET_VERSION/2404: classic-24.04
+  KERNEL_VERSION/2404: "24"
 
   MODEL_VERSION/2504: "2504"
   GADGET_VERSION/2504: "classic-25.04"
   KERNEL_VERSION/2504: "25.04"
-
-  MODEL_VERSION/2510: "2510"
-  GADGET_VERSION/2510: "classic-25.10"
-  KERNEL_VERSION/2510: "25.10"
 
   KDF_TYPE/pbkdf2: pbkdf2
   KDF_TYPE/argon2i: argon2i
@@ -109,6 +109,12 @@ restore: |
   rm -rf pc-kernel.* pc.* initrd* linux* kernel* tmp* pc-gadget
 
 execute: |
+  # the APIs tested here shouldn't be available on anything before 25.10
+  if [ "${MODEL_VERSION}" != "2510" ]; then
+    remote.exec sudo snap debug api /v2/system-volumes | gojq .result.message | MATCH "this action is not supported on this system"
+    exit 0
+  fi
+
   # Check encryption
   remote.exec sudo snap debug api /v2/system-volumes > containers.out
 


### PR DESCRIPTION
This PR blocks the usage of `/v2/system-recovery-keys` on newer hybrid systems. Additionally, the new FDE APIs that are intended for those newer hybrid systems are blocked on systems that do not support them.