### PR TITLE
o/fdestate: support protected keys replacement

### DIFF
--- a/overlord/fdestate/conflict.go
+++ b/overlord/fdestate/conflict.go
@@ -54,6 +54,7 @@ func checkFDEChangeConflict(st *state.State) error {
 				ChangeKind: chg.Kind(),
 				ChangeID:   chg.ID(),
 			}
+		// TODO:FDEM: add entry for passphrase reset when API lands
 		default:
 			// try to catch changes/tasks that could have been missed
 			// and log a warning.

--- a/overlord/fdestate/export_test.go
+++ b/overlord/fdestate/export_test.go
@@ -125,6 +125,10 @@ func MockSecbootAddContainerRecoveryKey(f func(devicePath string, slotName strin
 	return testutil.Mock(&secbootAddContainerRecoveryKey, f)
 }
 
+func MockSecbootAddContainerTPMProtectedKey(f func(devicePath string, slotName string, params *secboot.ProtectKeyParams) error) (restore func()) {
+	return testutil.Mock(&secbootAddContainerTPMProtectedKey, f)
+}
+
 func MockSecbootDeleteContainerKey(f func(devicePath string, slotName string) error) (restore func()) {
 	return testutil.Mock(&secbootDeleteContainerKey, f)
 }
@@ -159,4 +163,8 @@ func (o *changeAuthOptions) Old() string {
 
 func (o *changeAuthOptions) New() string {
 	return o.new
+}
+
+func VolumesAuthOptionsKey() volumesAuthOptionsKey {
+	return volumesAuthOptionsKey{}
 }

--- a/overlord/fdestate/fdemgr.go
+++ b/overlord/fdestate/fdemgr.go
@@ -488,7 +488,18 @@ func (m *FDEManager) GetParameters(role string, containerRole string) (hasParame
 	return s.getParameters(role, containerRole)
 }
 
-func (m *FDEManager) ensureParametersLoaded(role, containerRole string) error {
+// ensureParametersLoadedWithMaybeReseal will force a reseal if the
+// passed key role and container role do not have their parameters
+// loaded in the FDE state.
+//
+// This is needed because the FDE state is only partially initialized
+// until a reseal affecting all key roles occurs. This helper
+// effectively does its job once and then is considered a no-op when
+// called with a valid key role and container role because it checks
+// if the parameters are loaded first before forcing the reseal.
+//
+// Note: The state will be unlocked/relocked if a reseal is attempted.
+func (m *FDEManager) ensureParametersLoadedWithMaybeReseal(role, containerRole string) error {
 	hasParameters, _, _, _, err := m.GetParameters(role, containerRole)
 	if err != nil {
 		return err

--- a/overlord/fdestate/fdemgr.go
+++ b/overlord/fdestate/fdemgr.go
@@ -514,6 +514,10 @@ func (m *FDEManager) ensureParametersLoadedWithMaybeReseal(role, containerRole s
 		return err
 	}
 
+	// TODO:FDEM: we don't really need to force a reseal, it should
+	// be enough to calculate the parameters. For now, this is okay
+	// until we have a better way for loading FDE parameters.
+
 	wrapped := &unlockedStateManager{
 		FDEManager: m,
 		unlocker:   m.state.Unlocker(),

--- a/overlord/fdestate/fdestate.go
+++ b/overlord/fdestate/fdestate.go
@@ -685,7 +685,7 @@ func ReplaceProtectedKey(st *state.State, volumesAuth *device.VolumesAuthOptions
 		return nil, err
 	}
 	if unlockedWithRecoveryKey {
-		// primary key will be missing from kernel keyring if disk was
+		// primary key might be missing from kernel keyring if disk was
 		// unlocked with recovery key during boot.
 		return nil, errors.New("system was unlocked with a recovery key during boot: reboot required")
 	}
@@ -721,6 +721,11 @@ func ReplaceProtectedKey(st *state.State, volumesAuth *device.VolumesAuthOptions
 		kd, err := keyslot.KeyData()
 		if err != nil {
 			return nil, fmt.Errorf("cannot read key data for %s: %v", keyslot.Ref().String(), err)
+		}
+
+		// TODO:FDEM: support FDE hook setup
+		if kd.PlatformName() != secboot.PlatformTpm2 {
+			return nil, fmt.Errorf("invalid key slot reference %s: unsupported platform %q, expected %q", keyslot.Ref().String(), kd.PlatformName(), secboot.PlatformTpm2)
 		}
 
 		tmpKeyslotRef := tmpKeyslotRef(keyslot.Ref())

--- a/overlord/fdestate/fdestate.go
+++ b/overlord/fdestate/fdestate.go
@@ -624,6 +624,8 @@ func ChangeAuth(st *state.State, authMode device.AuthMode, old, new string, keys
 	return ts, nil
 }
 
+type volumesAuthOptionsKey struct{}
+
 // SystemEncryptedFromState reports whether FDE is enabled on the system.
 // It returns true if FDE is enabled, or false otherwise.
 func SystemEncryptedFromState(st *state.State) (bool, error) {

--- a/overlord/fdestate/fdestate.go
+++ b/overlord/fdestate/fdestate.go
@@ -22,9 +22,11 @@ import (
 	"crypto"
 	"errors"
 	"fmt"
+	"io/fs"
 	"time"
 
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget/device"
 	"github.com/snapcore/snapd/logger"
@@ -565,7 +567,7 @@ func ChangeAuth(st *state.State, authMode device.AuthMode, old, new string, keys
 		if err := keyslotRef.Validate(); err != nil {
 			return nil, fmt.Errorf("invalid key slot reference %s: %v", keyslotRef.String(), err)
 		}
-		// TODO:FDEM: accept custom recovery key slot names when a naming convension is defined
+		// TODO:FDEM: accept custom key slot names when a naming convension is defined
 		if keyslotRef.Name != "default" && keyslotRef.Name != "default-fallback" {
 			return nil, fmt.Errorf(`invalid key slot reference %s: unsupported name, expected "default" or "default-fallback"`, keyslotRef.String())
 		}
@@ -624,8 +626,6 @@ func ChangeAuth(st *state.State, authMode device.AuthMode, old, new string, keys
 	return ts, nil
 }
 
-type volumesAuthOptionsKey struct{}
-
 // SystemEncryptedFromState reports whether FDE is enabled on the system.
 // It returns true if FDE is enabled, or false otherwise.
 func SystemEncryptedFromState(st *state.State) (bool, error) {
@@ -635,4 +635,124 @@ func SystemEncryptedFromState(st *state.State) (bool, error) {
 		return false, fmt.Errorf("cannot determine if system is encrypted: %v", err)
 	}
 	return encrypted, nil
+}
+
+type volumesAuthOptionsKey struct{}
+
+// ReplaceProtectedKey creates a taskset that replaces the
+// protected key for the specified target key slots.
+//
+// If keyslotRefs is empty, the following key slots are targets:
+//   - container-role: system-data, name: default
+//   - container-role: system-data, name: default-fallback
+//   - container-role: system-save, name: default-fallback
+func ReplaceProtectedKey(st *state.State, volumesAuth *device.VolumesAuthOptions, keyslotRefs []KeyslotRef) (*state.TaskSet, error) {
+	authMode := device.AuthModeNone
+	if volumesAuth != nil {
+		if err := volumesAuth.Validate(); err != nil {
+			return nil, err
+		}
+		authMode = volumesAuth.Mode
+	}
+
+	if len(keyslotRefs) == 0 {
+		// by default, target protected keys that would have been added during installation.
+		keyslotRefs = append(keyslotRefs,
+			KeyslotRef{ContainerRole: "system-data", Name: "default"},
+			KeyslotRef{ContainerRole: "system-data", Name: "default-fallback"},
+			KeyslotRef{ContainerRole: "system-save", Name: "default-fallback"},
+		)
+	}
+
+	tmpKeyslotRefs := make([]KeyslotRef, 0, len(keyslotRefs))
+	tmpKeyslotRenames := make(map[string]string, len(keyslotRefs))
+	for _, keyslotRef := range keyslotRefs {
+		if err := keyslotRef.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid key slot reference %s: %v", keyslotRef.String(), err)
+		}
+		// TODO:FDEM: accept custom key slot names when a naming convension is defined
+		if keyslotRef.Name != "default" && keyslotRef.Name != "default-fallback" {
+			return nil, fmt.Errorf(`invalid key slot reference %s: unsupported name, expected "default" or "default-fallback"`, keyslotRef.String())
+		}
+
+		tmpKeyslotRef := tmpKeyslotRef(keyslotRef)
+		tmpKeyslotRefs = append(tmpKeyslotRefs, tmpKeyslotRef)
+		tmpKeyslotRenames[tmpKeyslotRef.String()] = keyslotRef.Name
+	}
+
+	unlockedWithRecoveryKey, err := boot.IsUnlockedWithRecoveryKey()
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return nil, err
+	}
+	if unlockedWithRecoveryKey {
+		// primary key will be missing from kernel keyring if disk was
+		// unlocked with recovery key during boot.
+		return nil, errors.New("system was unlocked with a recovery key during boot: reboot required")
+	}
+
+	// Note: checking that there are no ongoing conflicting changes and that the
+	// targeted key slots exist while state is locked ensures that we don't suffer
+	// from TOCTOU.
+
+	if err := checkFDEParametersChangeConflicts(st); err != nil {
+		return nil, err
+	}
+
+	if err := checkFDEChangeConflict(st); err != nil {
+		return nil, err
+	}
+
+	mgr := fdeMgr(st)
+
+	keyslots, missing, err := mgr.GetKeyslots(keyslotRefs)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(missing) != 0 {
+		return nil, &KeyslotRefsNotFoundError{KeyslotRefs: missing}
+	}
+
+	tmpKeyslotRoles := make(map[string][]string, len(keyslots))
+	for _, keyslot := range keyslots {
+		if keyslot.Type != KeyslotTypePlatform {
+			return nil, fmt.Errorf("invalid key slot reference %s: unsupported type %q, expected %q", keyslot.Ref().String(), keyslot.Type, KeyslotTypePlatform)
+		}
+		kd, err := keyslot.KeyData()
+		if err != nil {
+			return nil, fmt.Errorf("cannot read key data for %s: %v", keyslot.Ref().String(), err)
+		}
+
+		tmpKeyslotRef := tmpKeyslotRef(keyslot.Ref())
+		tmpKeyslotRoles[tmpKeyslotRef.String()] = kd.Roles()
+	}
+
+	if volumesAuth != nil {
+		// Auth data must be in memory to avoid leaking credentials.
+		if st.Cached(volumesAuthOptionsKey{}) != nil {
+			logger.Noticef("WARNING: authentication options already exists in memory")
+		}
+		st.Cache(volumesAuthOptionsKey{}, volumesAuth)
+	}
+
+	ts := state.NewTaskSet()
+
+	addTemporaryKeys := st.NewTask("fde-add-protected-keys", fmt.Sprintf("Add temporary %s key slots", authMode))
+	addTemporaryKeys.Set("keyslots", tmpKeyslotRefs)
+	addTemporaryKeys.Set("auth-mode", authMode)
+	addTemporaryKeys.Set("roles", tmpKeyslotRoles)
+	ts.AddTask(addTemporaryKeys)
+
+	removeOldKeys := st.NewTask("fde-remove-keys", fmt.Sprintf("Remove old %s key slots", authMode))
+	removeOldKeys.Set("keyslots", keyslotRefs)
+	removeOldKeys.WaitFor(addTemporaryKeys)
+	ts.AddTask(removeOldKeys)
+
+	renameTemporaryKeys := st.NewTask("fde-rename-keys", fmt.Sprintf("Rename temporary %s key slots", authMode))
+	renameTemporaryKeys.Set("keyslots", tmpKeyslotRefs)
+	renameTemporaryKeys.Set("renames", tmpKeyslotRenames)
+	renameTemporaryKeys.WaitFor(removeOldKeys)
+	ts.AddTask(renameTemporaryKeys)
+
+	return ts, nil
 }

--- a/overlord/fdestate/fdestate_test.go
+++ b/overlord/fdestate/fdestate_test.go
@@ -23,12 +23,14 @@ package fdestate_test
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"time"
 
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget/device"
 	"github.com/snapcore/snapd/logger"
@@ -37,6 +39,8 @@ import (
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/secboot"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -470,4 +474,335 @@ func (s *fdeMgrSuite) TestSystemEncryptedFromStateHasEncryptedDisks(c *C) {
 func (s *fdeMgrSuite) TestSystemEncryptedFromStateNoEncryptedDisks(c *C) {
 	hasEncryptedDisks := false
 	s.testSystemEncryptedFromState(c, hasEncryptedDisks)
+}
+
+func (s *fdeMgrSuite) testReplaceProtectedKey(c *C, authMode device.AuthMode, defaultKeyslots bool) {
+	keyslots := []fdestate.KeyslotRef{
+		{ContainerRole: "system-data", Name: "default"},
+	}
+	tmpKeyslots := []fdestate.KeyslotRef{
+		{ContainerRole: "system-data", Name: "snapd-tmp:default"},
+	}
+	if defaultKeyslots {
+		keyslots = append(keyslots, fdestate.KeyslotRef{ContainerRole: "system-data", Name: "default-fallback"})
+		keyslots = append(keyslots, fdestate.KeyslotRef{ContainerRole: "system-save", Name: "default-fallback"})
+		tmpKeyslots = append(tmpKeyslots, fdestate.KeyslotRef{ContainerRole: "system-data", Name: "snapd-tmp:default-fallback"})
+		tmpKeyslots = append(tmpKeyslots, fdestate.KeyslotRef{ContainerRole: "system-save", Name: "snapd-tmp:default-fallback"})
+	}
+
+	var volumesAuth *device.VolumesAuthOptions
+	switch authMode {
+	case device.AuthModePassphrase:
+		volumesAuth = &device.VolumesAuthOptions{Mode: device.AuthModePassphrase, Passphrase: "password"}
+	case device.AuthModePIN:
+		volumesAuth = &device.VolumesAuthOptions{Mode: device.AuthModePIN}
+	}
+
+	s.mockDeviceInState(&asserts.Model{}, "run")
+	s.mockCurrentKeys(c, nil, nil)
+
+	defer fdestate.MockSecbootReadContainerKeyData(func(devicePath, slotName string) (secboot.KeyData, error) {
+		switch fmt.Sprintf("%s:%s", devicePath, slotName) {
+		case "/dev/disk/by-uuid/data:default",
+			"/dev/disk/by-uuid/data:default-fallback",
+			"/dev/disk/by-uuid/save:default-fallback":
+			return &mockKeyData{authMode: device.AuthModePassphrase, roles: []string{"run"}}, nil
+		default:
+			panic("unexpected container")
+		}
+	})()
+
+	// initialize fde manager
+	onClassic := true
+	s.startedManager(c, onClassic)
+
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	var ts *state.TaskSet
+	var err error
+	if defaultKeyslots {
+		ts, err = fdestate.ReplaceProtectedKey(s.st, volumesAuth, nil)
+	} else {
+		ts, err = fdestate.ReplaceProtectedKey(s.st, volumesAuth, keyslots)
+	}
+	if authMode == device.AuthModePIN {
+		// this is expected to break when PIN support lands
+		c.Assert(err, ErrorMatches, `"pin" authentication mode is not implemented`)
+		c.Assert(ts, IsNil)
+		return
+	}
+	c.Assert(err, IsNil)
+	c.Assert(ts, NotNil)
+	tsks := ts.Tasks()
+	c.Check(tsks, HasLen, 3)
+
+	c.Check(tsks[0].Summary(), Matches, fmt.Sprintf("Add temporary %s key slots", authMode))
+	c.Check(tsks[0].Kind(), Equals, "fde-add-protected-keys")
+	// check tmp key slots are passed to task
+	var tskKeyslots []fdestate.KeyslotRef
+	c.Assert(tsks[0].Get("keyslots", &tskKeyslots), IsNil)
+	c.Check(tskKeyslots, DeepEquals, tmpKeyslots)
+	var tskAuthMode device.AuthMode
+	c.Assert(tsks[0].Get("auth-mode", &tskAuthMode), IsNil)
+	c.Check(tskAuthMode, Equals, authMode)
+	var tskRoles map[string][]string
+	c.Assert(tsks[0].Get("roles", &tskRoles), IsNil)
+	if defaultKeyslots {
+		c.Check(tskRoles, DeepEquals, map[string][]string{
+			`(container-role: "system-data", name: "snapd-tmp:default")`:          {"run"},
+			`(container-role: "system-data", name: "snapd-tmp:default-fallback")`: {"run"},
+			`(container-role: "system-save", name: "snapd-tmp:default-fallback")`: {"run"},
+		})
+	} else {
+		c.Check(tskRoles, DeepEquals, map[string][]string{
+			`(container-role: "system-data", name: "snapd-tmp:default")`: {"run"},
+		})
+	}
+
+	c.Check(tsks[1].Summary(), Matches, fmt.Sprintf("Remove old %s key slots", authMode))
+	c.Check(tsks[1].Kind(), Equals, "fde-remove-keys")
+	// check target key slots are passed to task
+	c.Assert(tsks[1].Get("keyslots", &tskKeyslots), IsNil)
+	c.Check(tskKeyslots, DeepEquals, keyslots)
+
+	c.Check(tsks[2].Summary(), Matches, fmt.Sprintf("Rename temporary %s key slots", authMode))
+	c.Check(tsks[2].Kind(), Equals, "fde-rename-keys")
+	// check tmp key slots are passed to task
+	c.Assert(tsks[2].Get("keyslots", &tskKeyslots), IsNil)
+	c.Check(tskKeyslots, DeepEquals, tmpKeyslots)
+	// and renames are also passed
+	var renames map[string]string
+	c.Assert(tsks[2].Get("renames", &renames), IsNil)
+	if defaultKeyslots {
+		c.Check(renames, DeepEquals, map[string]string{
+			`(container-role: "system-data", name: "snapd-tmp:default")`:          "default",
+			`(container-role: "system-data", name: "snapd-tmp:default-fallback")`: "default-fallback",
+			`(container-role: "system-save", name: "snapd-tmp:default-fallback")`: "default-fallback",
+		})
+	} else {
+		c.Check(renames, DeepEquals, map[string]string{
+			`(container-role: "system-data", name: "snapd-tmp:default")`: "default",
+		})
+	}
+
+	if authMode == device.AuthModeNone {
+		c.Check(s.st.Cached(fdestate.VolumesAuthOptionsKey()), IsNil)
+	} else {
+		c.Check(s.st.Cached(fdestate.VolumesAuthOptionsKey()), Equals, volumesAuth)
+	}
+}
+
+func (s *fdeMgrSuite) TestReplaceProtectedKeyAuthModeNone(c *C) {
+	const defaultKeyslots = false
+	const authMode = device.AuthModeNone
+	s.testReplaceProtectedKey(c, authMode, defaultKeyslots)
+}
+
+func (s *fdeMgrSuite) TestReplaceProtectedKeyAuthModePassphrase(c *C) {
+	const defaultKeyslots = false
+	const authMode = device.AuthModePassphrase
+	s.testReplaceProtectedKey(c, authMode, defaultKeyslots)
+}
+
+func (s *fdeMgrSuite) TestReplaceProtectedKeyAuthModePIN(c *C) {
+	const defaultKeyslots = false
+	const authMode = device.AuthModePIN
+	s.testReplaceProtectedKey(c, authMode, defaultKeyslots)
+}
+
+func (s *fdeMgrSuite) TestReplaceProtectedKeyDefaultKeyslots(c *C) {
+	const defaultKeyslots = true
+	const authMode = device.AuthModeNone
+	s.testReplaceProtectedKey(c, authMode, defaultKeyslots)
+}
+
+func (s *fdeMgrSuite) TestReplaceProtectedKeyErrors(c *C) {
+	defer fdestate.MockSecbootReadContainerKeyData(func(devicePath, slotName string) (secboot.KeyData, error) {
+		switch fmt.Sprintf("%s:%s", devicePath, slotName) {
+		case "/dev/disk/by-uuid/data:default":
+			return &mockKeyData{authMode: device.AuthModeNone}, nil
+		case "/dev/disk/by-uuid/data:default-fallback":
+			return nil, fmt.Errorf("boom!")
+		default:
+			panic("unexpected container")
+		}
+	})()
+
+	s.mockCurrentKeys(c, nil, []fdestate.KeyslotRef{
+		{ContainerRole: "system-data", Name: "default"},
+		{ContainerRole: "system-data", Name: "default-fallback"},
+	})
+
+	// initialize fde manager
+	onClassic := true
+	s.startedManager(c, onClassic)
+
+	model := s.mockBootAssetsStateForModeenv(c)
+	s.mockDeviceInState(model, "run")
+
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	// unsupported auth mode
+	_, err := fdestate.ReplaceProtectedKey(s.st, &device.VolumesAuthOptions{Mode: "unknown"}, nil)
+	c.Assert(err, ErrorMatches, `invalid authentication mode "unknown", only "passphrase" and "pin" modes are supported`)
+
+	// invalid key slot reference
+	badKeyslot := fdestate.KeyslotRef{ContainerRole: "", Name: "some-name"}
+	_, err = fdestate.ReplaceProtectedKey(s.st, nil, []fdestate.KeyslotRef{badKeyslot})
+	c.Assert(err, ErrorMatches, `invalid key slot reference \(container-role: "", name: "some-name"\): container role cannot be empty`)
+
+	// invalid key slot reference
+	badKeyslot = fdestate.KeyslotRef{ContainerRole: "system-data", Name: "default-recovery"}
+	_, err = fdestate.ReplaceProtectedKey(s.st, nil, []fdestate.KeyslotRef{badKeyslot})
+	c.Assert(err, ErrorMatches, `invalid key slot reference \(container-role: "system-data", name: "default-recovery"\): unsupported name, expected "default" or "default-fallback"`)
+
+	// missing keyslot
+	badKeyslot = fdestate.KeyslotRef{ContainerRole: "system-save", Name: "default-fallback"}
+	_, err = fdestate.ReplaceProtectedKey(s.st, nil, []fdestate.KeyslotRef{badKeyslot})
+	c.Assert(err, ErrorMatches, `key slot reference \(container-role: "system-save", name: "default-fallback"\) not found`)
+
+	// keyslot key data loading error
+	badKeyslot = fdestate.KeyslotRef{ContainerRole: "system-data", Name: "default-fallback"}
+	_, err = fdestate.ReplaceProtectedKey(s.st, nil, []fdestate.KeyslotRef{badKeyslot})
+	c.Assert(err, ErrorMatches, `cannot read key data for \(container-role: "system-data", name: "default-fallback"\): cannot read key data for "default-fallback" from "/dev/disk/by-uuid/data": boom!`)
+
+	// bad keyslot type (recovery instead of platform)
+	s.st.Unlock()
+	s.mockCurrentKeys(c, []fdestate.KeyslotRef{{ContainerRole: "system-data", Name: "default"}}, nil)
+	s.st.Lock()
+	badKeyslot = fdestate.KeyslotRef{ContainerRole: "system-data", Name: "default"}
+	_, err = fdestate.ReplaceProtectedKey(s.st, nil, []fdestate.KeyslotRef{badKeyslot})
+	c.Assert(err, ErrorMatches, `invalid key slot reference \(container-role: "system-data", name: "default"\): unsupported type "recovery", expected "platform"`)
+
+	// recovery mode
+	unlockState := boot.DiskUnlockState{
+		UbuntuData: boot.PartitionState{UnlockKey: "recovery"},
+	}
+	c.Assert(unlockState.WriteTo("unlocked.json"), IsNil)
+	_, err = fdestate.ReplaceProtectedKey(s.st, nil, nil)
+	c.Assert(err, ErrorMatches, "system was unlocked with a recovery key during boot: reboot required")
+	// cleanup
+	c.Assert(os.RemoveAll(filepath.Join(dirs.SnapBootstrapRunDir, "unlocked.json")), IsNil)
+
+	// change conflict with fde changes
+	chg := s.st.NewChange("fde-change-passphrase", "")
+	task := s.st.NewTask("some-fde-task", "")
+	chg.AddTask(task)
+	_, err = fdestate.ReplaceProtectedKey(s.st, nil, nil)
+	c.Assert(err, ErrorMatches, `changing passphrase in progress, no other FDE changes allowed until this is done`)
+	c.Check(err, testutil.ErrorIs, &snapstate.ChangeConflictError{})
+	// cleanup
+	chg.Abort()
+
+	// change conflict with snaps that cause a reseal
+	gadgetSnapYamlContent := fmt.Sprintf(`
+name: %s
+version: "1.0"
+type: gadget
+`[1:], model.Gadget())
+	kernelSnapYamlContent := fmt.Sprintf(`
+name: %s
+version: "1.0"
+type: kernel
+`[1:], model.Kernel())
+	baseSnapYamlContent := fmt.Sprintf(`
+name: %s
+version: "1.0"
+type: base
+`[1:], model.Base())
+
+	for _, sn := range []struct {
+		snapYaml string
+		name     string
+	}{
+		{snapYaml: gadgetSnapYamlContent, name: model.Gadget()},
+		{snapYaml: kernelSnapYamlContent, name: model.Kernel()},
+		{snapYaml: baseSnapYamlContent, name: model.Base()},
+	} {
+		path := snaptest.MakeTestSnapWithFiles(c, sn.snapYaml, nil)
+		s.st.Set("seeded", true)
+		ts, _, err := snapstate.InstallPath(s.st, &snap.SideInfo{
+			RealName: sn.name,
+		}, path, "", "", snapstate.Flags{}, nil)
+		c.Assert(err, IsNil)
+		chg = s.st.NewChange("install-essential-snap", "")
+		chg.AddAll(ts)
+		_, err = fdestate.ReplaceProtectedKey(s.st, nil, nil)
+		c.Check(err, ErrorMatches, fmt.Sprintf(`snap %q has "install-essential-snap" change in progress`, sn.name))
+		// cleanup
+		chg.Abort()
+	}
+}
+
+func (s *fdeMgrSuite) TestReplaceProtectedKeyConflictSnaps(c *C) {
+	defer fdestate.MockSecbootReadContainerKeyData(func(devicePath, slotName string) (secboot.KeyData, error) {
+		return &mockKeyData{authMode: device.AuthModeNone}, nil
+	})()
+
+	// initialize fde manager
+	onClassic := true
+	s.startedManager(c, onClassic)
+
+	s.mockCurrentKeys(c, nil, nil)
+
+	model := s.mockBootAssetsStateForModeenv(c)
+	s.mockDeviceInState(model, "run")
+
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	s.st.Set("seeded", true)
+
+	// mock change in progress
+	ts, err := fdestate.ReplaceProtectedKey(s.st, nil, nil)
+	chg := s.st.NewChange("fde-change", "")
+	chg.AddAll(ts)
+	c.Assert(err, IsNil)
+
+	gadgetSnapYamlContent := fmt.Sprintf(`
+name: %s
+version: "1.0"
+type: gadget
+`[1:], model.Gadget())
+	kernelSnapYamlContent := fmt.Sprintf(`
+name: %s
+version: "1.0"
+type: kernel
+`[1:], model.Kernel())
+	baseSnapYamlContent := fmt.Sprintf(`
+name: %s
+version: "1.0"
+type: base
+`[1:], model.Base())
+	appSnapYamlContent := `
+name: apps
+version: "1.0"
+type: app
+`[1:]
+
+	for _, sn := range []struct {
+		snapYaml   string
+		name       string
+		noConflict bool
+	}{
+		{snapYaml: gadgetSnapYamlContent, name: model.Gadget()},
+		{snapYaml: kernelSnapYamlContent, name: model.Kernel()},
+		{snapYaml: baseSnapYamlContent, name: model.Base()},
+		{snapYaml: appSnapYamlContent, name: "apps", noConflict: true},
+	} {
+		c.Logf("checking snap %s:\n%s", sn.name, sn.snapYaml)
+		path := snaptest.MakeTestSnapWithFiles(c, sn.snapYaml, nil)
+
+		_, _, err = snapstate.InstallPath(s.st, &snap.SideInfo{
+			RealName: sn.name,
+		}, path, "", "", snapstate.Flags{}, nil)
+
+		if !sn.noConflict {
+			c.Check(err, ErrorMatches, fmt.Sprintf(`snap %q has "fde-change" change in progress`, sn.name))
+		} else {
+			c.Check(err, IsNil)
+		}
+	}
 }

--- a/overlord/fdestate/handlers.go
+++ b/overlord/fdestate/handlers.go
@@ -323,10 +323,10 @@ func (m *FDEManager) doAddProtectedKeys(t *state.Task, _ *tomb.Tomb) (err error)
 		}
 		role := roles[0]
 
-		// NOTE: this is safe to call here even through internall the state is unlocked
+		// NOTE: this is safe to call here even though internally the state is unlocked
 		// because there is conflict detection enforced to prevent other tasks that might
 		// cause a reseal from running (e.g. a kernel refresh).
-		if err := m.ensureParametersLoaded(role, ref.ContainerRole); err != nil {
+		if err := m.ensureParametersLoadedWithMaybeReseal(role, ref.ContainerRole); err != nil {
 			return fmt.Errorf("internal error: cannot load FDE state parameters: %v", err)
 		}
 

--- a/overlord/fdestate/handlers.go
+++ b/overlord/fdestate/handlers.go
@@ -21,10 +21,12 @@ package fdestate
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"time"
 
 	"gopkg.in/tomb.v2"
 
+	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/gadget/device"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/state"
@@ -32,9 +34,10 @@ import (
 )
 
 var (
-	secbootAddContainerRecoveryKey = secboot.AddContainerRecoveryKey
-	secbootDeleteContainerKey      = secboot.DeleteContainerKey
-	secbootRenameContainerKey      = secboot.RenameContainerKey
+	secbootAddContainerRecoveryKey     = secboot.AddContainerRecoveryKey
+	secbootAddContainerTPMProtectedKey = secboot.AddContainerTPMProtectedKey
+	secbootDeleteContainerKey          = secboot.DeleteContainerKey
+	secbootRenameContainerKey          = secboot.RenameContainerKey
 )
 
 func (m *FDEManager) doAddRecoveryKeys(t *state.Task, tomb *tomb.Tomb) (err error) {
@@ -212,7 +215,145 @@ func (m *FDEManager) doRenameKeys(t *state.Task, tomb *tomb.Tomb) error {
 }
 
 func (m *FDEManager) doAddProtectedKeys(t *state.Task, _ *tomb.Tomb) (err error) {
-	// TODO:FDEM: implement handler
+	m.state.Lock()
+	defer m.state.Unlock()
+
+	var keyslotRefs []KeyslotRef
+	if err := t.Get("keyslots", &keyslotRefs); err != nil {
+		return err
+	}
+
+	var authMode device.AuthMode
+	if err := t.Get("auth-mode", &authMode); err != nil {
+		return err
+	}
+	switch authMode {
+	case device.AuthModeNone, device.AuthModePassphrase, device.AuthModePIN:
+	default:
+		return fmt.Errorf("internal error: unexpected authentication mode %q", authMode)
+	}
+
+	var keyslotRoles map[string][]string
+	if err := t.Get("roles", &keyslotRoles); err != nil {
+		return err
+	}
+
+	var volumesAuth *device.VolumesAuthOptions
+	// authentication options are only relevant for PINs and passphrases.
+	switch authMode {
+	case device.AuthModePassphrase, device.AuthModePIN:
+		cached := m.state.Cached(volumesAuthOptionsKey{})
+		if cached == nil {
+			return errors.New("cannot find authentication options in memory: unexpected snapd restart")
+		}
+		var ok bool
+		volumesAuth, ok = cached.(*device.VolumesAuthOptions)
+		if !ok {
+			return fmt.Errorf("internal error: wrong data type under volumesAuthOptionsKey: %T", cached)
+		}
+		if err := volumesAuth.Validate(); err != nil {
+			return fmt.Errorf("internal error: invalid authentication options: %v", err)
+		}
+	}
+
+	// XXX: unlock state and let conflict detection handle the rest?
+
+	unlockedWithRecoveryKey, err := boot.IsUnlockedWithRecoveryKey()
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+	if unlockedWithRecoveryKey {
+		// primary key will be missing from kernel keyring if disk was
+		// unlocked with recovery key during boot.
+		return errors.New("cannot add protected keys if the system was unlocked with a recovery key during boot")
+	}
+
+	containers, err := m.GetEncryptedContainers()
+	if err != nil {
+		return err
+	}
+	containerDevicePath := make(map[string]string, len(containers))
+	for _, container := range containers {
+		containerDevicePath[container.ContainerRole()] = container.DevPath()
+	}
+
+	var addedKeyslots []KeyslotRef
+	defer func() {
+		if err == nil {
+			return
+		}
+		for _, keyslotRef := range addedKeyslots {
+			devicePath := containerDevicePath[keyslotRef.ContainerRole]
+			if err := secbootDeleteContainerKey(devicePath, keyslotRef.Name); err != nil {
+				// best effort deletion, log errors only
+				logger.Noticef("cannot delete %s during clean up: %v", keyslotRef.String(), err)
+			}
+		}
+	}()
+
+	_, missingRefs, err := m.GetKeyslots(keyslotRefs)
+	if err != nil {
+		return fmt.Errorf("cannot get key slots: %v", err)
+	}
+	if len(missingRefs) == 0 {
+		// this could be re-run and all key slots were already added, do nothing
+		m.state.Cache(volumesAuthOptionsKey{}, nil)
+		return nil
+	}
+
+	var fdeKeyslotRoles map[string]KeyslotRoleInfo
+	err = withFdeState(m.state, func(fde *FdeState) (modified bool, err error) {
+		fdeKeyslotRoles = fde.KeyslotRoles
+		return false, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// we only care about missing key slots because this might be
+	// a re-run due a force reboot or abrupt shutdown, so we want
+	// to continue adding the remaining key slots.
+	for _, ref := range missingRefs {
+		devicePath := containerDevicePath[ref.ContainerRole]
+
+		roles := keyslotRoles[ref.String()]
+		if len(roles) != 1 {
+			// multiple roles per key slot are not supported yet by secboot.
+			return fmt.Errorf("internal error: expected one key role, found %v", roles)
+		}
+		role := roles[0]
+
+		// NOTE: this is safe to call here even through internall the state is unlocked
+		// because there is conflict detection enforced to prevent other tasks that might
+		// cause a reseal from running (e.g. a kernel refresh).
+		if err := m.ensureParametersLoaded(role, ref.ContainerRole); err != nil {
+			return fmt.Errorf("internal error: cannot load FDE state parameters: %v", err)
+		}
+
+		hasParamters, _, _, pcrProfile, err := m.GetParameters(role, ref.ContainerRole)
+		if err != nil {
+			return err
+		}
+		if !hasParamters {
+			return fmt.Errorf("internal error: cannot find parameters (key role: %s, container role: %s)", role, ref.ContainerRole)
+		}
+
+		params := secboot.ProtectKeyParams{
+			PCRProfile:             pcrProfile,
+			PCRPolicyCounterHandle: fdeKeyslotRoles[role].TPM2PCRPolicyRevocationCounter,
+			KeyRole:                role,
+			VolumesAuth:            volumesAuth,
+		}
+		if err := secbootAddContainerTPMProtectedKey(devicePath, ref.Name, &params); err != nil {
+			return fmt.Errorf("cannot add protected key slot %s: %v", ref.String(), err)
+		}
+
+		addedKeyslots = append(addedKeyslots, ref)
+	}
+	// avoid re-runs in case of abrupt shutdown since all key slots are now added.
+	t.SetStatus(state.DoneStatus)
+	m.state.Cache(volumesAuthOptionsKey{}, nil)
+
 	return nil
 }
 

--- a/overlord/fdestate/handlers.go
+++ b/overlord/fdestate/handlers.go
@@ -263,7 +263,7 @@ func (m *FDEManager) doAddProtectedKeys(t *state.Task, _ *tomb.Tomb) (err error)
 		return err
 	}
 	if unlockedWithRecoveryKey {
-		// primary key will be missing from kernel keyring if disk was
+		// primary key might be missing from kernel keyring if disk was
 		// unlocked with recovery key during boot.
 		return errors.New("cannot add protected keys if the system was unlocked with a recovery key during boot")
 	}
@@ -344,6 +344,7 @@ func (m *FDEManager) doAddProtectedKeys(t *state.Task, _ *tomb.Tomb) (err error)
 			KeyRole:                role,
 			VolumesAuth:            volumesAuth,
 		}
+		// TODO:FDEM: support FDE hook setup
 		if err := secbootAddContainerTPMProtectedKey(devicePath, ref.Name, &params); err != nil {
 			return fmt.Errorf("cannot add protected key slot %s: %v", ref.String(), err)
 		}

--- a/overlord/fdestate/handlers.go
+++ b/overlord/fdestate/handlers.go
@@ -330,11 +330,11 @@ func (m *FDEManager) doAddProtectedKeys(t *state.Task, _ *tomb.Tomb) (err error)
 			return fmt.Errorf("internal error: cannot load FDE state parameters: %v", err)
 		}
 
-		hasParamters, _, _, pcrProfile, err := m.GetParameters(role, ref.ContainerRole)
+		hasParameters, _, _, pcrProfile, err := m.GetParameters(role, ref.ContainerRole)
 		if err != nil {
 			return err
 		}
-		if !hasParamters {
+		if !hasParameters {
 			return fmt.Errorf("internal error: cannot find parameters (key role: %s, container role: %s)", role, ref.ContainerRole)
 		}
 

--- a/overlord/fdestate/handlers_test.go
+++ b/overlord/fdestate/handlers_test.go
@@ -23,15 +23,18 @@ package fdestate_test
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"sort"
 	"time"
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget/device"
 	"github.com/snapcore/snapd/overlord/fdestate"
+	"github.com/snapcore/snapd/overlord/fdestate/backend"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/secboot/keys"
@@ -845,4 +848,293 @@ func (s *fdeMgrSuite) TestDoChangeAuthKeysNoop(c *C) {
 	s.settle(c)
 
 	c.Check(chg.Status(), Equals, state.DoneStatus)
+}
+
+func (s *fdeMgrSuite) TestDoAddProtectedKeys(c *C) {
+	const onClassic = true
+	s.startedManager(c, onClassic)
+
+	model := s.mockBootAssetsStateForModeenv(c)
+	s.mockDeviceInState(model, "run")
+
+	s.mockCurrentKeys(c, nil, nil)
+
+	defaultKeyslots := []fdestate.KeyslotRef{{ContainerRole: "system-data", Name: "tmp-default"}}
+	defaultRoles := [][]string{{"run"}}
+
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	type testcase struct {
+		keyslots                      []fdestate.KeyslotRef
+		authMode                      device.AuthMode
+		noVolumesAuth                 bool
+		recoveryMode                  bool
+		noop                          bool
+		roles                         [][]string
+		expectedAdds, expectedDeletes []string
+		errOn                         []string
+		expectedErr                   string
+	}
+	tcs := []testcase{
+		{
+			authMode: device.AuthModeNone, noVolumesAuth: true,
+			expectedAdds: []string{"/dev/disk/by-uuid/data:tmp-default"},
+		},
+		{
+			authMode:     device.AuthModePassphrase,
+			expectedAdds: []string{"/dev/disk/by-uuid/data:tmp-default"},
+		},
+		{
+			authMode:    device.AuthModePIN,
+			expectedErr: `internal error: invalid authentication options: "pin" authentication mode is not implemented`,
+		},
+		{
+			authMode: device.AuthModePIN, noVolumesAuth: true,
+			expectedErr: "cannot find authentication options in memory: unexpected snapd restart",
+		},
+		{
+			authMode: device.AuthModePassphrase, noVolumesAuth: true,
+			expectedErr: "cannot find authentication options in memory: unexpected snapd restart",
+		},
+		{
+			authMode: device.AuthModePassphrase, recoveryMode: true,
+			expectedErr: "cannot add protected keys if the system was unlocked with a recovery key during boot",
+		},
+		{
+			authMode:    device.AuthModePassphrase,
+			roles:       [][]string{{"run", "recover"}},
+			expectedErr: `internal error: expected one key role, found \[run recover\]`,
+		},
+		{
+			authMode:    device.AuthModePassphrase,
+			roles:       [][]string{{"run+recover"}},
+			expectedErr: `internal error: cannot find parameters \(key role: run\+recover, container role: system-data\)`,
+		},
+		{
+			keyslots: []fdestate.KeyslotRef{
+				{ContainerRole: "system-data", Name: "tmp-default-1"},
+				{ContainerRole: "system-data", Name: "tmp-default-2"},
+				{ContainerRole: "system-data", Name: "tmp-default-3"},
+			},
+			authMode: device.AuthModePassphrase,
+			roles:    [][]string{{"run"}, {"run"}, {"run"}},
+			errOn: []string{
+				"add:/dev/disk/by-uuid/data:tmp-default-3",    // to trigger clean up
+				"delete:/dev/disk/by-uuid/data:tmp-default-2", // to test best effort deletion
+			},
+			// best effort deletion for clean up
+			expectedDeletes: []string{"/dev/disk/by-uuid/data:tmp-default-1"},
+			expectedAdds: []string{
+				"/dev/disk/by-uuid/data:tmp-default-1",
+				"/dev/disk/by-uuid/data:tmp-default-2",
+			},
+			expectedErr: `cannot add protected key slot \(container-role: "system-data", name: "tmp-default-3"\): add error on /dev/disk/by-uuid/data:tmp-default-3`,
+		},
+		{
+			keyslots: []fdestate.KeyslotRef{{ContainerRole: "system-data", Name: "default"}},
+			authMode: device.AuthModePassphrase,
+			noop:     true,
+		},
+	}
+
+	for i, tc := range tcs {
+		cmt := Commentf("tcs[%d] failed", i)
+
+		var added, deleted []string
+
+		if len(tc.keyslots) == 0 {
+			tc.keyslots = defaultKeyslots
+		}
+
+		roles := make(map[string][]string)
+		if len(tc.roles) == 0 {
+			tc.roles = defaultRoles
+		}
+
+		c.Assert(tc.roles, HasLen, len(tc.keyslots))
+		for idx, ref := range tc.keyslots {
+			roles[ref.String()] = tc.roles[idx]
+		}
+
+		if tc.recoveryMode {
+			unlockState := boot.DiskUnlockState{
+				UbuntuData: boot.PartitionState{UnlockKey: "recovery"},
+			}
+			c.Assert(unlockState.WriteTo("unlocked.json"), IsNil)
+		}
+
+		var volumesAuth *device.VolumesAuthOptions
+		if !tc.noVolumesAuth {
+			volumesAuth = &device.VolumesAuthOptions{Mode: tc.authMode}
+			if tc.authMode == device.AuthModePassphrase {
+				volumesAuth.Passphrase = "password"
+			}
+			s.st.Cache(fdestate.VolumesAuthOptionsKey(), volumesAuth)
+		}
+
+		defer fdestate.MockSecbootAddContainerTPMProtectedKey(func(devicePath string, slotName string, params *secboot.ProtectKeyParams) error {
+			c.Check(params.PCRProfile, DeepEquals, secboot.SerializedPCRProfile("serialized-pcr-profile"), cmt)
+			c.Check(params.PCRPolicyCounterHandle, Equals, uint32(41), cmt)
+			c.Check(params.VolumesAuth, DeepEquals, volumesAuth, cmt)
+
+			entry := fmt.Sprintf("%s:%s", devicePath, slotName)
+			if strutil.ListContains(tc.errOn, fmt.Sprintf("add:%s", entry)) {
+				return fmt.Errorf("add error on %s", entry)
+			}
+			added = append(added, entry)
+			return nil
+		})()
+
+		defer fdestate.MockSecbootDeleteContainerKey(func(devicePath, slotName string) error {
+			entry := fmt.Sprintf("%s:%s", devicePath, slotName)
+			if strutil.ListContains(tc.errOn, fmt.Sprintf("delete:%s", entry)) {
+				return fmt.Errorf("delete error on %s", entry)
+			}
+			deleted = append(deleted, entry)
+			return nil
+		})()
+
+		resealCalls := 0
+		defer fdestate.MockBackendResealKeyForBootChains(func(manager backend.FDEStateManager, method device.SealingMethod, rootdir string, resealParams *boot.ResealKeyForBootChainsParams) error {
+			resealCalls++
+			params := backend.SealingParameters{TpmPCRProfile: []byte("serialized-pcr-profile")}
+			c.Assert(manager.Update("run", "system-data", &params), IsNil)
+			return nil
+		})()
+
+		c.Assert(device.StampSealedKeys(dirs.GlobalRootDir, device.SealingMethodTPM), IsNil)
+
+		task := s.st.NewTask("fde-add-protected-keys", "test")
+		task.Set("keyslots", tc.keyslots)
+		task.Set("auth-mode", tc.authMode)
+		task.Set("roles", roles)
+
+		chg := s.st.NewChange("sample", "...")
+		chg.AddTask(task)
+
+		s.settle(c)
+
+		if tc.expectedErr == "" {
+			c.Check(chg.Status(), Equals, state.DoneStatus, cmt)
+			c.Assert(chg.Err(), IsNil, cmt)
+			if !tc.noop {
+				// only called once
+				c.Check(resealCalls, Equals, 1, cmt)
+			}
+			// volumes auth is removed
+			c.Assert(s.st.Cached(fdestate.VolumesAuthOptionsKey()), IsNil)
+		} else {
+			c.Check(chg.Err(), ErrorMatches, fmt.Sprintf(`cannot perform the following tasks:
+- test \(%s\)`, tc.expectedErr), cmt)
+			if !tc.noVolumesAuth {
+				// volumes auth is kept to account for re-runs
+				c.Assert(s.st.Cached(fdestate.VolumesAuthOptionsKey()), Equals, volumesAuth)
+			}
+		}
+
+		if tc.noop {
+			c.Check(resealCalls, Equals, 0, cmt)
+			c.Check(added, HasLen, 0)
+			c.Check(deleted, HasLen, 0)
+		}
+
+		sort.Strings(added)
+		c.Check(added, DeepEquals, tc.expectedAdds, cmt)
+
+		sort.Strings(deleted)
+		c.Check(deleted, DeepEquals, tc.expectedDeletes, cmt)
+
+		// clean up
+		c.Assert(os.RemoveAll(filepath.Join(dirs.SnapBootstrapRunDir, "unlocked.json")), IsNil, cmt)
+		s.st.Cache(fdestate.VolumesAuthOptionsKey(), nil)
+		var fdeState fdestate.FdeState
+		c.Assert(s.st.Get("fde", &fdeState), IsNil)
+		delete(fdeState.KeyslotRoles["run"].Parameters, "system-data")
+		s.st.Set("fde", fdeState)
+	}
+}
+
+func (s *fdeMgrSuite) TestDoAddProtectedKeysIdempotence(c *C) {
+	const onClassic = true
+	s.startedManager(c, onClassic)
+
+	model := s.mockBootAssetsStateForModeenv(c)
+	s.mockDeviceInState(model, "run")
+
+	currentKeys := []fdestate.KeyslotRef{{ContainerRole: "system-data", Name: "some-key"}}
+	s.mockCurrentKeys(c, currentKeys, nil)
+
+	defer fdestate.MockBackendResealKeyForBootChains(func(manager backend.FDEStateManager, method device.SealingMethod, rootdir string, params *boot.ResealKeyForBootChainsParams) error {
+		c.Assert(manager.Update("run", "system-data", &backend.SealingParameters{TpmPCRProfile: []byte("serialized-pcr-profile")}), IsNil)
+		return nil
+	})()
+
+	ops := make([]string, 0)
+	defer fdestate.MockSecbootAddContainerTPMProtectedKey(func(devicePath string, slotName string, params *secboot.ProtectKeyParams) error {
+		var containerRole string
+		switch filepath.Base(devicePath) {
+		case "data":
+			containerRole = "system-data"
+		case "save":
+			containerRole = "system-save"
+		default:
+			panic("unexpected device path")
+		}
+		newKeys := []fdestate.KeyslotRef{{ContainerRole: containerRole, Name: slotName}}
+		found := false
+		for _, ref := range currentKeys {
+			if ref.ContainerRole == containerRole && ref.Name == slotName {
+				found = true
+				continue
+			}
+			newKeys = append(newKeys, ref)
+		}
+		c.Assert(found, Equals, false, Commentf("%s:%s already exists", containerRole, slotName))
+
+		currentKeys = newKeys
+		s.mockCurrentKeys(c, currentKeys, nil)
+		ops = append(ops, fmt.Sprintf("add:%s:%s", containerRole, slotName))
+		return nil
+	})()
+
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	keyslotRefs := []fdestate.KeyslotRef{
+		{ContainerRole: "system-data", Name: "default-0"},
+		{ContainerRole: "system-data", Name: "default-1"},
+		{ContainerRole: "system-data", Name: "default-2"},
+		{ContainerRole: "system-data", Name: "default-3"},
+	}
+	roles := make(map[string][]string, 4)
+	for _, ref := range keyslotRefs {
+		roles[ref.String()] = []string{"run"}
+	}
+
+	c.Assert(device.StampSealedKeys(dirs.GlobalRootDir, device.SealingMethodTPM), IsNil)
+
+	chg := s.st.NewChange("sample", "...")
+
+	for i := 1; i <= 3; i++ {
+		t := s.st.NewTask("fde-add-protected-keys", "test")
+		t.Set("keyslots", keyslotRefs)
+		t.Set("auth-mode", device.AuthModeNone)
+		t.Set("roles", roles)
+		chg.AddTask(t)
+	}
+
+	s.settle(c)
+
+	sort.Strings(ops)
+
+	c.Check(chg.Err(), IsNil)
+	c.Check(chg.Status(), Equals, state.DoneStatus)
+	// task is idempotent
+	c.Check(ops, DeepEquals, []string{
+		"add:system-data:default-0",
+		"add:system-data:default-1",
+		"add:system-data:default-2",
+		"add:system-data:default-3",
+	})
 }

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -177,6 +177,14 @@ type KeyDataLocation struct {
 	SlotName string
 }
 
+const (
+	PlatformTpm2       = "tpm2"
+	PlatformTpm2Legacy = "tpm2-legacy"
+	PlatformPlainkey   = "plainkey"
+	PlatformFdeHookV2  = "fde-hook-v2"
+	PlatformFdeHooksV3 = "fde-hooks-v3"
+)
+
 // KeyData represents a disk unlock key protected by a platform's secure device.
 type KeyData interface {
 	PlatformName() string


### PR DESCRIPTION
This helper is needed to currently implement root passphrase reset without providing the old passphrase but the implementation is generic enough that it can be used for more use cases like:
- Reset a passphrase/PIN without providing the old value
- Change key authentication mode, for example:
    - Switch from passphrase to PIN authentication
    - Switch from PIN to passphrase authentication
    - Switch from no authentication to PIN or Passphrase authentication
    - Switch from PIN or Passphrase authentication to no authentication
- Change key authentication options, i.e. KDF options

API spec proposal: [SD201](https://docs.google.com/document/d/1Mbj7Ut0tgW0PCz8VWdhvBN52kHTxYqkZZKQODB1NlLk/edit?tab=t.0#bookmark=id.8kjwg3jmkwny)

This PR is built on top of https://github.com/canonical/snapd/pull/15758 and https://github.com/canonical/snapd/pull/15756 and should be rebased when they are merged. Relevant commits are those after 87165d9800e425d73095c84c77241c86d108eba0.