### PR TITLE
many: introduce KeyProtectorFactory abstraction to prepare for optee changes

### DIFF
--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -184,11 +184,11 @@ func MockBootloaderFind(f func(rootdir string, opts *bootloader.Options) (bootlo
 	return r
 }
 
-func MockHasFDESetupHook(f func(*snap.Info) (bool, error)) (restore func()) {
-	oldHasFDESetupHook := HasFDESetupHook
-	HasFDESetupHook = f
+func MockFDEKeyProtectorFactory(f func(*snap.Info) (secboot.KeyProtectorFactory, error)) (restore func()) {
+	oldFDEKeyProtector := FDEKeyProtectorFactory
+	FDEKeyProtectorFactory = f
 	return func() {
-		HasFDESetupHook = oldHasFDESetupHook
+		FDEKeyProtectorFactory = oldFDEKeyProtector
 	}
 }
 

--- a/boot/export_test.go
+++ b/boot/export_test.go
@@ -184,11 +184,11 @@ func MockBootloaderFind(f func(rootdir string, opts *bootloader.Options) (bootlo
 	return r
 }
 
-func MockFDEKeyProtectorFactory(f func(*snap.Info) (secboot.KeyProtectorFactory, error)) (restore func()) {
-	oldFDEKeyProtector := FDEKeyProtectorFactory
-	FDEKeyProtectorFactory = f
+func MockHookKeyProtectorFactory(f func(*snap.Info) (secboot.KeyProtectorFactory, error)) (restore func()) {
+	oldHookKeyProtectorFactory := HookKeyProtectorFactory
+	HookKeyProtectorFactory = f
 	return func() {
-		FDEKeyProtectorFactory = oldFDEKeyProtector
+		HookKeyProtectorFactory = oldHookKeyProtectorFactory
 	}
 }
 

--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -636,7 +636,7 @@ func makeRunnableSystem(model *asserts.Model, bootWith *BootableSet, observer Tr
 	}
 
 	if observer != nil && observerImpl.useEncryption {
-		protector, err := FDEKeyProtectorFactory(bootWith.Kernel)
+		protector, err := HookKeyProtectorFactory(bootWith.Kernel)
 		if err != nil && !errors.Is(err, secboot.ErrNoKeyProtector) {
 			return fmt.Errorf("cannot check for fde-setup hook key protector: %v", err)
 		}
@@ -649,12 +649,12 @@ func makeRunnableSystem(model *asserts.Model, bootWith *BootableSet, observer Tr
 		}
 
 		flags := sealKeyToModeenvFlags{
-			FDEKeyProtectorFactory: protector,
-			FactoryReset:           makeOpts.AfterDataReset,
-			StandaloneInstall:      makeOpts.Standalone,
-			SeedDir:                makeOpts.SeedDir,
-			StateUnlocker:          makeOpts.StateUnlocker,
-			UseTokens:              tokens,
+			HookKeyProtectorFactory: protector,
+			FactoryReset:            makeOpts.AfterDataReset,
+			StandaloneInstall:       makeOpts.Standalone,
+			SeedDir:                 makeOpts.SeedDir,
+			StateUnlocker:           makeOpts.StateUnlocker,
+			UseTokens:               tokens,
 		}
 		if makeOpts.Standalone {
 			flags.SnapsDir = snapBlobDir

--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -651,7 +651,6 @@ func makeRunnableSystem(model *asserts.Model, bootWith *BootableSet, observer Tr
 		flags := sealKeyToModeenvFlags{
 			HookKeyProtectorFactory: protector,
 			FactoryReset:            makeOpts.AfterDataReset,
-			StandaloneInstall:       makeOpts.Standalone,
 			SeedDir:                 makeOpts.SeedDir,
 			StateUnlocker:           makeOpts.StateUnlocker,
 			UseTokens:               tokens,

--- a/boot/makebootable_test.go
+++ b/boot/makebootable_test.go
@@ -765,7 +765,7 @@ version: 5.0
 	defer restore()
 
 	fdeKeyProtectorCalled := false
-	restore = boot.MockFDEKeyProtectorFactory(func(kernel *snap.Info) (secboot.KeyProtectorFactory, error) {
+	restore = boot.MockHookKeyProtectorFactory(func(kernel *snap.Info) (secboot.KeyProtectorFactory, error) {
 		c.Check(kernel, Equals, kernelInfo)
 		fdeKeyProtectorCalled = true
 		return nil, nil

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -91,10 +91,6 @@ type sealKeyToModeenvFlags struct {
 	// FactoryReset indicates that the sealing is happening during factory
 	// reset.
 	FactoryReset bool
-	// StandaloneInstall indicates that the sealing is happening when installing
-	// a standalone system. Installing a standalone system doesn't assume that
-	// the run system being set up is related to the current system.
-	StandaloneInstall bool
 	// SnapsDir is set to provide a non-default directory to find
 	// run mode snaps in.
 	SnapsDir string

--- a/boot/seal.go
+++ b/boot/seal.go
@@ -54,10 +54,10 @@ func MockSeedReadSystemEssential(f func(seedDir, label string, essentialTypes []
 // disk encryption implementations. The state must be locked when these
 // functions are called.
 var (
-	// FDEKeyProtectorFactory returns a secboot.KeyProtectorFactory
+	// HookKeyProtectorFactory returns a secboot.KeyProtectorFactory
 	// implementation, which will create a secboot.KeyProtector based on which
 	// sealing methods are detected as supported.
-	FDEKeyProtectorFactory = func(kernelInfo *snap.Info) (secboot.KeyProtectorFactory, error) {
+	HookKeyProtectorFactory = func(kernelInfo *snap.Info) (secboot.KeyProtectorFactory, error) {
 		return nil, nil
 	}
 )
@@ -85,9 +85,9 @@ func MockSealKeyToModeenv(f func(key, saveKey secboot.BootstrappedContainer, pri
 }
 
 type sealKeyToModeenvFlags struct {
-	// FDEKeyProtectorFactory will be used to create a [secboot.KeyProtector].
+	// HookKeyProtectorFactory will be used to create a [secboot.KeyProtector].
 	// If nil, it is assumed that TPM sealing should be used.
-	FDEKeyProtectorFactory secboot.KeyProtectorFactory
+	HookKeyProtectorFactory secboot.KeyProtectorFactory
 	// FactoryReset indicates that the sealing is happening during factory
 	// reset.
 	FactoryReset bool
@@ -138,7 +138,7 @@ func sealKeyToModeenvImpl(
 	}
 
 	method := device.SealingMethodTPM
-	if flags.FDEKeyProtectorFactory != nil {
+	if flags.HookKeyProtectorFactory != nil {
 		method = device.SealingMethodFDESetupHook
 	}
 
@@ -205,7 +205,7 @@ func sealKeyToModeenvForMethod(
 		UseTokens:              flags.UseTokens,
 		InstallHostWritableDir: InstallHostWritableDir(model),
 		PrimaryKey:             primaryKey,
-		KeyProtectorFactory:    flags.FDEKeyProtectorFactory,
+		KeyProtectorFactory:    flags.HookKeyProtectorFactory,
 	}
 
 	var tbl bootloader.TrustedAssetsBootloader

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -1640,7 +1640,7 @@ func (s *sealSuite) TestSealToModeenvWithFdeHookHappy(c *C) {
 
 	defer boot.MockSealModeenvLocked()()
 
-	err := boot.SealKeyToModeenv(myKey, myKey2, nil, nil, model, modeenv, boot.MockSealKeyToModeenvFlags{FDEKeyProtectorFactory: &fakeProtectorFactory{}, UseTokens: true})
+	err := boot.SealKeyToModeenv(myKey, myKey2, nil, nil, model, modeenv, boot.MockSealKeyToModeenvFlags{HookKeyProtectorFactory: &fakeProtectorFactory{}, UseTokens: true})
 	c.Assert(err, IsNil)
 	c.Check(sealKeyForBootChainsCalled, Equals, 1)
 }
@@ -1673,7 +1673,7 @@ func (s *sealSuite) TestSealToModeenvWithFdeHookSad(c *C) {
 
 	defer boot.MockSealModeenvLocked()()
 
-	err := boot.SealKeyToModeenv(key, saveKey, nil, nil, model, modeenv, boot.MockSealKeyToModeenvFlags{FDEKeyProtectorFactory: &fakeProtectorFactory{}})
+	err := boot.SealKeyToModeenv(key, saveKey, nil, nil, model, modeenv, boot.MockSealKeyToModeenvFlags{HookKeyProtectorFactory: &fakeProtectorFactory{}})
 	c.Assert(err, ErrorMatches, `seal key failed`)
 	c.Check(sealKeyForBootChainsCalled, Equals, 1)
 }
@@ -1697,7 +1697,7 @@ func (s *sealSuite) TestResealKeyToModeenvWithFdeHookCalled(c *C) {
 	// TODO: this simulates that the hook is not available yet
 	//       because of e.g. seeding. Longer term there will be
 	//       more, see TODO in resealKeyToModeenvUsingFDESetupHookImpl
-	restore = boot.MockFDEKeyProtectorFactory(func(kernel *snap.Info) (secboot.KeyProtectorFactory, error) {
+	restore = boot.MockHookKeyProtectorFactory(func(kernel *snap.Info) (secboot.KeyProtectorFactory, error) {
 		return nil, errors.New("hook not available yet because e.g. seeding")
 	})
 	defer restore()

--- a/boot/seal_test.go
+++ b/boot/seal_test.go
@@ -1640,7 +1640,7 @@ func (s *sealSuite) TestSealToModeenvWithFdeHookHappy(c *C) {
 
 	defer boot.MockSealModeenvLocked()()
 
-	err := boot.SealKeyToModeenv(myKey, myKey2, nil, nil, model, modeenv, boot.MockSealKeyToModeenvFlags{HasFDESetupHook: true, UseTokens: true})
+	err := boot.SealKeyToModeenv(myKey, myKey2, nil, nil, model, modeenv, boot.MockSealKeyToModeenvFlags{FDEKeyProtectorFactory: &fakeProtectorFactory{}, UseTokens: true})
 	c.Assert(err, IsNil)
 	c.Check(sealKeyForBootChainsCalled, Equals, 1)
 }
@@ -1673,7 +1673,7 @@ func (s *sealSuite) TestSealToModeenvWithFdeHookSad(c *C) {
 
 	defer boot.MockSealModeenvLocked()()
 
-	err := boot.SealKeyToModeenv(key, saveKey, nil, nil, model, modeenv, boot.MockSealKeyToModeenvFlags{HasFDESetupHook: true})
+	err := boot.SealKeyToModeenv(key, saveKey, nil, nil, model, modeenv, boot.MockSealKeyToModeenvFlags{FDEKeyProtectorFactory: &fakeProtectorFactory{}})
 	c.Assert(err, ErrorMatches, `seal key failed`)
 	c.Check(sealKeyForBootChainsCalled, Equals, 1)
 }
@@ -1697,8 +1697,8 @@ func (s *sealSuite) TestResealKeyToModeenvWithFdeHookCalled(c *C) {
 	// TODO: this simulates that the hook is not available yet
 	//       because of e.g. seeding. Longer term there will be
 	//       more, see TODO in resealKeyToModeenvUsingFDESetupHookImpl
-	restore = boot.MockHasFDESetupHook(func(kernel *snap.Info) (bool, error) {
-		return false, fmt.Errorf("hook not available yet because e.g. seeding")
+	restore = boot.MockFDEKeyProtectorFactory(func(kernel *snap.Info) (secboot.KeyProtectorFactory, error) {
+		return nil, errors.New("hook not available yet because e.g. seeding")
 	})
 	defer restore()
 

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -83,7 +83,7 @@ func init() {
 type cmdInitramfsMounts struct{}
 
 func (c *cmdInitramfsMounts) Execute([]string) error {
-	boot.FDEKeyProtectorFactory = fdeKeyProtectorFactory
+	boot.HookKeyProtectorFactory = fdeKeyProtectorFactory
 
 	logger.Noticef("snap-bootstrap version %v starting", snapdtool.Version)
 
@@ -297,7 +297,7 @@ func runFDESetupHook(req *fde.SetupRequest) ([]byte, error) {
 }
 func fdeKeyProtectorFactory(kernelInfo *snap.Info) (secboot.KeyProtectorFactory, error) {
 	if _, ok := kernelInfo.Hooks["fde-setup"]; ok {
-		return secboot.FDEKeyProtectorFactory(runFDESetupHook), nil
+		return secboot.HookKeyProtectorFactory(runFDESetupHook), nil
 	}
 
 	// TODO: add OPTEE support here when available

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -87,7 +87,7 @@ func init() {
 type cmdInitramfsMounts struct{}
 
 func (c *cmdInitramfsMounts) Execute([]string) error {
-	boot.HookKeyProtectorFactory = fdeKeyProtectorFactory
+	boot.HookKeyProtectorFactory = hookKeyProtectorFactory
 
 	logger.Noticef("snap-bootstrap version %v starting", snapdtool.Version)
 
@@ -299,9 +299,9 @@ func runFDESetupHook(req *fde.SetupRequest) ([]byte, error) {
 	}
 	return output, nil
 }
-func fdeKeyProtectorFactory(kernelInfo *snap.Info) (secboot.KeyProtectorFactory, error) {
+func hookKeyProtectorFactory(kernelInfo *snap.Info) (secboot.KeyProtectorFactory, error) {
 	if _, ok := kernelInfo.Hooks["fde-setup"]; ok {
-		return secboot.HookKeyProtectorFactory(runFDESetupHook), nil
+		return secboot.FDESetupHookKeyProtectorFactory(runFDESetupHook), nil
 	}
 
 	// TODO: add OPTEE support here when available

--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -52,6 +52,10 @@ import (
 
 	// to set sysconfig.ApplyFilesystemOnlyDefaultsImpl
 	_ "github.com/snapcore/snapd/overlord/configstate/configcore"
+
+	// to set [boot.SealKeyForBootChains]
+	_ "github.com/snapcore/snapd/overlord/fdestate/backend"
+
 	"github.com/snapcore/snapd/overlord/install"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/secboot"

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -2759,7 +2759,7 @@ func (m *DeviceManager) hookKeyProtectorFactory(kernelInfo *snap.Info) (secboot.
 	}
 
 	if _, ok := kernelInfo.Hooks["fde-setup"]; ok {
-		return secboot.HookKeyProtectorFactory(m.runFDESetupHook), nil
+		return secboot.FDESetupHookKeyProtectorFactory(m.runFDESetupHook), nil
 	}
 
 	// TODO: add OPTEE support here when available

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -264,7 +264,7 @@ func Manager(s *state.State, hookManager *hookstate.HookManager, runner *state.T
 	runner.AddBlocked(gadgetUpdateBlocked)
 
 	// wire FDE kernel hook support into boot
-	boot.FDEKeyProtectorFactory = m.fdeKeyProtector
+	boot.HookKeyProtectorFactory = m.hookKeyProtectorFactory
 	hookManager.Register(regexp.MustCompile("^fde-setup$"), newFdeSetupHandler)
 
 	return m, nil
@@ -2741,7 +2741,7 @@ func (m *DeviceManager) ntpSyncedOrWaitedLongerThan(maxWait time.Duration) bool 
 	return m.ntpSyncedOrTimedOut
 }
 
-func (m *DeviceManager) fdeKeyProtector(kernelInfo *snap.Info) (secboot.KeyProtectorFactory, error) {
+func (m *DeviceManager) hookKeyProtectorFactory(kernelInfo *snap.Info) (secboot.KeyProtectorFactory, error) {
 	// state must be locked
 	st := m.state
 
@@ -2759,7 +2759,7 @@ func (m *DeviceManager) fdeKeyProtector(kernelInfo *snap.Info) (secboot.KeyProte
 	}
 
 	if _, ok := kernelInfo.Hooks["fde-setup"]; ok {
-		return secboot.FDEKeyProtectorFactory(m.runFDESetupHook), nil
+		return secboot.HookKeyProtectorFactory(m.runFDESetupHook), nil
 	}
 
 	// TODO: add OPTEE support here when available

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -1805,7 +1805,7 @@ hooks:
  fde-setup:
 `
 
-func (s *deviceMgrSuite) TestFDEKeyProtector(c *C) {
+func (s *deviceMgrSuite) TestHookKeyProtectorFactory(c *C) {
 	st := s.state
 	st.Lock()
 	defer st.Unlock()
@@ -1829,7 +1829,7 @@ func (s *deviceMgrSuite) TestFDEKeyProtector(c *C) {
 	} {
 		makeInstalledMockKernelSnap(c, st, tc.kernelYaml)
 
-		_, err := devicestate.DeviceManagerFDEKeyProtector(s.mgr, nil)
+		_, err := devicestate.DeviceManagerHookKeyProtectorFactory(s.mgr, nil)
 		if tc.hasFdeSetupHook {
 			c.Assert(err, IsNil)
 		} else {
@@ -1857,10 +1857,10 @@ func (s *deviceMgrSuite) TestHasFdeSetupHookOtherKernel(c *C) {
 	_, otherInfo := snaptest.MakeTestSnapInfoWithFiles(c, kernelYamlWithFdeSetup, nil, otherSI)
 	makeInstalledMockKernelSnap(c, st, kernelYamlNoFdeSetup)
 
-	_, err := devicestate.DeviceManagerFDEKeyProtector(s.mgr, nil)
+	_, err := devicestate.DeviceManagerHookKeyProtectorFactory(s.mgr, nil)
 	c.Assert(err, testutil.ErrorIs, secboot.ErrNoKeyProtector)
 
-	_, err = devicestate.DeviceManagerFDEKeyProtector(s.mgr, otherInfo)
+	_, err = devicestate.DeviceManagerHookKeyProtectorFactory(s.mgr, otherInfo)
 	c.Assert(err, IsNil)
 }
 

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -60,6 +60,7 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/overlord/storecontext"
 	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/secboot/keys"
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/seed/seedtest"
@@ -1804,7 +1805,7 @@ hooks:
  fde-setup:
 `
 
-func (s *deviceMgrSuite) TestHasFdeSetupHook(c *C) {
+func (s *deviceMgrSuite) TestFDEKeyProtector(c *C) {
 	st := s.state
 	st.Lock()
 	defer st.Unlock()
@@ -1828,9 +1829,12 @@ func (s *deviceMgrSuite) TestHasFdeSetupHook(c *C) {
 	} {
 		makeInstalledMockKernelSnap(c, st, tc.kernelYaml)
 
-		hasHook, err := devicestate.DeviceManagerHasFDESetupHook(s.mgr, nil)
-		c.Assert(err, IsNil)
-		c.Check(hasHook, Equals, tc.hasFdeSetupHook)
+		_, err := devicestate.DeviceManagerFDEKeyProtector(s.mgr, nil)
+		if tc.hasFdeSetupHook {
+			c.Assert(err, IsNil)
+		} else {
+			c.Assert(err, testutil.ErrorIs, secboot.ErrNoKeyProtector)
+		}
 	}
 }
 
@@ -1853,13 +1857,11 @@ func (s *deviceMgrSuite) TestHasFdeSetupHookOtherKernel(c *C) {
 	_, otherInfo := snaptest.MakeTestSnapInfoWithFiles(c, kernelYamlWithFdeSetup, nil, otherSI)
 	makeInstalledMockKernelSnap(c, st, kernelYamlNoFdeSetup)
 
-	hasHook, err := devicestate.DeviceManagerHasFDESetupHook(s.mgr, nil)
-	c.Assert(err, IsNil)
-	c.Check(hasHook, Equals, false)
+	_, err := devicestate.DeviceManagerFDEKeyProtector(s.mgr, nil)
+	c.Assert(err, testutil.ErrorIs, secboot.ErrNoKeyProtector)
 
-	hasHook, err = devicestate.DeviceManagerHasFDESetupHook(s.mgr, otherInfo)
+	_, err = devicestate.DeviceManagerFDEKeyProtector(s.mgr, otherInfo)
 	c.Assert(err, IsNil)
-	c.Check(hasHook, Equals, true)
 }
 
 func (s *deviceMgrSuite) TestRunFDESetupHookHappy(c *C) {

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -492,8 +492,8 @@ func MockRestrictCloudInit(f func(sysconfig.CloudInitState, *sysconfig.CloudInit
 	}
 }
 
-func DeviceManagerFDEKeyProtector(mgr *DeviceManager, kernelInfo *snap.Info) (secboot.KeyProtectorFactory, error) {
-	return mgr.fdeKeyProtector(kernelInfo)
+func DeviceManagerHookKeyProtectorFactory(mgr *DeviceManager, kernelInfo *snap.Info) (secboot.KeyProtectorFactory, error) {
+	return mgr.hookKeyProtectorFactory(kernelInfo)
 }
 
 func DeviceManagerRunFDESetupHook(mgr *DeviceManager, req *fde.SetupRequest) ([]byte, error) {

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -492,8 +492,8 @@ func MockRestrictCloudInit(f func(sysconfig.CloudInitState, *sysconfig.CloudInit
 	}
 }
 
-func DeviceManagerHasFDESetupHook(mgr *DeviceManager, kernelInfo *snap.Info) (bool, error) {
-	return mgr.hasFDESetupHook(kernelInfo)
+func DeviceManagerFDEKeyProtector(mgr *DeviceManager, kernelInfo *snap.Info) (secboot.KeyProtectorFactory, error) {
+	return mgr.fdeKeyProtector(kernelInfo)
 }
 
 func DeviceManagerRunFDESetupHook(mgr *DeviceManager, req *fde.SetupRequest) ([]byte, error) {

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -1426,7 +1426,7 @@ func createSaveBootstrappedContainer(saveNode string) (secboot.BootstrappedConta
 //   - Remove factory-reset-* keyslots.
 //   - Release TPM handles used by the removed keys.
 func rotateSaveKeyAndDeleteOldKeys(saveMntPnt string) error {
-	protector, err := boot.FDEKeyProtectorFactory(nil)
+	protector, err := boot.HookKeyProtectorFactory(nil)
 	if err != nil {
 		logger.Noticef("WARNING: cannot determine whether FDE hooks are in use: %v", err)
 	}

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -1426,10 +1426,9 @@ func createSaveBootstrappedContainer(saveNode string) (secboot.BootstrappedConta
 //   - Remove factory-reset-* keyslots.
 //   - Release TPM handles used by the removed keys.
 func rotateSaveKeyAndDeleteOldKeys(saveMntPnt string) error {
-	hasHook, err := boot.HasFDESetupHook(nil)
+	protector, err := boot.FDEKeyProtectorFactory(nil)
 	if err != nil {
 		logger.Noticef("WARNING: cannot determine whether FDE hooks are in use: %v", err)
-		hasHook = false
 	}
 
 	uuid, err := disksDMCryptUUIDFromMountPoint(saveMntPnt)
@@ -1456,11 +1455,12 @@ func rotateSaveKeyAndDeleteOldKeys(saveMntPnt string) error {
 		renameKey = true
 	}
 
+	hintExpectHook := protector != nil
 	err = secbootRemoveOldCounterHandles(
 		diskPath,
 		oldPossiblyTPMKeySlots,
 		oldKeys,
-		hasHook,
+		hintExpectHook,
 	)
 	if err != nil {
 		return fmt.Errorf("could not clean up old counter handles: %v", err)

--- a/secboot/secboot_dummy.go
+++ b/secboot/secboot_dummy.go
@@ -41,7 +41,7 @@ type KeyProtector interface {
 
 var ErrNoKeyProtector = errors.New("cannot find supported FDE key protector")
 
-func FDEKeyProtectorFactory(runHook fde.RunSetupHookFunc) KeyProtectorFactory {
+func HookKeyProtectorFactory(runHook fde.RunSetupHookFunc) KeyProtectorFactory {
 	return nil
 }
 

--- a/secboot/secboot_dummy.go
+++ b/secboot/secboot_dummy.go
@@ -23,12 +23,27 @@ package secboot
 import (
 	"crypto"
 	"errors"
+	"io"
 
 	"github.com/snapcore/snapd/kernel/fde"
 	"github.com/snapcore/snapd/secboot/keys"
 )
 
 var errBuildWithoutSecboot = errors.New("build without secboot support")
+
+type KeyProtectorFactory interface {
+	ForKeyName(name string) KeyProtector
+}
+
+type KeyProtector interface {
+	ProtectKey(rand io.Reader, cleartext, aad []byte) (ciphertext []byte, handle []byte, err error)
+}
+
+var ErrNoKeyProtector = errors.New("cannot find supported FDE key protector")
+
+func FDEKeyProtectorFactory(runHook fde.RunSetupHookFunc) KeyProtectorFactory {
+	return nil
+}
 
 type DiskUnlockKey []byte
 
@@ -40,7 +55,7 @@ func SealKeys(keys []SealKeyRequest, params *SealKeysParams) ([]byte, error) {
 	return nil, errBuildWithoutSecboot
 }
 
-func SealKeysWithFDESetupHook(runHook fde.RunSetupHookFunc, keys []SealKeyRequest, params *SealKeysWithFDESetupHookParams) error {
+func SealKeysWithProtector(kpf KeyProtectorFactory, keys []SealKeyRequest, params *SealKeysWithFDESetupHookParams) error {
 	return errBuildWithoutSecboot
 }
 

--- a/secboot/secboot_dummy.go
+++ b/secboot/secboot_dummy.go
@@ -41,7 +41,7 @@ type KeyProtector interface {
 
 var ErrNoKeyProtector = errors.New("cannot find supported FDE key protector")
 
-func HookKeyProtectorFactory(runHook fde.RunSetupHookFunc) KeyProtectorFactory {
+func FDESetupHookKeyProtectorFactory(runHook fde.RunSetupHookFunc) KeyProtectorFactory {
 	return nil
 }
 

--- a/secboot/secboot_hooks.go
+++ b/secboot/secboot_hooks.go
@@ -92,7 +92,10 @@ func (f *fdeKeyProtectorFactory) ForKeyName(name string) KeyProtector {
 	}
 }
 
-func HookKeyProtectorFactory(runHook fde.RunSetupHookFunc) KeyProtectorFactory {
+// FDESetupHookKeyProtectorFactory returns a [KeyProtectorFactory] that will use
+// the kernel's fde-setup hook to protect the key, invoked via the given
+// runHook.
+func FDESetupHookKeyProtectorFactory(runHook fde.RunSetupHookFunc) KeyProtectorFactory {
 	return &fdeKeyProtectorFactory{runHook: runHook}
 }
 

--- a/secboot/secboot_hooks.go
+++ b/secboot/secboot_hooks.go
@@ -92,7 +92,7 @@ func (f *fdeKeyProtectorFactory) ForKeyName(name string) KeyProtector {
 	}
 }
 
-func FDEKeyProtectorFactory(runHook fde.RunSetupHookFunc) KeyProtectorFactory {
+func HookKeyProtectorFactory(runHook fde.RunSetupHookFunc) KeyProtectorFactory {
 	return &fdeKeyProtectorFactory{runHook: runHook}
 }
 

--- a/secboot/secboot_sb_test.go
+++ b/secboot/secboot_sb_test.go
@@ -1886,7 +1886,7 @@ func (s *secbootSuite) testSealKeysWithProtectorHappy(c *C, useKeyFiles bool) {
 		myKeys[0].KeyFile = filepath.Join(tmpDir, "key-file-1")
 		myKeys[1].KeyFile = filepath.Join(tmpDir, "key-file-2")
 	}
-	factory := secboot.HookKeyProtectorFactory(runFDESetupHook)
+	factory := secboot.FDESetupHookKeyProtectorFactory(runFDESetupHook)
 	err := secboot.SealKeysWithProtector(factory, myKeys, &params)
 	c.Assert(err, IsNil)
 	// check that runFDESetupHook was called the expected way

--- a/secboot/secboot_sb_test.go
+++ b/secboot/secboot_sb_test.go
@@ -1850,7 +1850,7 @@ func (s *secbootSuite) TestLockSealedKeysCallsFdeReveal(c *C) {
 	c.Check(ops, DeepEquals, []string{"lock"})
 }
 
-func (s *secbootSuite) testSealKeysWithFDESetupHookHappy(c *C, useKeyFiles bool) {
+func (s *secbootSuite) testSealKeysWithProtectorHappy(c *C, useKeyFiles bool) {
 	n := 0
 	sealedPrefix := []byte("SEALED:")
 	rawHandle1 := json.RawMessage(`{"handle-for":"key1"}`)
@@ -1886,7 +1886,8 @@ func (s *secbootSuite) testSealKeysWithFDESetupHookHappy(c *C, useKeyFiles bool)
 		myKeys[0].KeyFile = filepath.Join(tmpDir, "key-file-1")
 		myKeys[1].KeyFile = filepath.Join(tmpDir, "key-file-2")
 	}
-	err := secboot.SealKeysWithFDESetupHook(runFDESetupHook, myKeys, &params)
+	factory := secboot.FDEKeyProtectorFactory(runFDESetupHook)
+	err := secboot.SealKeysWithProtector(factory, myKeys, &params)
 	c.Assert(err, IsNil)
 	// check that runFDESetupHook was called the expected way
 	c.Check(runFDESetupHookReqs, HasLen, 2)
@@ -1913,14 +1914,14 @@ func (s *secbootSuite) testSealKeysWithFDESetupHookHappy(c *C, useKeyFiles bool)
 	}
 }
 
-func (s *secbootSuite) TestSealKeysWithFDESetupHookHappyKeyFiles(c *C) {
+func (s *secbootSuite) TestSealKeysWithProtectorHappyKeyFiles(c *C) {
 	const useKeyFiles = true
-	s.testSealKeysWithFDESetupHookHappy(c, useKeyFiles)
+	s.testSealKeysWithProtectorHappy(c, useKeyFiles)
 }
 
-func (s *secbootSuite) TestSealKeysWithFDESetupHookHappyTokens(c *C) {
+func (s *secbootSuite) TestSealKeysWithProtectorHappyTokens(c *C) {
 	const useKeyFiles = false
-	s.testSealKeysWithFDESetupHookHappy(c, useKeyFiles)
+	s.testSealKeysWithProtectorHappy(c, useKeyFiles)
 }
 
 func makeMockDiskKey() keys.EncryptionKey {

--- a/secboot/secboot_sb_test.go
+++ b/secboot/secboot_sb_test.go
@@ -1886,7 +1886,7 @@ func (s *secbootSuite) testSealKeysWithProtectorHappy(c *C, useKeyFiles bool) {
 		myKeys[0].KeyFile = filepath.Join(tmpDir, "key-file-1")
 		myKeys[1].KeyFile = filepath.Join(tmpDir, "key-file-2")
 	}
-	factory := secboot.FDEKeyProtectorFactory(runFDESetupHook)
+	factory := secboot.HookKeyProtectorFactory(runFDESetupHook)
 	err := secboot.SealKeysWithProtector(factory, myKeys, &params)
 	c.Assert(err, IsNil)
 	// check that runFDESetupHook was called the expected way


### PR DESCRIPTION
This is a preliminary change split out from the main OPTEE branch. Will eventually be used to integrate OPTEE.