### PR TITLE
tests: disable the interfaces-posix-mq test on Ubuntu 20.04

### DIFF
--- a/tests/main/interfaces-posix-mq/task.yaml
+++ b/tests/main/interfaces-posix-mq/task.yaml
@@ -18,6 +18,7 @@ systems:
     # Affected by https://gitlab.com/apparmor/apparmor/-/issues/492
     - -ubuntu-16.04-64
     - -ubuntu-18.04-64
+    - -ubuntu-20.04-64
     - -ubuntu-core-18-*
     - -ubuntu-core-20-*
     - -debian-12-64


### PR DESCRIPTION
We were mislead to believe that the test works on the kernel present in Ubuntu 20.04 (focal) because up until recently the CI/CD stack used virtual machines allocated in GCE (Google Compute Engine). GCE kernels are somewhat more recent than their regular counterparts and happened to contain mqueue support that is present in later kernels.

It's probably something we should have noticed when we excluded Ubuntu Core 20 which had the same kernel as Ubuntu 20.04, but at the time the test just passed so why would we.

Interestingly the 5.4.0 kernel used on Ubuntu 20.04 doesn't even advertise the mqueue feature:

```
garden:ubuntu-20.04-64 .../tests/main/interfaces-posix-mq# uname -a
Linux ubuntu-20-04 5.4.0-216-generic #236-Ubuntu SMP Fri Apr 11 19:53:21 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux
garden:ubuntu-20.04-64 .../tests/main/interfaces-posix-mq# find /sys/kernel/security/apparmor/features -name posix_mqueue
```

In comparison the Jammy 22.04 kernel where this feature exists:

```
garden:ubuntu-22.04-64 .../tests/main/interfaces-posix-mq# uname -a
Linux ubuntu-22-04 5.15.0-140-generic #150-Ubuntu SMP Sat Apr 12 06:00:09 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux
garden:ubuntu-22.04-64 .../tests/main/interfaces-posix-mq# find /sys/kernel/security/apparmor/features -name posix_mqueue
/sys/kernel/security/apparmor/features/ipc/posix_mqueue
```

The test is somewhat less obviously broken because the snapd interface is implemented with both seccomp filters, that work all the way back, and with apparmor mqueue mediation class. The particular failure we saw was that of stat(2) which relies entirely on apparmor to mediate.

As such, mask the test on Focal.
