### PR TITLE
packaging/snapd.mk: pass nooptee

### DIFF
--- a/packaging/snapd.mk
+++ b/packaging/snapd.mk
@@ -56,6 +56,8 @@ endif
 go_binaries = $(addprefix $(builddir)/, snap snapctl snap-seccomp snap-update-ns snap-exec snapd snapd-apparmor)
 
 GO_TAGS = nosecboot
+# optee integration is only relevant for snapd managed FDE
+GO_TAGS += nooptee
 ifeq ($(with_testkeys),1)
 GO_TAGS += withtestkeys
 GO_TAGS += structuredlogging


### PR DESCRIPTION
Pass nooptee tag to disable TEE integration.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
