### PR TITLE
microstack: add permissions required by dpdk

### DIFF
--- a/interfaces/builtin/microstack_support.go
+++ b/interfaces/builtin/microstack_support.go
@@ -222,6 +222,10 @@ unmount /run/netns/ovnmeta-*,
 capability ipc_lock,
 # Allow anonymous files backed by huge pages.
 # https://gitlab.com/apparmor/apparmor/-/issues/545
+# This is safe as we aren't granting "/* rw" or "/** rw", which would allow
+# top level files and directories to be removed.
+# At the same time, subpaths are expected to be on squashfs unless modified
+# through layouts.
 owner / rw,
 `
 

--- a/interfaces/builtin/microstack_support.go
+++ b/interfaces/builtin/microstack_support.go
@@ -222,8 +222,7 @@ unmount /run/netns/ovnmeta-*,
 capability ipc_lock,
 # Allow anonymous files backed by huge pages.
 # https://gitlab.com/apparmor/apparmor/-/issues/545
-# This is safe as we aren't granting "/* rw" or "/** rw", which would allow
-# top level files and directories to be removed.
+# Note that this rule doesn't allow top level files and directories to be removed.
 # At the same time, subpaths are expected to be on squashfs unless modified
 # through layouts.
 owner / rw,

--- a/interfaces/builtin/microstack_support.go
+++ b/interfaces/builtin/microstack_support.go
@@ -215,6 +215,14 @@ unmount /run/netns/ovnmeta-*,
 
 # Required by libvirtd to detect and utilise AMD SEV capabilities for AMD CPU's
 /dev/sev rw,
+
+# Required by OVS to initialize DPDK
+# https://doc.dpdk.org/guides/linux_gsg/enable_func.html
+@{PROC}/@{pids}/pagemap r,
+capability ipc_lock,
+# Allow anonymous files backed by huge pages.
+# https://bugs.launchpad.net/ubuntu/+source/libvirt/+bug/2073214
+owner / rw,
 `
 
 const microStackSupportConnectedPlugSecComp = `

--- a/interfaces/builtin/microstack_support.go
+++ b/interfaces/builtin/microstack_support.go
@@ -221,7 +221,7 @@ unmount /run/netns/ovnmeta-*,
 @{PROC}/@{pids}/pagemap r,
 capability ipc_lock,
 # Allow anonymous files backed by huge pages.
-# https://bugs.launchpad.net/ubuntu/+source/libvirt/+bug/2073214
+# https://gitlab.com/apparmor/apparmor/-/issues/545
 owner / rw,
 `
 


### PR DESCRIPTION
ovs-vswitchd currently fails to initialize DPDK, lacking hugepage related permissions.

```
  2025-08-08T12:51:02.760Z|00015|dpdk|INFO|EAL: rte_mem_virt2phy():
  cannot open /proc/self/pagemap: Permission denied
  2025-08-08T12:51:02.764Z|00020|dpdk|EMER|EAL: Cannot init memory
  2025-08-08T12:51:02.764Z|00021|dpdk|EMER|Unable to initialize DPDK: Cannot allocate memory
```

Apparmor events:

```
  apparmor="DENIED" operation="open" class="file"
  profile="snap.openstack-hypervisor.ovs-vswitchd"
  name="/proc/1391152/pagemap" pid=1391152 comm="ovs-vswitchd" requested_mask="r"
  denied_mask="r" fsuid=0 ouid=0

  apparmor="DENIED" operation="truncate" class="file"
  profile="snap.openstack-hypervisor.ovs-vswitchd"
  name="/" pid=841157 comm="ovs-vswitchd" requested_mask="w"
  denied_mask="w" fsuid=0 ouid=0
```

The following page documents (most of) the necessary permissions, some of which are already provided.
https://doc.dpdk.org/guides/linux_gsg/enable_func.html

The `owner / rw` rule might seem unusual, however it's necessary in order to allow anonymous files backed by huge pages: https://bugs.launchpad.net/ubuntu/+source/libvirt/+bug/2073214