### PR TITLE
o/state: add methods to get notice id, key, and last data

### DIFF
--- a/overlord/state/notices_test.go
+++ b/overlord/state/notices_test.go
@@ -46,12 +46,15 @@ func (s *noticesSuite) TestNewNotice(c *C) {
 	notice := state.NewNotice(id, &userID, nType, key, timestamp, data, repeatAfter, expireAfter)
 
 	// Check the fields which are exported via methods for correctness
+	c.Check(notice.ID(), Equals, id)
 	c.Check(notice.String(), Equals, "Notice foo (123:bar:baz)")
 	uid, isSet := notice.UserID()
 	c.Check(uid, Equals, userID)
 	c.Check(isSet, Equals, true)
 	c.Check(notice.Type(), Equals, nType)
+	c.Check(notice.Key(), Equals, key)
 	c.Check(notice.LastRepeated(), Equals, timestamp)
+	c.Check(notice.LastData(), DeepEquals, data)
 	// TODO: expand method checks when more public methods are added
 	n := noticeToMap(c, notice)
 	c.Check(n["id"], Equals, id)

--- a/overlord/state/state.go
+++ b/overlord/state/state.go
@@ -506,7 +506,7 @@ func (s *State) Prune(startOfOperation time.Time, pruneWait, abortWait time.Dura
 	s.pruneWarnings(now)
 
 	for k, n := range s.notices {
-		if n.expired(now) {
+		if n.Expired(now) {
 			delete(s.notices, k)
 		}
 	}


### PR DESCRIPTION
This PR exposes some additional notice fields which are necessary for #15768

This will need to be backported to pebble along with the other notice state changes.