### PR TITLE
packaging/fedora: drop fakeroot

### DIFF
--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -134,9 +134,6 @@ ExclusiveArch:  %{ix86} x86_64 %{arm} aarch64 ppc64le s390x
 BuildRequires: make
 BuildRequires:  %{?go_compiler:compiler(go-compiler)}%{!?go_compiler:golang >= 1.9}
 BuildRequires:  systemd
-%if ! 0%{?amzn2}
-BuildRequires:  fakeroot
-%endif
 BuildRequires:  squashfs-tools
 %{?systemd_requires}
 


### PR DESCRIPTION
Drop fakeroot as build dependency.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
