### PR TITLE
osutil/vfs/tests: expand bind-semantics test for better clarity and visibilty

### DIFF
--- a/osutil/vfs/tests/bind-semantics/task.yaml
+++ b/osutil/vfs/tests/bind-semantics/task.yaml
@@ -24,36 +24,36 @@ environment:
     # Source and destination are both shared.
     ALTER_A/shared_to_shared: --make-shared
     ALTER_B/shared_to_shared: --make-shared
-    EXPECTED_A/shared_to_shared: "/a shared:42 -"
-    EXPECTED_B/shared_to_shared: "/b shared:42 -"
+    EXPECTED_A/shared_to_shared: "/ /a shared:42 - tmpfs-a"
+    EXPECTED_B/shared_to_shared: "/ /b shared:42 - tmpfs-a"
     # Source is shared, destination is private.
     ALTER_A/shared_to_private: --make-shared
     ALTER_B/shared_to_private: --make-private
-    EXPECTED_A/shared_to_private: "/a shared:42 -"
-    EXPECTED_B/shared_to_private: "/b shared:42 -"
+    EXPECTED_A/shared_to_private: "/ /a shared:42 - tmpfs-a"
+    EXPECTED_B/shared_to_private: "/ /b shared:42 - tmpfs-a"
     # Source is private, destination is shared.
     ALTER_A/private_to_shared: --make-private
     ALTER_B/private_to_shared: --make-shared
-    EXPECTED_A/private_to_shared: "/a -"
+    EXPECTED_A/private_to_shared: "/ /a - tmpfs-a"
     # NOTE: shared:42 is the /b mount that is created by mount --make-shared b.
     # Here we are seeing that /b is another shared mount but the underlying
     # filesystem is tmpfs-a.
-    EXPECTED_B/private_to_shared: "/b shared:43 -"
+    EXPECTED_B/private_to_shared: "/ /b shared:43 - tmpfs-a"
     # Source and destination are both private.
     ALTER_A/private_to_private: --make-private
     ALTER_B/private_to_private: --make-private
-    EXPECTED_A/private_to_private: "/a -"
-    EXPECTED_B/private_to_private: "/b -"
+    EXPECTED_A/private_to_private: "/ /a - tmpfs-a"
+    EXPECTED_B/private_to_private: "/ /b - tmpfs-a"
     # Source is a slave, destination is shared.
     ALTER_A/slave_to_shared: --make-slave
     ALTER_B/slave_to_shared: --make-shared
-    EXPECTED_A/slave_to_shared: "/a master:42 -"
-    EXPECTED_B/slave_to_shared: "/b shared:44 master:42 -"
+    EXPECTED_A/slave_to_shared: "/ /a master:42 - tmpfs-a"
+    EXPECTED_B/slave_to_shared: "/ /b shared:44 master:42 - tmpfs-a"
     # Source is a slave, destination is private.
     ALTER_A/slave_to_private: --make-slave
     ALTER_B/slave_to_private: --make-private
-    EXPECTED_A/slave_to_private: "/a master:42 -"
-    EXPECTED_B/slave_to_private: "/b master:42 -"
+    EXPECTED_A/slave_to_private: "/ /a master:42 - tmpfs-a"
+    EXPECTED_B/slave_to_private: "/ /b master:42 - tmpfs-a"
 prepare: |
     mkdir a
     mount -t tmpfs tmpfs-a a
@@ -81,6 +81,6 @@ restore: |
 debug: |
     cat /proc/self/mountinfo
 execute: |
-    grep -F "$SPREAD_TASK" /proc/self/mountinfo | ../rewrite-peer-groups.awk | ../mount-point-and-optional-fields.awk | grep -v a-helper >actual.txt
+    grep -F "$SPREAD_TASK" /proc/self/mountinfo | ../rewrite-peer-groups.awk | ../root-dir-mount-point-optional-fields-and-source.awk | grep -v a-helper >actual.txt
     test "$(head -n 1 actual.txt)" = "$EXPECTED_A"
     test "$(tail -n 1 actual.txt)" = "$EXPECTED_B"

--- a/osutil/vfs/tests/bind-semantics/task.yaml
+++ b/osutil/vfs/tests/bind-semantics/task.yaml
@@ -24,63 +24,76 @@ environment:
     # Source and destination are both shared.
     ALTER_A/shared_to_shared: --make-shared
     ALTER_B/shared_to_shared: --make-shared
