### PR TITLE
o/fdestate, o/h/ctlcmd: extended snapctl system-mode to detect if system is encrypted

### DIFF
--- a/overlord/fdestate/fdemgr.go
+++ b/overlord/fdestate/fdemgr.go
@@ -608,10 +608,10 @@ func (m *FDEManager) systemEncrypted() (bool, error) {
 		return false, err
 	}
 
-	// Systems with FDE enabled will have a snapd managed primary key (ID 0)
+	// Systems with FDE enabled will have a snapd managed primary key
 	// with the exception of two legacy scenarios. See comment on type
 	// FdeState field PrimaryKeys for details.
-	_, hasPrimaryKey := s.PrimaryKeys[0]
+	hasPrimaryKey := len(s.PrimaryKeys) > 0
 	return hasPrimaryKey, nil
 }
 

--- a/overlord/fdestate/fdemgr.go
+++ b/overlord/fdestate/fdemgr.go
@@ -599,6 +599,22 @@ func (m *FDEManager) CheckRecoveryKey(rkey keys.RecoveryKey, containerRoles []st
 	return nil
 }
 
+// systemEncrypted reports whether FDE is enabled on the system.
+// It returns true if FDE is enabled, or false otherwise.
+func (m *FDEManager) systemEncrypted() (bool, error) {
+	var s FdeState
+	err := m.state.Get(fdeStateKey, &s)
+	if err != nil {
+		return false, err
+	}
+
+	// Systems with FDE enabled will have a primary key with the exception
+	// of a limited legacy cases. See comment on type FdeState field
+	// PrimaryKeys for details.
+	_, hasPrimaryKey := s.PrimaryKeys[0]
+	return hasPrimaryKey, nil
+}
+
 func MockDisksDMCryptUUIDFromMountPoint(f func(mountpoint string) (string, error)) (restore func()) {
 	osutil.MustBeTestBinary("mocking disks.DMCryptUUIDFromMountPoint can be done only from tests")
 

--- a/overlord/fdestate/fdemgr.go
+++ b/overlord/fdestate/fdemgr.go
@@ -608,9 +608,9 @@ func (m *FDEManager) systemEncrypted() (bool, error) {
 		return false, err
 	}
 
-	// Systems with FDE enabled will have a primary key with the exception
-	// of two legacy scenarios. See comment on type FdeState field
-	// PrimaryKeys for details.
+	// Systems with FDE enabled will have a snapd managed primary key (ID 0)
+	// with the exception of two legacy scenarios. See comment on type
+	// FdeState field PrimaryKeys for details.
 	_, hasPrimaryKey := s.PrimaryKeys[0]
 	return hasPrimaryKey, nil
 }

