### PR TITLE
desktop: Actually use desktop file IDs as desktop IDs

### DIFF
--- a/interfaces/builtin/utils.go
+++ b/interfaces/builtin/utils.go
@@ -140,7 +140,7 @@ func getDesktopFileRules(s *snap.Info) (string, error) {
 			// Unexpected, should have failed in BeforePreparePlug
 			return "", fmt.Errorf("internal error: invalid desktop file ID %q found in snap %q: %v", desktopFileID, s.InstanceName(), err)
 		}
-		fmt.Fprintf(&b, "%s/%s r,\n", dirs.SnapDesktopFilesDir, desktopFileID+".desktop")
+		fmt.Fprintf(&b, "%s/%s r,\n", dirs.SnapDesktopFilesDir, desktopFileID)
 	}
 
 	// Generate deny rules to suppress apparmor warnings

--- a/interfaces/builtin/utils_test.go
+++ b/interfaces/builtin/utils_test.go
@@ -261,13 +261,14 @@ func (s *desktopFileRulesBaseSuite) TestDesktopFileRulesHappy(c *C) {
 	opts := testDesktopFileRulesOptions{
 		snapName:       "some-snap",
 		desktopFiles:   []string{"org.example.desktop", "org.example.Foo.desktop", "org.example.Bar.desktop", "bar.desktop"},
-		desktopFileIDs: []string{"org.example", "org.example.Foo"},
+		desktopFileIDs: []string{"org.example.desktop", "org.example.Foo.desktop", "org.example.Foo.WithoutSuffix"},
 		isInstance:     false,
 		expectedRules: []string{
 			// allow rules for snap's desktop files
-			fmt.Sprintf("%s/@{SNAP_INSTANCE_DESKTOP}_*.desktop r,", dirs.SnapDesktopFilesDir),        // prefixed with DesktopPrefix()
-			fmt.Sprintf("%s r,", filepath.Join(dirs.SnapDesktopFilesDir, "org.example.desktop")),     // desktop-file-ids, unchanged
-			fmt.Sprintf("%s r,", filepath.Join(dirs.SnapDesktopFilesDir, "org.example.Foo.desktop")), // desktop-file-ids, unchanged
+			fmt.Sprintf("%s/@{SNAP_INSTANCE_DESKTOP}_*.desktop r,", dirs.SnapDesktopFilesDir),                      // prefixed with DesktopPrefix()
+			fmt.Sprintf("%s r,", filepath.Join(dirs.SnapDesktopFilesDir, "org.example.desktop")),                   // desktop-file-ids, unchanged
+			fmt.Sprintf("%s r,", filepath.Join(dirs.SnapDesktopFilesDir, "org.example.Foo.desktop")),               // desktop-file-ids, unchanged
+			fmt.Sprintf("%s r,", filepath.Join(dirs.SnapDesktopFilesDir, "org.example.Foo.WithoutSuffix.desktop")), // desktop-file-ids, unchanged
 			// check all deny patterns are generated
 			fmt.Sprintf("deny %s r,", filepath.Join(dirs.SnapDesktopFilesDir, "[^so]**.desktop")), // ^s from some-snap and ^o from org
 			fmt.Sprintf("deny %s r,", filepath.Join(dirs.SnapDesktopFilesDir, "{o[^r],s[^o]}**.desktop")),
@@ -425,7 +426,7 @@ func (s *desktopFileRulesBaseSuite) TestDesktopFileRulesBadDesktopFileIDs(c *C) 
 		desktopFiles:   []string{"org.*.example.desktop"},
 		desktopFileIDs: []string{"org.*.example"},
 		expectedRules:  s.fallbackRules,
-		expectedErr:    `internal error: invalid desktop file ID "org.*.example" found in snap "some-snap": "org.*.example" contains a reserved apparmor char from ` + "?*[]{}^\"\x00",
+		expectedErr:    `internal error: invalid desktop file ID "org.*.example.desktop" found in snap "some-snap": "org.*.example.desktop" contains a reserved apparmor char from ` + "?*[]{}^\"\x00",
 	}
 	s.testDesktopFileRules(c, opts)
 }

--- a/overlord/snapstate/check_snap_test.go
+++ b/overlord/snapstate/check_snap_test.go
@@ -1568,7 +1568,7 @@ func (s *snapmgrTestSuite) TestCheckDesktopFileIDsConflicts(c *C) {
 	})
 
 	err = snapstate.CheckDesktopFileIDsConflicts(s.state, someSnap)
