### PR TITLE
go.mod: update secboot

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/mvo5/libseccomp-golang v0.9.1-0.20180308152521-f4de83b52afb // old trusty builds only
 	github.com/seccomp/libseccomp-golang v0.9.2-0.20220502024300-f57e1d55ea18
 	github.com/snapcore/go-gettext v0.0.0-20191107141714-82bbea49e785
-	github.com/snapcore/secboot v0.0.0-20250716090113-a44df50f5352
+	github.com/snapcore/secboot v0.0.0-20250723142039-3e181c8edf0f
 	golang.org/x/crypto v0.23.0
 	golang.org/x/net v0.21.0 // indirect
 	golang.org/x/sys v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/snapcore/maze.io-x-crypto v0.0.0-20190131090603-9b94c9afe066 h1:InG0E
 github.com/snapcore/maze.io-x-crypto v0.0.0-20190131090603-9b94c9afe066/go.mod h1:VuAdaITF1MrGzxPU+8GxagM1HW2vg7QhEFEeGHbmEMU=
 github.com/snapcore/secboot v0.0.0-20250716090113-a44df50f5352 h1:2r8fFh1ItbDAZp31tck02YJ81gjmqnOVsQjsMf2Iwq0=
 github.com/snapcore/secboot v0.0.0-20250716090113-a44df50f5352/go.mod h1:YOJQnKKG5YXotxAebtzIJrnDiDAMirAbVTRj7IkGa7U=
+github.com/snapcore/secboot v0.0.0-20250723142039-3e181c8edf0f h1:9fDxDbmLSfDTk3T9pAdHqmP/cm5s8brua3OnIbG8d9Y=
+github.com/snapcore/secboot v0.0.0-20250723142039-3e181c8edf0f/go.mod h1:YOJQnKKG5YXotxAebtzIJrnDiDAMirAbVTRj7IkGa7U=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 go.etcd.io/bbolt v1.3.9 h1:8x7aARPEXiXbHmtUwAIv7eV2fQFHrLLavdiJ3uzJXoI=
 go.etcd.io/bbolt v1.3.9/go.mod h1:zaO32+Ti0PK1ivdPtgMESzuzL2VPoIG1PCQNvOdo/dE=


### PR DESCRIPTION
This contains the fix needed for pre-OS verification events: https://github.com/canonical/secboot/pull/442