--- a/overlord/fdestate/fdemgr.go
+++ b/overlord/fdestate/fdemgr.go
@@ -604,12 +604,12 @@ func (m *FDEManager) CheckRecoveryKey(rkey keys.RecoveryKey, containerRoles []st
 func (m *FDEManager) systemEncrypted() (bool, error) {
 	var s FdeState
 	err := m.state.Get(fdeStateKey, &s)
-	if err != nil {
+	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return false, err
 	}
 
 	// Systems with FDE enabled will have a primary key with the exception
-	// of a limited legacy cases. See comment on type FdeState field
+	// of two legacy scenarios. See comment on type FdeState field
 	// PrimaryKeys for details.
 	_, hasPrimaryKey := s.PrimaryKeys[0]
 	return hasPrimaryKey, nil

--- a/overlord/fdestate/fdestate.go
+++ b/overlord/fdestate/fdestate.go
@@ -623,3 +623,14 @@ func ChangeAuth(st *state.State, authMode device.AuthMode, old, new string, keys
 
 	return ts, nil
 }
+
+// SystemEncryptedFromState reports whether FDE is enabled on the system.
+// It returns true if FDE is enabled, or false otherwise.
+func SystemEncryptedFromState(st *state.State) (bool, error) {
+	mgr := fdeMgr(st)
+	encrypted, err := mgr.systemEncrypted()
+	if err != nil {
+		return false, fmt.Errorf("cannot determine if system is encrypted: %v", err)
+	}
+	return encrypted, nil
+}

--- a/overlord/fdestate/fdestate_test.go
+++ b/overlord/fdestate/fdestate_test.go
@@ -444,3 +444,30 @@ func (s *fdeMgrSuite) TestChangeAuthErrors(c *C) {
 	c.Assert(err, ErrorMatches, `external EFI DBX update in progress, no other FDE changes allowed until this is done`)
 	c.Check(err, testutil.ErrorIs, &snapstate.ChangeConflictError{})
 }
+
+func (s *fdeMgrSuite) testSystemEncryptedFromState(c *C, hasEncryptedDisks bool) {
+	onClassic := true
+	if hasEncryptedDisks {
+		s.startedManager(c, onClassic)
+	} else {
+		s.startedManagerNoEncryptedDisks(c, onClassic)
+	}
+
+	st := s.st
+	st.Lock()
+	defer st.Unlock()
+
+	encrypted, err := fdestate.SystemEncryptedFromState(st)
+	c.Assert(err, IsNil)
+	c.Assert(encrypted, Equals, hasEncryptedDisks)
+}
+
+func (s *fdeMgrSuite) TestSystemEncryptedFromStateHasEncryptedDisks(c *C) {
+	hasEncryptedDisks := true
+	s.testSystemEncryptedFromState(c, hasEncryptedDisks)
+}
+
+func (s *fdeMgrSuite) TestSystemEncryptedFromStateNoEncryptedDisks(c *C) {
+	hasEncryptedDisks := false
+	s.testSystemEncryptedFromState(c, hasEncryptedDisks)
+}

--- a/overlord/hookstate/ctlcmd/export_test.go
+++ b/overlord/hookstate/ctlcmd/export_test.go
@@ -94,6 +94,12 @@ func MockDevicestateSystemModeInfoFromState(f func(*state.State) (*devicestate.S
 	return func() { devicestateSystemModeInfoFromState = old }
 }
 
+func MockFdestateSystemEncryptedFromState(f func(*state.State) (bool, error)) (restore func()) {
+	old := fdestateSystemEncryptedFromState
+	fdestateSystemEncryptedFromState = f
+	return func() { fdestateSystemEncryptedFromState = old }
+}
+
 func AddMockCommand(name string) *MockCommand {
 	return addMockCmd(name, false)
 }

--- a/overlord/hookstate/ctlcmd/system_mode.go
+++ b/overlord/hookstate/ctlcmd/system_mode.go
@@ -62,7 +62,7 @@ type systemModeResult struct {
 	SystemMode string `yaml:"system-mode,omitempty"`
 	Seeded     bool   `yaml:"seed-loaded"`
 	Factory    bool   `yaml:"factory,omitempty"`
-	Encrypted  bool   `yaml:"encrypted"`
+	Encrypted  bool   `yaml:"encrypted,omitempty"`
 }
 
 func (c *systemModeCommand) Execute(args []string) error {

--- a/overlord/hookstate/ctlcmd/system_mode.go
+++ b/overlord/hookstate/ctlcmd/system_mode.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/overlord/devicestate"
+	"github.com/snapcore/snapd/overlord/fdestate"
 	"github.com/snapcore/snapd/strutil"
 )
 
@@ -36,7 +37,7 @@ var shortSystemModeHelp = i18n.G("Get the current system mode and associated det
 var longSystemModeHelp = i18n.G(`
 The system-mode command returns information about the device's current system mode.
 
-This information includes the mode itself and whether the model snaps have been installed from the seed (seed-loaded). The system mode is either run, recover, or install.
+This information includes the mode itself, whether the model snaps have been installed from the seed (seed-loaded), and whether Full Disk Encryption (FDE) is enabled. The system mode is either run, recover, or install.
 
 Retrieved information can also include "factory mode" details: 'factory: true' declares whether the device booted an image flagged as for factory use. This flag can be set for convenience when building the image. No security sensitive decisions should be based on this bit alone.
 
@@ -45,18 +46,23 @@ The output is in YAML format. Example output:
     system-mode: install
     seed-loaded: true
     factory: true
+    encryption: true
 `)
 
 func init() {
 	addCommand("system-mode", shortSystemModeHelp, longSystemModeHelp, func() command { return &systemModeCommand{} })
 }
 
-var devicestateSystemModeInfoFromState = devicestate.SystemModeInfoFromState
+var (
+	devicestateSystemModeInfoFromState = devicestate.SystemModeInfoFromState
+	fdestateSystemEncryptedFromState   = fdestate.SystemEncryptedFromState
+)
 
 type systemModeResult struct {
 	SystemMode string `yaml:"system-mode,omitempty"`
 	Seeded     bool   `yaml:"seed-loaded"`
 	Factory    bool   `yaml:"factory,omitempty"`
+	Encrypted  bool   `yaml:"encrypted"`
 }
 
 func (c *systemModeCommand) Execute(args []string) error {
@@ -74,9 +80,15 @@ func (c *systemModeCommand) Execute(args []string) error {
 		return err
 	}
 
+	encrypted, err := fdestateSystemEncryptedFromState(st)
+	if err != nil {
+		return err
+	}
+
 	res := systemModeResult{
 		SystemMode: smi.Mode,
 		Seeded:     smi.Seeded,
+		Encrypted:  encrypted,
 	}
 	if strutil.ListContains(smi.BootFlags, "factory") {
 		res.Factory = true

--- a/overlord/hookstate/ctlcmd/system_mode.go
+++ b/overlord/hookstate/ctlcmd/system_mode.go
@@ -62,7 +62,7 @@ type systemModeResult struct {
 	SystemMode       string `yaml:"system-mode,omitempty"`
 	Seeded           bool   `yaml:"seed-loaded"`
 	Factory          bool   `yaml:"factory,omitempty"`
-	StorageEncrypted bool   `yaml:"storage-encrypted,omitempty"`
+	StorageEncrypted string `yaml:"storage-encrypted,omitempty"`
 }
 
 func (c *systemModeCommand) Execute(args []string) error {
@@ -88,10 +88,12 @@ func (c *systemModeCommand) Execute(args []string) error {
 	res := systemModeResult{
 		SystemMode:       smi.Mode,
 		Seeded:           smi.Seeded,
-		StorageEncrypted: encrypted,
 	}
 	if strutil.ListContains(smi.BootFlags, "factory") {
 		res.Factory = true
+	}
+	if encrypted {
+		res.StorageEncrypted = "managed"
 	}
 
 	b, err := yaml.Marshal(res)

--- a/overlord/hookstate/ctlcmd/system_mode.go
+++ b/overlord/hookstate/ctlcmd/system_mode.go
@@ -46,7 +46,7 @@ The output is in YAML format. Example output:
     system-mode: install
     seed-loaded: true
     factory: true
-    storage-encrypted: true
+    storage-encrypted: managed
 `)
 
 func init() {

--- a/overlord/hookstate/ctlcmd/system_mode.go
+++ b/overlord/hookstate/ctlcmd/system_mode.go
@@ -46,7 +46,7 @@ The output is in YAML format. Example output:
     system-mode: install
     seed-loaded: true
     factory: true
-    encryption: true
+    storage-encrypted: true
 `)
 
 func init() {
@@ -59,10 +59,10 @@ var (
 )
 
 type systemModeResult struct {
-	SystemMode string `yaml:"system-mode,omitempty"`
-	Seeded     bool   `yaml:"seed-loaded"`
-	Factory    bool   `yaml:"factory,omitempty"`
-	Encrypted  bool   `yaml:"encrypted,omitempty"`
+	SystemMode       string `yaml:"system-mode,omitempty"`
+	Seeded           bool   `yaml:"seed-loaded"`
+	Factory          bool   `yaml:"factory,omitempty"`
+	StorageEncrypted bool   `yaml:"storage-encrypted,omitempty"`
 }
 
 func (c *systemModeCommand) Execute(args []string) error {
@@ -86,9 +86,9 @@ func (c *systemModeCommand) Execute(args []string) error {
 	}
 
 	res := systemModeResult{
-		SystemMode: smi.Mode,
-		Seeded:     smi.Seeded,
-		Encrypted:  encrypted,
+		SystemMode:       smi.Mode,
+		Seeded:           smi.Seeded,
+		StorageEncrypted: encrypted,
 	}
 	if strutil.ListContains(smi.BootFlags, "factory") {
 		res.Factory = true

--- a/overlord/hookstate/ctlcmd/system_mode_test.go
+++ b/overlord/hookstate/ctlcmd/system_mode_test.go
@@ -91,8 +91,8 @@ func (s *systemModeSuite) TestSystemMode(c *C) {
 			smiErr: fmt.Errorf("too early"),
 			err:    "too early",
 		}, {
-			systemEncryptedErr: fmt.Errorf("too early"),
-			err:                "too early",
+			systemEncryptedErr: fmt.Errorf("cannot get fde state"),
+			err:                "cannot get fde state",
 		}, {
 			smi: devicestate.SystemModeInfo{
 				Mode:   "run",
@@ -108,14 +108,14 @@ func (s *systemModeSuite) TestSystemMode(c *C) {
 				BootFlags:  []string{"factory"},
 			},
 			systemEncrypted: false,
-			stdout:          "system-mode: install\nseed-loaded: true\nfactory: true\nencrypted: false\n",
+			stdout:          "system-mode: install\nseed-loaded: true\nfactory: true\n",
 		}, {
 			smi: devicestate.SystemModeInfo{
 				Mode:       "run",
 				HasModeenv: true,
 				Seeded:     false,
 			},
-			stdout: "system-mode: run\nseed-loaded: false\nencrypted: false\n",
+			stdout: "system-mode: run\nseed-loaded: false\n",
 		},
 	}
 

--- a/overlord/hookstate/ctlcmd/system_mode_test.go
+++ b/overlord/hookstate/ctlcmd/system_mode_test.go
@@ -69,9 +69,21 @@ func (s *systemModeSuite) TestSystemMode(c *C) {
 	})
 	defer r()
 
+	var systemEncrypted bool
+	var systemEncryptedErr error
+	defer ctlcmd.MockFdestateSystemEncryptedFromState(func(s *state.State) (bool, error) {
+		// the mocked function requires the state lock,
+		// panic if it is not held
+		s.Unlock()
+		defer s.Lock()
+		return systemEncrypted, systemEncryptedErr
+	})()
+
 	tests := []struct {
 		smi                 devicestate.SystemModeInfo
 		smiErr              error
+		systemEncrypted     bool
+		systemEncryptedErr  error
 		stdout, stderr, err string
 		exitCode            int
 	}{
@@ -79,11 +91,15 @@ func (s *systemModeSuite) TestSystemMode(c *C) {
 			smiErr: fmt.Errorf("too early"),
 			err:    "too early",
 		}, {
+			systemEncryptedErr: fmt.Errorf("too early"),
+			err:                "too early",
+		}, {
 			smi: devicestate.SystemModeInfo{
 				Mode:   "run",
 				Seeded: true,
 			},
-			stdout: "system-mode: run\nseed-loaded: true\n",
+			systemEncrypted: true,
+			stdout:          "system-mode: run\nseed-loaded: true\nencrypted: true\n",
 		}, {
 			smi: devicestate.SystemModeInfo{
 				Mode:       "install",
@@ -91,14 +107,15 @@ func (s *systemModeSuite) TestSystemMode(c *C) {
 				Seeded:     true,
 				BootFlags:  []string{"factory"},
 			},
-			stdout: "system-mode: install\nseed-loaded: true\nfactory: true\n",
+			systemEncrypted: false,
+			stdout:          "system-mode: install\nseed-loaded: true\nfactory: true\nencrypted: false\n",
 		}, {
 			smi: devicestate.SystemModeInfo{
 				Mode:       "run",
 				HasModeenv: true,
 				Seeded:     false,
 			},
-			stdout: "system-mode: run\nseed-loaded: false\n",
+			stdout: "system-mode: run\nseed-loaded: false\nencrypted: false\n",
 		},
 	}
 
@@ -106,6 +123,8 @@ func (s *systemModeSuite) TestSystemMode(c *C) {
 		for _, test := range tests {
 			smi = &test.smi
 			smiErr = test.smiErr
+			systemEncrypted = test.systemEncrypted
+			systemEncryptedErr = test.systemEncryptedErr
 
 			stdout, stderr, err := ctlcmd.Run(mockContext, []string{"system-mode"}, uid)
 			comment := Commentf("%v", test)

--- a/overlord/hookstate/ctlcmd/system_mode_test.go
+++ b/overlord/hookstate/ctlcmd/system_mode_test.go
@@ -99,7 +99,7 @@ func (s *systemModeSuite) TestSystemMode(c *C) {
 				Seeded: true,
 			},
 			systemEncrypted: true,
-			stdout:          "system-mode: run\nseed-loaded: true\nstorage-encrypted: true\n",
+			stdout:          "system-mode: run\nseed-loaded: true\nstorage-encrypted: managed\n",
 		}, {
 			smi: devicestate.SystemModeInfo{
 				Mode:       "install",

--- a/overlord/hookstate/ctlcmd/system_mode_test.go
+++ b/overlord/hookstate/ctlcmd/system_mode_test.go
@@ -99,7 +99,7 @@ func (s *systemModeSuite) TestSystemMode(c *C) {
 				Seeded: true,
 			},
 			systemEncrypted: true,
-			stdout:          "system-mode: run\nseed-loaded: true\nencrypted: true\n",
+			stdout:          "system-mode: run\nseed-loaded: true\nstorage-encrypted: true\n",
 		}, {
 			smi: devicestate.SystemModeInfo{
 				Mode:       "install",

--- a/tests/nested/manual/muinstaller-core/task.yaml
+++ b/tests/nested/manual/muinstaller-core/task.yaml
@@ -287,7 +287,13 @@ execute: |
   remote.exec "snap list" | MATCH pc-kernel
 
   # check encryption
-  if [ "$NESTED_ENABLE_TPM" = true ]; then
+  remote.exec "sudo snap install test-snapd-tools"
+  remote.exec "snap list" | MATCH "test-snapd-tools"
+  if [ "$NESTED_ENABLE_TPM" = false ]; then
+      remote.exec "test-snapd-tools.cmd snapctl system-mode" | NOMATCH "storage-encrypted"
+  else
+      remote.exec "test-snapd-tools.cmd snapctl system-mode" | MATCH "storage-encrypted: managed"
+
       remote.exec "sudo test -d /var/lib/snapd/device/fde"
       remote.exec "sudo test -e /var/lib/snapd/device/fde/marker"
       remote.exec "sudo test -e /var/lib/snapd/device/fde/marker"

--- a/tests/nested/manual/muinstaller-real/task.yaml
+++ b/tests/nested/manual/muinstaller-real/task.yaml
@@ -147,8 +147,14 @@ execute: |
       remote.exec sudo snap remove pc-kernel+efi-pstore
   fi
 
-  # check encryption
-  if [ "$NESTED_ENABLE_TPM" = true ]; then
+  # check encryption 
+  remote.exec "sudo snap install test-snapd-tools"
+  remote.exec "snap list" | MATCH "test-snapd-tools"
+  if [ "$NESTED_ENABLE_TPM" = false ]; then
+      remote.exec "test-snapd-tools.cmd snapctl system-mode" | NOMATCH "storage-encrypted"
+  else
+      remote.exec "test-snapd-tools.cmd snapctl system-mode" | MATCH "storage-encrypted: managed"
+
       remote.exec "sudo test -d /var/lib/snapd/device/fde"
       remote.exec "sudo test -e /var/lib/snapd/device/fde/marker"
       remote.exec "sudo test -e /var/lib/snapd/device/fde/marker"


### PR DESCRIPTION
Extended snapctl system-mode to detect if system is encrypted.

The proposed method of detecting FDE is based on the presence of a primary key in the FDE state.
This method does not work for specific legacy scenarios:
 - v1 TPM keys are in used because an old snapd was used during installation
 - snap-bootstrap in the kernel is old and does not provide a primary key in the keyring
[See details](https://github.com/canonical/snapd/blob/master/overlord/fdestate/fdestate.go#L165).

Spec: [SD201 | Heading: Detect system storage encryption](https://docs.google.com/document/d/1Mbj7Ut0tgW0PCz8VWdhvBN52kHTxYqkZZKQODB1NlLk/edit?tab=t.0#heading=h.f54182akcjzb)
Jira: https://warthogs.atlassian.net/browse/SNAPDENG-35246