### PR TITLE
packaging/snapd.mk: pass tags when running unit tests

### DIFF
--- a/packaging/snapd.mk
+++ b/packaging/snapd.mk
@@ -221,7 +221,7 @@ endif
 # output that unit tests do not mock.
 .PHONY: check
 check:
-	LC_ALL=C.UTF-8 go test $(GO_MOD) $(import_path)/...
+	LC_ALL=C.UTF-8 go test $(GO_MOD) $(if $(GO_TAGS),-tags "$(GO_TAGS)") $(import_path)/...
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Pass tags when running unit tests.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
