### PR TITLE
client/snap: add a note when snap data snapshot was created during remove

### DIFF
--- a/client/change_test.go
+++ b/client/change_test.go
@@ -202,6 +202,33 @@ func (cs *clientSuite) TestClientChangesData(c *check.C) {
 	c.Assert(err, check.Equals, client.ErrNoData)
 }
 
+func (cs *clientSuite) TestClientTaskData(c *check.C) {
+	cs.rsp = `{"type": "sync", "result": [{
+  "id":   "uno",
+  "kind": "foo",
+  "summary": "...",
+  "status": "Do",
+  "ready": false,
+  "tasks": [{"data":{"foo":"bar"}, "kind": "bar", "summary": "...", "status": "Do", "progress": {"done": 0, "total": 1}, "spawn-time": "2016-04-21T01:02:03Z", "ready-time": "2016-04-21T01:02:04Z"}]
+}]}`
+
+	chgs, err := cs.cli.Changes(&client.ChangesOptions{Selector: client.ChangesAll})
+	c.Assert(err, check.IsNil)
+
+	chg := chgs[0]
+	c.Assert(chg.Tasks, check.HasLen, 1)
+	tsk := chg.Tasks[0]
+	var v string
+	err = tsk.Get("foo", &v)
+	c.Assert(err, check.IsNil)
+	c.Check(v, check.Equals, "bar")
+
+	var n string
+	err = tsk.Get("missing", &n)
+	c.Check(err, check.Equals, client.ErrNoData)
+	c.Check(n, check.Equals, "")
+}
+
 func (cs *clientSuite) TestClientAbort(c *check.C) {
 	cs.rsp = `{"type": "sync", "result": {
   "id":   "uno",

--- a/tests/main/snapshot-basic/task.yaml
+++ b/tests/main/snapshot-basic/task.yaml
@@ -131,7 +131,8 @@ execute: |
 
     # check automatic snapshot can be disabled
     snap set core snapshots.automatic.retention=no
-    snap remove test-snapd-sh
+    snap remove test-snapd-sh > remove-snapshot-disabled.out
+    MATCH 'test-snapd-sh removed$' < remove-snapshot-disabled.out
     if snap saved | MATCH "test-snapd-sh"; then
         echo "did not expect a snapshot for test-snapd-sh"
         exit 1
@@ -140,7 +141,8 @@ execute: |
     # re-enable snapshots, check automatic snapshot is created on snap remove
     snap install test-snapd-sh
     snap set core snapshots.automatic.retention=30h
-    snap remove test-snapd-sh
+    snap remove test-snapd-sh > remove-snapshot-auto.out
+    MATCH 'test-snapd-sh removed \(snap data snapshot saved\)$' < remove-snapshot-auto.out
     snap saved test-snapd-sh | MATCH "auto"
     SET_ID=$( snap saved test-snapd-sh | cut -d\  -f1 | tail -n1 )
     snap forget "$SET_ID"
@@ -148,7 +150,8 @@ execute: |
     # removing with --purge doesn't create automatic snapshot
     snap set core snapshots.automatic.retention=30h
     snap install test-snapd-sh
-    snap remove --purge test-snapd-sh
+    snap remove --purge test-snapd-sh > remove-purge.out
+    MATCH 'test-snapd-sh removed$' < remove-purge.out
     if snap saved test-snapd-sh | MATCH "auto" ; then
         echo "automatic snapshot is not expected"
         exit 1


### PR DESCRIPTION
Add a note in the output when a snapshot of snap's data was created when
removing a snap.

Related: SNAPDENG-35165
Fixes: LP#2114704