### PR TITLE
tests/lib/muinstaller: change 24.04 ubuntu base to .3

### DIFF
--- a/tests/lib/muinstaller/mk-classic-rootfs.sh
+++ b/tests/lib/muinstaller/mk-classic-rootfs.sh
@@ -110,7 +110,7 @@ else
             pointrel=.4
             ;;
         24.04)
-            pointrel=.2
+            pointrel=.3
             ;;
         *)
             pointrel=


### PR DESCRIPTION
http://cdimage.ubuntu.com/ubuntu-base/releases/24.04/release/ubuntu-base-24.04.2-base-amd64.tar.gz is not available anymore. Change to new .3 which is now available. This solves below  error as seen for e.g. tests/nested/manual/muinstaller-real.

```cannot create classic rootfs: 
stderr:
+ DST=/run/muinstaller-mnt/ubuntu-data
+ '[' '!' -d /run/muinstaller-mnt/ubuntu-data ']'
+ ROLE=
+ '[' -f /cdrom/casper/base.squashfs ']'
+ BASETAR=ubuntu-base.tar.gz
++ lsb_release -r -s
+ release=24.04
+ case "$release" in
+ pointrel=.2
+ wget -q -c http://cdimage.ubuntu.com/ubuntu-base/releases/24.04/release/ubuntu-base-24.04.2-base-amd64.tar.gz -O ubuntu-base.tar.gz
```