### PR TITLE
intefaces/builtin/bool-file: Allow configuring multi_intensity and pattern fields within LED driver

### DIFF
--- a/interfaces/builtin/bool_file.go
+++ b/interfaces/builtin/bool_file.go
@@ -63,7 +63,7 @@ func (iface *boolFileInterface) StaticInfo() interfaces.StaticInfo {
 var boolFileGPIOValuePattern = regexp.MustCompile(
 	"^/sys/class/gpio/gpio[0-9]+/value$")
 var boolFileLedPattern = regexp.MustCompile(
-	"^/sys/devices/platform/leds/[^/]+/[^/]+/brightness$")
+	"^/sys/devices/platform/.*leds/.*/brightness$")
 var boolFileAllowedPathPatterns = []*regexp.Regexp{
 	// The brightness of standard LED class device
 	regexp.MustCompile("^/sys/class/leds/[^/]+/brightness$"),
@@ -113,12 +113,15 @@ func (iface *boolFileInterface) AppArmorConnectedPlug(spec *apparmor.Specificati
 		return fmt.Errorf("cannot compute plug security snippet: %v", err)
 	}
 	spec.AddSnippet(fmt.Sprintf("%s rwk,", path))
-	// Provide read/write access to trigger, delay_on and delay_off kernel files
+	// Provide read/write access to trigger, delay_on, delay_off, multi_intensity
+	// and pattern kernel files
 	if boolFileLedPattern.MatchString(path) {
 		pathDir := filepath.Dir(path)
 		spec.AddSnippet(fmt.Sprintf("%s/trigger rw,", pathDir))
 		spec.AddSnippet(fmt.Sprintf("%s/delay_on rw,", pathDir))
 		spec.AddSnippet(fmt.Sprintf("%s/delay_off rw,", pathDir))
+		spec.AddSnippet(fmt.Sprintf("%s/multi_intensity rw,", pathDir))
+		spec.AddSnippet(fmt.Sprintf("%s/pattern rw,", pathDir))
 	}
 
 	return nil

--- a/interfaces/builtin/bool_file_test.go
+++ b/interfaces/builtin/bool_file_test.go
@@ -198,6 +198,8 @@ func (s *BoolFileInterfaceSuite) TestAddConnectedPlugAdditionalSnippetsForLeds(c
 			"/sys/devices/platform/leds/leds/status-grn-led/brightness rwk,",
 			"/sys/devices/platform/leds/leds/status-grn-led/delay_off rw,",
 			"/sys/devices/platform/leds/leds/status-grn-led/delay_on rw,",
+			"/sys/devices/platform/leds/leds/status-grn-led/multi_intensity rw,",
+			"/sys/devices/platform/leds/leds/status-grn-led/pattern rw,",
 			"/sys/devices/platform/leds/leds/status-grn-led/trigger rw,",
 		},
 	})


### PR DESCRIPTION
### Summary
One of the customers needs to access `/sys/devices/platform/led-controller/leds/rgb:status/pattern`, `/sys/devices/platform/led-controller/leds/rgb:status/multi_intensity` and `/sys/devices/platform/pwm-leds/leds/White-Status-LED/pattern`. However, the original bool-file interface does not suuport them. 

So this PR extends the bool-file interface to support additional LED control files (`multi_intensity` and `pattern`) and improve path matching for platform LED devices.

### Problem
The current `bool-file` interface only provides access to basic LED control files (brightness, trigger, delay_on, delay_off) but doesn't support accessing:

- `multi_intensity` - required for RGB LED color intensity control
- `pattern` - required for complex LED pattern sequences

Additionally, the existing regex pattern `^/sys/devices/platform/leds/[^/]+/[^/]+/brightness$` was too restrictive and couldn't match paths like `/sys/devices/platform/led-controller/leds/rgb:status/brightness`.

### Solution
- Added support for additional LED files: Extended AppArmor rules to include `multi_intensity` and `pattern` files alongside existing LED control files
- Improved path matching: Updated the `boolFileLedPattern` regex from `^/sys/devices/platform/leds/[^/]+/[^/]+/brightness$` to `^/sys/devices/platform/.*leds/.*/brightness$` to support more flexible LED device paths
- Updated tests: Added test coverage for the new LED control files

-------
I noticed that when certain values are set for /sys/class/leds/*/trigger (e.g., setting it to `timer` or `netdev`), the LED subsystem dynamically creates additional control files in the same directory. For example:

Setting trigger to `timer` creates `delay_on` and `delay_off` files
Setting trigger to `netdev` creates `device_name`, `interval`, `link_10`, `link_100`, etc.
Question: What's the preferred approach for handling these dynamically created LED control files? Should we:

- Add them individually to the bool-file interface as needed?
- Consider a more flexible pattern that allows access to common LED control files?
- Create a separate interface for advanced LED control?
