### PR TITLE
daemon: return only system service statuses by default for root user unless global is specified.

### DIFF
--- a/tests/main/snap-user-service/task.yaml
+++ b/tests/main/snap-user-service/task.yaml
@@ -34,3 +34,34 @@ execute: |
 
     echo "We can see the service running"
     tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.test-snapd-user-service
+
+    echo "Test default behaviour for service status for user"
+    tests.session -u test exec snap debug api /v2/apps > app.infos
+    gojq '.status' app.infos | MATCH '"OK"'
+    gojq '.result | length' app.infos | MATCH '1'
+    gojq '.result[0].active' app.infos | MATCH 'true'
+    gojq '.result[0].enabled' app.infos | MATCH 'true'
+    gojq '.result[0].name' app.infos | MATCH '"test-snapd-user-service"'
+
+    echo "Test default behaviour for service status for user with global"
+    tests.session -u test exec snap debug api /v2/apps?global=true > app.infos
+    gojq '.status' app.infos | MATCH '"OK"'
+    gojq '.result | length' app.infos | MATCH '1'
+    # should not return an active status
+    ! gojq -e '.result[0].active' app.infos
+    gojq '.result[0].enabled' app.infos | MATCH 'true'
+    gojq '.result[0].name' app.infos | MATCH '"test-snapd-user-service"'
+
+    echo "Test default behaviour for service status for root"
+    snap debug api /v2/apps > app.infos
+    gojq '.status' app.infos | MATCH '"OK"'
+    gojq '.result | length' app.infos | MATCH '0'
+    
+    echo "Test default behaviour for service status for root with global"
+    snap debug api /v2/apps?global=true > app.infos
+    gojq '.status' app.infos | MATCH '"OK"'
+    gojq '.result | length' app.infos | MATCH '1'
+    # should not return an active status
+    ! gojq -e '.result[0].active' app.infos
+    gojq '.result[0].enabled' app.infos | MATCH 'true'
+    gojq '.result[0].name' app.infos | MATCH '"test-snapd-user-service"'


### PR DESCRIPTION
This fixes the following issue for a normal installation of snapd on ubuntu when user-services are present:

```
sudo curl -X GET --unix-socket /run/snapd.socket "http://localhost/v2/apps" 
{"type":"error","status-code":500,"status":"Internal Server Error","result":{"message":"cannot get status of services of app \"firmware-notifier\": expected 2 results, got 0"}}%  
```

The issue here is that it is required to add ?global=true to get the global status of user-services since those user-services are not running for the root user when called with sudo, so it fails trying to get the status of those user services for the root user.

Also add missing spread coverage of the behaviours