### PR TITLE
github: when retrieving artifacts, fail tests without successful artifact download

### DIFF
--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -422,7 +422,7 @@ jobs:
                   for test in $RUN_TESTS; do
                       dir="$(find $ARTIFACTS_FOLDER -name "$(sed 's/\//--/g' <<<$test)" -type d 2>/dev/null || true)"
                       if [ -z "$dir" ] && ! grep -q "$test" "$FAILED_TESTS_FILE"; then
-                          echo -n " $test " >> "$FAILED_TESTS_FILE"
+                          printf "%s %s\n" "$(< $FAILED_TESTS_FILE)" "$test" > "$FAILED_TESTS_FILE"
                       fi
                   done
               fi

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -428,11 +428,13 @@ jobs:
     - name: Prepare artifact upload
       if: always() && fromJSON(inputs.upload-artifacts)
       run: |
-        echo "${{ github.run_attempt }}" > "${ARTIFACTS_FOLDER}/run-attempt.txt"
-        cp "$FAILED_TESTS_FILE" "${ARTIFACTS_FOLDER}/failed-tests.txt"
-        echo "SPREAD_EXPERIMENTAL_FEATURES=${SPREAD_EXPERIMENTAL_FEATURES}" > "${ARTIFACTS_FOLDER}/env-variables.txt"
-        echo "SPREAD_SNAPD_DEB_FROM_REPO=${SPREAD_SNAPD_DEB_FROM_REPO}" >> "${ARTIFACTS_FOLDER}/env-variables.txt"
-        tar -czf "spread-artifacts-${{ inputs.group }}-${{ inputs.systems }}_${{ github.run_id }}_${{ github.run_attempt }}.tar.gz" "$ARTIFACTS_FOLDER"
+        if [ -n "${ARTIFACTS_FOLDER}" ]; then
+          echo "${{ github.run_attempt }}" > "${ARTIFACTS_FOLDER}/run-attempt.txt"
+          cp "$FAILED_TESTS_FILE" "${ARTIFACTS_FOLDER}/failed-tests.txt"
+          echo "SPREAD_EXPERIMENTAL_FEATURES=${SPREAD_EXPERIMENTAL_FEATURES}" > "${ARTIFACTS_FOLDER}/env-variables.txt"
+          echo "SPREAD_SNAPD_DEB_FROM_REPO=${SPREAD_SNAPD_DEB_FROM_REPO}" >> "${ARTIFACTS_FOLDER}/env-variables.txt"
+          tar -czf "spread-artifacts-${{ inputs.group }}-${{ inputs.systems }}_${{ github.run_id }}_${{ github.run_attempt }}.tar.gz" "$ARTIFACTS_FOLDER"
+        fi
 
     - name: Upload artifacts
       if: always() && fromJSON(inputs.upload-artifacts)
@@ -440,6 +442,7 @@ jobs:
       with:
         name: "spread-artifacts-${{ inputs.group }}-${{ inputs.systems }}_${{ github.run_id }}_${{ github.run_attempt }}"
         path: "spread-artifacts-${{ inputs.group }}-${{ inputs.systems }}_${{ github.run_id }}_${{ github.run_attempt }}.tar.gz"
+        if-no-files-found: ignore
 
     - name: Save spread test results to cache
       if: always()

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -413,6 +413,20 @@ jobs:
               echo "Running spread log analyzer"
               ./tests/lib/external/snapd-testing-tools/utils/log-analyzer list-reexecute-tasks "$RUN_TESTS" spread-results.json > "$FAILED_TESTS_FILE"
 
+              if [ -n "${{ inputs.upload-artifacts }}" ] && \
+                  [ -d "$ARTIFACTS_FOLDER" ] && \
+                  grep -Eq "Failed (task|suite|project) restore: " spread.log; then
+                  
+                  # Restore encountered some errors, so check the retrieved data for any missing tests.
+                  # If any data is missing, add the corresponding test to the list of failed tests.
+                  for test in $RUN_TESTS; do
+                      dir="$(find $ARTIFACTS_FOLDER -name "$(sed 's/\//--/g' <<<$test)" -type d 2>/dev/null || true)"
+                      if [ -z "$dir" ] && ! grep -q "$test" "$FAILED_TESTS_FILE"; then
+                          echo -n " $test " >> "$FAILED_TESTS_FILE"
+                      fi
+                  done
+              fi
+
               echo "List of failed tests saved"
               cat "$FAILED_TESTS_FILE"
           else

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -442,13 +442,16 @@ jobs:
     - name: Prepare artifact upload
       if: always() && fromJSON(inputs.upload-artifacts)
       run: |
-        if [ -n "${ARTIFACTS_FOLDER}" ]; then
-          echo "${{ github.run_attempt }}" > "${ARTIFACTS_FOLDER}/run-attempt.txt"
-          cp "$FAILED_TESTS_FILE" "${ARTIFACTS_FOLDER}/failed-tests.txt"
-          echo "SPREAD_EXPERIMENTAL_FEATURES=${SPREAD_EXPERIMENTAL_FEATURES}" > "${ARTIFACTS_FOLDER}/env-variables.txt"
-          echo "SPREAD_SNAPD_DEB_FROM_REPO=${SPREAD_SNAPD_DEB_FROM_REPO}" >> "${ARTIFACTS_FOLDER}/env-variables.txt"
-          tar -czf "spread-artifacts-${{ inputs.group }}-${{ inputs.systems }}_${{ github.run_id }}_${{ github.run_attempt }}.tar.gz" "$ARTIFACTS_FOLDER"
+        if [ -z "${ARTIFACTS_FOLDER}" ]; then
+            echo "No artifacts folder found"
+            exit 0
         fi
+
+        echo "${{ github.run_attempt }}" > "${ARTIFACTS_FOLDER}/run-attempt.txt"
+        cp "$FAILED_TESTS_FILE" "${ARTIFACTS_FOLDER}/failed-tests.txt"
+        echo "SPREAD_EXPERIMENTAL_FEATURES=${SPREAD_EXPERIMENTAL_FEATURES}" > "${ARTIFACTS_FOLDER}/env-variables.txt"
+        echo "SPREAD_SNAPD_DEB_FROM_REPO=${SPREAD_SNAPD_DEB_FROM_REPO}" >> "${ARTIFACTS_FOLDER}/env-variables.txt"
+        tar -czf "spread-artifacts-${{ inputs.group }}-${{ inputs.systems }}_${{ github.run_id }}_${{ github.run_attempt }}.tar.gz" "$ARTIFACTS_FOLDER"
 
     - name: Upload artifacts
       if: always() && fromJSON(inputs.upload-artifacts)


### PR DESCRIPTION
Spread errors during restore could mean unsuccessful artifact retrieval. When the workflow's goal is to retrieve artifacts and spread had errors during restore, this adds a check to go through all tests and make sure that all those without data are considered failed.