### PR TITLE
o/notices: optionally drain notices on backend registration

### DIFF
--- a/overlord/state/notices_test.go
+++ b/overlord/state/notices_test.go
@@ -46,12 +46,15 @@ func (s *noticesSuite) TestNewNotice(c *C) {
 	notice := state.NewNotice(id, &userID, nType, key, timestamp, data, repeatAfter, expireAfter)
 
 	// Check the fields which are exported via methods for correctness
+	c.Check(notice.ID(), Equals, id)
 	c.Check(notice.String(), Equals, "Notice foo (123:bar:baz)")
 	uid, isSet := notice.UserID()
 	c.Check(uid, Equals, userID)
 	c.Check(isSet, Equals, true)
 	c.Check(notice.Type(), Equals, nType)
+	c.Check(notice.Key(), Equals, key)
 	c.Check(notice.LastRepeated(), Equals, timestamp)
+	c.Check(notice.LastData(), DeepEquals, data)
 	// TODO: expand method checks when more public methods are added
 	n := noticeToMap(c, notice)
 	c.Check(n["id"], Equals, id)

--- a/overlord/state/state.go
+++ b/overlord/state/state.go
@@ -506,7 +506,7 @@ func (s *State) Prune(startOfOperation time.Time, pruneWait, abortWait time.Dura
 	s.pruneWarnings(now)
 
 	for k, n := range s.notices {
-		if n.expired(now) {
+		if n.Expired(now) {
 			delete(s.notices, k)
 		}
 	}


### PR DESCRIPTION
This PR is an alternative to #15787 which moves the call to `DrainNotices` into `RegisterBackend`. This PR is based on #15786 and will be a prerequisite for #15768 once the latter is rebased/reworked.
    
When a new notice backend is registered, the intention may be for it to be the sole provider of notices of a given type, and state should no longer produce or manage those notices. As such, notices of that type should be drained from state and re-added into that backend instead.
    
Add a new boolean parameter to `RegisterBackend` which, if true, will drain all notices of the type newly registered to the backend, and return them. The intention is that the caller will then migrate these existing notices into that backend.