-	c.Assert(err, ErrorMatches, `snap "some-snap" requesting desktop-file-id "org.example.Foo" conflicts with snap "other-snap" use`)
+	c.Assert(err, ErrorMatches, `snap "some-snap" requesting desktop-file-id "org.example.Foo.desktop" conflicts with snap "other-snap" use`)
 }
 
 func (s *snapmgrTestSuite) TestCheckDesktopFileIDsConflictsNoConflictWithSelf(c *C) {
@@ -1639,7 +1639,7 @@ func (s *snapmgrTestSuite) TestInstallDesktopFileIDsConflicts(c *C) {
 	// Conflict should be detected in early checks
 	opts := &snapstate.RevisionOptions{Channel: "channel-for-desktop-file-ids"}
 	_, err = snapstate.Install(context.Background(), s.state, "some-snap", opts, s.user.ID, snapstate.Flags{})
-	c.Assert(err, ErrorMatches, `snap "some-snap" requesting desktop-file-id "org.example.Foo" conflicts with snap "other-snap" use`)
+	c.Assert(err, ErrorMatches, `snap "some-snap" requesting desktop-file-id "org.example.Foo.desktop" conflicts with snap "other-snap" use`)
 }
 
 func (s *snapmgrTestSuite) TestInstallManyDesktopFileIDsConflicts(c *C) {
@@ -1678,5 +1678,5 @@ func (s *snapmgrTestSuite) TestInstallManyDesktopFileIDsConflicts(c *C) {
 	s.settle(c)
 
 	// The order of installation is indeterminant, but one will fail
-	c.Check(chg.Err(), ErrorMatches, `cannot perform the following tasks:\n- Make snap "(some|other)-snap" \(11\) available to the system \(snap "(some|other)-snap" requesting desktop-file-id "org.example.Foo" conflicts with snap "(some|other)-snap" use\)`)
+	c.Check(chg.Err(), ErrorMatches, `cannot perform the following tasks:\n- Make snap "(some|other)-snap" \(11\) available to the system \(snap "(some|other)-snap" requesting desktop-file-id "org.example.Foo.desktop" conflicts with snap "(some|other)-snap" use\)`)
 }

--- a/snap/info.go
+++ b/snap/info.go
@@ -980,6 +980,10 @@ func (s *Info) DesktopPlugFileIDs() ([]string, error) {
 		if !ok {
 			return nil, errors.New(`internal error: "desktop-file-ids" must be a list of strings`)
 		}
+		if !strings.HasSuffix(desktopFileID, ".desktop") {
+			logger.Noticef("adding missing .desktop suffix to desktop file ID %s (snap %s)", desktopFileID, s.InstanceName())
+			desktopFileID = desktopFileID + ".desktop"
+		}
 		desktopFileIDs = append(desktopFileIDs, desktopFileID)
 	}
 	return desktopFileIDs, nil
@@ -1021,7 +1025,7 @@ func (s *Info) MangleDesktopFileName(desktopFile string) (string, error) {
 	// XXX: Do we want to fail if a desktop-file-ids entry doesn't
 	// have a corresponding file?
 	for _, desktopFileID := range desktopFileIDs {
-		if strings.TrimSuffix(base, ".desktop") == desktopFileID {
+		if base == desktopFileID {
 			return filepath.Join(dir, base), nil
 		}
 	}
@@ -1458,7 +1462,7 @@ func (app *AppInfo) DesktopFile() string {
 	// Loop through desktop-file-ids desktop interface plug attribute in order to
 	// have deterministic output
 	for _, desktopFileID := range desktopFileIDs {
-		desktopFile := filepath.Join(dirs.SnapDesktopFilesDir, desktopFileID+".desktop")
+		desktopFile := filepath.Join(dirs.SnapDesktopFilesDir, desktopFileID)
 		if !osutil.FileExists(desktopFile) {
 			continue
 		}

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -2599,7 +2599,7 @@ version: 1.0
 		desktopAppYaml += "\nplugs:\n  desktop:"
 	}
 	if hasDesktopFileIDs {
-		desktopAppYaml += "\n    desktop-file-ids: [org.example, org.example.Foo]"
+		desktopAppYaml += "\n    desktop-file-ids: [org.example.desktop, org.example.Foo.desktop, org.example.Foo.WithoutDesktopSuffix]"
 	}
 	info, err := snap.InfoFromSnapYaml([]byte(desktopAppYaml))
 	c.Assert(err, IsNil)
@@ -2611,7 +2611,7 @@ version: 1.0
 	c.Assert(err, IsNil)
 
 	if hasDesktopFileIDs {
-		c.Assert(desktopFileIDs, DeepEquals, []string{"org.example", "org.example.Foo"})
+		c.Assert(desktopFileIDs, DeepEquals, []string{"org.example.desktop", "org.example.Foo.desktop", "org.example.Foo.WithoutDesktopSuffix.desktop"})
 	} else {
 		c.Assert(desktopFileIDs, IsNil)
 	}

--- a/wrappers/desktop.go
+++ b/wrappers/desktop.go
@@ -348,7 +348,7 @@ func EnsureSnapDesktopFiles(snaps []*snap.Info) error {
 		}
 		desktopFilesGlobs := []string{fmt.Sprintf("%s_*.desktop", info.DesktopPrefix())}
 		for _, desktopFileID := range desktopFileIDs {
-			desktopFilesGlobs = append(desktopFilesGlobs, desktopFileID+".desktop")
+			desktopFilesGlobs = append(desktopFilesGlobs, desktopFileID)
 		}
 		content, err := deriveDesktopFilesContent(info)
 		if err != nil {

--- a/wrappers/desktop_test.go
+++ b/wrappers/desktop_test.go
@@ -134,7 +134,7 @@ plugs:
   desktop:
 `
 	if hasDesktopFileIDs {
-		desktopAppYaml += "\n    desktop-file-ids: [org.example.Foo]"
+		desktopAppYaml += "\n    desktop-file-ids: [org.example.Foo.desktop]"
 	}
 	info := snaptest.MockSnap(c, desktopAppYaml, &snap.SideInfo{Revision: snap.R(11)})
 	c.Assert(info.Plugs["desktop"], NotNil)


### PR DESCRIPTION
The desktop interfaces now exposes the desktop-file-ids, however it does not takes desktop IDs as parameters.

In fact the specification [1] clearly states that the desktop file ID must contain the .desktop suffix.

In particular:

>   To determine the ID of a desktop file, make its full path relative to
>   the $XDG_DATA_DIRS component in which the desktop file is installed,
>   remove the "applications/" prefix, and turn '/' into '-'.
> 
>   For example /usr/share/applications/foo/bar.desktop has the desktop
>   file ID foo-bar.desktop.

As per this, expect the list to contain desktop IDs with .desktop suffixes by default, and adjust them in case this fails.

[1] https://specifications.freedesktop.org/desktop-entry-spec/latest/file-naming.html#desktop-file-id

UDENG-7612