### PR TITLE
tests: run spread tests in ps7 arm environment

### DIFF
--- a/.github/workflows/data-non-fundamental-systems.json
+++ b/.github/workflows/data-non-fundamental-systems.json
@@ -92,7 +92,7 @@
         "group": "ubuntu-arm64",
         "backend": "openstack-arm-ps7",
         "alternative-backend": "google-arm",
-        "systems": "ubuntu-22.04-arm-64 ubuntu-core-24-arm-64",
+        "systems": "ubuntu-24.04-arm-64 ubuntu-core-24-arm-64",
         "tasks": "tests/...",
         "rules": "main"
       },

--- a/.github/workflows/data-non-fundamental-systems.json
+++ b/.github/workflows/data-non-fundamental-systems.json
@@ -90,7 +90,7 @@
       },
       {
         "group": "ubuntu-arm64",
-        "backend": "google-arm",
+        "backend": "openstack-arm-ps7",
         "alternative-backend": "google-arm",
         "systems": "ubuntu-22.04-arm-64 ubuntu-core-24-arm-64",
         "tasks": "tests/...",

--- a/spread.yaml
+++ b/spread.yaml
@@ -518,7 +518,7 @@ backends:
                 image: snapd-spread/ubuntu-22.04-arm-64
                 workers: 8
             - ubuntu-24.04-arm-64:
-                image: snapd-spread/ubuntu-20.04-arm-64
+                image: snapd-spread/ubuntu-24.04-arm-64
                 workers: 8
 
             - ubuntu-core-22-arm-64:

--- a/tests/main/cloud-init/task.yaml
+++ b/tests/main/cloud-init/task.yaml
@@ -6,6 +6,11 @@ details: |
     properly.
 
 prepare: |
+    TODO: revert this once cloud-init v25.1.4 is landed for arm
+    if os.query is-arm && os.query is-core && [[ "$SPREAD_BACKEND" =~ openstack ]]; then
+        tests.exec skip-test "Openstack metadata service for configuration data cannot be accessed on arm64" && exit 0
+    fi
+
     cat <<EOF > /etc/systemd/system/snapd.service.d/http-debug.conf
     [Service]
     Environment=SNAPD_DEBUG_HTTP=7
@@ -13,10 +18,12 @@ prepare: |
     systemctl restart snapd.service
 
 restore: |
+    tests.exec is-skipped && exit 0
     rm /etc/systemd/system/snapd.service.d/http-debug.conf
     systemctl restart snapd.service
 
 execute: |
+    tests.exec is-skipped && exit 0
     if ! [[ "$SPREAD_BACKEND" =~ google ]] && ! [[ "$SPREAD_BACKEND" =~ openstack ]]; then
         tests.exec skip-test "This test is only valid for google and openstack backends that provide cloud info" && exit 0
     fi

--- a/tests/main/cloud-init/task.yaml
+++ b/tests/main/cloud-init/task.yaml
@@ -6,7 +6,7 @@ details: |
     properly.
 
 prepare: |
-    TODO: revert this once cloud-init v25.1.4 is landed for arm
+    # TODO: revert this once cloud-init v25.1.4 is landed for arm
     if os.query is-arm && os.query is-core && [[ "$SPREAD_BACKEND" =~ openstack ]]; then
         tests.exec skip-test "Openstack metadata service for configuration data cannot be accessed on arm64" && exit 0
     fi

--- a/tests/main/docker-smoke/task.yaml
+++ b/tests/main/docker-smoke/task.yaml
@@ -10,7 +10,8 @@ environment:
   # downloading docker snap occasionally triggers OOM
   SNAPD_NO_MEMORY_LIMIT: 1
   CHANNEL: "latest/stable"
-  IMAGE_URL: https://storage.googleapis.com/snapd-spread-tests/images/docker/hello-world.tar
+  IMAGE_URL_X86: https://storage.googleapis.com/snapd-spread-tests/images/docker/hello-world.tar
+  IMAGE_URL_ARM: https://storage.googleapis.com/snapd-spread-tests/images/docker/hello-world-arm64.tar
 
 prepare: |
   if ! snap install --channel="$CHANNEL" docker; then
@@ -22,7 +23,12 @@ prepare: |
     if ! command -v curl; then
         snap install --devmode --edge test-snapd-curl
         snap alias test-snapd-curl.curl curl
-    fi    
+    fi
+    if os.query is-arm; then
+      IMAGE_URL=$IMAGE_URL_ARM
+    else
+      IMAGE_URL=$IMAGE_URL_X86
+    fi
     curl -sL "$IMAGE_URL" -o hello-world.tar
     # retry until docker is ready lo load images
     retry -n 30 --wait 1 docker load -i hello-world.tar  

--- a/tests/main/interfaces-mount-control-cifs/task.yaml
+++ b/tests/main/interfaces-mount-control-cifs/task.yaml
@@ -114,7 +114,7 @@ execute: |
 
     echo "Same thing works through snapctl"
     # note using 'localhost' occasionally fails, let's use the IP address
-    test-snapd-mount-control-cifs.cmd snapctl mount -t cifs -o rw,user=guest //127.0.0.1/var-cifs-share /media/mounted
+    test-snapd-mount-control-cifs.cmd snapctl mount -t cifs -o rw,guest //127.0.0.1/var-cifs-share /media/mounted
     test-snapd-mount-control-cifs.cmd cat /media/mounted/hello | MATCH 'hello from CIFS share'
     test-snapd-mount-control-cifs.cmd snapctl umount /media/mounted
 

--- a/tests/main/interfaces-mount-control-cifs/task.yaml
+++ b/tests/main/interfaces-mount-control-cifs/task.yaml
@@ -114,7 +114,7 @@ execute: |
 
     echo "Same thing works through snapctl"
     # note using 'localhost' occasionally fails, let's use the IP address
-    test-snapd-mount-control-cifs.cmd snapctl mount -t cifs -o rw,guest //127.0.0.1/var-cifs-share /media/mounted
+    test-snapd-mount-control-cifs.cmd snapctl mount -t cifs -o rw,user=guest //127.0.0.1/var-cifs-share /media/mounted
     test-snapd-mount-control-cifs.cmd cat /media/mounted/hello | MATCH 'hello from CIFS share'
     test-snapd-mount-control-cifs.cmd snapctl umount /media/mounted
 

--- a/tests/regression/lp-1910456/task.yaml
+++ b/tests/regression/lp-1910456/task.yaml
@@ -10,7 +10,8 @@ systems: [-ubuntu-14.04-64]
 
 
 environment:
-  IMAGE_URL: https://storage.googleapis.com/snapd-spread-tests/images/docker/ubuntu-24.04.tar
+  IMAGE_URL_X86: https://storage.googleapis.com/snapd-spread-tests/images/docker/ubuntu-24.04.tar
+  IMAGE_URL_ARM: https://storage.googleapis.com/snapd-spread-tests/images/docker/ubuntu-24.04-arm64.tar
 
 prepare: |
     # build and install the strict test snap
@@ -144,7 +145,12 @@ execute: |
         if ! command -v curl; then
             snap install --devmode --edge test-snapd-curl
             snap alias test-snapd-curl.curl curl
-        fi    
+        fi  
+        if os.query is-arm; then
+            IMAGE_URL=$IMAGE_URL_ARM
+        else
+            IMAGE_URL=$IMAGE_URL_X86
+        fi  
         curl -sL "$IMAGE_URL" -o ubuntu-24.04.tar
         retry -n 30 --wait 1 docker load -i ubuntu-24.04.tar
     fi


### PR DESCRIPTION
Move arm tests from google to openstack ps7

Migrating from ubuntu-22.04-arm-64 to ubuntu-24.04-arm-64 because kernel in jammy does not support the apparmor prompting features, so all those tests have to be skipped if tests are executed in jammy,

unit tests fixed in https://github.com/canonical/snapd/pull/15735