### PR TITLE
feat: support for `SuccessExitStatus=` generation for systemd daemon

### DIFF
--- a/snap/info.go
+++ b/snap/info.go
@@ -1301,20 +1301,21 @@ type AppInfo struct {
 	CommandChain  []string
 	CommonID      string
 
-	Daemon          string
-	DaemonScope     DaemonScope
-	StopTimeout     timeout.Timeout
-	StartTimeout    timeout.Timeout
-	WatchdogTimeout timeout.Timeout
-	StopCommand     string
-	ReloadCommand   string
-	PostStopCommand string
-	RestartCond     RestartCondition
-	RestartDelay    timeout.Timeout
-	Completer       string
-	RefreshMode     string
-	StopMode        StopModeType
-	InstallMode     string
+	Daemon            string
+	DaemonScope       DaemonScope
+	StopTimeout       timeout.Timeout
+	StartTimeout      timeout.Timeout
+	WatchdogTimeout   timeout.Timeout
+	StopCommand       string
+	ReloadCommand     string
+	PostStopCommand   string
+	RestartCond       RestartCondition
+	RestartDelay      timeout.Timeout
+	SuccessExitStatus []string
+	Completer         string
+	RefreshMode       string
+	StopMode          StopModeType
+	InstallMode       string
 
 	// TODO: this should go away once we have more plumbing and can change
 	// things vs refactor

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -89,10 +89,11 @@ type appYaml struct {
 	StopMode        StopModeType    `yaml:"stop-mode,omitempty"`
 	InstallMode     string          `yaml:"install-mode,omitempty"`
 
-	RestartCond  RestartCondition `yaml:"restart-condition,omitempty"`
-	RestartDelay timeout.Timeout  `yaml:"restart-delay,omitempty"`
-	SlotNames    []string         `yaml:"slots,omitempty"`
-	PlugNames    []string         `yaml:"plugs,omitempty"`
+	RestartCond       RestartCondition `yaml:"restart-condition,omitempty"`
+	RestartDelay      timeout.Timeout  `yaml:"restart-delay,omitempty"`
+	SuccessExitStatus []string         `yaml:"success-exit-status,omitempty"`
+	SlotNames         []string         `yaml:"slots,omitempty"`
+	PlugNames         []string         `yaml:"plugs,omitempty"`
 
 	BusName     string   `yaml:"bus-name,omitempty"`
 	ActivatesOn []string `yaml:"activates-on,omitempty"`
@@ -429,31 +430,32 @@ func setAppsFromSnapYaml(y snapYaml, snap *Info, strk *scopedTracker) error {
 	for appName, yApp := range y.Apps {
 		// Collect all apps
 		app := &AppInfo{
-			Snap:            snap,
-			Name:            appName,
-			LegacyAliases:   yApp.Aliases,
-			Command:         yApp.Command,
-			CommandChain:    yApp.CommandChain,
-			StartTimeout:    yApp.StartTimeout,
-			Daemon:          yApp.Daemon,
-			DaemonScope:     yApp.DaemonScope,
-			StopTimeout:     yApp.StopTimeout,
-			StopCommand:     yApp.StopCommand,
-			ReloadCommand:   yApp.ReloadCommand,
-			PostStopCommand: yApp.PostStopCommand,
-			RestartCond:     yApp.RestartCond,
-			RestartDelay:    yApp.RestartDelay,
-			BusName:         yApp.BusName,
-			CommonID:        yApp.CommonID,
-			Environment:     yApp.Environment,
-			Completer:       yApp.Completer,
-			StopMode:        yApp.StopMode,
-			RefreshMode:     yApp.RefreshMode,
-			InstallMode:     yApp.InstallMode,
-			Before:          yApp.Before,
-			After:           yApp.After,
-			Autostart:       yApp.Autostart,
-			WatchdogTimeout: yApp.WatchdogTimeout,
+			Snap:              snap,
+			Name:              appName,
+			LegacyAliases:     yApp.Aliases,
+			Command:           yApp.Command,
+			CommandChain:      yApp.CommandChain,
+			StartTimeout:      yApp.StartTimeout,
+			Daemon:            yApp.Daemon,
+			DaemonScope:       yApp.DaemonScope,
+			StopTimeout:       yApp.StopTimeout,
+			StopCommand:       yApp.StopCommand,
+			ReloadCommand:     yApp.ReloadCommand,
+			PostStopCommand:   yApp.PostStopCommand,
+			RestartCond:       yApp.RestartCond,
+			RestartDelay:      yApp.RestartDelay,
+			SuccessExitStatus: yApp.SuccessExitStatus,
+			BusName:           yApp.BusName,
+			CommonID:          yApp.CommonID,
+			Environment:       yApp.Environment,
+			Completer:         yApp.Completer,
+			StopMode:          yApp.StopMode,
+			RefreshMode:       yApp.RefreshMode,
+			InstallMode:       yApp.InstallMode,
+			Before:            yApp.Before,
+			After:             yApp.After,
+			Autostart:         yApp.Autostart,
+			WatchdogTimeout:   yApp.WatchdogTimeout,
 		}
 		if len(y.Plugs) > 0 || len(yApp.PlugNames) > 0 {
 			app.Plugs = make(map[string]*PlugInfo)

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -1969,6 +1969,22 @@ apps:
 	c.Check(app.RestartDelay, Equals, timeout.Timeout(12*time.Second))
 }
 
+func (s *YamlSuite) TestSnapYamlSuccessExitStatus(c *C) {
+	ySuccessExitStatus := []byte(`name: wat
+version: 42
+apps:
+ foo:
+  command: bin/foo
+  daemon: simple
+  success-exit-status: [TEMPFAIL, 250, SIGKILL]
+`)
+	info, err := snap.InfoFromSnapYaml(ySuccessExitStatus)
+	c.Assert(err, IsNil)
+	app := info.Apps["foo"]
+	c.Assert(app, NotNil)
+	c.Check(app.SuccessExitStatus, DeepEquals, []string{"TEMPFAIL", "250", "SIGKILL"})
+}
+
 func (s *YamlSuite) TestSnapYamlSystemUsernamesParsing(c *C) {
 	y := []byte(`name: binary
 version: 1.0

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -813,6 +813,24 @@ func validateAppRestart(app *AppInfo) error {
 	return nil
 }
 
+func validateAppSuccessExitStatus(app *AppInfo) error {
+	if len(app.SuccessExitStatus) == 0 {
+		return nil
+	}
+
+	if !app.IsService() {
+		return errors.New("success-exit-status is only applicable to services")
+	}
+
+	for _, status := range app.SuccessExitStatus {
+		if status == "" {
+			return errors.New("success-exit-status cannot contain empty values")
+		}
+	}
+
+	return nil
+}
+
 func validateAppActivatesOn(app *AppInfo) error {
 	if len(app.ActivatesOn) == 0 {
 		return nil
@@ -939,6 +957,10 @@ func ValidateApp(app *AppInfo) error {
 	}
 
 	if err := validateAppTimeouts(app); err != nil {
+		return err
+	}
+
+	if err := validateAppSuccessExitStatus(app); err != nil {
 		return err
 	}
 

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -2008,6 +2008,60 @@ apps:
 	}
 }
 
+func (s *ValidateSuite) TestValidateAppSuccessExitStatus(c *C) {
+	meta := []byte(`
+name: foo
+version: 1.0
+`)
+	fooAllGood := []byte(`
+apps:
+  foo:
+    daemon: simple
+    success-exit-status: [TEMPFAIL, 250, SIGKILL]
+`)
+	fooSuccessExitStatusNotADaemon := []byte(`
+apps:
+  foo:
+    success-exit-status: [0, 1]
+`)
+	fooSuccessExitStatusEmpty := []byte(`
+apps:
+  foo:
+    daemon: simple
+    success-exit-status: [""]
+`)
+
+	tcs := []struct {
+		name string
+		desc []byte
+		err  string
+	}{{
+		name: "foo success-exit-status all good",
+		desc: fooAllGood,
+	}, {
+		name: "foo success-exit-status but not a service",
+		desc: fooSuccessExitStatusNotADaemon,
+		err:  `success-exit-status is only applicable to services`,
+	}, {
+		name: "foo success-exit-status with empty value",
+		desc: fooSuccessExitStatusEmpty,
+		err:  `success-exit-status cannot contain empty values`,
+	}}
+	for _, tc := range tcs {
+		c.Logf("trying %q", tc.name)
+		info, err := InfoFromSnapYaml(append(meta, tc.desc...))
+		c.Assert(err, IsNil)
+		c.Assert(info, NotNil)
+
+		err = Validate(info)
+		if tc.err != "" {
+			c.Assert(err, ErrorMatches, `invalid definition of application "foo": `+tc.err)
+		} else {
+			c.Assert(err, IsNil)
+		}
+	}
+}
+
 func (s *ValidateSuite) TestValidateSystemUsernames(c *C) {
 	const yaml1 = `name: binary
 version: 1.0

--- a/wrappers/internal/service_unit_gen.go
+++ b/wrappers/internal/service_unit_gen.go
@@ -156,6 +156,9 @@ Restart={{.Restart}}
 {{- if .App.RestartDelay}}
 RestartSec={{.App.RestartDelay.Seconds}}
 {{- end}}
+{{- if .SuccessExitStatus}}
+SuccessExitStatus={{ stringsJoin .SuccessExitStatus " " }}
+{{- end}}
 WorkingDirectory={{.WorkingDir}}
 {{- if .App.StopCommand}}
 ExecStop={{.App.LauncherStopCommand}}
@@ -265,6 +268,7 @@ WantedBy={{.ServicesTarget}}
 		KillSignal               string
 		OOMAdjustScore           int
 		BusName                  string
+		SuccessExitStatus        []string
 		Before                   []string
 		After                    []string
 		Requires                 []string
@@ -283,14 +287,15 @@ WantedBy={{.ServicesTarget}}
 		InterfaceServiceSnippets: ifaceSpecifiedServiceSnippet,
 		InterfaceUnitSnippets:    ifaceSpecifiedUnitSnippet,
 
-		Restart:        restartCond,
-		StopTimeout:    serviceStopTimeout(appInfo),
-		StartTimeout:   time.Duration(appInfo.StartTimeout),
-		Remain:         remain,
-		KillMode:       killMode,
-		KillSignal:     appInfo.StopMode.KillSignal(),
-		OOMAdjustScore: oomAdjustScore,
-		BusName:        busName,
+		Restart:           restartCond,
+		StopTimeout:       serviceStopTimeout(appInfo),
+		StartTimeout:      time.Duration(appInfo.StartTimeout),
+		Remain:            remain,
+		KillMode:          killMode,
+		KillSignal:        appInfo.StopMode.KillSignal(),
+		OOMAdjustScore:    oomAdjustScore,
+		BusName:           busName,
+		SuccessExitStatus: appInfo.SuccessExitStatus,
 
 		Before: generateServiceNames(appInfo.Snap, appInfo.Before),
 		After:  generateServiceNames(appInfo.Snap, appInfo.After),

--- a/wrappers/internal/service_unit_gen_test.go
+++ b/wrappers/internal/service_unit_gen_test.go
@@ -950,3 +950,44 @@ apps:
 	_, err = internal.GenerateSnapServiceUnitFile(app, nil)
 	c.Assert(err, ErrorMatches, `internal error: unknown plug service snippet section "bad"`)
 }
+
+func (s *serviceUnitGenSuite) TestSuccessExitStatus(c *C) {
+	service := &snap.AppInfo{
+		Snap: &snap.Info{
+			SuggestedName: "snap",
+			Version:       "0.3.4",
+			SideInfo:      snap.SideInfo{Revision: snap.R(44)},
+		},
+		Name:              "app",
+		Command:           "bin/foo start",
+		Daemon:            "simple",
+		DaemonScope:       snap.SystemDaemon,
+		SuccessExitStatus: []string{"TEMPFAIL", "250", "SIGKILL"},
+	}
+
+	generatedWrapper, err := internal.GenerateSnapServiceUnitFile(service, nil)
+	c.Assert(err, IsNil)
+
+	c.Check(string(generatedWrapper), Matches, `(?s).*\nSuccessExitStatus=TEMPFAIL 250 SIGKILL\n.*`)
+}
+
+func (s *serviceUnitGenSuite) TestSuccessExitStatusEmpty(c *C) {
+	service := &snap.AppInfo{
+		Snap: &snap.Info{
+			SuggestedName: "snap",
+			Version:       "0.3.4",
+			SideInfo:      snap.SideInfo{Revision: snap.R(44)},
+		},
+		Name:        "app",
+		Command:     "bin/foo start",
+		Daemon:      "simple",
+		DaemonScope: snap.SystemDaemon,
+		// No SuccessExitStatus specified
+	}
+
+	generatedWrapper, err := internal.GenerateSnapServiceUnitFile(service, nil)
+	c.Assert(err, IsNil)
+
+	// Should not contain SuccessExitStatus line
+	c.Check(string(generatedWrapper), Not(Matches), `(?s).*SuccessExitStatus.*`)
+}


### PR DESCRIPTION
Related to https://bugs.launchpad.net/snapd/+bug/2120479

Snapcraft reference is https://github.com/canonical/snapcraft/issues/5692