-    EXPECTED_A/shared_to_shared: "/ /a shared:42 - tmpfs-a"
-    EXPECTED_B/shared_to_shared: "/ /b shared:42 - tmpfs-a"
+    EXPECTED_A/shared_to_shared: "/ /A shared:42 - tmpfs-A"
+    EXPECTED_B/shared_to_shared: "/ /B shared:43 - tmpfs-B"
+    EXPECTED_BIND/shared_to_shared: "/a /B/b shared:42 - tmpfs-A"
     # Source is shared, destination is private.
     ALTER_A/shared_to_private: --make-shared
     ALTER_B/shared_to_private: --make-private
-    EXPECTED_A/shared_to_private: "/ /a shared:42 - tmpfs-a"
-    EXPECTED_B/shared_to_private: "/ /b shared:42 - tmpfs-a"
+    EXPECTED_A/shared_to_private: "/ /A shared:42 - tmpfs-A"
+    EXPECTED_B/shared_to_private: "/ /B - tmpfs-B"
+    EXPECTED_BIND/shared_to_private: "/a /B/b shared:42 - tmpfs-A"
     # Source is private, destination is shared.
+    # NOTE: shared:42 is the /B mount that is created by mount --make-shared B.
+    # Here we are seeing that B/b is another shared mount but the underlying
+    # filesystem is tmpfs-A.
     ALTER_A/private_to_shared: --make-private
     ALTER_B/private_to_shared: --make-shared
-    EXPECTED_A/private_to_shared: "/ /a - tmpfs-a"
-    # NOTE: shared:42 is the /b mount that is created by mount --make-shared b.
-    # Here we are seeing that /b is another shared mount but the underlying
-    # filesystem is tmpfs-a.
-    EXPECTED_B/private_to_shared: "/ /b shared:43 - tmpfs-a"
+    EXPECTED_A/private_to_shared: "/ /A - tmpfs-A"
+    EXPECTED_B/private_to_shared: "/ /B shared:42 - tmpfs-B"
+    EXPECTED_BIND/private_to_shared: "/a /B/b shared:43 - tmpfs-A"
     # Source and destination are both private.
     ALTER_A/private_to_private: --make-private
     ALTER_B/private_to_private: --make-private
-    EXPECTED_A/private_to_private: "/ /a - tmpfs-a"
-    EXPECTED_B/private_to_private: "/ /b - tmpfs-a"
+    EXPECTED_A/private_to_private: "/ /A - tmpfs-A"
+    EXPECTED_B/private_to_private: "/ /B - tmpfs-B"
+    EXPECTED_BIND/private_to_private: "/a /B/b - tmpfs-A"
     # Source is a slave, destination is shared.
     ALTER_A/slave_to_shared: --make-slave
     ALTER_B/slave_to_shared: --make-shared
-    EXPECTED_A/slave_to_shared: "/ /a master:42 - tmpfs-a"
-    EXPECTED_B/slave_to_shared: "/ /b shared:44 master:42 - tmpfs-a"
+    EXPECTED_A/slave_to_shared: "/ /A master:42 - tmpfs-A"
+    EXPECTED_B/slave_to_shared: "/ /B shared:43 - tmpfs-B"
+    EXPECTED_BIND/slave_to_shared: "/a /B/b shared:44 master:42 - tmpfs-A"
     # Source is a slave, destination is private.
     ALTER_A/slave_to_private: --make-slave
     ALTER_B/slave_to_private: --make-private
-    EXPECTED_A/slave_to_private: "/ /a master:42 - tmpfs-a"
-    EXPECTED_B/slave_to_private: "/ /b master:42 - tmpfs-a"
+    EXPECTED_A/slave_to_private: "/ /A master:42 - tmpfs-A"
+    EXPECTED_B/slave_to_private: "/ /B - tmpfs-B"
+    EXPECTED_BIND/slave_to_private: "/a /B/b master:42 - tmpfs-A"
 prepare: |
-    mkdir a
-    mount -t tmpfs tmpfs-a a
+    mkdir A
+    mount -t tmpfs tmpfs-A A
+
     # If A needs to be slave then we need some help to allow it to be a slave.
     if [ "$ALTER_A" = --make-slave ]; then
-      mount --make-shared a
-      mkdir a-helper
-      mount --bind a a-helper
+      mount --make-shared A
+      mkdir A-helper
+      mount --bind A A-helper
     fi
-    mount "$ALTER_A" a
-    mkdir b
-    mount -t tmpfs tmpfs-b b
-    mount "$ALTER_B" b
-    mount --bind a b
+    mount "$ALTER_A" A
+
+    mkdir B
+    mount -t tmpfs tmpfs-B B
+    mount "$ALTER_B" B
+    mkdir A/a B/b
+    mount --bind A/a B/b
 restore: |
