### PR TITLE
osutil/vfs: replace [mount.mountPoint] with [mount.attachedAt]

### DIFF
--- a/osutil/vfs/export_test.go
+++ b/osutil/vfs/export_test.go
@@ -36,7 +36,7 @@ func (v *VFS) RootMount() *mount {
 
 // MountPoint returns the mount point of the given mount.
 func (m *mount) MountPoint() string {
-	return m.mountPoint
+	return m.mountPoint()
 }
 
 // Parent returns the parent mount.

--- a/osutil/vfs/mount.go
+++ b/osutil/vfs/mount.go
@@ -61,7 +61,7 @@ func (v *VFS) Mount(fsFS fs.StatFS, mountPoint string) error {
 
 	// Mount and return.
 	m := &mount{
-		mountPoint: mountPoint,
+		attachedAt: pd.suffix,
 		isDir:      true,
 		fsFS:       fsFS,
 	}
@@ -128,7 +128,7 @@ func (v *VFS) unlockedBindMount(sourcePoint, mountPoint string) (*mount, error) 
 
 	// Mount and return.
 	m := &mount{
-		mountPoint: mountPoint,
+		attachedAt: pd.suffix,
 		rootDir:    sourcePd.combinedRootDir(),
 		isDir:      fsFi.IsDir(),
 		fsFS:       sourcePd.mount.fsFS,
@@ -186,7 +186,7 @@ func (v *VFS) unlockedRecursiveBindMount(sourcePoint, mountPoint string) error {
 		// suffix within the mount entry that dominates the path. In other
 		// words, when sourcePoint is a directory and we are processing
 		// this loop, skip everything that is NOT in that directory.
-		if !strings.HasPrefix(m.mountPoint, sourcePoint+"/") {
+		if !strings.HasPrefix(m.mountPoint(), sourcePoint+"/") {
 			continue
 		}
 
@@ -199,10 +199,10 @@ func (v *VFS) unlockedRecursiveBindMount(sourcePoint, mountPoint string) error {
 		// will now bind-mount /home/user to /var/home/user, replacing
 		// /home with /var/home.
 		//
-		// The replacement works beucause m.mountPoint is guaranteed to
+		// The replacement works because m.mountPoint is guaranteed to
 		// start with sourcePoint which we just checked above.
-		newSourcePoint := m.mountPoint
-		newMountPoint := strings.Replace(m.mountPoint, sourcePoint, mountPoint, 1)
+		newSourcePoint := m.mountPoint()
+		newMountPoint := strings.Replace(m.mountPoint(), sourcePoint, mountPoint, 1)
 		if err := v.unlockedRecursiveBindMount(newSourcePoint, newMountPoint); err != nil {
 			return err
 		}


### PR DESCRIPTION
The change is perhaps tiny but helps greatly in upcoming operations. The main benefit is that the suffix of the mount is no longer interested as to where it is exactly attached. Recursive bind, pivot root and mount move operation all change that location. With the new design most of the operations will no longer need to touch the new `mount.attachedAt` value, but merely invalidate the mount point cache.

