### PR TITLE
o/hookstate/ctlcmd: fix formatting

### DIFF
--- a/overlord/hookstate/ctlcmd/system_mode.go
+++ b/overlord/hookstate/ctlcmd/system_mode.go
@@ -86,8 +86,8 @@ func (c *systemModeCommand) Execute(args []string) error {
 	}
 
 	res := systemModeResult{
-		SystemMode:       smi.Mode,
-		Seeded:           smi.Seeded,
+		SystemMode: smi.Mode,
+		Seeded:     smi.Seeded,
 	}
 	if strutil.ListContains(smi.BootFlags, "factory") {
 		res.Factory = true


### PR DESCRIPTION
Tiny fix for formatting on master.
