### PR TITLE
snap: Drop legacy BAMF_DESKTOP_FILE_HINT in desktop files

### DIFF
--- a/desktop/desktopentry/desktopentry_test.go
+++ b/desktop/desktopentry/desktopentry_test.go
@@ -461,7 +461,7 @@ Comment[vi]=Truy cập Internet
 Comment[zh_CN]=访问互联网
 Comment[zh_HK]=連線到網際網路
 Comment[zh_TW]=連線到網際網路
-Exec=env BAMF_DESKTOP_FILE_HINT=/var/lib/snapd/desktop/applications/chromium_chromium.desktop /snap/bin/chromium %U
+Exec=/snap/bin/chromium %U
 Terminal=false
 Type=Application
 Icon=/snap/chromium/1193/chromium.png
@@ -509,7 +509,7 @@ Name[uk]=Відкрити нове вікно
 Name[vi]=Mở cửa sổ mới
 Name[zh_CN]=打开新窗口
 Name[zh_TW]=開啟新視窗
-Exec=env BAMF_DESKTOP_FILE_HINT=/var/lib/snapd/desktop/applications/chromium_chromium.desktop /snap/bin/chromium
+Exec=/snap/bin/chromium
 
 [Desktop Action Incognito]
 Name=Open a New Window in incognito mode
@@ -547,7 +547,7 @@ Name[uk]=Відкрити нове вікно у приватному режим
 Name[vi]=Mở cửa sổ mới trong chế độ ẩn danh
 Name[zh_CN]=以隐身模式打开新窗口
 Name[zh_TW]=以匿名模式開啟新視窗
-Exec=env BAMF_DESKTOP_FILE_HINT=/var/lib/snapd/desktop/applications/chromium_chromium.desktop /snap/bin/chromium --incognito
+Exec=/snap/bin/chromium --incognito
 
 [Desktop Action TempProfile]
 Name=Open a New Window with a temporary profile
@@ -585,7 +585,7 @@ Name[ug]=ۋاقىتلىق سەپلىمە ھۆججەت بىلەن يېڭى كۆز
 Name[vi]=Mở cửa sổ mới với hồ sơ tạm
 Name[zh_CN]=以临时配置文件打开新窗口
 Name[zh_TW]=以暫時性個人身分開啟新視窗
-Exec=env BAMF_DESKTOP_FILE_HINT=/var/lib/snapd/desktop/applications/chromium_chromium.desktop /snap/bin/chromium --temp-profile
+Exec=/snap/bin/chromium --temp-profile
 `
 
 func (s *desktopentrySuite) TestParseChromiumDesktopEntry(c *C) {
@@ -595,29 +595,29 @@ func (s *desktopentrySuite) TestParseChromiumDesktopEntry(c *C) {
 
 	c.Check(de.Name, Equals, "Chromium Web Browser")
 	c.Check(de.Icon, Equals, "/snap/chromium/1193/chromium.png")
-	c.Check(de.Exec, Equals, "env BAMF_DESKTOP_FILE_HINT=/var/lib/snapd/desktop/applications/chromium_chromium.desktop /snap/bin/chromium %U")
+	c.Check(de.Exec, Equals, "/snap/bin/chromium %U")
 	c.Check(de.Actions, HasLen, 3)
 
 	c.Assert(de.Actions["NewWindow"], NotNil)
 	c.Check(de.Actions["NewWindow"].Name, Equals, "Open a New Window")
 	c.Check(de.Actions["NewWindow"].Icon, Equals, "")
-	c.Check(de.Actions["NewWindow"].Exec, Equals, "env BAMF_DESKTOP_FILE_HINT=/var/lib/snapd/desktop/applications/chromium_chromium.desktop /snap/bin/chromium")
+	c.Check(de.Actions["NewWindow"].Exec, Equals, "/snap/bin/chromium")
 
 	c.Assert(de.Actions["Incognito"], NotNil)
 	c.Check(de.Actions["Incognito"].Name, Equals, "Open a New Window in incognito mode")
 	c.Check(de.Actions["Incognito"].Icon, Equals, "")
-	c.Check(de.Actions["Incognito"].Exec, Equals, "env BAMF_DESKTOP_FILE_HINT=/var/lib/snapd/desktop/applications/chromium_chromium.desktop /snap/bin/chromium --incognito")
+	c.Check(de.Actions["Incognito"].Exec, Equals, "/snap/bin/chromium --incognito")
 
 	c.Assert(de.Actions["TempProfile"], NotNil)
 	c.Check(de.Actions["TempProfile"].Name, Equals, "Open a New Window with a temporary profile")
 	c.Check(de.Actions["TempProfile"].Icon, Equals, "")
-	c.Check(de.Actions["TempProfile"].Exec, Equals, "env BAMF_DESKTOP_FILE_HINT=/var/lib/snapd/desktop/applications/chromium_chromium.desktop /snap/bin/chromium --temp-profile")
+	c.Check(de.Actions["TempProfile"].Exec, Equals, "/snap/bin/chromium --temp-profile")
 
 	args, err := de.ExpandExec([]string{"http://example.org"})
 	c.Assert(err, IsNil)
-	c.Check(args, DeepEquals, []string{"env", "BAMF_DESKTOP_FILE_HINT=/var/lib/snapd/desktop/applications/chromium_chromium.desktop", "/snap/bin/chromium", "http://example.org"})
+	c.Check(args, DeepEquals, []string{"/snap/bin/chromium", "http://example.org"})
 
 	args, err = de.ExpandActionExec("Incognito", nil)
 	c.Assert(err, IsNil)
-	c.Check(args, DeepEquals, []string{"env", "BAMF_DESKTOP_FILE_HINT=/var/lib/snapd/desktop/applications/chromium_chromium.desktop", "/snap/bin/chromium", "--incognito"})
+	c.Check(args, DeepEquals, []string{"/snap/bin/chromium", "--incognito"})
 }

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -9871,8 +9871,8 @@ X-SnapInstanceName=test-snap`)
 X-SnapInstanceName=test-snap
 Name=test
 X-SnapAppName=test-snap
