### PR TITLE
o/h/ctlcmd: check confdb plug connection in snapctl

### DIFF
--- a/overlord/confdbstate/confdbstate.go
+++ b/overlord/confdbstate/confdbstate.go
@@ -439,7 +439,7 @@ func getCustodianPlugsForView(st *state.State, view *confdb.View) ([]string, map
 		// TODO: if a snap has more than one plug providing access to a view, then
 		// which plug we're getting here becomes unpredictable. We should check
 		// for this at some point (interface connection?)
-		custodianPlugs[plug.Snap.SnapName()] = plug
+		custodianPlugs[plug.Snap.InstanceName()] = plug
 		custodians = append(custodians, plug.Snap.InstanceName())
 	}
 

--- a/overlord/hookstate/ctlcmd/set.go
+++ b/overlord/hookstate/ctlcmd/set.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/overlord/configstate"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/hookstate"
+	"github.com/snapcore/snapd/snap"
 )
 
 var confdbstateTransactionForSet = confdbstate.GetTransactionToSet
@@ -236,9 +237,14 @@ func setConfdbValues(ctx *hookstate.Context, plugName string, requests map[strin
 	ctx.Lock()
 	defer ctx.Unlock()
 
-	account, dbSchemaName, viewName, err := getConfdbViewID(ctx, plugName)
+	plug, err := checkConfdbPlugConnection(ctx, plugName)
 	if err != nil {
 		return err
+	}
+
+	account, dbSchemaName, viewName, err := snap.ConfdbPlugAttrs(plug)
+	if err != nil {
+		return fmt.Errorf(i18n.G("invalid plug :%s: %w"), plugName, err)
 	}
 
 	view, err := confdbstateGetView(ctx.State(), account, dbSchemaName, viewName)

--- a/tests/main/confdb/task.yaml
+++ b/tests/main/confdb/task.yaml
@@ -9,9 +9,11 @@ systems: [ -ubuntu-16.04 ]
 
 prepare: |
   snap set system experimental.confdb=true
+  snap set system experimental.parallel-instances=true
 
 restore: |
   snap unset system experimental.confdb
+  snap unset system experimental.parallel-instances
 
 execute: |
   if [ "$TRUST_TEST_KEYS" = "false" ]; then
@@ -62,3 +64,18 @@ execute: |
   snap set developer1/network/wifi-setup status=foo 2>&1 | tr -d '\n' | tr -s '  ' ' ' | MATCH 'cannot set "status" through developer1/network/wifi-setup: no matching rule'
   snap set developer1/network/wifi-setup password=foo
   snap get developer1/network/wifi-setup password 2>&1 | tr -d '\n' | tr -s '  ' ' ' | MATCH 'cannot get "password" through developer1/network/wifi-setup: no matching rule'
+
+  # check that snaps can't access confdb through snapctl without a connected plug
+  snap disconnect test-custodian-snap:manage-wifi
+
+  # install another snap to serve as the custodian
+  "$TESTSTOOLS"/snaps-state install-local-as test-custodian-snap test-custodian-snap_other
+  snap connect test-custodian-snap_other:manage-wifi
+  # the new custodian can still access confdb
+  snap run --shell test-custodian-snap_other.sh -c 'snapctl set --view :manage-wifi ssid=foo'
+  snap run --shell test-custodian-snap_other.sh -c 'snapctl get --view :manage-wifi ssid' | MATCH "foo"
+
+  # but the disconnected snap cannot
+  snap run --shell test-custodian-snap.sh -c 'snapctl get --view :manage-wifi ssid' 2>&1 | MATCH "error: snapctl: cannot access confdb through unconnected plug :manage-wifi"
+  snap run --shell test-custodian-snap.sh -c 'snapctl set --view :manage-wifi ssid=foo' 2>&1 | MATCH "error: snapctl: cannot access confdb through unconnected plug :manage-wifi"
+  snap run --shell test-custodian-snap.sh -c 'snapctl unset --view :manage-wifi ssid' 2>&1 | MATCH "error: snapctl: cannot access confdb through unconnected plug :manage-wifi"


### PR DESCRIPTION
Add a check in snapctl that the confdb plug is actually connected. Also adds spread test coverage