### PR TITLE
image-garden: include optional local overrides file

### DIFF
--- a/.image-garden.mk
+++ b/.image-garden.mk
@@ -74,3 +74,6 @@ opensuse-cloud-tumbleweed-selinux.x86_64.user-data: export USER_DATA = $(call $(
 opensuse-cloud-tumbleweed-selinux.x86_64.user-data: $(MAKEFILE_LIST) $(wildcard $(GARDEN_PROJECT_DIR)/.image-garden.mk)
 	echo "$${USER_DATA}" | tee $@
 	touch --reference=$(shell stat $^ -c '%Y %n' | sort -nr | cut -d ' ' -f 2 | head -n 1) $@
+
+# include local overrides if present
+-include $(GARDEN_PROJECT_DIR)/.image-garden.local.mk


### PR DESCRIPTION
Add support for local overrides files, where one can redefine variables or targets.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
