### PR TITLE
many: read notices without state lock

### DIFF
--- a/daemon/api_notices_test.go
+++ b/daemon/api_notices_test.go
@@ -869,9 +869,7 @@ func (s *noticesSuite) TestAddNotice(c *C) {
 	resultBytes, err := json.Marshal(rsp.Result)
 	c.Assert(err, IsNil)
 
-	st.Lock()
 	notices := st.Notices(nil)
-	st.Unlock()
 	c.Assert(notices, HasLen, 1)
 	n := noticeToMap(c, notices[0])
 	noticeID, ok := n["id"].(string)

--- a/overlord/notices/notices.go
+++ b/overlord/notices/notices.go
@@ -87,20 +87,14 @@ type stateBackend struct {
 }
 
 func (sb stateBackend) BackendNotices(filter *state.NoticeFilter) []*state.Notice {
-	sb.Lock()
-	defer sb.Unlock()
 	return sb.Notices(filter)
 }
 
 func (sb stateBackend) BackendNotice(id string) *state.Notice {
-	sb.Lock()
-	defer sb.Unlock()
 	return sb.Notice(id)
 }
 
 func (sb stateBackend) BackendWaitNotices(ctx context.Context, filter *state.NoticeFilter) ([]*state.Notice, error) {
-	sb.Lock()
-	defer sb.Unlock()
 	return sb.WaitNotices(ctx, filter)
 }
 

--- a/overlord/notices/notices_test.go
+++ b/overlord/notices/notices_test.go
@@ -757,10 +757,11 @@ func (s *noticesSuite) TestNotice(c *C) {
 	// other channels are populated with notices.
 	bknd3.noticeChan <- notice
 
-	// Hold state lock so we know state isn't checked (else it would block)
-	s.st.Lock()
+	// Previously, calling state.Notice() would require state lock, so we could
+	// hold state lock while querying nm.Notice() to make sure state was not
+	// checked, but since nm.Notice no longer requires state lock, we can't
+	// test this as easily anymore.
 	result := nm.Notice(queryID)
-	s.st.Unlock()
 	c.Check(result, Equals, notice)
 
 	// Now query for the notice which was previously added to state. If other
@@ -770,12 +771,10 @@ func (s *noticesSuite) TestNotice(c *C) {
 	c.Check(result.Type(), Equals, state.ChangeUpdateNotice)
 
 	// Now query notice with ID namespace which no backend has registered.
-	// Since it is namespaced, state cannot be asked either. Hold state lock
-	// to test this. And since no backends have been fed notices, querying them
-	// would block too. So test that nothing blocks.
-	s.st.Lock()
+	// Since it is namespaced, state cannot be asked either. And since no
+	// backends have been fed notices, querying them would block too.
+	// So test that nothing blocks.
 	result = nm.Notice("unregistered-1234")
-	s.st.Unlock()
 	c.Check(result, IsNil)
 }
 

--- a/overlord/state/notices_test.go
+++ b/overlord/state/notices_test.go
@@ -141,9 +141,8 @@ func (s *noticesSuite) TestReoccur(c *C) {
 
 func (s *noticesSuite) TestMarshal(c *C) {
 	st := state.New(nil)
-	st.Lock()
-	defer st.Unlock()
 
+	st.Lock()
 	start := time.Now()
 	uid := uint32(1000)
 	addNotice(c, st, &uid, state.ChangeUpdateNotice, "123", nil)
@@ -151,6 +150,7 @@ func (s *noticesSuite) TestMarshal(c *C) {
 	addNotice(c, st, &uid, state.ChangeUpdateNotice, "123", &state.AddNoticeOptions{
 		Data: map[string]string{"k": "v"},
 	})
+	st.Unlock()
 
 	notices := st.Notices(nil)
 	c.Assert(notices, HasLen, 1)
@@ -254,12 +254,12 @@ func (s *noticesSuite) TestString(c *C) {
 
 func (s *noticesSuite) TestType(c *C) {
 	st := state.New(nil)
-	st.Lock()
-	defer st.Unlock()
 
+	st.Lock()
 	addNotice(c, st, nil, state.ChangeUpdateNotice, "123", nil)
 	addNotice(c, st, nil, state.RefreshInhibitNotice, "-", nil)
 	addNotice(c, st, nil, state.WarningNotice, "danger!", nil)
+	st.Unlock()
 
 	notices := st.Notices(&state.NoticeFilter{Types: []state.NoticeType{state.ChangeUpdateNotice}})
 	c.Assert(notices, HasLen, 1)
@@ -276,14 +276,14 @@ func (s *noticesSuite) TestType(c *C) {
 
 func (s *noticesSuite) TestOccurrences(c *C) {
 	st := state.New(nil)
-	st.Lock()
-	defer st.Unlock()
 
+	st.Lock()
 	addNotice(c, st, nil, state.WarningNotice, "foo.com/bar", nil)
 	addNotice(c, st, nil, state.WarningNotice, "foo.com/bar", nil)
 	addNotice(c, st, nil, state.WarningNotice, "foo.com/bar", nil)
 	time.Sleep(time.Microsecond)
 	addNotice(c, st, nil, state.ChangeUpdateNotice, "123", nil)
+	st.Unlock()
 
 	notices := st.Notices(nil)
 	c.Assert(notices, HasLen, 2)
@@ -344,9 +344,8 @@ func (s *noticesSuite) testRepeatAfter(c *C, first, second, delay time.Duration)
 
 func (s *noticesSuite) TestNoticesFilterUserID(c *C) {
 	st := state.New(nil)
-	st.Lock()
-	defer st.Unlock()
 
+	st.Lock()
 	uid1 := uint32(1000)
 	uid2 := uint32(0)
 	addNotice(c, st, &uid1, state.ChangeUpdateNotice, "443", nil)
@@ -356,6 +355,7 @@ func (s *noticesSuite) TestNoticesFilterUserID(c *C) {
 	addNotice(c, st, &uid2, state.WarningNotice, "Warning 1!", nil)
 	time.Sleep(time.Microsecond)
 	addNotice(c, st, nil, state.WarningNotice, "Warning 2!", nil)
+	st.Unlock()
 
 	// No filter
 	notices := st.Notices(nil)
@@ -383,9 +383,8 @@ func (s *noticesSuite) TestNoticesFilterUserID(c *C) {
 
 func (s *noticesSuite) TestNoticesFilterType(c *C) {
 	st := state.New(nil)
-	st.Lock()
-	defer st.Unlock()
 
+	st.Lock()
 	addNotice(c, st, nil, state.RefreshInhibitNotice, "-", nil)
 	time.Sleep(time.Microsecond)
 	addNotice(c, st, nil, state.InterfacesRequestsPromptNotice, "443", nil)
@@ -397,6 +396,7 @@ func (s *noticesSuite) TestNoticesFilterType(c *C) {
 	addNotice(c, st, nil, state.WarningNotice, "Warning 2!", nil)
 	time.Sleep(time.Microsecond)
 	addNotice(c, st, nil, state.SnapRunInhibitNotice, "snap-name", nil)
+	st.Unlock()
 
 	// No filter
 	notices := st.Notices(nil)
@@ -452,14 +452,14 @@ func (s *noticesSuite) TestNoticesFilterType(c *C) {
 
 func (s *noticesSuite) TestNoticesFilterKey(c *C) {
 	st := state.New(nil)
-	st.Lock()
-	defer st.Unlock()
 
+	st.Lock()
 	addNotice(c, st, nil, state.WarningNotice, "foo.com/bar", nil)
 	time.Sleep(time.Microsecond)
 	addNotice(c, st, nil, state.WarningNotice, "example.com/x", nil)
 	time.Sleep(time.Microsecond)
 	addNotice(c, st, nil, state.WarningNotice, "foo.com/baz", nil)
+	st.Unlock()
 
 	// No filter
 	notices := st.Notices(nil)
@@ -495,9 +495,8 @@ func (s *noticesSuite) TestNoticesFilterKey(c *C) {
 
 func (s *noticesSuite) TestNoticesFilterAfter(c *C) {
 	st := state.New(nil)
-	st.Lock()
-	defer st.Unlock()
 
+	st.Lock()
 	addNotice(c, st, nil, state.WarningNotice, "foo.com/x", nil)
 	notices := st.Notices(nil)
 	c.Assert(notices, HasLen, 1)
@@ -507,6 +506,7 @@ func (s *noticesSuite) TestNoticesFilterAfter(c *C) {
 
 	time.Sleep(time.Microsecond)
 	addNotice(c, st, nil, state.WarningNotice, "foo.com/y", nil)
+	st.Unlock()
 
 	// After unset
 	notices = st.Notices(nil)
@@ -523,8 +523,8 @@ func (s *noticesSuite) TestNoticesFilterAfter(c *C) {
 
 func (s *noticesSuite) TestNoticesFilterBeforeOrAt(c *C) {
 	st := state.New(nil)
+
 	st.Lock()
-	defer st.Unlock()
 
 	addNotice(c, st, nil, state.WarningNotice, "foo.com/x", nil)
 	notices := st.Notices(nil)
@@ -535,6 +535,8 @@ func (s *noticesSuite) TestNoticesFilterBeforeOrAt(c *C) {
 
 	time.Sleep(time.Microsecond)
 	addNotice(c, st, nil, state.WarningNotice, "foo.com/z", nil)
+
+	st.Unlock()
 
 	// After unset
 	notices = st.Notices(nil)
@@ -603,9 +605,8 @@ func (s *noticesSuite) TestDrainNotices(c *C) {
 
 func (s *noticesSuite) TestNotice(c *C) {
 	st := state.New(nil)
-	st.Lock()
-	defer st.Unlock()
 
+	st.Lock()
 	uid1 := uint32(0)
 	uid2 := uint32(123)
 	uid3 := uint32(1000)
@@ -614,6 +615,7 @@ func (s *noticesSuite) TestNotice(c *C) {
 	addNotice(c, st, &uid2, state.WarningNotice, "foo.com/y", nil)
 	time.Sleep(time.Microsecond)
 	addNotice(c, st, &uid3, state.WarningNotice, "foo.com/z", nil)
+	st.Unlock()
 
 	notices := st.Notices(nil)
 	c.Assert(notices, HasLen, 3)
@@ -631,8 +633,6 @@ func (s *noticesSuite) TestNotice(c *C) {
 
 func (s *noticesSuite) TestEmptyState(c *C) {
 	st := state.New(nil)
-	st.Lock()
-	defer st.Unlock()
 
 	notices := st.Notices(nil)
 	c.Check(notices, HasLen, 0)
@@ -689,12 +689,12 @@ func (s *noticesSuite) TestDeleteExpired(c *C) {
 
 func (s *noticesSuite) TestWaitNoticesExisting(c *C) {
 	st := state.New(nil)
-	st.Lock()
-	defer st.Unlock()
 
+	st.Lock()
 	addNotice(c, st, nil, state.WarningNotice, "foo.com/bar", nil)
 	addNotice(c, st, nil, state.WarningNotice, "example.com/x", nil)
 	addNotice(c, st, nil, state.WarningNotice, "foo.com/baz", nil)
+	st.Unlock()
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -718,8 +718,6 @@ func (s *noticesSuite) TestWaitNoticesNew(c *C) {
 		addNotice(c, st, nil, state.WarningNotice, "example.com/y", nil)
 	}()
 
-	st.Lock()
-	defer st.Unlock()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	notices, err := st.WaitNotices(ctx, &state.NoticeFilter{Keys: []string{"example.com/y"}})
@@ -731,8 +729,6 @@ func (s *noticesSuite) TestWaitNoticesNew(c *C) {
 
 func (s *noticesSuite) TestWaitNoticesTimeout(c *C) {
 	st := state.New(nil)
-	st.Lock()
-	defer st.Unlock()
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 	defer cancel()
@@ -763,8 +759,6 @@ func (s *noticesSuite) TestReadStateWaitNotices(c *C) {
 
 func (s *noticesSuite) TestWaitNoticesLongPoll(c *C) {
 	st := state.New(nil)
-	st.Lock()
-	defer st.Unlock()
 
 	go func() {
 		for i := 0; i < 10; i++ {
@@ -792,8 +786,6 @@ func (s *noticesSuite) TestWaitNoticesLongPoll(c *C) {
 
 func (s *noticesSuite) TestWaitNoticesBeforeOrAtFilter(c *C) {
 	st := state.New(nil)
-	st.Lock()
-	defer st.Unlock()
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -806,7 +798,9 @@ func (s *noticesSuite) TestWaitNoticesBeforeOrAtFilter(c *C) {
 
 	// If we ask for notices before now and there are notices matching the
 	// filter, return them immediately
+	st.Lock()
 	addNotice(c, st, nil, state.WarningNotice, "existing", nil)
+	st.Unlock()
 	notices, err = st.WaitNotices(ctx, &state.NoticeFilter{BeforeOrAt: time.Now()})
 	c.Assert(err, IsNil)
 	c.Assert(notices, HasLen, 1)
@@ -822,14 +816,12 @@ func (s *noticesSuite) TestWaitNoticesBeforeOrAtFilter(c *C) {
 	// If we ask for notices before a time in the future, then a matching
 	// notice occurs, it will be returned
 	go func() {
-		time.Sleep(10 * time.Millisecond)
 		st.Lock()
+		defer st.Unlock()
+		time.Sleep(10 * time.Millisecond)
 		addNotice(c, st, nil, state.WarningNotice, "hay", nil)
-		st.Unlock()
 		time.Sleep(10 * time.Millisecond)
-		st.Lock()
 		addNotice(c, st, nil, state.WarningNotice, "needle", nil)
-		st.Unlock()
 	}()
 	notices, err = st.WaitNotices(ctx, &state.NoticeFilter{
 		BeforeOrAt: time.Now().Add(time.Second),
@@ -877,8 +869,6 @@ func (s *noticesSuite) TestWaitNoticesConcurrent(c *C) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			st.Lock()
-			defer st.Unlock()
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 			defer cancel()
 			key := fmt.Sprintf("a.b/%d", i)
@@ -890,10 +880,10 @@ func (s *noticesSuite) TestWaitNoticesConcurrent(c *C) {
 		}(i)
 	}
 
+	st.Lock()
+	defer st.Unlock()
 	for i := 0; i < numWaiters; i++ {
-		st.Lock()
 		addNotice(c, st, nil, state.WarningNotice, fmt.Sprintf("a.b/%d", i), nil)
-		st.Unlock()
 		time.Sleep(time.Microsecond)
 	}
 

--- a/overlord/state/state_test.go
+++ b/overlord/state/state_test.go
@@ -759,6 +759,8 @@ func (ss *stateSuite) TestMethodEntrance(c *C) {
 		func() { st.Warnf("hello") },
 		func() { st.OkayWarnings(time.Time{}) },
 		func() { st.UnshowAllWarnings() },
+		func() { st.AddNotice(nil, state.WarningNotice, "foo", nil) },
+		func() { st.DrainNotices(nil) },
 	}
 
 	reads := []func(){


### PR DESCRIPTION
Add a `RWMutex` to guard the state notices map, and no longer require the state lock to be held just to read notices.
    
This means that callers of `state.Notices`, `state.Notice`, and `state.WaitNotices` no longer need to hold the state lock.
    
As a result, the `state.noticeCond` locker is switched from locking `state` itself to instead locking the `RWMutex`.

This change is the first step towards using notices as the backend for warnings. Since we need to query warnings without requiring state lock, we also need a way to query warning notices from state without state lock.

This PR is modeled closely after the changes which made warnings not require state lock: #15309

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-35358