### PR TITLE
github: fix if condition for triggering a rerun via dispatch

### DIFF
--- a/.github/workflows/rerun.yaml
+++ b/.github/workflows/rerun.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   rerun:
-    if: github.event.workflow_dispatch
+    if: github.event_name == 'workflow_dispatch'
     permissions: 
       actions: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
The condition on the rerun via workflow dispatch was incorrect. There is no `github.event.workflow_dispatch` object, but I verified that the `github.event_name` is `workflow_dispatch` when the workflow was called via dispatch