### PR TITLE
interfaces: support setting exclusive snap connections

### DIFF
--- a/interfaces/builtin/all_test.go
+++ b/interfaces/builtin/all_test.go
@@ -472,3 +472,26 @@ func (s *AllSuite) TestPrioritizedSnippets(c *C) {
 	c.Assert(len(keys), Equals, 1)
 	c.Assert(keys, testutil.Contains, "desktop-file-access")
 }
+
+type conflictsWithOtherConnectedInterfacesDefiner interface {
+	ConflictsWithOtherConnectedInterfaces() []string
+}
+
+func (s *AllSuite) TestDefinedConflictingConnectedInterfaces(c *C) {
+	// Check that all expected connection conflicts are defined.
+	//
+	// Note: Conflicting connection relations are bi-directional, it
+	// is okay to define one-side of the relation only.
+	expected := map[string][]string{
+		"gpio-chardev": {"gpio"},
+	}
+
+	found := make(map[string][]string, len(expected))
+	for _, i := range builtin.Interfaces() {
+		if iface, ok := i.(conflictsWithOtherConnectedInterfacesDefiner); ok {
+			found[i.Name()] = iface.ConflictsWithOtherConnectedInterfaces()
+		}
+	}
+
+	c.Assert(found, DeepEquals, found)
+}

--- a/interfaces/builtin/common.go
+++ b/interfaces/builtin/common.go
@@ -91,6 +91,8 @@ type commonInterface struct {
 	controlsDeviceCgroup bool
 
 	serviceSnippets []interfaces.PlugServicesSnippet
+
+	exclusiveConnectedInterfaces []string
 }
 
 // Name returns the interface name.
@@ -218,4 +220,8 @@ func (iface *commonInterface) UDevConnectedPlug(spec *udev.Specification, plug *
 	}
 
 	return nil
+}
+
+func (iface *commonInterface) ExclusiveConnectedInterfaces() []string {
+	return iface.exclusiveConnectedInterfaces
 }

--- a/interfaces/builtin/common.go
+++ b/interfaces/builtin/common.go
@@ -92,7 +92,7 @@ type commonInterface struct {
 
 	serviceSnippets []interfaces.PlugServicesSnippet
 
-	exclusiveConnectedInterfaces []string
+	conflictingConnectedInterfaces []string
 }
 
 // Name returns the interface name.
@@ -222,6 +222,6 @@ func (iface *commonInterface) UDevConnectedPlug(spec *udev.Specification, plug *
 	return nil
 }
 
