### PR TITLE
tests: add modal popups with test lists in feature tagging dashboard

### DIFF
--- a/tests/utils/features/dashboard.py
+++ b/tests/utils/features/dashboard.py
@@ -192,6 +192,11 @@ app.layout = html.Div(
                                 id="only-same-switch",
                                 label="Only compare features across tests that are present in both systems",
                             ),
+                            daq.BooleanSwitch(
+                                id="match-snap-types",
+                                label="Match snap types when comparing features",
+                                disabled=False
+                            ),
                         ],
                         style={"width": "25%"},
                     ),

--- a/tests/utils/features/dashboard.py
+++ b/tests/utils/features/dashboard.py
@@ -198,6 +198,15 @@ app.layout = html.Div(
                     dcc.Loading(
                         html.Div(id="coverage-diff-container"),
                     ),
+                    dbc.Modal(
+                        [
+                            dbc.ModalHeader(dbc.ModalTitle("Tests with feature")),
+                            dbc.ModalBody(id="coverage-diff-modal-body"),
+                        ],
+                        id="coverage-diff-modal",
+                        size="xl",
+                        is_open=False,
+                    ),
                 ]
             ),
             id={"type": "collapse", "index": 2},
@@ -300,6 +309,15 @@ app.layout = html.Div(
                                 "margin": "auto",
                             },
                         ),
+                    ),
+                    dbc.Modal(
+                        [
+                            dbc.ModalHeader(dbc.ModalTitle("Tests with feature")),
+                            dbc.ModalBody(id="coverage-modal-body"),
+                        ],
+                        id="coverage-modal",
+                        size="xl",
+                        is_open=False,
                     ),
                 ]
             ),

--- a/tests/utils/features/dashboard_callbacks.py
+++ b/tests/utils/features/dashboard_callbacks.py
@@ -626,7 +626,7 @@ def update_test_list(active_cell, table_data, timestamp, selected_feature):
     for p in processed:
         s = json.dumps(p)
         p["systems"] = "\n".join(sorted(sys_dict[s]))
-        p["systems"] = p["systems"].replace('-', '\u2011')
+        p["systems"] = p["systems"].replace('-', '_')
 
     return [
         html.H4(f"Tests that contain feature {feature}"),

--- a/tests/utils/features/dashboard_callbacks.py
+++ b/tests/utils/features/dashboard_callbacks.py
@@ -193,13 +193,14 @@ def display_column_details(active_cell, table_data, timestamp):
     Input({"type": "systems-dropdown", "index": 3}, "value"),
     Input("remove-failed-switch", "on"),
     Input("only-same-switch", "on"),
+    Input("match-snap-types", "on"),
 )
-def update_totals_table(ts_2, sys_2, ts_3, sys_3, remove_failed_value, only_same_value):
+def update_totals_table(ts_2, sys_2, ts_3, sys_3, remove_failed_value, only_same_value, match_snap_types):
     if not ts_2 or not sys_2 or not ts_3 or not sys_3:
         return []
 
     diff = qf.diff(
-        retriever, ts_2, sys_2, ts_3, sys_3, remove_failed_value, only_same_value
+        retriever, ts_2, sys_2, ts_3, sys_3, remove_failed_value, only_same_value, match_snap_types
     )
 
     tables = []
@@ -241,8 +242,9 @@ def update_totals_table(ts_2, sys_2, ts_3, sys_3, remove_failed_value, only_same
     State({"type": "coverage-diff-table", "index": ALL}, "derived_viewport_data"),
     State({"type": "timestamp-dropdown", "index": 2}, "value"),
     State({"type": "systems-dropdown", "index": 2}, "value"),
+    Input("match-snap-types", "on"),
 )
-def populate_tests_in_coverage_diff_cmds(active_cell, table_data, timestamp, system):
+def populate_tests_in_coverage_diff_cmds(active_cell, table_data, timestamp, system, match_snap_types):
     triggered = dash.callback_context.triggered_id
     if not active_cell or not table_data or not triggered or not 'index' in triggered or not active_cell[triggered["index"]] or not table_data[triggered["index"]]:
         raise dash.exceptions.PreventUpdate
