### PR TITLE
boot: make sure that we seal properly with kernel command line defaults

### DIFF
--- a/boot/makebootable.go
+++ b/boot/makebootable.go
@@ -606,13 +606,15 @@ func makeRunnableSystem(model *asserts.Model, bootWith *BootableSet, observer Tr
 		if err != nil {
 			return fmt.Errorf("cannot compose the candidate command line: %v", err)
 		}
-		modeenv.CurrentKernelCommandLines = bootCommandLines{cmdline}
 
 		// Look at gadget default values for system.kernel.*cmdline-append options
 		cmdlineAppend, err := buildOptionalKernelCommandLine(model, bootWith.UnpackedGadgetDir)
 		if err != nil {
 			return fmt.Errorf("while retrieving system.kernel.*cmdline-append defaults: %v", err)
 		}
+
+		modeenv.CurrentKernelCommandLines = bootCommandLines{
+			strutil.JoinNonEmpty([]string{cmdline, cmdlineAppend}, " ")}
 
 		candidate := false
 		defaultCmdLine, err := tbl.DefaultCommandLine(candidate)

--- a/tests/nested/manual/cmdline-option/defaults.yaml
+++ b/tests/nested/manual/cmdline-option/defaults.yaml
@@ -4,3 +4,5 @@ defaults:
       hold: "@HOLD-TIME@"
     journal:
       persistent: true
+    system:
+      kernel.cmdline-append: foo=1 foo=2

--- a/tests/nested/manual/cmdline-option/task.yaml
+++ b/tests/nested/manual/cmdline-option/task.yaml
@@ -138,6 +138,9 @@ execute: |
   remote.exec "sudo cat /proc/cmdline" | MATCH "foo=1 foo=2"
   remote.exec cat /var/lib/snapd/modeenv | MATCH "foo=1 foo=2"
 
+  echo "No errors in snap change 1"
+  remote.exec snap change 1 | NOMATCH ERROR
+
   cmdlineOptDang="extradang.val=1 extradang.flag"
   remoteCmd="sudo snap set system system.kernel.dangerous-cmdline-append=\"$cmdlineOptDang\""
   remote.exec "$remoteCmd"

--- a/tests/nested/manual/cmdline-option/task.yaml
+++ b/tests/nested/manual/cmdline-option/task.yaml
@@ -134,6 +134,10 @@ execute: |
   echo "Check we have the right model from snap model"
   remote.exec "sudo snap model --verbose" | MATCH "grade:\s+${MODEL_GRADE}"
 
+  echo "Check that gadget kernel command line defaults have been respected"
+  remote.exec "sudo cat /proc/cmdline" | MATCH "foo=1 foo=2"
+  remote.exec cat /var/lib/snapd/modeenv | MATCH "foo=1 foo=2"
+
   cmdlineOptDang="extradang.val=1 extradang.flag"
   remoteCmd="sudo snap set system system.kernel.dangerous-cmdline-append=\"$cmdlineOptDang\""
   remote.exec "$remoteCmd"


### PR DESCRIPTION
Add kernel command line coming from defaults in gadget.yaml to the modeenv so
we seal against the correct arguments. Fixes LP#2120717.

Also, if not seeded, we do not want to create an update kernel command line change that
comes from the gadget defaults, as those have already been applied to the
current kernel command line on installation. This created an unexpected error
messages as a conflict was detected. Fixes LP#2120184.

Add checks for this in spread test.