-func (iface *commonInterface) ExclusiveConnectedInterfaces() []string {
-	return iface.exclusiveConnectedInterfaces
+func (iface *commonInterface) ConflictsWithOtherConnectedInterfaces() []string {
+	return iface.conflictingConnectedInterfaces
 }

--- a/interfaces/builtin/common.go
+++ b/interfaces/builtin/common.go
@@ -95,6 +95,8 @@ type commonInterface struct {
 	conflictingConnectedInterfaces []string
 }
 
+var _ = interfaces.ConflictingConnectedInterfacesDefiner(&commonInterface{})
+
 // Name returns the interface name.
 func (iface *commonInterface) Name() string {
 	return iface.name

--- a/interfaces/builtin/gpio_chardev.go
+++ b/interfaces/builtin/gpio_chardev.go
@@ -203,11 +203,12 @@ func (iface *gpioChardevInterface) UDevConnectedPlug(spec *udev.Specification, p
 func init() {
 	registerIface(&gpioChardevInterface{
 		commonInterface{
-			name:                     "gpio-chardev",
-			summary:                  gpioChardevSummary,
-			baseDeclarationSlots:     gpioChardevBaseDeclarationSlots,
-			connectedSlotKModModules: gpioChardevConnectedSlotKmod,
-			serviceSnippets:          gpioChardevPlugServiceSnippets,
+			name:                         "gpio-chardev",
+			summary:                      gpioChardevSummary,
+			baseDeclarationSlots:         gpioChardevBaseDeclarationSlots,
+			connectedSlotKModModules:     gpioChardevConnectedSlotKmod,
+			serviceSnippets:              gpioChardevPlugServiceSnippets,
+			exclusiveConnectedInterfaces: []string{"gpio"},
 		},
 	})
 }

--- a/interfaces/builtin/gpio_chardev.go
+++ b/interfaces/builtin/gpio_chardev.go
@@ -203,12 +203,14 @@ func (iface *gpioChardevInterface) UDevConnectedPlug(spec *udev.Specification, p
 func init() {
 	registerIface(&gpioChardevInterface{
 		commonInterface{
-			name:                         "gpio-chardev",
-			summary:                      gpioChardevSummary,
-			baseDeclarationSlots:         gpioChardevBaseDeclarationSlots,
-			connectedSlotKModModules:     gpioChardevConnectedSlotKmod,
-			serviceSnippets:              gpioChardevPlugServiceSnippets,
-			exclusiveConnectedInterfaces: []string{"gpio"},
+			name:                     "gpio-chardev",
+			summary:                  gpioChardevSummary,
+			baseDeclarationSlots:     gpioChardevBaseDeclarationSlots,
+			connectedSlotKModModules: gpioChardevConnectedSlotKmod,
+			serviceSnippets:          gpioChardevPlugServiceSnippets,
+			// gpio-chardev and gpio export the same kernel GPIO devices but through
+			// different kernel APIs, connecting both at the same time is not supported.
+			conflictingConnectedInterfaces: []string{"gpio"},
 		},
 	})
 }

--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -237,6 +237,19 @@ type SymlinksUser interface {
 	TrackedDirectories() []string
 }
 
+// ConflictingConnectedInterfacesDefiner must be implemented by Interfaces
+// that conflicts with other connected interfaces.
+type ConflictingConnectedInterfacesDefiner interface {
+	// ConflictsWithOtherConnectedInterfaces returns a list of interface names
+	// that conflict with this interface on connection.
+	//
+	// The mutually exclusive connection relation is bi-directional, so if any
+	// of the conflicting interfaces has an active connection then this interface
+	// cannot be connected, and if this interface has an active connection then
+	// non of the conflicting interfaces can be connected.
+	ConflictsWithOtherConnectedInterfaces() []string
+}
+
 // StaticInfo describes various static-info of a given interface.
 //
 // The Summary must be a one-line string of length suitable for listing views.

--- a/interfaces/ifacetest/testiface.go
+++ b/interfaces/ifacetest/testiface.go
@@ -167,6 +167,16 @@ type TestSymlinksInterface struct {
 	DirectoriesCallback func() []string
 }
 
+// TestConflictingConnectionInterface is used to test support for
+// defining conflicting interface connections, which needs interfaces
+// implementing ConflictsWithOtherConnectedInterfaces.
+type TestConflictingConnectionInterface struct {
+	TestInterface
+
+	// Support for defining conflicting interface connections.
+	ConflictingConnectedInterfaces []string
+}
+
 // String() returns the same value as Name().
 func (t *TestInterface) String() string {
 	return t.Name()
@@ -621,4 +631,10 @@ func (t *TestSymlinksInterface) TrackedDirectories() []string {
 		return t.DirectoriesCallback()
 	}
 	return nil
+}
+
+// Support for defining conflicting interface connections.
+
+func (t *TestConflictingConnectionInterface) ConflictsWithOtherConnectedInterfaces() []string {
+	return t.ConflictingConnectedInterfaces
 }

--- a/interfaces/repo.go
+++ b/interfaces/repo.go
@@ -39,7 +39,7 @@ type Repository struct {
 	ifaces map[string]Interface
 	// subset of ifaces that implement HotplugDeviceAdded method
 	hotplugIfaces map[string]Interface
-	// Indexed by [snapName][plugName]
+	// indexed by [snapName][plugName]
 	plugs map[string]map[string]*snap.PlugInfo
 	slots map[string]map[string]*snap.SlotInfo
 	// given a slot and a plug, are they connected?
@@ -49,8 +49,9 @@ type Repository struct {
 	backends  []SecurityBackend
 	// mapping of snap name to app set that was added to the repo with AddAppSet
 	appSets map[string]*SnapAppSet
-
-	exclusiveConnectedInterfaces map[string]map[string]struct{}
+	// indexed by [ifaceName1][ifaceName2] indicates that interface "ifaceName1"
+	// cannot be connected if interface "ifaceName2" already has a connection
+	conflictingConnectedInterfaces map[string]map[string]struct{}
 }
 
 // defaultIfaceDocURLTemplate is used as template for generating the default interface
@@ -60,14 +61,14 @@ const defaultIfaceDocURLTemplate = "https://snapcraft.io/docs/%s-interface"
 // NewRepository creates an empty plug repository.
 func NewRepository() *Repository {
 	repo := &Repository{
-		ifaces:                       make(map[string]Interface),
-		hotplugIfaces:                make(map[string]Interface),
-		plugs:                        make(map[string]map[string]*snap.PlugInfo),
-		slots:                        make(map[string]map[string]*snap.SlotInfo),
-		slotPlugs:                    make(map[*snap.SlotInfo]map[*snap.PlugInfo]*Connection),
-		plugSlots:                    make(map[*snap.PlugInfo]map[*snap.SlotInfo]*Connection),
-		appSets:                      make(map[string]*SnapAppSet),
-		exclusiveConnectedInterfaces: make(map[string]map[string]struct{}),
+		ifaces:                         make(map[string]Interface),
+		hotplugIfaces:                  make(map[string]Interface),
+		plugs:                          make(map[string]map[string]*snap.PlugInfo),
+		slots:                          make(map[string]map[string]*snap.SlotInfo),
+		slotPlugs:                      make(map[*snap.SlotInfo]map[*snap.PlugInfo]*Connection),
+		plugSlots:                      make(map[*snap.PlugInfo]map[*snap.SlotInfo]*Connection),
+		appSets:                        make(map[string]*SnapAppSet),
+		conflictingConnectedInterfaces: make(map[string]map[string]struct{}),
 	}
 
 	return repo
@@ -82,7 +83,7 @@ func ResetRepository(repo *Repository) {
 	repo.slotPlugs = make(map[*snap.SlotInfo]map[*snap.PlugInfo]*Connection)
 	repo.plugSlots = make(map[*snap.PlugInfo]map[*snap.SlotInfo]*Connection)
 	repo.appSets = make(map[string]*SnapAppSet)
-	repo.exclusiveConnectedInterfaces = map[string]map[string]struct{}{}
+	repo.conflictingConnectedInterfaces = map[string]map[string]struct{}{}
 }
 
 // Interface returns an interface with a given name.
@@ -111,19 +112,19 @@ func (r *Repository) AddInterface(i Interface) error {
 		r.hotplugIfaces[interfaceName] = i
 	}
 
-	type exclusiveConnectedInterfacesDefiner interface {
-		ExclusiveConnectedInterfaces() []string
+	type conflictsWithOtherConnectedInterfacesDefiner interface {
+		ConflictsWithOtherConnectedInterfaces() []string
 	}
-	if iface, ok := i.(exclusiveConnectedInterfacesDefiner); ok {
-		for _, otherInterfaceName := range iface.ExclusiveConnectedInterfaces() {
-			if r.exclusiveConnectedInterfaces[interfaceName] == nil {
-				r.exclusiveConnectedInterfaces[interfaceName] = make(map[string]struct{}, 1)
+	if iface, ok := i.(conflictsWithOtherConnectedInterfacesDefiner); ok {
+		for _, otherInterfaceName := range iface.ConflictsWithOtherConnectedInterfaces() {
+			if r.conflictingConnectedInterfaces[interfaceName] == nil {
+				r.conflictingConnectedInterfaces[interfaceName] = make(map[string]struct{}, 1)
 			}
-			if r.exclusiveConnectedInterfaces[otherInterfaceName] == nil {
-				r.exclusiveConnectedInterfaces[otherInterfaceName] = make(map[string]struct{}, 1)
+			if r.conflictingConnectedInterfaces[otherInterfaceName] == nil {
+				r.conflictingConnectedInterfaces[otherInterfaceName] = make(map[string]struct{}, 1)
 			}
-			r.exclusiveConnectedInterfaces[interfaceName][otherInterfaceName] = struct{}{}
-			r.exclusiveConnectedInterfaces[otherInterfaceName][interfaceName] = struct{}{}
+			r.conflictingConnectedInterfaces[interfaceName][otherInterfaceName] = struct{}{}
+			r.conflictingConnectedInterfaces[otherInterfaceName][interfaceName] = struct{}{}
 		}
 	}
 
@@ -570,11 +571,11 @@ func (r *Repository) Connect(ref *ConnRef, plugStaticAttrs, plugDynamicAttrs, sl
 		return nil, fmt.Errorf("internal error: unknown interface %q", plug.Interface)
 	}
 
-	if r.exclusiveConnectedInterfaces[iface.Name()] != nil {
+	if r.conflictingConnectedInterfaces[iface.Name()] != nil {
 		// check no conflicting interfaces are connected
 		for slot := range r.slotPlugs {
-			if _, ok := r.exclusiveConnectedInterfaces[iface.Name()][slot.Interface]; ok {
-				return nil, fmt.Errorf("interface %[1]q and %[2]q are exclusive: connection already exists for %[2]q", iface.Name(), slot.Interface)
+			if _, ok := r.conflictingConnectedInterfaces[iface.Name()][slot.Interface]; ok {
+				return nil, fmt.Errorf("interface %[1]q and %[2]q cannot be connected at the same time: %[2]q is already connected", iface.Name(), slot.Interface)
 			}
 		}
 	}


### PR DESCRIPTION
This PR adds the ability for an interface to define a set of exclusive connected interfaces, this is needed when two interfaces cannot be connected at the same time e.g. `gpio-chardev` and `gpio`.