### PR TITLE
cmd: fix installation of snap-confine profile with 'make hack'

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -72,10 +72,17 @@ fmt-check:: $(wildcard $(addsuffix /*.[ch],$(addprefix $(srcdir)/,$(subdirs))))
 # The hack target helps developers work on snap-confine on their live system by
 # installing a fresh copy of snap confine and the appropriate apparmor profile.
 .PHONY: hack
+hack: PROF_NAME=$(patsubst .%,%,$(subst /,.,$(libexecdir))).snap-confine
 hack: snap-confine/snap-confine-debug snap-confine/snap-confine.apparmor snap-update-ns/snap-update-ns snap-seccomp/snap-seccomp snap-discard-ns/snap-discard-ns snap-device-helper/snap-device-helper snapd-apparmor/snapd-apparmor
 	sudo install -D -m 755 snap-confine/snap-confine-debug $(DESTDIR)$(libexecdir)/snap-confine
 	sudo setcap "$$(cat $(top_srcdir)/snap-confine/snap-confine.caps)" $(DESTDIR)$(libexecdir)/snap-confine
-	if [ -d $(DESTDIR)$(APPARMOR_SYSCONFIG) ]; then sudo install -m 644 snap-confine/snap-confine.apparmor $(DESTDIR)$(APPARMOR_SYSCONFIG)/$(patsubst .%,%,$(subst /,.,$(libexecdir))).snap-confine.real; fi
+	if [ -d $(DESTDIR)$(APPARMOR_SYSCONFIG) ]; then \
+		if [ -f $(DESTDIR)$(APPARMOR_SYSCONFIG)/$(PROF_NAME).real ]; then \
+			sudo install -m 644 snap-confine/snap-confine.apparmor $(DESTDIR)$(APPARMOR_SYSCONFIG)/$(PROF_NAME).real; \
+		else \
+			sudo install -m 644 snap-confine/snap-confine.apparmor $(DESTDIR)$(APPARMOR_SYSCONFIG)/$(PROF_NAME); \
+		fi ; \
+	fi
 	sudo install -d -m 755 $(DESTDIR)$(snapdstatedir)/apparmor/snap-confine/
 	if [ "$$(command -v apparmor_parser)" != "" ]; then sudo apparmor_parser -r snap-confine/snap-confine.apparmor; fi
 	sudo install -m 755 snap-update-ns/snap-update-ns $(DESTDIR)$(libexecdir)/snap-update-ns


### PR DESCRIPTION
Fix how snap-confine profile is installed when using 'make hack'. Install the appropriate profile for the target system. This avoids situation when on Arch or openSUSE, one could end up with 2 AppArmor profiles for snap-confine, one in usr.lib.snapd.snap-confine and another in usr.lib.snapd.snap-confine.real. This causes a situation in which a parallelized profile loading at boot time which would nondeterministically put one or the other profile in effect.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
