### PR TITLE
tests: fix document-inetrfaces-url test when connection fails

### DIFF
--- a/tests/main/document-interfaces-url/task.yaml
+++ b/tests/main/document-interfaces-url/task.yaml
@@ -19,13 +19,17 @@ execute: |
 
         for retry in $(seq $num_retries); do
             # Make a HEAD request to the URL and capture the HTTP status code
-            status_code=$(curl -I -o /dev/null -s -w "%{http_code}\n" -k --connect-timeout 10 "$url")
+            status_code=$(curl -I -o /dev/null -s -w "%{http_code}\n" -k -L --connect-timeout 10 "$url")
 
             # The code 000 in curl means that a connection to the server could not be established
             if [ "$status_code" == 000 ]; then
                 if [ "$retry" == "$num_retries" ]; then
                     # When we cannot check the page, we validate at least it is included in the docs index
-                    grep -q "$url" index.html
+                    if grep -q "$url" index.html; then
+                        return 0
+                    else
+                        return 1
+                    fi
                 else
                     sleep 8
                 fi

--- a/tests/main/document-interfaces-url/task.yaml
+++ b/tests/main/document-interfaces-url/task.yaml
@@ -21,14 +21,14 @@ execute: |
             # The code 000 in curl means that a connection to the server could not be established
             if [ "$status_code" == 000 ]; then
                 if [ "$retry" == "$num_retries" ]; then
-                    # When we cannot check the page, we validate at least it is included in the docs index
+                    # When we cannot check the page, we validate at least it is included in the supported interfaces page
                     if grep -q "$url" index.html; then
                         return 0
                     else
                         return 1
                     fi
                 else
-                    sleep 8
+                    sleep 5
                 fi
             fi
 

--- a/tests/main/document-interfaces-url/task.yaml
+++ b/tests/main/document-interfaces-url/task.yaml
@@ -14,23 +14,9 @@ execute: |
         local status_code
         local num_retries=3
 
-        for retry in $(seq $num_retries); do
+        for _ in $(seq $num_retries); do
             # Make a HEAD request to the URL and capture the HTTP status code
-            status_code=$(curl -I -o /dev/null -s -w "%{http_code}\n" -k -L --connect-timeout 10 "$url")
-
-            # The code 000 in curl means that a connection to the server could not be established
-            if [ "$status_code" == 000 ]; then
-                if [ "$retry" == "$num_retries" ]; then
-                    # When we cannot check the page, we validate at least it is included in the supported interfaces page
-                    if grep -q "$url" index.html; then
-                        return 0
-                    else
-                        return 1
-                    fi
-                else
-                    sleep 5
-                fi
-            fi
+            status_code=$(curl --retry 5 --retry-connrefused -I -o /dev/null -s -w "%{http_code}\n" -k -L --connect-timeout 10 "$url")
 
             # If the status code is 2xx the url is ok
             if [ "$status_code" -ge 200 ] && [ "$status_code" -lt 300 ]; then
@@ -53,9 +39,6 @@ execute: |
         return 1
     }
 
-    # Download the supported interfaces page index to index.html
-    retry -n 5 --wait 1 sh -c "wget --convert-links --no-parent --no-check-certificate https://snapcraft.io/docs/supported-interfaces/"
-     
     # The exclusion_map contains interfaces that are missing              
     # documentation. Each key is the name of the interface, while its    
     # value is the date by which it should have a working URL.           

--- a/tests/main/document-interfaces-url/task.yaml
+++ b/tests/main/document-interfaces-url/task.yaml
@@ -7,6 +7,9 @@ details: |
 
 systems: [ubuntu-24.04-64]
 
+environment:
+    DOCS_URL: https://snapcraft.io/docs
+
 execute: |
     # Checks to see if the url supplied as the first argument returns an OK HTML status code
     webpage_exists() {
@@ -21,7 +24,8 @@ execute: |
             # The code 000 in curl means that a connection to the server could not be established
             if [ "$status_code" == 000 ]; then
                 if [ "$retry" == "$num_retries" ]; then
-                    return 0
+                    # When we cannot check the page, we validate at least it is included in the docs index
+                    grep -q "$url" index.html
                 else
                     sleep 5
                 fi
@@ -47,6 +51,9 @@ execute: |
         # If status code 4xx is returned then the page is not found, return error
         return 1
     }
+
+    # Download the supported interfaces page index to index.html
+    wget --convert-links --no-parent "$DOCS_URL/supported-interfaces/"
      
     # The exclusion_map contains interfaces that are missing              
     # documentation. Each key is the name of the interface, while its    
@@ -83,7 +90,7 @@ execute: |
     # Loop through all interfaces
     for iface in $(snap interface --all | awk 'NR > 1 {print $1}' | tr '\n' ' '); do
         echo "Checking presence of documentation url for interface $iface"
