### PR TITLE
o/install, daemon: rename CheckHybridPluckyRelease to CheckHybridQuestingRelease

### DIFF
--- a/daemon/api_system_recovery_keys.go
+++ b/daemon/api_system_recovery_keys.go
@@ -54,7 +54,7 @@ func systemVolumesAPISupported(st *state.State) (bool, *apiError) {
 		return false, InternalError(err.Error())
 	}
 
-	supported, err := install.CheckHybridPluckyRelease(deviceCtx.Model())
+	supported, err := install.CheckHybridQuestingRelease(deviceCtx.Model())
 	if err != nil {
 		return false, InternalError(err.Error())
 	}

--- a/overlord/install/install.go
+++ b/overlord/install/install.go
@@ -363,13 +363,13 @@ func preinstallCheckSupportedWithEnvFallback(model *asserts.Model) (bool, error)
 		return false, nil
 	}
 
-	return CheckHybridPluckyRelease(model)
+	return CheckHybridQuestingRelease(model)
 }
 
-// CheckHybridPluckyRelease returns true if the given model and runtime release
+// CheckHybridQuestingRelease returns true if the given model and runtime release
 // information indicates that this is a hybrid Ubuntu system with a version of
 // 25.10 or higher.
-func CheckHybridPluckyRelease(model *asserts.Model) (bool, error) {
+func CheckHybridQuestingRelease(model *asserts.Model) (bool, error) {
 	if !model.HybridClassic() {
 		return false, nil
 	}


### PR DESCRIPTION
25.10 is Questing not Plucky, renamed function accordingly.
