### PR TITLE
osutil/vfs/tests: add more tests for propagation

### DIFF
--- a/.woke.yaml
+++ b/.woke.yaml
@@ -1,32 +1,34 @@
 ignore_files:
+  - build-aux/snap/local/apparmor/apparmor-parser-fix-protocol-error-on-older-kernels-caused-by.patch
+  - build-aux/snap/local/apparmor/parser-add-support-for-prompting.patch
   - cmd/Makefile.am
   - cmd/configure.ac
-  - packaging/fedora/snapd.spec
-  - packaging/debian-sid/changelog
-  - cmd/snap-confine/snap-confine.c
-  - packaging/ubuntu-14.04/changelog
-  - packaging/ubuntu-16.04/changelog
   - cmd/libsnap-confine-private/snap.c
+  - cmd/libsnap-confine-private/string-utils-test.c
+  - cmd/libsnap-confine-private/string-utils.c
+  - cmd/snap-confine/snap-confine.apparmor.in
+  - cmd/snap-confine/snap-confine.c
+  - osutil/mount/libmount/libmount_linux.go
+  - osutil/mount/libmount/libmount_linux_test.go
+  - osutil/vfs/tests/bind-semantics/task.yaml
+  - osutil/vfs/tests/bind-shadow-propagate/task.yaml
+  - osutil/vfs/tests/mount-in-slave/expected.txt
+  - osutil/vfs/tests/mount-in-slave/task.yaml
+  - osutil/vfs/tests/propagation-to-shared-slave/expected.txt
+  - osutil/vfs/tests/propagation-to-shared-slave/task.yaml
+  - osutil/vfs/tests/propagation-to-shared-subdirectory/expected.txt
+  - osutil/vfs/tests/propagation-to-shared-subdirectory/task.txt
+  - osutil/vfs/tests/propagation-to-slave/expected.txt
+  - osutil/vfs/tests/propagation-to-slave/task.yaml
+  - osutil/vfs/tests/rewrite-peer-groups.awk
+  - osutil/vfs/tests/root-dir-mount-point-optional-fields-and-source.awk
+  - osutil/vfs/tests/shared-reduction/task.yaml
   - osutil/vfs/tests/slave-bind/task.yaml
   - osutil/vfs/tests/slave-mount/task.yaml
-  - osutil/mount/libmount/libmount_linux.go
-  - osutil/vfs/tests/rewrite-peer-groups.awk
-  - cmd/snap-confine/snap-confine.apparmor.in
-  - osutil/vfs/tests/mount-in-slave/task.yaml
-  - osutil/vfs/tests/bind-semantics/task.yaml
-  - cmd/libsnap-confine-private/string-utils.c
-  - osutil/vfs/tests/slave-reduction/task.yaml
-  - osutil/vfs/tests/shared-reduction/task.yaml
-  - osutil/mount/libmount/libmount_linux_test.go
-  - osutil/vfs/tests/mount-in-slave/expected.txt
   - osutil/vfs/tests/slave-reduction/expected.txt
-  - cmd/libsnap-confine-private/string-utils-test.c
-  - cmd/libsnap-confine-private/string-utils-test.c
-  - osutil/vfs/tests/propagation-to-slave/task.yaml
-  - osutil/vfs/tests/bind-shadow-propagate/task.yaml
-  - osutil/vfs/tests/propagation-to-slave/expected.txt
+  - osutil/vfs/tests/slave-reduction/task.yaml
+  - packaging/debian-sid/changelog
+  - packaging/fedora/snapd.spec
+  - packaging/ubuntu-14.04/changelog
+  - packaging/ubuntu-16.04/changelog
   - tests/lib/snaps/store/test-snapd-ovmf/snapcraft.yaml
-  - osutil/vfs/tests/propagation-to-shared-slave/task.yaml
-  - osutil/vfs/tests/propagation-to-shared-slave/expected.txt
-  - build-aux/snap/local/apparmor/parser-add-support-for-prompting.patch
-  - build-aux/snap/local/apparmor/apparmor-parser-fix-protocol-error-on-older-kernels-caused-by.patch