-Exec=env BAMF_DESKTOP_FILE_HINT=%s/test-snap_test-snap.desktop %s/test-snap
-`[1:], dirs.SnapDesktopFilesDir, dirs.SnapBinariesDir)
+Exec=%s/test-snap
+`[1:], dirs.SnapBinariesDir)
 
 	c.Assert(desktopFile, testutil.FileEquals, expectedContent)
 	c.Assert(otherDesktopFile, testutil.FileAbsent)

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -1387,7 +1387,7 @@ plugs:
 X-SnapInstanceName=%s
 Name=foo
 X-SnapAppName=%s
-Exec=env BAMF_DESKTOP_FILE_HINT=foo.desktop %s
+Exec=%s
 `
 		content := fmt.Sprintf(mockDesktopFileTemplate, snapInfo.InstanceName(), app.Name, app.WrapperPath())
 		c.Assert(os.WriteFile(path, []byte(content), 0644), IsNil)

--- a/tests/main/install-sideload/task.yaml
+++ b/tests/main/install-sideload/task.yaml
@@ -55,7 +55,7 @@ execute: |
     	Name=Echo
     	Comment=It echos stuff
     	X-SnapAppName=echo
-    	Exec=env BAMF_DESKTOP_FILE_HINT=/var/lib/snapd/desktop/applications/basic-desktop_echo.desktop $SNAP_MOUNT_DIR/bin/basic-desktop.echo
+    	Exec=$SNAP_MOUNT_DIR/bin/basic-desktop.echo
     EOF
 
     echo "Sideload devmode snap fails without flags"

--- a/tests/main/parallel-install-desktop/task.yaml
+++ b/tests/main/parallel-install-desktop/task.yaml
@@ -38,7 +38,7 @@ execute: |
     Name=Echo
     Comment=It echos stuff
     X-SnapAppName=echo
-    Exec=env BAMF_DESKTOP_FILE_HINT=/var/lib/snapd/desktop/applications/basic-desktop+${instance}_echo.desktop $SNAP_MOUNT_DIR/bin/basic-desktop_$instance.echo
+    Exec=$SNAP_MOUNT_DIR/bin/basic-desktop_$instance.echo
     EOF
 
         test -d "$SNAP_MOUNT_DIR/basic-desktop_$instance/x1"

--- a/usersession/userd/privileged_desktop_launcher_test.go
+++ b/usersession/userd/privileged_desktop_launcher_test.go
@@ -52,7 +52,7 @@ func (s *privilegedDesktopLauncherSuite) SetUpTest(c *C) {
 	var rawMircadeDesktop = `[Desktop Entry]
   X-SnapInstanceName=mircade
   Name=mircade
-  Exec=env BAMF_DESKTOP_FILE_HINT=/var/lib/snapd/desktop/applications/mircade_mircade.desktop /snap/bin/mircade
+  Exec=/snap/bin/mircade
   Icon=/snap/mircade/143/meta/gui/mircade.png
   Comment=Sample confined desktop
   Type=Application

