### PR TITLE
snap: added 'Grade' field to  types.go, info.go, and info_snap_yaml.go

### DIFF
--- a/snap/info.go
+++ b/snap/info.go
@@ -381,6 +381,7 @@ type Info struct {
 	Epoch            Epoch
 	Base             string
 	Confinement      ConfinementType
+	Grade            GradeType
 	Apps             map[string]*AppInfo
 	LegacyAliases    map[string]*AppInfo // FIXME: eventually drop this
 	Hooks            map[string]*HookInfo

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -47,6 +47,7 @@ type snapYaml struct {
 	Epoch           Epoch                    `yaml:"epoch,omitempty"`
 	Base            string                   `yaml:"base,omitempty"`
 	Confinement     ConfinementType          `yaml:"confinement,omitempty"`
+	Grade           GradeType                `yaml:"grade,omitempty"`
 	Environment     strutil.OrderedMap       `yaml:"environment,omitempty"`
 	Plugs           map[string]any           `yaml:"plugs,omitempty"`
 	Slots           map[string]any           `yaml:"slots,omitempty"`
@@ -251,6 +252,7 @@ func infoFromSnapYaml(yamlData []byte, strk *scopedTracker) (*Info, error) {
 	}
 
 	// FIXME: validation of the fields
+
 	return snap, nil
 }
 
@@ -297,6 +299,7 @@ func infoSkeletonFromSnapYaml(y snapYaml) *Info {
 		License:             y.License,
 		Epoch:               y.Epoch,
 		Confinement:         confinement,
+		Grade:               y.Grade,
 		Base:                y.Base,
 		Apps:                make(map[string]*AppInfo),
 		LegacyAliases:       make(map[string]*AppInfo),

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -1463,6 +1463,37 @@ version: 1.0
 	c.Assert(info.Confinement, Equals, snap.StrictConfinement)
 }
 
+func (s *YamlSuite) TestSnapYamlGradeComplete(c *C) {
+	const (
+		str = `
+name: snap
+version: '0.1.0'
+grade: %q
+`
+		invalidGrade = "invalid"
+	)
+
+	yStable := []byte(fmt.Sprintf(str, "stable"))
+	infoStable, err := snap.InfoFromSnapYaml(yStable)
+	c.Assert(infoStable.Grade, Equals, snap.StableGrade)
+	c.Assert(err, IsNil)
+
+	yDevel := []byte(fmt.Sprintf(str, "devel"))
+	infoDevel, err := snap.InfoFromSnapYaml(yDevel)
+	c.Assert(infoDevel.Grade, Equals, snap.DevelGrade)
+	c.Assert(err, IsNil)
+
+	yEmpty := []byte(fmt.Sprintf(str, ""))
+	infoEmpty, err := snap.InfoFromSnapYaml(yEmpty)
+	c.Assert(infoEmpty.Grade, Equals, snap.EmptyGrade)
+	c.Assert(err, IsNil)
+
+	yInvalid := []byte(fmt.Sprintf(str, invalidGrade))
+	infoInvalid, err := snap.InfoFromSnapYaml(yInvalid)
+	c.Assert(infoInvalid, IsNil)
+	c.Assert(err, ErrorMatches, fmt.Sprintf("^.*unknown grade type: %q", invalidGrade))
+}
+
 func (s *YamlSuite) TestSnapYamlMultipleArchitecturesParsing(c *C) {
 	y := []byte(`name: binary
 version: 1.0

--- a/snap/types.go
+++ b/snap/types.go
@@ -140,6 +140,30 @@ func (confinementType *ConfinementType) fromString(str string) error {
 	return nil
 }
 
+// GradeType represents the grade of the snap
+type GradeType string
+
+const (
+	DevelGrade  GradeType = "devel"
+	StableGrade GradeType = "stable"
+	EmptyGrade  GradeType = ""
+)
+
+// UnmarshalText sets *gradeType to a copy of data, assuming validation passes
+func (gt *GradeType) UnmarshalText(data []byte) error {
+	g := GradeType(string(data))
+
+	// Validate grade field
+	switch g {
+	case EmptyGrade, DevelGrade, StableGrade:
+		*gt = g
+	default:
+		return fmt.Errorf("unknown grade type: %q", g)
+	}
+
+	return nil
+}
+
 type ServiceStopReason string
 
 const (

--- a/store/details_v2_test.go
+++ b/store/details_v2_test.go
@@ -171,7 +171,7 @@ const (
   },
   "revision": 21,
   "snap-id": "XYZEfjn4WJYnm0FzDKwqqRZZI77awQEV",
-  "snap-yaml": "name: test-snapd-content-plug\nversion: 1.0\nassumes: [snapd2.49]\napps:\n    user-svc:\n        command: bin/user-svc\n        daemon-scope: user\n        daemon: simple\n    content-plug:\n        command: bin/content-plug\n        plugs: [shared-content-plug]\nplugs:\n    shared-content-plug:\n        interface: content\n        target: import\n        content: mylib\n        default-provider: test-snapd-content-slot\nslots:\n    shared-content-slot:\n        interface: content\n        content: mylib\n        read:\n            - /\nprovenance: prov\ncomponents:\n  some-component:\n    type: standard\n    name: some-component\n    description: Some component\n    summary: Component summary\n    hooks:\n      install:",
+  "snap-yaml": "name: test-snapd-content-plug\nversion: 1.0\ngrade: stable\nassumes: [snapd2.49]\napps:\n    user-svc:\n        command: bin/user-svc\n        daemon-scope: user\n        daemon: simple\n    content-plug:\n        command: bin/content-plug\n        plugs: [shared-content-plug]\nplugs:\n    shared-content-plug:\n        interface: content\n        target: import\n        content: mylib\n        default-provider: test-snapd-content-slot\nslots:\n    shared-content-slot:\n        interface: content\n        content: mylib\n        read:\n            - /\nprovenance: prov\ncomponents:\n  some-component:\n    type: standard\n    name: some-component\n    description: Some component\n    summary: Component summary\n    hooks:\n      install:",
   "store-url": "https://snapcraft.io/thingy",
   "summary": "useful thingy",
   "title": "This Is The Most Fantastical Snap of Thingy",
@@ -322,6 +322,7 @@ func (s *detailsV2Suite) TestInfoFromStoreSnap(c *C) {
 		SnapType:    snap.TypeApp,
 		Version:     "9.50",
 		Confinement: snap.StrictConfinement,
+		Grade:       snap.StableGrade,
 		License:     "Proprietary",
 		Publisher: snap.StoreAccount{
 			ID:          "ZvtzsxbsHivZLdvzrt0iqW529riGLfXJ",


### PR DESCRIPTION
Modifications:
- info.go Ln 384 - Added Grade field of type GradeType to Info structure
- types.go Ln 113 - Added GradeType (string)
- types.go Ln 117 - 118 - Added two default grade types, representing "devel" or "stable"
- info_snap_yaml.go Ln 50 - Added Grade field of type GradeType to snapYaml structure 
- info_snap_yaml.go Ln 255-260 - Added grade field validation, invalid field will throw error
- info_snap_yaml.go Ln 293-297 - If grade is empty set as "devel" for default
- info_snap_yaml.go Ln 312 - Added grade initialization in infoSkeletonFromSnapYaml()
- - info_snap_yaml_test.go Ln 2363 - 2398 - Added three tests for snap.yaml with "stable", "invalid", and "" as the three test cases.