--- a/osutil/vfs/tests/propagation-to-shared-slave/expected.txt
+++ b/osutil/vfs/tests/propagation-to-shared-slave/expected.txt
@@ -1,6 +1,8 @@
 / /a shared:42 - tmpfs-a
 / /b shared:43 master:42 - tmpfs-a
 / /c shared:44 master:42 - tmpfs-a
+/ /d shared:44 master:42 - tmpfs-a
 / /a/1 shared:45 - tmpfs-a-1
 / /c/1 shared:46 master:45 - tmpfs-a-1
+/ /d/1 shared:46 master:45 - tmpfs-a-1
 / /b/1 shared:47 master:45 - tmpfs-a-1

--- a/osutil/vfs/tests/propagation-to-shared-slave/expected.txt
+++ b/osutil/vfs/tests/propagation-to-shared-slave/expected.txt
@@ -1,6 +1,6 @@
-/a shared:42 -
-/b shared:43 master:42 -
-/c shared:44 master:42 -
-/a/1 shared:45 -
-/c/1 shared:46 master:45 -
-/b/1 shared:47 master:45 -
+/ /a shared:42 - tmpfs-a
+/ /b shared:43 master:42 - tmpfs-a
+/ /c shared:44 master:42 - tmpfs-a
+/ /a/1 shared:45 - tmpfs-a-1
+/ /c/1 shared:46 master:45 - tmpfs-a-1
+/ /b/1 shared:47 master:45 - tmpfs-a-1

--- a/osutil/vfs/tests/propagation-to-shared-slave/task.yaml
+++ b/osutil/vfs/tests/propagation-to-shared-slave/task.yaml
@@ -1,13 +1,15 @@
 summary: observe how propagation to shared slave mounts works
 details: |
     A shared file system is bind-mounted from a to b and c. The b and c mounts
-    are then turned into slaves and shared again. A new mount is created at
-    a/1. What are the propagation settings of the propagated copies to b/1 and
-    c/1?
+    are then turned into slaves and shared again. The shared slave mount at c
+    is then re-bound to d. A new mount is created at a/1. What are the
+    propagation settings of the propagated copies to b/1 and c/1? What
+    propagates to d?
 prepare: |
     mkdir a
     mkdir b
     mkdir c
+    mkdir d
     mount -t tmpfs tmpfs-a a
     mount --make-shared a
     mount --bind a b
@@ -16,15 +18,17 @@ prepare: |
     mount --bind a c
     mount --make-slave c
     mount --make-shared c
+    mount --bind c d
     mkdir a/1
     mount -t tmpfs tmpfs-a-1 a/1
 restore: |
     umount -l a
     umount -l b
     umount -l c
-    rmdir a b c
+    umount -l d
+    rmdir a b c d
 debug: |
-    tail -n 6 /proc/self/mountinfo
+    tail -n 8 /proc/self/mountinfo
 execute: |
-    tail -n 6 /proc/self/mountinfo | ../rewrite-peer-groups.awk | ../root-dir-mount-point-optional-fields-and-source.awk >actual.txt
+    tail -n 8 /proc/self/mountinfo | ../rewrite-peer-groups.awk | ../root-dir-mount-point-optional-fields-and-source.awk >actual.txt
     diff -u actual.txt expected.txt

--- a/osutil/vfs/tests/propagation-to-shared-slave/task.yaml
+++ b/osutil/vfs/tests/propagation-to-shared-slave/task.yaml
@@ -1,6 +1,6 @@
 summary: observe how propagation to shared slave mounts works
 details: |
-    A file shared system is bind-mounted from a to b and c. The b and c mounts
+    A shared file system is bind-mounted from a to b and c. The b and c mounts
     are then turned into slaves and shared again. A new mount is created at
     a/1. What are the propagation settings of the propagated copies to b/1 and
     c/1?

--- a/osutil/vfs/tests/propagation-to-shared-slave/task.yaml
+++ b/osutil/vfs/tests/propagation-to-shared-slave/task.yaml
@@ -26,5 +26,5 @@ restore: |
 debug: |
     tail -n 6 /proc/self/mountinfo
 execute: |