--- a/wrappers/desktop.go
+++ b/wrappers/desktop.go
@@ -107,8 +107,6 @@ var isValidDesktopFileLine = regexp.MustCompile(strings.Join([]string{
 // detectAppAndRewriteExecLine parses snap app name from passed "Exec=" line and rewrites it
 // to use the wrapper path for snap application.
 func detectAppAndRewriteExecLine(s *snap.Info, desktopFile, line string) (appName string, execLine string, err error) {
-	env := fmt.Sprintf("env BAMF_DESKTOP_FILE_HINT=%s ", desktopFile)
-
 	cmd := strings.SplitN(line, "=", 2)[1]
 	for _, app := range s.Apps {
 		wrapper := app.WrapperPath()
@@ -123,9 +121,9 @@ func detectAppAndRewriteExecLine(s *snap.Info, desktopFile, line string) (appNam
 		// this is ok because desktop files are not run through sh
 		// so we don't have to worry about the arguments too much
 		if cmd == validCmd {
-			return app.Name, "Exec=" + env + wrapper, nil
+			return app.Name, "Exec=" + wrapper, nil
 		} else if strings.HasPrefix(cmd, validCmd+" ") {
-			return app.Name, fmt.Sprintf("Exec=%s%s%s", env, wrapper, line[len("Exec=")+len(validCmd):]), nil
+			return app.Name, fmt.Sprintf("Exec=%s%s", wrapper, line[len("Exec=")+len(validCmd):]), nil
 		}
 	}
 
@@ -137,7 +135,7 @@ func detectAppAndRewriteExecLine(s *snap.Info, desktopFile, line string) (appNam
 	desktopFileApp := strings.TrimSuffix(df, filepath.Ext(df))
 	app, ok := s.Apps[desktopFileApp]
 	if ok {
-		newExec := fmt.Sprintf("Exec=%s%s", env, app.WrapperPath())
+		newExec := fmt.Sprintf("Exec=%s", app.WrapperPath())
 		logger.Noticef("rewriting desktop file %q to %q", desktopFile, newExec)
 		return app.Name, newExec, nil
 	}

--- a/wrappers/desktop_test.go
+++ b/wrappers/desktop_test.go
@@ -545,7 +545,7 @@ Exec=snap.app.evil.evil
 X-SnapInstanceName=snap
 Name=foo
 X-SnapAppName=app
-Exec=env BAMF_DESKTOP_FILE_HINT=app.desktop %s/bin/snap.app
+Exec=%s/bin/snap.app
 `, dirs.SnapMountDir))
 }
 
@@ -568,7 +568,7 @@ Exec=snap.app %U
 X-SnapInstanceName=snap
 Name=foo
 X-SnapAppName=app
-Exec=env BAMF_DESKTOP_FILE_HINT=foo.desktop %s/bin/snap.app %%U
+Exec=%s/bin/snap.app %%U
 `, dirs.SnapMountDir))
 }
 
@@ -668,7 +668,7 @@ Exec=snap.app
 X-SnapInstanceName=snap_bar
 Name=foo
 X-SnapAppName=app
-Exec=env BAMF_DESKTOP_FILE_HINT=snap+bar_app.desktop %s/bin/snap_bar.app
+Exec=%s/bin/snap_bar.app
 `, dirs.SnapMountDir))
 }
 
@@ -693,7 +693,7 @@ Exec=snap.app %U
 X-SnapInstanceName=snap_bar
 Name=foo
 X-SnapAppName=app
-Exec=env BAMF_DESKTOP_FILE_HINT=snap+bar_app.desktop %s/bin/snap_bar.app %%U
+Exec=%s/bin/snap_bar.app %%U
 `, dirs.SnapMountDir))
 }
 
@@ -716,7 +716,7 @@ apps:
 	appName, newl, err := wrappers.DetectAppAndRewriteExecLine(snap, "foo.desktop", "Exec=snap.app")
 	c.Assert(err, IsNil)
 	c.Assert(appName, Equals, "app")
-	c.Assert(newl, Equals, fmt.Sprintf("Exec=env BAMF_DESKTOP_FILE_HINT=foo.desktop %s/bin/snap.app", dirs.SnapMountDir))
+	c.Assert(newl, Equals, fmt.Sprintf("Exec=%s/bin/snap.app", dirs.SnapMountDir))
 }
 
 func (s *sanitizeDesktopFileSuite) TestLangLang(c *C) {
@@ -806,7 +806,7 @@ X-SnapInstanceName=snap_bar
 Name=foo
 Icon=snap.snap_bar.icon
 X-SnapAppName=app
-Exec=env BAMF_DESKTOP_FILE_HINT=snap+bar_app.desktop %s/bin/snap_bar.app
+Exec=%s/bin/snap_bar.app
 `, dirs.SnapMountDir))
 }
 


### PR DESCRIPTION
This is something that was only supported by Unity desktop and it was not particularly well designed either (as sandboxed apps might have been not properly matched), so after many years I think it's safe to drop it given that unity is not anymore used in any major distros for many years

At the same time for those that may be affected, I've updated BAMF to do some better matching in the snap case [1].

So we may consider to SRU it if many people will be affected, but I feel dropping this obsolete (and not clean) code is safe nowadays.

[1] https://git.launchpad.net/bamf/commit/?id=9183645dc5