### PR TITLE
t/m/snap-user-service: varying number of services between core and classic

### DIFF
--- a/tests/main/snap-user-service/task.yaml
+++ b/tests/main/snap-user-service/task.yaml
@@ -7,8 +7,15 @@ details: |
 systems:
     # Ubuntu 14.04's systemd doesn't have user@.service
     - -ubuntu-14.04-*
-    # Amazon Linux 2 gives error "Unit user@12345.service not loaded."
+    # Ubuntu 16 is too old for the user services
+    - -ubuntu-16.04-*
+    # The following distros do not the user agent running
     - -amazon-linux-2-*
+    - -amazon-linux-2023-*
+    - -opensuse-15.6-*
+    - -arch-linux-*
+    - -centos-9-*
+    - -fedora-42-*
 
 kill-timeout: 10m
 

--- a/tests/main/snap-user-service/task.yaml
+++ b/tests/main/snap-user-service/task.yaml
@@ -38,36 +38,28 @@ execute: |
     echo "Test default behaviour for service status for user"
     tests.session -u test exec snap debug api /v2/apps > app.infos
     gojq '.status' app.infos | MATCH '"OK"'
-    gojq '.result | length' app.infos | MATCH '1'
-    gojq '.result[0].active' app.infos | MATCH 'true'
-    gojq '.result[0].enabled' app.infos | MATCH 'true'
-    gojq '.result[0].name' app.infos | MATCH '"test-snapd-user-service"'
+    gojq '.result | map(select(.name == "test-snapd-user-service")) | .[0].active' app.infos | MATCH 'true'
+    gojq '.result | map(select(.name == "test-snapd-user-service")) | .[0].enabled' app.infos | MATCH 'true'
 
     echo "Test default behaviour for service status for user with global"
     tests.session -u test exec snap debug api /v2/apps?global=true > app.infos
     gojq '.status' app.infos | MATCH '"OK"'
-    gojq '.result | length' app.infos | MATCH '1'
     # should not return an active status
-    (gojq -e '.result[0].active' app.infos && exit 1) || true
-    gojq '.result[0].enabled' app.infos | MATCH 'true'
-    gojq '.result[0].name' app.infos | MATCH '"test-snapd-user-service"'
+    (gojq -e '.result | map(select(.name == "test-snapd-user-service")) | .[0].active' app.infos && exit 1) || true
+    gojq '.result | map(select(.name == "test-snapd-user-service")) | .[0].enabled' app.infos | MATCH 'true'
 
     echo "Test default behaviour for service status for root"
     snap debug api /v2/apps > app.infos
     gojq '.status' app.infos | MATCH '"OK"'
-    gojq '.result | length' app.infos | MATCH '1'
     # should not return an active status
-    (gojq -e '.result[0].active' app.infos && exit 1) || true
-    gojq '.result[0].enabled' app.infos | MATCH 'true'
-    gojq '.result[0].name' app.infos | MATCH '"test-snapd-user-service"'
+    (gojq -e '.result | map(select(.name == "test-snapd-user-service")) | .[0].active' app.infos && exit 1) || true
+    gojq '.result | map(select(.name == "test-snapd-user-service")) | .[0].enabled' app.infos | MATCH 'true'
 
     # For root user, both global=false and global=true will have the same behaviour
     # as global will be set to true for the root user by default.
     echo "Test default behaviour for service status for root with global"
     snap debug api /v2/apps?global=true > app.infos
     gojq '.status' app.infos | MATCH '"OK"'
-    gojq '.result | length' app.infos | MATCH '1'
     # should not return an active status
-    (gojq -e '.result[0].active' app.infos && exit 1) || true
-    gojq '.result[0].enabled' app.infos | MATCH 'true'
-    gojq '.result[0].name' app.infos | MATCH '"test-snapd-user-service"'
+    (gojq -e '.result | map(select(.name == "test-snapd-user-service")) | .[0].active' app.infos && exit 1) || true
+    gojq '.result | map(select(.name == "test-snapd-user-service")) | .[0].enabled' app.infos | MATCH 'true'


### PR DESCRIPTION
Instead of checking against specific service count, just make sure the service we care about is there / not there with the correct enable/active statuses.

On core, there is the 'rsync' service present.