### PR TITLE
github: skip spread artifacts with missing data in feature tagging

### DIFF
--- a/.github/workflows/weekly-feature-tagging.yaml
+++ b/.github/workflows/weekly-feature-tagging.yaml
@@ -201,6 +201,11 @@ jobs:
           for file in "feature-tags-artifacts"/*; do
             mkdir working
             tar -xzf "$file" -C working
+            if ! [ -d "working/spread-artifacts/feature-tags" ]; then
+              echo "Artifact $file has no artifact data"
+              rm -r working
+              continue
+            fi
             for dir in "working/spread-artifacts/feature-tags"/*/; do
               if [ -f "${dir}/journal.txt" ] && [ -f "${dir}/state.json" ]; then
                 ./tests/utils/features/featextractor.py \


### PR DESCRIPTION
If something goes amiss during a spread run and no data gets retrieved, the artifact is empty except for meta data. This adds a check that if no feature tagging data is present, to skip the artifact.