### PR TITLE
Store the common ID in the desktop file

### DIFF
--- a/desktop/desktopentry/desktopentry.go
+++ b/desktop/desktopentry/desktopentry.go
@@ -41,6 +41,7 @@ type DesktopEntry struct {
 
 	SnapInstanceName string
 	SnapAppName      string
+	SnapCommonID     string
 
 	Hidden                bool
 	OnlyShowIn            []string
@@ -164,6 +165,8 @@ func parse(filename string, r io.Reader) (*DesktopEntry, error) {
 				de.SnapInstanceName = value
 			case "X-SnapAppName":
 				de.SnapAppName = value
+			case "X-SnapCommonID":
+				de.SnapCommonID = value
 			default:
 				// Ignore all other keys
 			}

--- a/wrappers/desktop.go
+++ b/wrappers/desktop.go
@@ -106,7 +106,7 @@ var isValidDesktopFileLine = regexp.MustCompile(strings.Join([]string{
 
 // detectAppAndRewriteExecLine parses snap app name from passed "Exec=" line and rewrites it
 // to use the wrapper path for snap application.
-func detectAppAndRewriteExecLine(s *snap.Info, desktopFile, line string) (appName string, execLine string, err error) {
+func detectAppAndRewriteExecLine(s *snap.Info, desktopFile, line string) (appInfo *snap.AppInfo, execLine string, err error) {
 	env := fmt.Sprintf("env BAMF_DESKTOP_FILE_HINT=%s ", desktopFile)
 
 	cmd := strings.SplitN(line, "=", 2)[1]
@@ -123,9 +123,9 @@ func detectAppAndRewriteExecLine(s *snap.Info, desktopFile, line string) (appNam
 		// this is ok because desktop files are not run through sh
 		// so we don't have to worry about the arguments too much
 		if cmd == validCmd {
-			return app.Name, "Exec=" + env + wrapper, nil
+			return app, "Exec=" + env + wrapper, nil
 		} else if strings.HasPrefix(cmd, validCmd+" ") {
-			return app.Name, fmt.Sprintf("Exec=%s%s%s", env, wrapper, line[len("Exec=")+len(validCmd):]), nil
+			return app, fmt.Sprintf("Exec=%s%s%s", env, wrapper, line[len("Exec=")+len(validCmd):]), nil
 		}
 	}
 
@@ -139,10 +139,10 @@ func detectAppAndRewriteExecLine(s *snap.Info, desktopFile, line string) (appNam
 	if ok {
 		newExec := fmt.Sprintf("Exec=%s%s", env, app.WrapperPath())
 		logger.Noticef("rewriting desktop file %q to %q", desktopFile, newExec)
-		return app.Name, newExec, nil
+		return app, newExec, nil
 	}
 
-	return "", "", fmt.Errorf("invalid exec command: %q", cmd)
+	return nil, "", fmt.Errorf("invalid exec command: %q", cmd)
 }
 
 func rewriteIconLine(s *snap.Info, line string) (string, error) {
@@ -190,13 +190,18 @@ func sanitizeDesktopFile(s *snap.Info, desktopFile string, rawcontent []byte) []
 		// rewrite exec lines to an absolute path for the binary
 		if bytes.HasPrefix(bline, []byte("Exec=")) {
 			var err error
-			appName, line, err := detectAppAndRewriteExecLine(s, desktopFile, string(bline))
+			appInfo, line, err := detectAppAndRewriteExecLine(s, desktopFile, string(bline))
 			if err != nil {
 				// something went wrong, ignore the line
 				continue
 			}
 			// Add metadata entry to associate the exec line with a snap app
-			newContent.Write([]byte("X-SnapAppName=" + appName + "\n"))
+			newContent.Write([]byte("X-SnapAppName=" + appInfo.Name + "\n"))
+
+			if appInfo.CommonID != "" {
+				// Add metadata entry to associate the application with a common ID.
+				newContent.Write([]byte("X-SnapCommonID=" + appInfo.CommonID + "\n"))
+			}
 
 			bline = []byte(line)
 		}

--- a/wrappers/desktop_test.go
+++ b/wrappers/desktop_test.go
@@ -549,6 +549,32 @@ Exec=env BAMF_DESKTOP_FILE_HINT=app.desktop %s/bin/snap.app
 `, dirs.SnapMountDir))
 }
 
+func (s *sanitizeDesktopFileSuite) TestSanitizeFiltersExecRewriteFromDesktopWithCommonID(c *C) {
+	snap, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+version: 1.0
+apps:
+ app:
+  command: cmd
+  common-id: io.snapcraft.app
+`))
+	c.Assert(err, IsNil)
+	desktopContent := []byte(`[Desktop Entry]
+X-SnapInstanceName=snap
+Name=foo
+Exec=snap.app.evil.evil
+`)
+
+	e := wrappers.SanitizeDesktopFile(snap, "app.desktop", desktopContent)
+	c.Assert(string(e), Equals, fmt.Sprintf(`[Desktop Entry]
+X-SnapInstanceName=snap
+Name=foo
+X-SnapAppName=app
+X-SnapCommonID=io.snapcraft.app
+Exec=env BAMF_DESKTOP_FILE_HINT=app.desktop %s/bin/snap.app
+`, dirs.SnapMountDir))
+}
+
 func (s *sanitizeDesktopFileSuite) TestSanitizeFiltersExecOk(c *C) {
 	snap, err := snap.InfoFromSnapYaml([]byte(`
 name: snap
@@ -713,9 +739,27 @@ apps:
 `))
 	c.Assert(err, IsNil)
 
-	appName, newl, err := wrappers.DetectAppAndRewriteExecLine(snap, "foo.desktop", "Exec=snap.app")
+	app, newl, err := wrappers.DetectAppAndRewriteExecLine(snap, "foo.desktop", "Exec=snap.app")
 	c.Assert(err, IsNil)
-	c.Assert(appName, Equals, "app")
+	c.Assert(app.Name, Equals, "app")
+	c.Assert(newl, Equals, fmt.Sprintf("Exec=env BAMF_DESKTOP_FILE_HINT=foo.desktop %s/bin/snap.app", dirs.SnapMountDir))
+}
+
+func (s *sanitizeDesktopFileSuite) TestDetectAppAndRewriteExecLineOkWithCommonID(c *C) {
+	snap, err := snap.InfoFromSnapYaml([]byte(`
+name: snap
+version: 1.0
+apps:
+ app:
+  command: cmd
+  common-id: io.snapcraft.app
+`))
+	c.Assert(err, IsNil)
+
+	app, newl, err := wrappers.DetectAppAndRewriteExecLine(snap, "foo.desktop", "Exec=snap.app")
+	c.Assert(err, IsNil)
+	c.Assert(app.Name, Equals, "app")
+	c.Assert(app.CommonID, Equals, "io.snapcraft.app")
 	c.Assert(newl, Equals, fmt.Sprintf("Exec=env BAMF_DESKTOP_FILE_HINT=foo.desktop %s/bin/snap.app", dirs.SnapMountDir))
 }
 


### PR DESCRIPTION
The value can be used by both portals and shell applications to do some
matching between the applications and their DBus service.