### PR TITLE
cmd/snap-confine: switch to root:root to operate v1 freezer

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -75,7 +75,7 @@ fmt-check:: $(wildcard $(addsuffix /*.[ch],$(addprefix $(srcdir)/,$(subdirs))))
 hack: PROF_NAME=$(patsubst .%,%,$(subst /,.,$(libexecdir))).snap-confine
 hack: snap-confine/snap-confine-debug snap-confine/snap-confine.apparmor snap-update-ns/snap-update-ns snap-seccomp/snap-seccomp snap-discard-ns/snap-discard-ns snap-device-helper/snap-device-helper snapd-apparmor/snapd-apparmor
 	sudo install -D -m 755 snap-confine/snap-confine-debug $(DESTDIR)$(libexecdir)/snap-confine
-	sudo setcap "$$(cat $(top_srcdir)/snap-confine/snap-confine.caps)" $(DESTDIR)$(libexecdir)/snap-confine
+	sudo setcap "$$(cat $(top_srcdir)/snap-confine/snap-confine.v2-only.caps)" $(DESTDIR)$(libexecdir)/snap-confine
 	if [ -d $(DESTDIR)$(APPARMOR_SYSCONFIG) ]; then \
 		if [ -f $(DESTDIR)$(APPARMOR_SYSCONFIG)/$(PROF_NAME).real ]; then \
 			sudo install -m 644 snap-confine/snap-confine.apparmor $(DESTDIR)$(APPARMOR_SYSCONFIG)/$(PROF_NAME).real; \
@@ -261,6 +261,7 @@ endif
 EXTRA_DIST += snap-confine/snap-confine.rst
 EXTRA_DIST += snap-confine/snap-confine.apparmor.in
 EXTRA_DIST += snap-confine/snap-confine.caps
+EXTRA_DIST += snap-confine/snap-confine.v2-only.caps
 
 snap_confine_snap_confine_SOURCES = \
 	snap-confine/cookie-support.c \
@@ -408,6 +409,7 @@ endif
 # NOTE: The 'void' directory *has to* be chmod 111
 	install -d -m 111 $(DESTDIR)$(snapdstatedir)/void
 	install -m 644 $(srcdir)/snap-confine/snap-confine.caps $(DESTDIR)$(libexecdir)/
+	install -m 644 $(srcdir)/snap-confine/snap-confine.v2-only.caps $(DESTDIR)$(libexecdir)/
 
 uninstall-local:
 if APPARMOR
@@ -415,6 +417,7 @@ if APPARMOR
 endif
 	rmdir $(DESTDIR)$(snapdstatedir)/void || true
 	rm -f $(DESTDIR)$(libexecdir)/snap-confine.caps || true
+	rm -f $(DESTDIR)$(libexecdir)/snap-confine.v2-only.caps || true
 
 ##
 ## snap-mgmt

--- a/cmd/snap-confine/snap-confine.caps
+++ b/cmd/snap-confine/snap-confine.caps
@@ -1,1 +1,1 @@
-cap_chown,cap_dac_override,cap_dac_read_search,cap_fowner,cap_sys_chroot,cap_sys_ptrace,cap_sys_admin=p
+cap_chown,cap_dac_override,cap_dac_read_search,cap_fowner,cap_setgid,cap_setuid,cap_sys_chroot,cap_sys_ptrace,cap_sys_admin=p

--- a/cmd/snap-confine/snap-confine.v2-only.caps
+++ b/cmd/snap-confine/snap-confine.v2-only.caps
@@ -1,0 +1,1 @@
+cap_chown,cap_dac_override,cap_dac_read_search,cap_fowner,cap_sys_chroot,cap_sys_ptrace,cap_sys_admin=p

--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -657,7 +657,7 @@ userdom_admin_home_dir_filetrans(snappy_confine_t, snappy_home_t, dir, "snap")
 allow snappy_confine_t snappy_snap_t:process transition;
 
 allow snappy_confine_t self:process { setexec setcap };
-allow snappy_confine_t self:capability { setgid setuid sys_admin sys_chroot dac_read_search dac_override };
+allow snappy_confine_t self:capability { setgid setuid sys_admin sys_chroot dac_read_search dac_override sys_ptrace };
 # when managing cgroup v2 snap-confine creates a BPF map and attaches a BPF
 # device cgroup program, however those bits can only be built on a sufficiently
 # recent system

--- a/packaging/arch/snapd.install
+++ b/packaging/arch/snapd.install
@@ -1,5 +1,5 @@
 _set_snap_confine_caps() {
-  /usr/bin/setcap -q - /usr/lib/snapd/snap-confine < /usr/lib/snapd/snap-confine.caps
+  /usr/bin/setcap -q - /usr/lib/snapd/snap-confine < /usr/lib/snapd/snap-confine.v2-only.caps
 }
 
 ## arg 1:  the new package version

--- a/packaging/debian-sid/snapd.install
+++ b/packaging/debian-sid/snapd.install
@@ -19,6 +19,7 @@ usr/bin/snapd /usr/lib/snapd/
 usr/bin/snapd-apparmor /usr/lib/snapd/
 usr/lib/snapd/snap-confine
 usr/lib/snapd/snap-confine.caps
+usr/lib/snapd/snap-confine.v2-only.caps
 usr/lib/snapd/snap-device-helper
 usr/lib/snapd/snap-discard-ns
 # gdb helper

--- a/packaging/debian-sid/snapd.postinst
+++ b/packaging/debian-sid/snapd.postinst
@@ -38,7 +38,7 @@ case "$1" in
         chmod 111 /var/lib/snapd/void
 
         # ensure required caps on snap-confine
-        setcap -q - /usr/lib/snapd/snap-confine < /usr/lib/snapd/snap-confine.caps
+        setcap -q - /usr/lib/snapd/snap-confine < /usr/lib/snapd/snap-confine.v2-only.caps
         ;;
 esac
 

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -375,7 +375,7 @@ chmod 755 %{buildroot}%{_localstatedir}/lib/snapd/void
 # once snap-confine is added to the permissions package. This is done following
 # the recommendations on
 # https://en.opensuse.org/openSUSE:Package_security_guidelines
-install_caps="$(cat %{buildroot}%{_libexecdir}/snapd/snap-confine.caps)"
+install_caps="$(cat %{buildroot}%{_libexecdir}/snapd/snap-confine.v2-only.caps)"
 sed -e 's,@LIBEXECDIR@,%{_libexecdir},' -e "s#@CAPS@#$install_caps#" < %{indigo_srcdir}/packaging/opensuse/permissions.in > permissions
 install -pm 644 -D permissions %{buildroot}%{_sysconfdir}/permissions.d/snapd
 sed -e 's,@LIBEXECDIR@,%{_libexecdir},' -e "s#@CAPS@#$install_caps#" < %{indigo_srcdir}/packaging/opensuse/permissions.paranoid.in > permissions.paranoid
@@ -547,6 +547,7 @@ fi
 %ghost %{snap_mount_dir}/README
 # capabilities and permissions are set through permctl and set_permissions snippet in post
 %verify(not caps) %attr(0755,root,root) %{_libexecdir}/snapd/snap-confine
+%{_libexecdir}/snapd/snap-confine.v2-only.caps
 %{_libexecdir}/snapd/snap-confine.caps
 %{_bindir}/snap
 %{_bindir}/snapctl

--- a/packaging/ubuntu-14.04/snapd.install
+++ b/packaging/ubuntu-14.04/snapd.install
@@ -21,6 +21,7 @@ usr/bin/snapctl /usr/lib/snapd/
 usr/bin/snapd /usr/lib/snapd/
 usr/lib/snapd/snap-confine
 usr/lib/snapd/snap-confine.caps
+usr/lib/snapd/snap-confine.v2-only.caps
 usr/lib/snapd/snap-device-helper
 usr/lib/snapd/snap-discard-ns
 # gdb helper

--- a/packaging/ubuntu-16.04/snapd.install.in
+++ b/packaging/ubuntu-16.04/snapd.install.in
@@ -31,6 +31,7 @@ usr/lib/snapd/snap-device-helper
 usr/lib/snapd/snap-mgmt
 usr/lib/snapd/snap-confine
 usr/lib/snapd/snap-confine.caps
+usr/lib/snapd/snap-confine.v2-only.caps
 usr/lib/snapd/snap-discard-ns
 usr/share/man/
 

--- a/tests/main/lxd/task.yaml
+++ b/tests/main/lxd/task.yaml
@@ -117,6 +117,8 @@ execute: |
         echo "Install snapd in container"
         lxd.lxc exec $cont_name -- /root/prep-snapd-in-lxd.sh
         lxd.lxc exec $cont_name -- snap set system experimental.refresh-app-awareness=$REFRESH_APP_AWARENESS_INNER
+        lxd.lxc file push "$(find "$SNAPD_WORK_DIR/snapd_snap" -name 'snapd_*.snap')" "$cont_name"/
+        lxd.lxc exec $cont_name -- sh -c 'snap install --dangerous /snapd_*.snap'
     done
 
     # FIXME: ensure that the kernel running is recent enough, this
@@ -128,7 +130,7 @@ execute: |
     lxd.lxc exec my-ubuntu -- apt-get update
     lxd.lxc exec my-ubuntu -- apt-get install -y dbus-user-session
     lxd.lxc exec my-ubuntu -- su -l ubuntu -c "systemctl --user enable dbus.socket"
-    lxd.lxc exec my-ubuntu -- su -l ubuntu -c "/snap/bin/test-snapd-sh.sh -c 'echo from-the-inside'" | MATCH from-the-inside
+    lxd.lxc exec my-ubuntu -- su -l ubuntu -c "SNAP_CONFINE_DEBUG=yes /snap/bin/test-snapd-sh.sh -c 'echo from-the-inside'" | MATCH from-the-inside
     echo "And as root"
     lxd.lxc exec my-ubuntu -- test-snapd-sh.sh -c 'echo from-the-inside' | MATCH from-the-inside
     echo "We can also remove snaps successfully"

--- a/tests/main/snap-confine-caps/task.yaml
+++ b/tests/main/snap-confine-caps/task.yaml
@@ -18,11 +18,23 @@ execute: |
     # newer version (at least 2.44+, Ubuntu 22.04+):
     # <file-name> cap_sys_admin=ep
     MATCH ' .*cap_sys_admin(.*)?(=|\+)p$' < s-c-snap.caps
+    MATCH 'cap_setgid' < s-c-snap.caps
+    MATCH 'cap_setgid' < s-c-snap.caps
 
     if ! os.query is-core && ! tests.info is-snapd-from-archive; then
         getcap "$LIBEXEC_DIR/snapd/snap-confine" | tee s-c-pkg.caps
         MATCH ' .*cap_sys_admin(.*)?(=|\+)p$' < s-c-pkg.caps
 
-        echo "Capabilities from a snap and a local package are identical"
-        diff -up <(cut -f2 -d' ' < s-c-pkg.caps) <(cut -f2 -d' ' < s-c-snap.caps)
+        case "$SPREAD_SYSTEM" in
+            fedora-*|opensuse-*|centos-*|amazon-linux-2023-*|debian-*|arch-*)
+                echo "Capabilities from a snap and a local package are not identical"
+                not diff -up <(cut -f2 -d' ' < s-c-pkg.caps) <(cut -f2 -d' ' < s-c-snap.caps)
+                NOMATCH 'cap_setgid' < s-c-pkg.caps
+                NOMATCH 'cap_setuid' < s-c-pkg.caps
+                ;;
+            *)
+                echo "Capabilities from a snap and a local package are identical"
+                diff -up <(cut -f2 -d' ' < s-c-pkg.caps) <(cut -f2 -d' ' < s-c-snap.caps)
+                ;;
+        esac
     fi


### PR DESCRIPTION
Snap-confine contains cgroup-v1-specific behavior: the use of the freezer group
for both application tracking and consistency guarantee for snap-update-ns that
may be concurrently modify the mount namespace.

The switch to capability-based snap-confine missed the fact that moving
processes within a cgroup is governed by additional constraints that no
capabilities can remedy. The process making the move must either be a global
root (not in the process namespace) or the UID of the process being moved (here
snap-confine moves itself) must match the UID of the target cgroup hierarchy.
This is not true in LXD containers that use user namespaces.

The failure was introduced in snapd 2.70 but due to a faulty test, was not
detected until after the release.

The fix alters the freezer join logic to raise UID/GID to root, to create the
cgroup directory (GID) and move the process (UID) and then revert the changes.
This approach was selected by eliminating alternatives driven by the ultimate
constraint that the kernel imposes.

```c
/*
   * Even if we're attaching all tasks in the thread group, we only need
   * to check permissions on one of them. Check permissions using the
   * credentials from file open to protect against inherited fd attacks.
   */
  cred = of->file->f_cred;
  tcred = get_task_cred(task);
  if (!uid_eq(cred->euid, GLOBAL_ROOT_UID) &&
      !uid_eq(cred->euid, tcred->uid) &&
      !uid_eq(cred->euid, tcred->suid))
    ret = -EACCES;
```

Any of the three alternatives grants us access. We cannot rely on global root
as snapd is required to work in user namespaces.  We must then attempt
snap-confine to match itself (second comparison) while also having enough
permissions to create the freezer sub-directory and open the cgroup.procs file.

In order to alter uid/gid we need the capabilities CAP_SETUID and
CAP_SETGID.  Sadly, this brings us closer to the original permission set
before the capability switch in snap-confine. As a small remedy this
code can be eventually dropped when support for cgroup-v1 systems is
removed.  To further harden snap-confine, we are dropping the new
capabilities from all the sets early on startup, as soon as it is clear
we are using cgroup-v2 mode.

Capabilities for snap-confine are now split into two sets, the v2-only
set is used on Debian (sid), Arch and Fedora, where support for hosts
running on cgroup-v1 systems has been removed alongside with new
systemd. On Ubuntu and in snapd snap this compatibility is retained as
snapd snap is still required to work on older cgroup-v1 systems.

Lastly fix the critical test that tested stable, released copy of snapd, making this
bug slip past CI/CD during the release process of snapd 2.70.