### PR TITLE
many: replace confdb error kinds and add --default for no data

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -129,11 +129,8 @@ const (
 	// ErrorKindAssertionNotFound: assertion can not be found.
 	ErrorKindAssertionNotFound ErrorKind = "assertion-not-found"
 
-	// ErrorKindConfdbViewNotFound: the confdb view can not be found.
-	ErrorKindConfdbViewNotFound ErrorKind = "confdb-view-not-found"
-
-	// ErrorKindConfdbNoMatchingRule: no view rule matches the request.
-	ErrorKindConfdbNoMatchingRule ErrorKind = "confdb-no-matching-rule"
+	// ErrorKindOptionNotAvailable: the configuration option cannot be requested.
+	ErrorKindOptionNotAvailable ErrorKind = "option-not-available"
 
 	// ErrorKindUnsuccessful: snapctl command was unsuccessful.
 	ErrorKindUnsuccessful ErrorKind = "unsuccessful"

--- a/daemon/api_confdb.go
+++ b/daemon/api_confdb.go
@@ -135,11 +135,13 @@ func toAPIError(err error) *apiError {
 			Kind:    client.ErrorKindAssertionNotFound,
 			Value:   err,
 		}
+	case errors.Is(err, &confdbstate.NoViewError{}):
+		fallthrough
 	case errors.Is(err, &confdb.NoMatchError{}):
 		return &apiError{
 			Status:  400,
 			Message: err.Error(),
-			Kind:    client.ErrorKindConfdbNoMatchingRule,
+			Kind:    client.ErrorKindOptionNotAvailable,
 			Value:   err,
 		}
 	case errors.Is(err, &confdb.NoDataError{}):
@@ -147,13 +149,6 @@ func toAPIError(err error) *apiError {
 			Status:  400,
 			Message: err.Error(),
 			Kind:    client.ErrorKindConfigNoSuchOption,
-			Value:   err,
-		}
-	case errors.Is(err, &confdbstate.NoViewError{}):
-		return &apiError{
-			Status:  400,
-			Message: err.Error(),
-			Kind:    client.ErrorKindConfdbViewNotFound,
 			Value:   err,
 		}
 	case errors.Is(err, &confdb.BadRequestError{}):

--- a/daemon/api_confdb_test.go
+++ b/daemon/api_confdb_test.go
@@ -219,7 +219,8 @@ func (s *confdbSuite) TestGetViewError(c *C) {
 
 	for _, t := range []test{
 		{name: "no assertion", err: notFoundErr, status: 400, kind: client.ErrorKindAssertionNotFound},
-		{name: "no view", err: &confdbstate.NoViewError{}, status: 400, kind: client.ErrorKindConfdbViewNotFound},
+		{name: "no view", err: &confdbstate.NoViewError{}, status: 400, kind: client.ErrorKindOptionNotAvailable},
+		{name: "no match", err: confdb.NewNoMatchError(s.schema.View("wifi-setup"), "", nil), status: 400, kind: client.ErrorKindOptionNotAvailable},
 		{name: "internal", err: errors.New("internal"), status: 500},
 	} {
 		restore := daemon.MockConfdbstateGetView(func(_ *state.State, _, _, _ string) (*confdb.View, error) {
@@ -263,7 +264,8 @@ func (s *confdbSuite) TestGetTxError(c *C) {
 
 	for _, t := range []test{
 		{name: "no data", err: confdb.NewNoDataError(view, nil), status: 400, kind: client.ErrorKindConfigNoSuchOption},
-		{name: "no match", err: confdb.NewNoMatchError(view, "", nil), status: 400, kind: client.ErrorKindConfdbNoMatchingRule},
+		{name: "no view", err: &confdbstate.NoViewError{}, status: 400, kind: client.ErrorKindOptionNotAvailable},
+		{name: "no match", err: confdb.NewNoMatchError(view, "", nil), status: 400, kind: client.ErrorKindOptionNotAvailable},
 		{name: "internal", err: errors.New("internal"), status: 500},
 	} {
 		restore := daemon.MockConfdbstateLoadConfdbAsync(func(*state.State, *confdb.View, []string) (string, error) {
@@ -439,7 +441,7 @@ func (s *confdbSuite) TestSetViewError(c *C) {
 	view := s.schema.View("wifi-setup")
 	for _, t := range []test{
 		{name: "no data", err: confdb.NewNoDataError(view, nil), status: 400, kind: client.ErrorKindConfigNoSuchOption},
-		{name: "no match", err: confdb.NewNoMatchError(view, "", nil), status: 400, kind: client.ErrorKindConfdbNoMatchingRule},
+		{name: "no match", err: confdb.NewNoMatchError(view, "", nil), status: 400, kind: client.ErrorKindOptionNotAvailable},
 		{name: "internal", err: errors.New("internal"), status: 500},
 		{name: "bad query", err: &confdb.BadRequestError{}, status: 400},
 	} {

--- a/overlord/confdbstate/confdbmgr.go
+++ b/overlord/confdbstate/confdbmgr.go
@@ -161,6 +161,7 @@ func readViewIntoChange(chg *state.Change, tx *Transaction, view *confdb.View, r
 	result, err := GetViaView(tx, view, requests)
 	if err != nil {
 		if !errors.Is(err, &confdb.NoDataError{}) {
+			// other errors (no match/view) would be detected before the change is created
 			return fmt.Errorf("internal error: cannot read confdb %s/%s: %w", tx.ConfdbAccount, tx.ConfdbName, err)
 		}
 


### PR DESCRIPTION
Replaces the error kinds returned when a request tries to get a non-existing view or non-existing request path (nothing to match the request to) with a more generic "option not available". The second commit introduces a --default flag (only to snap get, for now) that allows passing a default value in case the request was matched but there was no data. We intentionally don't use the default for the "not available" cases, although this might change in the future