-    tail -n 6 /proc/self/mountinfo | ../rewrite-peer-groups.awk | ../mount-point-and-optional-fields.awk >actual.txt
+    tail -n 6 /proc/self/mountinfo | ../rewrite-peer-groups.awk | ../root-dir-mount-point-optional-fields-and-source.awk >actual.txt
     diff -u actual.txt expected.txt

--- a/osutil/vfs/tests/propagation-to-shared-subdirectory/expected.txt
+++ b/osutil/vfs/tests/propagation-to-shared-subdirectory/expected.txt
@@ -1,0 +1,5 @@
+/ /a shared:42 - tmpfs-a
+/1 /b shared:42 - tmpfs-a
+/ /a/1 shared:43 - tmpfs-a-1
+/ /b shared:43 - tmpfs-a-1
+/ /a/2 shared:44 - tmpfs-a-2

--- a/osutil/vfs/tests/propagation-to-shared-subdirectory/task.yaml
+++ b/osutil/vfs/tests/propagation-to-shared-subdirectory/task.yaml
@@ -1,0 +1,22 @@
+summary: observe how propagation traverses to peers that share a subset of a fs
+details: |
+    A shared file system is mounted on a, with two additional directories a/1 and a/2.
+    The b directory is a bind mount of a/1. A pair of file systems are then mounted on
+    a/1 and a/2. How are those events propagated to b?
+prepare: |
+    mkdir a b
+    mount -t tmpfs tmpfs-a a
+    mount --make-shared a
+    mkdir a/1 a/2
+    mount --bind a/1 b
+    mount -t tmpfs tmpfs-a-1 a/1
+    mount -t tmpfs tmpfs-a-2 a/2
+restore: |
+    umount -l a
+    umount -l b
+    rmdir a b
+debug: |
+    tail -n 5 /proc/self/mountinfo
+execute: |
+    tail -n 5 /proc/self/mountinfo | ../rewrite-peer-groups.awk | ../root-dir-mount-point-optional-fields-and-source.awk >actual.txt
+    diff -u actual.txt expected.txt

--- a/osutil/vfs/tests/root-dir-mount-point-optional-fields-and-source.awk
+++ b/osutil/vfs/tests/root-dir-mount-point-optional-fields-and-source.awk
@@ -1,0 +1,40 @@
+#!/usr/bin/awk -f
+# This awk program consumes proc_pid_mountinfo(5) and displays a portion of the
+# mount point and all the optional fields, up until the optional field
+# separator, dash. The common prefix of the mount point and the current working
+# directory is discarded.
+
+BEGIN {
+    prefix_len = length(ENVIRON["PWD"])
+}
+
+{
+    # We will be printing fields one by one so use space for output record
+    # separator and the empty string for output field separator. Each print
+    # is one record.
+    ORS = " "
+    OFS = ""
+    print $4
+    # If the mount point starts with the current working directory then discard
+    # the common prefix.  This makes test output more invariant to test
+    # location or relocation.
+    print substr($5, 1, prefix_len) == ENVIRON["PWD"] ? substr($5, prefix_len + 1) : $5
+
+    # Starting with field 7, which is the first optional field, print
+    # subsequent fields until we reach the end all fields or until we see the
+    # optional field list terminator, dash.
+    for (n=7; n<NF; n++) {
+        # Ensure that the dash is printed too.
+        print $(n)
+
+        if ($(n) == "-") {
+            break
+        }
+
+    }
+
+    # Print the mount source with just the trailing newline.
+    ORS = "\n"
+    OFS = ""
+    print $(n+2)
+}


### PR DESCRIPTION
The sub-directory test shows how having a peer group member that sees a subtree of a file system may cause it to not observe some events and translate attachment of all events it does see.

The shared-slave test extends behavior to show secondary propagation (from shared to slave which
is separately shared and to its peers).

A new helper script that shows somewhat more information is used in those two tests.