@@ -255,7 +257,7 @@ def populate_tests_in_coverage_diff_cmds(active_cell, table_data, timestamp, sys
         except:
             pass
 
-    results = qf.find_feat(retriever, timestamp, feature, remove_failed=False, system=system, force_exact=True)
+    results = qf.find_feat(retriever, timestamp, feature, remove_failed=False, system=system, match_snap_types=match_snap_types)
     table = dash_table.DataTable(
         data=get_task_list_from_dict(results),
         columns=[{"name":"suite","id":"suite"}, {"name":"test","id":"test"}, {"name":"variant","id":"variant"}],
@@ -404,8 +406,9 @@ def display_cell_data(active_cell, table_data, timestamp):
     State("coverage-matrix-table", "active_cell"),
     State("coverage-matrix-table", "derived_viewport_data"),
     State({"type": "timestamp-dropdown", "index": 4}, "value"),
+    State("match-snap-types", "on"),
 )
-def populate_tests_in_coverage_diff_cmds(active_cell, table_data, system_active_cell, system_table_data, timestamp):
+def populate_tests_in_coverage_diff_cmds(active_cell, table_data, system_active_cell, system_table_data, timestamp, match_snap_types):
     if not active_cell:
         raise dash.exceptions.PreventUpdate
 
@@ -420,7 +423,7 @@ def populate_tests_in_coverage_diff_cmds(active_cell, table_data, system_active_
         except:
             pass
 
-    results = qf.find_feat(retriever, timestamp, feature, remove_failed=False, system=system, force_exact=True)
+    results = qf.find_feat(retriever, timestamp, feature, remove_failed=False, system=system, match_snap_types=match_snap_types)
     table = dash_table.DataTable(
         data=get_task_list_from_dict(results),
         columns=[{"name":"suite","id":"suite"}, {"name":"test","id":"test"}, {"name":"variant","id":"variant"}],

--- a/tests/utils/features/dashboard_callbacks.py
+++ b/tests/utils/features/dashboard_callbacks.py
@@ -203,6 +203,7 @@ def update_totals_table(ts_2, sys_2, ts_3, sys_3, remove_failed_value, only_same
     )
 
     tables = []
+    i = 0
     for feature_name, features in reversed(diff.items()):
         processed = []
         for feature in features:
@@ -211,6 +212,7 @@ def update_totals_table(ts_2, sys_2, ts_3, sys_3, remove_failed_value, only_same
                 feat_dict[k] = json.dumps(v) if isinstance(v, list) else v
             processed.append(feat_dict)
         table = dash_table.DataTable(
+            id={"type": "coverage-diff-table", "index":i},
             data=processed,
             columns=get_columns_from_list_of_dicts(features),
             filter_action="native",
@@ -228,8 +230,48 @@ def update_totals_table(ts_2, sys_2, ts_3, sys_3, remove_failed_value, only_same
                 style={"maxWidth": "100%", "margin": "auto"},
             )
         )
+        i=i+1
 
     return tables
+
+@app.callback(
+    Output("coverage-diff-modal-body", "children"),
+    Output("coverage-diff-modal", "is_open"),
+    Input({"type": "coverage-diff-table", "index": ALL}, "active_cell"),
+    State({"type": "coverage-diff-table", "index": ALL}, "derived_viewport_data"),
+    State({"type": "timestamp-dropdown", "index": 2}, "value"),
+    State({"type": "systems-dropdown", "index": 2}, "value"),
+)
+def populate_tests_in_coverage_diff_cmds(active_cell, table_data, timestamp, system):
+    triggered = dash.callback_context.triggered_id
+    if not active_cell or not table_data or not triggered or not 'index' in triggered or not active_cell[triggered["index"]] or not table_data[triggered["index"]]:
+        raise dash.exceptions.PreventUpdate
+
+    row_idx = active_cell[triggered["index"]]["row"]
+    feature = copy.deepcopy(table_data[triggered["index"]][row_idx])
+    for k, v in feature.items():
+        try:
+            feature[k] = json.loads(v)
+        except:
+            pass
+
+    results = qf.find_feat(retriever, timestamp, feature, remove_failed=False, system=system, force_exact=True)
+    table = dash_table.DataTable(
+        data=get_task_list_from_dict(results),
+        columns=[{"name":"suite","id":"suite"}, {"name":"test","id":"test"}, {"name":"variant","id":"variant"}],
+        filter_action="native",
+        sort_action="native",
+        style_cell={
+            "textAlign": "center",
+            "maxWidth": "100%",
+            "whiteSpace": "normal",
+        },
+        style_table={"overflowX": "auto", "maxWidth": "100%", "minWidth": "600px", "margin": "auto"},
+    )
+    return html.Div(
+        [html.H4(f"{system} --- {feature}", style={"textAlign": "center"}), table],
+        style={"maxWidth": "100%", "margin": "auto"},
+    ), True
 
 
 @app.callback(
@@ -335,6 +377,7 @@ def display_cell_data(active_cell, table_data, timestamp):
         return "No data found for the selected cell."
 
     table = dash_table.DataTable(
+        id="coverage-feature-table",
         data=make_dict_table_friendly(features),
         columns=get_columns_from_list_of_dicts(features),
         filter_action="native",
@@ -350,6 +393,50 @@ def display_cell_data(active_cell, table_data, timestamp):
         [html.H4(f"{system} ---- {col_idx}:", style={"textAlign": "center"}), table],
         style={"maxWidth": "100%", "margin": "auto"},
     )
+
+
+
+@app.callback(
+    Output("coverage-modal-body", "children"),
+    Output("coverage-modal", "is_open"),
+    Input("coverage-feature-table", "active_cell"),
+    State("coverage-feature-table", "derived_viewport_data"),
+    State("coverage-matrix-table", "active_cell"),
+    State("coverage-matrix-table", "derived_viewport_data"),
+    State({"type": "timestamp-dropdown", "index": 4}, "value"),
+)
+def populate_tests_in_coverage_diff_cmds(active_cell, table_data, system_active_cell, system_table_data, timestamp):
+    if not active_cell:
+        raise dash.exceptions.PreventUpdate
+
+    # Get the system name from the system matrix data
+    system = system_table_data[system_active_cell["row"]]["system"]
+
+    row_idx = active_cell["row"]
+    feature = copy.deepcopy(table_data[row_idx])
+    for k, v in feature.items():
+        try:
+            feature[k] = json.loads(v)
+        except:
+            pass
+
+    results = qf.find_feat(retriever, timestamp, feature, remove_failed=False, system=system, force_exact=True)
+    table = dash_table.DataTable(
+        data=get_task_list_from_dict(results),
+        columns=[{"name":"suite","id":"suite"}, {"name":"test","id":"test"}, {"name":"variant","id":"variant"}],
+        filter_action="native",
+        sort_action="native",
+        style_cell={
+            "textAlign": "center",
+            "maxWidth": "100%",
+            "whiteSpace": "normal",
+        },
+        style_table={"overflowX": "auto", "maxWidth": "100%", "minWidth": "600px", "margin": "auto"},
+    )
+    return html.Div(
+        [html.H4(f"{system} --- {feature}", style={"textAlign": "center"}), table],
+        style={"maxWidth": "100%", "margin": "auto"},
+    ), True
 
 
 @app.callback(

--- a/tests/utils/features/dashboard_callbacks.py
+++ b/tests/utils/features/dashboard_callbacks.py
@@ -253,6 +253,9 @@ def populate_tests_in_coverage_diff_cmds(active_cell, table_data, timestamp, sys
     feature = copy.deepcopy(table_data[triggered["index"]][row_idx])
     for k, v in feature.items():
         try:
+            # Features with a snap type list like tasks and changes have been stringified
+            # for visualization purposes in the GUI. Change them back to lists of strings.
+            # All other field values that are not valid json can remain unaltered.
             feature[k] = json.loads(v)
         except:
             pass
@@ -419,6 +422,9 @@ def populate_tests_in_coverage_diff_cmds(active_cell, table_data, system_active_
     feature = copy.deepcopy(table_data[row_idx])
     for k, v in feature.items():
         try:
+            # Features with a snap type list like tasks and changes have been stringified
+            # for visualization purposes in the GUI. Change them back to lists of strings.
+            # All other field values that are not valid json can remain unaltered.
             feature[k] = json.loads(v)
         except:
             pass

--- a/tests/utils/features/query_features.py
+++ b/tests/utils/features/query_features.py
@@ -720,6 +720,7 @@ def add_all_features_parser(subparsers: argparse._SubParsersAction) -> tuple[str
     find.add_argument('-s', '--system', help='(optional) system to search for feature in', default=None, type=str)
     find.add_argument('--feat', help='feature to search for (json format)', required=True, type=str)
     find.add_argument('--remove-failed', help='remove all tasks that failed', action='store_true')
+    find.add_argument('--force-exact', help='force match the entire feature', action='store_true')
     return cmd, cmd_all, cmd_sys, cmd_find
 
 
@@ -778,7 +779,7 @@ def main():
             elif args.features_cmd == feat_find_cmd:
                 try:
                     feat = json.loads(args.feat)
-                    result = find_feat(retriever, args.timestamp, feat, args.remove_failed, args.system)
+                    result = find_feat(retriever, args.timestamp, feat, args.remove_failed, args.system, args.force_exact)
                     json.dump(result, sys.stdout, default=lambda x: str(x))
                 except Exception as e:
                     raise RuntimeError(f'Error parsing feature {args.feat}: {e}')


### PR DESCRIPTION
Changes:
- Change the `-` lookalike to an `_` in the feature exploration section. The lookalike's original purpose was to not allow the GUI to wrap systems names. However, the `-` lookalike in feature exploration made it difficult to search systems because it was not possible to search for system names that included a `-` (e.g. one could only search for `18` but not `core-18`). 
- Makes matching snap types optional (by adding a boolean switch) in feature coverage comparison between systems.
- Adds a modal popup to coverage diff and system coverage sections.


## Modal popup

When a user clicks on a feature, a popup will open with the list of tests that contain that feature.

### Example in feature coverage difference

<img width="1897" height="720" alt="Screenshot from 2025-08-01 16-44-08" src="https://github.com/user-attachments/assets/351020ec-e453-419e-a48c-c6f61a857e1b" />

### Example in feature coverage

<img width="1897" height="720" alt="Screenshot from 2025-08-01 16-47-22" src="https://github.com/user-attachments/assets/33756410-5edf-424d-acc3-a749ac19e875" />