-        url="https://snapcraft.io/docs/${iface}-interface"
+        url="$DOCS_URL/${iface}-interface"
         actual="$( snap interface "$iface" )"
         if MATCH "documentation: $url" <<<"$actual"; then
             if exclude "$iface"; then

--- a/tests/main/document-interfaces-url/task.yaml
+++ b/tests/main/document-interfaces-url/task.yaml
@@ -14,13 +14,17 @@ execute: |
         local status_code
         local num_retries=3
 
-        for _ in $(seq $num_retries); do
+        for retry in $(seq $num_retries); do
             # Make a HEAD request to the URL and capture the HTTP status code
             status_code=$(curl -I -o /dev/null -s -w "%{http_code}\n" --connect-timeout 10 "$url")
 
             # The code 000 in curl means that a connection to the server could not be established
-            if [ "$status_code" -eq 000 ]; then
-                sleep 5
+            if [ "$status_code" == 000 ]; then
+                if [ "$retry" == "$num_retries" ]; then
+                    return 0
+                else
+                    sleep 5
+                fi
             fi
 
             # If the status code is 2xx the url is ok

--- a/tests/main/document-interfaces-url/task.yaml
+++ b/tests/main/document-interfaces-url/task.yaml
@@ -18,6 +18,11 @@ execute: |
             # Make a HEAD request to the URL and capture the HTTP status code
             status_code=$(curl -I -o /dev/null -s -w "%{http_code}\n" --connect-timeout 10 "$url")
 
+            # The code 000 in curl means that a connection to the server could not be established
+            if [ "$status_code" -eq 000 ]; then
+                sleep 5
+            fi
+
             # If the status code is 2xx the url is ok
             if [ "$status_code" -ge 200 ] && [ "$status_code" -lt 300 ]; then
                 return 0

--- a/tests/main/document-interfaces-url/task.yaml
+++ b/tests/main/document-interfaces-url/task.yaml
@@ -19,7 +19,7 @@ execute: |
 
         for retry in $(seq $num_retries); do
             # Make a HEAD request to the URL and capture the HTTP status code
-            status_code=$(curl -I -o /dev/null -s -w "%{http_code}\n" --connect-timeout 10 "$url")
+            status_code=$(curl -I -o /dev/null -s -w "%{http_code}\n" -k --connect-timeout 10 "$url")
 
             # The code 000 in curl means that a connection to the server could not be established
             if [ "$status_code" == 000 ]; then
@@ -27,7 +27,7 @@ execute: |
                     # When we cannot check the page, we validate at least it is included in the docs index
                     grep -q "$url" index.html
                 else
-                    sleep 5
+                    sleep 8
                 fi
             fi
 

--- a/tests/main/document-interfaces-url/task.yaml
+++ b/tests/main/document-interfaces-url/task.yaml
@@ -7,9 +7,6 @@ details: |
 
 systems: [ubuntu-24.04-64]
 
-environment:
-    DOCS_URL: https://snapcraft.io/docs
-
 execute: |
     # Checks to see if the url supplied as the first argument returns an OK HTML status code
     webpage_exists() {
@@ -57,7 +54,7 @@ execute: |
     }
 
     # Download the supported interfaces page index to index.html
-    wget --convert-links --no-parent --no-check-certificate "$DOCS_URL/supported-interfaces/"
+    retry -n 5 --wait 1 sh -c "wget --convert-links --no-parent --no-check-certificate https://snapcraft.io/docs/supported-interfaces/"
      
     # The exclusion_map contains interfaces that are missing              
     # documentation. Each key is the name of the interface, while its    
@@ -94,7 +91,7 @@ execute: |
     # Loop through all interfaces
     for iface in $(snap interface --all | awk 'NR > 1 {print $1}' | tr '\n' ' '); do
         echo "Checking presence of documentation url for interface $iface"
-        url="$DOCS_URL/${iface}-interface"
+        url="https://snapcraft.io/docs/${iface}-interface"
         actual="$( snap interface "$iface" )"
         if MATCH "documentation: $url" <<<"$actual"; then
             if exclude "$iface"; then

--- a/tests/main/document-interfaces-url/task.yaml
+++ b/tests/main/document-interfaces-url/task.yaml
@@ -53,7 +53,7 @@ execute: |
     }
 
     # Download the supported interfaces page index to index.html
-    wget --convert-links --no-parent "$DOCS_URL/supported-interfaces/"
+    wget --convert-links --no-parent --no-check-certificate "$DOCS_URL/supported-interfaces/"
      
     # The exclusion_map contains interfaces that are missing              
     # documentation. Each key is the name of the interface, while its    


### PR DESCRIPTION
Add a sleep when teh status code returned is 000, which means that a connection to the server could not be established.

The sleep helps to add extra time to avoid connections issues.