-    umount -l a
-    rmdir a
-    umount -l b
-    umount -l b || true
-    rmdir b
-    if [ -d a-helper ]; then
-      umount -l a-helper
-      rmdir a-helper
+    umount -l A
+    rmdir A
+    umount -l B/b
+    umount -l B
+    rmdir B
+    if [ -d A-helper ]; then
+      umount -l A-helper
+      rmdir A-helper
     fi
 debug: |
     cat /proc/self/mountinfo
 execute: |
-    grep -F "$SPREAD_TASK" /proc/self/mountinfo | ../rewrite-peer-groups.awk | ../root-dir-mount-point-optional-fields-and-source.awk | grep -v a-helper >actual.txt
-    test "$(head -n 1 actual.txt)" = "$EXPECTED_A"
-    test "$(tail -n 1 actual.txt)" = "$EXPECTED_B"
+    grep -F "$SPREAD_TASK" /proc/self/mountinfo | ../rewrite-peer-groups.awk | ../root-dir-mount-point-optional-fields-and-source.awk | grep -v A-helper >actual.txt
+    echo "Expected A mount is..."
+    test "$(tail -n 3 actual.txt | head -n 1)" = "${EXPECTED_A-}"
+    echo "Expected B mount is..."
+    test "$(tail -n 2 actual.txt | head -n 1)" = "${EXPECTED_B-}"
+    echo "Expected A/a -> B/b bind-mount is..."
+    test "$(tail -n 1 actual.txt)" = "${EXPECTED_BIND-}"

--- a/osutil/vfs/tests/bind-semantics/task.yaml
+++ b/osutil/vfs/tests/bind-semantics/task.yaml
@@ -26,6 +26,10 @@ environment:
     ALTER_B/shared_to_shared: --make-shared
     EXPECTED_A/shared_to_shared: "/ /A shared:42 - tmpfs-A"
     EXPECTED_B/shared_to_shared: "/ /B shared:43 - tmpfs-B"
+    # This test shows that the peer group of the new bind mount is taken from
+    # the source.  One can think of this as a bind-mount that is followed by
+    # --make-shared. Because B/b is already shared then nothing changes and no
+    # new group is allocated.
     EXPECTED_BIND/shared_to_shared: "/a /B/b shared:42 - tmpfs-A"
     # Source is shared, destination is private.
     ALTER_A/shared_to_private: --make-shared
@@ -41,6 +45,9 @@ environment:
     ALTER_B/private_to_shared: --make-shared
     EXPECTED_A/private_to_shared: "/ /A - tmpfs-A"
     EXPECTED_B/private_to_shared: "/ /B shared:42 - tmpfs-B"
+    # This test shows that the peer group of the new bind mount is a new
+    # allocated group. One can think of this as a bind-mount followed by
+    # --make-shared. Because B/b is private, a new group _is_ allocated.
     EXPECTED_BIND/private_to_shared: "/a /B/b shared:43 - tmpfs-A"
     # Source and destination are both private.
     ALTER_A/private_to_private: --make-private
@@ -53,6 +60,9 @@ environment:
     ALTER_B/slave_to_shared: --make-shared
     EXPECTED_A/slave_to_shared: "/ /A master:42 - tmpfs-A"
     EXPECTED_B/slave_to_shared: "/ /B shared:43 - tmpfs-B"
+    # This test shows that the new bind-mount B/b becomes shared (shared:44),
+    # exactly as in the private_to_shared test, but also retains the slave peer
+    # group from A (master:42)
     EXPECTED_BIND/slave_to_shared: "/a /B/b shared:44 master:42 - tmpfs-A"
     # Source is a slave, destination is private.
     ALTER_A/slave_to_private: --make-slave

--- a/osutil/vfs/tests/bind-semantics/task.yaml
+++ b/osutil/vfs/tests/bind-semantics/task.yaml
@@ -66,7 +66,7 @@ prepare: |
     mount "$ALTER_A" a
     mkdir b
     mount -t tmpfs tmpfs-b b
-    for op in $ALTER_B; do mount "$op" b; done
+    mount "$ALTER_B" b
     mount --bind a b
 restore: |
     umount -l a


### PR DESCRIPTION
I used the pattern where capital letters A and B are actual file system mounts and lower-case letters are directories that are bind mounted. I also expanded both the measured data and the data that is displayed for each measurement.