### PR TITLE
client, clientutil, cmd: Add Grade field to Client.Snap -SNAPDENG-34170

### DIFF
--- a/client/clientutil/snapinfo.go
+++ b/client/clientutil/snapinfo.go
@@ -72,6 +72,7 @@ func ClientSnapFromSnapInfo(snapInfo *snap.Info, decorator StatusDecorator) (*cl
 		Channel:     snapInfo.Channel,
 		Private:     snapInfo.Private,
 		Confinement: string(confinement),
+		Grade:       string(snapInfo.Grade),
 		Apps:        apps,
 		Broken:      snapInfo.Broken,
 		Title:       snapInfo.Title(),

--- a/client/clientutil/snapinfo_test.go
+++ b/client/clientutil/snapinfo_test.go
@@ -114,6 +114,7 @@ func (*cmdSuite) TestClientSnapFromSnapInfo(c *C) {
 		"TrackingChannel",
 		"IgnoreValidation",
 		"CohortKey",
+		"Grade",
 		"DevMode",
 		"TryMode",
 		"JailMode",

--- a/client/packages.go
+++ b/client/packages.go
@@ -55,6 +55,7 @@ type Snap struct {
 	IgnoreValidation bool          `json:"ignore-validation"`
 	Revision         snap.Revision `json:"revision"`
 	Confinement      string        `json:"confinement"`
+	Grade            string        `json:"grade"`
 	Private          bool          `json:"private"`
 	DevMode          bool          `json:"devmode"`
 	JailMode         bool          `json:"jailmode"`

--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -482,6 +482,10 @@ func (iw *infoWriter) maybePrintNotes() {
 	}
 	fmt.Fprintln(iw, "notes:\t")
 	fmt.Fprintf(iw, "  private:\t%t\n", iw.theSnap.Private)
+	if iw.theSnap.Grade != "" {
+		fmt.Fprintf(iw, "  grade:\t%s\n", iw.theSnap.Grade)
+	}
+
 	fmt.Fprintf(iw, "  confinement:\t%s\n", iw.theSnap.Confinement)
 	if iw.localSnap == nil {
 		return

--- a/cmd/snap/cmd_info_test.go
+++ b/cmd/snap/cmd_info_test.go
@@ -200,15 +200,17 @@ func (s *infoSuite) TestMaybePrintNotes(c *check.C) {
 	for i, t := range []T{
 		{
 			nil,
-			&client.Snap{Private: true, Confinement: "devmode"},
+			&client.Snap{Private: true, Confinement: "devmode", Grade: "devel"},
 			"notes:\t\n" +
 				"  private:\ttrue\n" +
+				"  grade:\tdevel\n" +
 				"  confinement:\tdevmode\n",
 		}, {
-			&client.Snap{Private: true, Confinement: "devmode"},
+			&client.Snap{Private: true, Confinement: "devmode", Grade: "stable"},
 			nil,
 			"notes:\t\n" +
 				"  private:\ttrue\n" +
+				"  grade:\tstable\n" +
 				"  confinement:\tdevmode\n" +
 				"  devmode:\tfalse\n" +
 				"  jailmode:\ttrue\n" +
@@ -217,7 +219,7 @@ func (s *infoSuite) TestMaybePrintNotes(c *check.C) {
 				"  broken:\tfalse\n" +
 				"  ignore-validation:\tfalse\n",
 		}, {
-			&client.Snap{Private: true, Confinement: "devmode", Broken: "ouch"},
+			&client.Snap{Private: true, Confinement: "devmode", Grade: "", Broken: "ouch"},
 			nil,
 			"notes:\t\n" +
 				"  private:\ttrue\n" +

--- a/snap/types.go
+++ b/snap/types.go
@@ -140,7 +140,7 @@ func (confinementType *ConfinementType) fromString(str string) error {
 	return nil
 }
 
-// GradeType represents the grade of the snap
+// GradeType represents the grade of the snap.
 type GradeType string
 
 const (
@@ -149,11 +149,12 @@ const (
 	EmptyGrade  GradeType = ""
 )
 
-// UnmarshalText sets *gradeType to a copy of data, assuming validation passes
+// UnmarshalText sets *gradeType to a copy of data, after ensuring value is valid.
 func (gt *GradeType) UnmarshalText(data []byte) error {
 	g := GradeType(string(data))
 
-	// Validate grade field
+	// Validate the grade field, if it doesn't match a supported grade constant,
+	// return an error informing the user what value caused the validation to fail.
 	switch g {
 	case EmptyGrade, DevelGrade, StableGrade:
 		*gt = g

--- a/tests/lib/snaps/basic/meta/snap.yaml
+++ b/tests/lib/snaps/basic/meta/snap.yaml
@@ -2,3 +2,4 @@ name: basic
 version: 1.0
 summary: Basic snap
 description: A basic buildable snap
+grade: devel

--- a/tests/main/snap-info/task.yaml
+++ b/tests/main/snap-info/task.yaml
@@ -42,6 +42,18 @@ execute: |
     "$TESTSTOOLS"/snaps-state install-local basic-desktop
     snap info basic-desktop|MATCH "license:[ ]+GPL-3.0"
 
+    # Ensure the basic snap has a grade of stable - Local snap file.
+    snap info --verbose basic_1.0_all.snap|MATCH "grade:\s*devel"
+
+    # Use locally installed snap
+    snap info --verbose snapd|MATCH "grade:\s*stable"
+
+    # Ensure the basic snap has no grade when not using --verbose - Local snap file.
+    snap info basic_1.0_all.snap|NOMATCH "grade:"
+
+    # This should not have a grade assigned. This snap doesn't have a grade in its snap.yaml
+    snap info --verbose test-snapd-tools|NOMATCH "grade:"
+
     snap info --verbose basic_1.0_all.snap|MATCH "sha3-384:"
     snap info --verbose test-snapd-tools|MATCH "  ignore-validation:"
 


### PR DESCRIPTION
- Client: Added Grade field to Snap struct, and modified clientutil  to properly convert from a Snap.Info to a client.Snap, modified tests accordingly.
- Cmd: Added code to print grade when printing snap info with --verbose flag, modified tests to check output of Snaps with "stable", "devel", and "", the three supported grades.