### PR TITLE
secboot: add helper for adding new TPM protected keys

### DIFF
--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -255,6 +255,17 @@ type UnlockResult struct {
 	UnlockMethod UnlockMethod
 }
 
+type ProtectKeyParams struct {
+	// The snap model parameter
+	PCRProfile SerializedPCRProfile
+	// The handle at which to create a NV index for dynamic authorization policy revocation support
+	PCRPolicyCounterHandle uint32
+	// The key role (run, run+recover, recover)
+	KeyRole string
+	// Optional volume authentication options
+	VolumesAuth *device.VolumesAuthOptions
+}
+
 // EncryptedPartitionName returns the name/label used by an encrypted partition
 // corresponding to a given name.
 func EncryptedPartitionName(name string) string {

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -194,7 +194,7 @@ type KeyData interface {
 type SerializedPCRProfile []byte
 
 type ResealKeysParams struct {
-	// The snap model parameters
+	// The serialized PCR profile
 	PCRProfile SerializedPCRProfile
 	// The locations to the key data
 	Keys []KeyDataLocation
@@ -256,7 +256,7 @@ type UnlockResult struct {
 }
 
 type ProtectKeyParams struct {
-	// The snap model parameter
+	// The serialized PCR profile
 	PCRProfile SerializedPCRProfile
 	// The handle at which to create a NV index for dynamic authorization policy revocation support
 	PCRPolicyCounterHandle uint32

--- a/secboot/secboot_dummy.go
+++ b/secboot/secboot_dummy.go
@@ -198,3 +198,7 @@ func DeleteContainerKey(devicePath, slotName string) error {
 func AddContainerRecoveryKey(devicePath string, slotName string, rkey keys.RecoveryKey) error {
 	return errBuildWithoutSecboot
 }
+
+func AddContainerTPMProtectedKey(devicePath, slotName string, params *ProtectKeyParams) error {
+	return errBuildWithoutSecboot
+}

--- a/secboot/secboot_sb.go
+++ b/secboot/secboot_sb.go
@@ -30,8 +30,11 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/canonical/go-tpm2"
+	"github.com/canonical/go-tpm2/mu"
 	sb "github.com/snapcore/secboot"
 	sb_plainkey "github.com/snapcore/secboot/plainkey"
+	sb_tpm2 "github.com/snapcore/secboot/tpm2"
 	"golang.org/x/xerrors"
 
 	"github.com/snapcore/snapd/gadget/device"
@@ -675,4 +678,55 @@ func AddContainerRecoveryKey(devicePath string, slotName string, rkey keys.Recov
 		return fmt.Errorf("cannot get key from kernel keyring for unlocked disk %s: %v", devicePath, err)
 	}
 	return sbAddLUKS2ContainerRecoveryKey(devicePath, slotName, unlockKey, sb.RecoveryKey(rkey))
+}
+
+// AddContainerRecoveryKey adds a new TPM protected key to specified device.
+//
+// Note: The unlock and primary keys are implicitly obtained from the kernel
+// keyring so this will not work if the disk was unlocked with a recovery key
+// during boot.
+func AddContainerTPMProtectedKey(devicePath, slotName string, params *ProtectKeyParams) error {
+	var pcrProfile sb_tpm2.PCRProtectionProfile
+	if _, err := mu.UnmarshalFromBytes(params.PCRProfile, &pcrProfile); err != nil {
+		return fmt.Errorf("cannot unmarshal PCR profile: %v", err)
+	}
+
+	// this will fail if the disk was unlocked with a recovery key during boot.
+	primaryKey, err := sbGetPrimaryKeyFromKernel(defaultKeyringPrefix, devicePath, false)
+	if err != nil {
+		return fmt.Errorf("cannot get primary key from kernel keyring for unlocked disk %s: %v", devicePath, err)
+	}
+
+	unlockKey, err := sbGetDiskUnlockKeyFromKernel(defaultKeyringPrefix, devicePath, false)
+	if err != nil {
+		return fmt.Errorf("cannot get unlock key from kernel keyring for unlocked disk %s: %v", devicePath, err)
+	}
+
+	tpm, err := sbConnectToDefaultTPM()
+	if err != nil {
+		return fmt.Errorf("cannot connect to TPM: %v", err)
+	}
+	defer tpm.Close()
+	if !isTPMEnabled(tpm) {
+		return errors.New("TPM device is not enabled")
+	}
+
+	creationParams := &sb_tpm2.ProtectKeyParams{
+		PCRProfile:             &pcrProfile,
+		Role:                   params.KeyRole,
+		PCRPolicyCounterHandle: tpm2.Handle(params.PCRPolicyCounterHandle),
+		PrimaryKey:             primaryKey,
+	}
+
+	protectedKey, _, newKey, err := newTPMProtectedKey(tpm, creationParams, params.VolumesAuth)
+	if err != nil {
+		return fmt.Errorf("cannot seal key: %v", err)
+	}
+
+	if err := sbAddLUKS2ContainerUnlockKey(devicePath, slotName, unlockKey, newKey); err != nil {
+		return fmt.Errorf("cannot add key: %v", err)
+	}
+
+	keyData := keyData{kd: protectedKey}
+	return keyData.WriteTokenAtomic(devicePath, slotName)
 }

--- a/secboot/secboot_sb_test.go
+++ b/secboot/secboot_sb_test.go
@@ -4563,3 +4563,123 @@ func (s *secbootSuite) TestKeyDataWriteTokenAtomicError(c *C) {
 	err := kd.WriteTokenAtomic("/dev/foo", "bar")
 	c.Assert(err, ErrorMatches, "boom!")
 }
+
+func (s *secbootSuite) TestAddContainerTPMProtectedKey(c *C) {
+	mockErr := errors.New("some error")
+
+	for idx, tc := range []struct {
+		tpmEnabled          bool
+		volumesAuth         *device.VolumesAuthOptions
+		tpmErr              error
+		sealErr             error
+		addErr              error
+		primaryKeyErr       error
+		unlockKeyErr        error
+		sealCalls           int
+		passphraseSealCalls int
+		expectedErr         string
+	}{
+		{tpmEnabled: false, expectedErr: "TPM device is not enabled"},
+		{tpmEnabled: true, sealCalls: 1},
+		{tpmEnabled: true, primaryKeyErr: mockErr, expectedErr: "cannot get primary key from kernel keyring for unlocked disk /dev/foo: some error"},
+		{tpmEnabled: true, unlockKeyErr: mockErr, expectedErr: "cannot get unlock key from kernel keyring for unlocked disk /dev/foo: some error"},
+		{tpmEnabled: true, tpmErr: mockErr, expectedErr: "cannot connect to TPM: some error"},
+		{tpmEnabled: true, sealErr: mockErr, sealCalls: 1, expectedErr: "cannot seal key: some error"},
+		{tpmEnabled: true, addErr: mockErr, sealCalls: 1, expectedErr: "cannot add key: some error"},
+		{tpmEnabled: true, passphraseSealCalls: 1, volumesAuth: mockAuthOptions("passphrase", ""), expectedErr: ""},
+		{tpmEnabled: true, passphraseSealCalls: 1, volumesAuth: mockAuthOptions("passphrase", "argon2i"), expectedErr: ""},
+		{tpmEnabled: true, passphraseSealCalls: 1, volumesAuth: mockAuthOptions("passphrase", "argon2id"), expectedErr: ""},
+		{tpmEnabled: true, passphraseSealCalls: 1, volumesAuth: mockAuthOptions("passphrase", "pbkdf2"), expectedErr: ""},
+	} {
+		c.Logf("tc: %v", idx)
+
+		pcrProfile, err := secboot.BuildPCRProtectionProfile(nil, false)
+		c.Assert(err, IsNil)
+
+		defer secboot.MockSbGetPrimaryKeyFromKernel(func(prefix, devicePath string, remove bool) (sb.PrimaryKey, error) {
+			c.Check(prefix, Equals, "ubuntu-fde")
+			c.Check(devicePath, Equals, "/dev/foo")
+			c.Check(remove, Equals, false)
+			return sb.PrimaryKey{'p', 'r', 'i', 'm', 'a', 'r', 'y'}, tc.primaryKeyErr
+		})()
+
+		defer secboot.MockGetDiskUnlockKeyFromKernel(func(prefix, devicePath string, remove bool) (sb.DiskUnlockKey, error) {
+			c.Check(prefix, Equals, "ubuntu-fde")
+			c.Check(devicePath, Equals, "/dev/foo")
+			c.Check(remove, Equals, false)
+			return sb.DiskUnlockKey{'u', 'n', 'l', 'o', 'c', 'k', '-', '1'}, tc.unlockKeyErr
+		})()
+
+		tpm, restore := mockSbTPMConnection(c, tc.tpmErr)
+		defer restore()
+
+		defer secboot.MockIsTPMEnabled(func(tpm *sb_tpm2.Connection) bool {
+			return tc.tpmEnabled
+		})()
+
+		sealCalls := 0
+		defer secboot.MockSbNewTPMProtectedKey(func(t *sb_tpm2.Connection, params *sb_tpm2.ProtectKeyParams) (protectedKey *sb.KeyData, primaryKey sb.PrimaryKey, unlockKey sb.DiskUnlockKey, err error) {
+			sealCalls++
+			c.Assert(t, Equals, tpm)
+			c.Assert(params.PCRPolicyCounterHandle, Equals, tpm2.Handle(12))
+			c.Check(params.Role, Equals, "somerole")
+			return &sb.KeyData{}, sb.PrimaryKey{}, sb.DiskUnlockKey{'u', 'n', 'l', 'o', 'c', 'k', '-', '2'}, tc.sealErr
+		})()
+
+		passphraseSealCalls := 0
+		defer secboot.MockSbNewTPMPassphraseProtectedKey(func(t *sb_tpm2.Connection, params *sb_tpm2.PassphraseProtectKeyParams, passphrase string) (protectedKey *sb.KeyData, primaryKey sb.PrimaryKey, unlockKey sb.DiskUnlockKey, err error) {
+			passphraseSealCalls++
+			c.Assert(t, Equals, tpm)
+			c.Assert(params.PCRPolicyCounterHandle, Equals, tpm2.Handle(12))
+			c.Check(params.Role, Equals, "somerole")
+			var expectedKDFOptions sb.KDFOptions
+			switch tc.volumesAuth.KDFType {
+			case "argon2id":
+				expectedKDFOptions = &sb.Argon2Options{Mode: sb.Argon2id, TargetDuration: tc.volumesAuth.KDFTime}
+			case "argon2i":
+				expectedKDFOptions = &sb.Argon2Options{Mode: sb.Argon2i, TargetDuration: tc.volumesAuth.KDFTime}
+			case "pbkdf2":
+				expectedKDFOptions = &sb.PBKDF2Options{TargetDuration: tc.volumesAuth.KDFTime}
+			}
+			c.Assert(params.KDFOptions, DeepEquals, expectedKDFOptions)
+			c.Assert(passphrase, Equals, tc.volumesAuth.Passphrase)
+			return &sb.KeyData{}, sb.PrimaryKey{}, sb.DiskUnlockKey{'u', 'n', 'l', 'o', 'c', 'k', '-', '2'}, tc.sealErr
+		})()
+
+		defer secboot.MockAddLUKS2ContainerUnlockKey(func(devicePath, keyslotName string, existingKey, newKey sb.DiskUnlockKey) error {
+			c.Check(devicePath, Equals, "/dev/foo")
+			c.Check(keyslotName, Equals, "bar")
+			c.Check(existingKey, DeepEquals, sb.DiskUnlockKey{'u', 'n', 'l', 'o', 'c', 'k', '-', '1'})
+			c.Check(newKey, DeepEquals, sb.DiskUnlockKey{'u', 'n', 'l', 'o', 'c', 'k', '-', '2'})
+			return tc.addErr
+		})()
+
+		keyDataWriter := &myKeyDataWriter{}
+		tokenWritten := 0
+		restore = secboot.MockNewLUKS2KeyDataWriter(func(devicePath string, name string) (secboot.KeyDataWriter, error) {
+			tokenWritten++
+			c.Check(devicePath, Equals, "/dev/foo")
+			c.Check(name, Equals, "bar")
+			return keyDataWriter, nil
+		})
+		defer restore()
+
+		params := secboot.ProtectKeyParams{
+			PCRProfile:             pcrProfile,
+			PCRPolicyCounterHandle: 12,
+			KeyRole:                "somerole",
+			VolumesAuth:            tc.volumesAuth,
+		}
+		err = secboot.AddContainerTPMProtectedKey("/dev/foo", "bar", &params)
+
+		if tc.expectedErr == "" {
+			c.Check(tokenWritten, Equals, 1)
+			c.Assert(err, IsNil)
+		} else {
+			c.Check(tokenWritten, Equals, 0)
+			c.Assert(err, ErrorMatches, tc.expectedErr)
+		}
+		c.Check(sealCalls, Equals, tc.sealCalls)
+		c.Check(passphraseSealCalls, Equals, tc.passphraseSealCalls)
+	}
+}

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -1265,3 +1265,54 @@ func FindFreeHandle() (uint32, error) {
 
 	return 0, fmt.Errorf("no free handle on TPM")
 }
+
+// AddContainerRecoveryKey adds a new TPM protected key to specified device.
+//
+// Note: The unlock and primary keys are implicitly obtained from the kernel
+// keyring so this will not work if the disk was unlocked with a recovery key
+// during boot.
+func AddContainerTPMProtectedKey(devicePath, slotName string, params *ProtectKeyParams) error {
+	var pcrProfile sb_tpm2.PCRProtectionProfile
+	if _, err := mu.UnmarshalFromBytes(params.PCRProfile, &pcrProfile); err != nil {
+		return fmt.Errorf("cannot unmarshal PCR profile: %v", err)
+	}
+
+	// this will fail if the disk was unlocked with a recovery key during boot.
+	primaryKey, err := sbGetPrimaryKeyFromKernel(defaultKeyringPrefix, devicePath, false)
+	if err != nil {
+		return fmt.Errorf("cannot get primary key from kernel keyring for unlocked disk %s: %v", devicePath, err)
+	}
+
+	unlockKey, err := sbGetDiskUnlockKeyFromKernel(defaultKeyringPrefix, devicePath, false)
+	if err != nil {
+		return fmt.Errorf("cannot get unlock key from kernel keyring for unlocked disk %s: %v", devicePath, err)
+	}
+
+	tpm, err := sbConnectToDefaultTPM()
+	if err != nil {
+		return fmt.Errorf("cannot connect to TPM: %v", err)
+	}
+	defer tpm.Close()
+	if !isTPMEnabled(tpm) {
+		return errors.New("TPM device is not enabled")
+	}
+
+	creationParams := &sb_tpm2.ProtectKeyParams{
+		PCRProfile:             &pcrProfile,
+		Role:                   params.KeyRole,
+		PCRPolicyCounterHandle: tpm2.Handle(params.PCRPolicyCounterHandle),
+		PrimaryKey:             primaryKey,
+	}
+
+	protectedKey, _, newKey, err := newTPMProtectedKey(tpm, creationParams, params.VolumesAuth)
+	if err != nil {
+		return fmt.Errorf("cannot seal key: %v", err)
+	}
+
+	if err := sbAddLUKS2ContainerUnlockKey(devicePath, slotName, unlockKey, newKey); err != nil {
+		return fmt.Errorf("cannot add key: %v", err)
+	}
+
+	keyData := keyData{kd: protectedKey}
+	return keyData.WriteTokenAtomic(devicePath, slotName)
+}


### PR DESCRIPTION
This PR adds a secboot helper for adding new TPM protected keys, this is split from https://github.com/canonical/snapd/pull/15705.