### PR TITLE
core-initrd: do not use writable-paths when not available

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -562,6 +562,12 @@ func doInstall(mst *initramfsMountsState, model *asserts.Model, sysSnaps map[sna
 	}
 
 	if hasDriversTree {
+		// FIXME: we should not remove or stop units while
+		// booting. That causes inconsistent jobs when
+		// something is depending on the removed unit,
+		// like: "[unit] has 'start' job queued, but 'stop' is
+		// included in transaction"
+
 		// Unmount the kernel snap mount, we keep it only for UC20/22
 		stdout, stderr, err := osutil.RunSplitOutput("systemd-mount", "--umount", kernelMountDir)
 		if err != nil {

--- a/core-initrd/latest/factory/usr/lib/systemd/system/core-ensure-kernel-in-sysroot.service
+++ b/core-initrd/latest/factory/usr/lib/systemd/system/core-ensure-kernel-in-sysroot.service
@@ -1,0 +1,13 @@
+[Unit]
+DefaultDependencies=no
+Conflicts=shutdown.target
+Before=initrd-root-fs.target initrd-parse-etc.target shutdown.target
+After=snap-initramfs-mounts.service
+ConditionPathIsMountPoint=/run/mnt/kernel
+ConditionPathExists=!/sysroot/etc/system-image/writable-paths
+
+[Service]
+# FIXME: It would be better to use dependencies rather than starting
+# units. However, since snap-bootstrap stops some mount units mid way,
+# this creates some conflicts.
+ExecStart=systemctl start sysroot-run-mnt-kernel.mount sysroot-run.mount

--- a/core-initrd/latest/factory/usr/lib/systemd/system/initrd-core-system-defaults.service
+++ b/core-initrd/latest/factory/usr/lib/systemd/system/initrd-core-system-defaults.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Set base defaults
+ConditionPathExists=!/sysroot/etc/system-image/writable-paths
+ConditionPathExists=!/sysroot/writable/_writable_defaults/.done
+ConditionPathExists=/sysroot/writable/system-data/_writable_defaults
+DefaultDependencies=no
+Conflicts=shutdown.target
+Before=initrd-root-fs.target shutdown.target
+RequiresMountsFor=/sysroot/writable
+
+[Service]
+Type=oneshot
+ExecStart=-/bin/mkdir -p /sysroot/writable/system-data
+ExecStart=/bin/cp -aT /sysroot/writable/system-data/_writable_defaults /sysroot/writable/system-data
+ExecStart=/bin/touch /sysroot/writable/system-data/_writable_defaults/.done
+RemainAfterExit=true

--- a/core-initrd/latest/factory/usr/lib/systemd/system/initrd-core-tmpfiles-setup.service
+++ b/core-initrd/latest/factory/usr/lib/systemd/system/initrd-core-tmpfiles-setup.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Create initial writable directories
+ConditionPathExists=!/sysroot/etc/system-image/writable-paths
+DefaultDependencies=no
+Conflicts=shutdown.target
+Before=initrd-root-fs.target shutdown.target
+RefuseManualStop=yes
+RequiresMountsFor=/sysroot/writable
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/systemd-tmpfiles --root=/sysroot --create core-writable.conf
+SuccessExitStatus=DATAERR CANTCREAT

--- a/core-initrd/latest/factory/usr/lib/systemd/system/initrd-parse-etc.service.wants/core-ensure-kernel-in-sysroot.service
+++ b/core-initrd/latest/factory/usr/lib/systemd/system/initrd-parse-etc.service.wants/core-ensure-kernel-in-sysroot.service
@@ -1,0 +1,1 @@
+../core-ensure-kernel-in-sysroot.service

--- a/core-initrd/latest/factory/usr/lib/systemd/system/initrd-root-fs.target.wants/initrd-core-system-defaults.service
+++ b/core-initrd/latest/factory/usr/lib/systemd/system/initrd-root-fs.target.wants/initrd-core-system-defaults.service
@@ -1,0 +1,1 @@
+../initrd-core-system-defaults.service

--- a/core-initrd/latest/factory/usr/lib/systemd/system/initrd-root-fs.target.wants/initrd-core-tmpfiles-setup.service
+++ b/core-initrd/latest/factory/usr/lib/systemd/system/initrd-root-fs.target.wants/initrd-core-tmpfiles-setup.service
@@ -1,0 +1,1 @@
+../initrd-core-tmpfiles-setup.service

--- a/core-initrd/latest/factory/usr/lib/systemd/system/populate-writable.service
+++ b/core-initrd/latest/factory/usr/lib/systemd/system/populate-writable.service
@@ -1,4 +1,5 @@
 [Unit]
+ConditionPathExists=/sysroot/etc/system-image/writable-paths
 OnFailure=emergency.target
 OnFailureJobMode=replace-irreversibly
 DefaultDependencies=no

--- a/core-initrd/latest/factory/usr/lib/systemd/system/sysroot-run-mnt-kernel.mount
+++ b/core-initrd/latest/factory/usr/lib/systemd/system/sysroot-run-mnt-kernel.mount
@@ -1,0 +1,13 @@
+[Unit]
+DefaultDependencies=no
+ConditionPathIsMountPoint=/run/mnt/kernel
+ConditionPathExists=!/sysroot/etc/system-image/writable-paths
+After=snap-initramfs-mounts.service
+RequiresMountsFor=/sysroot/run
+Before=initrd-root-fs.target
+
+[Mount]
+Where=/sysroot/run/mnt/kernel
+What=/run/mnt/kernel
+Type=none
+Options=bind

--- a/core-initrd/latest/factory/usr/lib/systemd/system/sysroot-run.mount
+++ b/core-initrd/latest/factory/usr/lib/systemd/system/sysroot-run.mount
@@ -1,0 +1,23 @@
+# Because we are still using /run for some mounts, we need to have it
+# mounted while we resolve initrd-fs.target after daemon-reload from
+# initrd-parse-etc.service has executed fstab-generation.
+# However this unit is not part of initrd-fs.target. So when
+# the system gets isolated to initrd-switch-root.target from
+# initrd-cleanup.service, then this unit will get unmounted.
+# systemd's switch root then will move /run (along with /dev, /sys,
+# /proc) into /sysroot.
+#
+# In the future, we should avoid mounting in /run, and instead directly
+# mount within /sysroot.
+[Unit]
+DefaultDependencies=no
+ConditionPathExists=!/sysroot/etc/system-image/writable-paths
+After=snap-initramfs-mounts.service
+RequiresMountsFor=/sysroot
+Before=initrd-root-fs.target
+
+[Mount]
+Where=/sysroot/run
+What=/run
+Type=none
+Options=bind

--- a/core-initrd/latest/factory/usr/lib/systemd/system/sysroot-writable.mount
+++ b/core-initrd/latest/factory/usr/lib/systemd/system/sysroot-writable.mount
@@ -2,9 +2,7 @@
 DefaultDependencies=no
 Before=initrd-root-fs.target
 
-Wants=sysroot.mount
 After=sysroot.mount
-
 After=run-mnt-data.mount
 After=run-mnt-base.mount
 After=snap-initramfs-mounts.service


### PR DESCRIPTION
Rebase of https://github.com/canonical/core-initrd/pull/74 but keeping backward compatibility for now.

This goes along https://github.com/canonical/core-base/pull/25