### PR TITLE
fix(ros-snapd-support): add access to /v2/changes/

### DIFF
--- a/daemon/api_general.go
+++ b/daemon/api_general.go
@@ -67,7 +67,7 @@ var (
 		GET:         getChange,
 		POST:        abortChange,
 		Actions:     []string{"abort"},
-		ReadAccess:  interfaceOpenAccess{Interfaces: []string{"snap-refresh-observe"}},
+		ReadAccess:  interfaceOpenAccess{Interfaces: []string{"snap-refresh-observe", "ros-snapd-support"}},
 		WriteAccess: authenticatedAccess{Polkit: polkitActionManage},
 	}
 

--- a/daemon/api_general_test.go
+++ b/daemon/api_general_test.go
@@ -65,6 +65,10 @@ func (s *generalSuite) expectChangesReadAccess() {
 	s.expectReadAccess(daemon.InterfaceOpenAccess{Interfaces: []string{"snap-refresh-observe"}})
 }
 
+func (s *generalSuite) expectChangeReadAccess() {
+	s.expectReadAccess(daemon.InterfaceOpenAccess{Interfaces: []string{"snap-refresh-observe", "ros-snapd-support"}})
+}
+
 func (s *generalSuite) TestRoot(c *check.C) {
 	s.daemon(c)
 
@@ -911,7 +915,7 @@ func (s *generalSuite) TestStateChange(c *check.C) {
 	defer restore()
 
 	// Setup
-	s.expectChangesReadAccess()
+	s.expectChangeReadAccess()
 	d := s.daemon(c)
 	st := d.Overlord().State()
 	st.Lock()
@@ -997,7 +1001,7 @@ func (s *generalSuite) TestStateChangeAbort(c *check.C) {
 	defer restore()
 
 	// Setup
-	s.expectChangesReadAccess()
+	s.expectChangeReadAccess()
 	d := s.daemon(c)
 	st := d.Overlord().State()
 	st.Lock()
@@ -1063,7 +1067,7 @@ func (s *generalSuite) TestStateChangeAbortIsReady(c *check.C) {
 	defer restore()
 
 	// Setup
-	s.expectChangesReadAccess()
+	s.expectChangeReadAccess()
 	d := s.daemon(c)
 	st := d.Overlord().State()
 	st.Lock()

--- a/tests/main/interfaces-ros-snapd-support/api-apps-client/bin/api-apps-client.py
+++ b/tests/main/interfaces-ros-snapd-support/api-apps-client/bin/api-apps-client.py
@@ -18,12 +18,14 @@ def main(argv):
     parser = argparse.ArgumentParser('Call the snapd REST API')
     parser.add_argument('--method', default='GET',
                         help='The HTTP method to use')
+    parser.add_argument('--url',
+                        help='The request url')
     parser.add_argument('body', metavar='BODY', default=None, nargs='?',
                         help='The HTTP request body')
     args = parser.parse_args(argv[1:])
 
     conn = UnixSocketHTTPConnection()
-    conn.request(args.method, '/v2/apps', args.body)
+    conn.request(args.method, args.url, args.body)
 
     response = conn.getresponse()
     body = response.read()

--- a/tests/main/interfaces-ros-snapd-support/task.yaml
+++ b/tests/main/interfaces-ros-snapd-support/task.yaml
@@ -38,14 +38,16 @@ execute: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-simple-service
 
     echo "Check for presence of a the example snap service"
-    api-apps-client > response.txt
+    api-apps-client --url="/v2/apps" > response.txt
     gojq . < response.txt
 
     gojq -r '.result[] | select(.snap == "test-snapd-simple-service").enabled' < response.txt | MATCH '^true'
 
     echo "We can disable a snap service"
-    api-apps-client --method=POST '{"action": "stop", "disable": true, "names": ["test-snapd-simple-service"]}' > response.txt
+    api-apps-client --method=POST --url="/v2/apps" '{"action": "stop", "disable": true, "names": ["test-snapd-simple-service"]}' > response.txt
     gojq . < response.txt
 
+    CHANGE=$(gojq -r '.change' < response.txt)
+
     echo "Check if the service is now disabled"
-    retry -n 30 --wait 1 sh -c "api-apps-client | gojq -r '.result[] | select(.snap == \"test-snapd-simple-service\").enabled' | MATCH '^null'"
+    retry -n 30 --wait 1 sh -c "api-apps-client --url=\"/v2/changes/${CHANGE}\" | gojq -r '.result.status' | MATCH '^Done'"


### PR DESCRIPTION
As discussed: https://forum.snapcraft.io/t/ros2-snapd-ros-snapd-support-and-snap-refresh-observe/47862/5

The `ros-snapd-support` interface should have its own access to `/v2/changes/{id}`
