### PR TITLE
tests: run tests/nested/manual/hybrid-fde-recovery-keys for 25.10 again

### DIFF
--- a/tests/nested/manual/hybrid-fde-recovery-keys/task.yaml
+++ b/tests/nested/manual/hybrid-fde-recovery-keys/task.yaml
@@ -11,9 +11,9 @@ details: |
 systems: [-ubuntu-1*, -ubuntu-20*, -ubuntu-22*]
 
 environment:
-  MODEL_VERSION: "25.10"
-  GADGET_VERSION: "classic-25.10"
-  KERNEL_VERSION: "25.10"
+  MODEL_VERSION/2510: "25.10"
+  GADGET_VERSION/2510: "classic-25.10"
+  KERNEL_VERSION/2510: "25.10"
 
   # Only 25.10+ systems (including core) should be able to
   # use the new TPM FDE recovery key APIs, so keep those systems

--- a/tests/nested/manual/passphrase-support-on-hybrid/task.yaml
+++ b/tests/nested/manual/passphrase-support-on-hybrid/task.yaml
@@ -7,11 +7,9 @@ details: |
 systems: [-ubuntu-1*, -ubuntu-20*, -ubuntu-22*]
 
 environment:
-  # Defaults
-  MODEL_VERSION: "25.10"
-  GADGET_VERSION: "classic-25.10"
-  KERNEL_VERSION: "25.10"
-  KDF_TYPE: default
+  MODEL_VERSION/2510: "25.10"
+  GADGET_VERSION/2510: "classic-25.10"
+  KERNEL_VERSION/2510: "25.10"
 
   MODEL_VERSION/2404: "24.04"
   GADGET_VERSION/2404: classic-24.04
@@ -21,6 +19,7 @@ environment:
   GADGET_VERSION/2504: "classic-25.04"
   KERNEL_VERSION/2504: "25.04"
 
+  KDF_TYPE: default
   KDF_TYPE/pbkdf2: pbkdf2
   KDF_TYPE/argon2i: argon2i
   KDF_TYPE/argon2id: argon2id


### PR DESCRIPTION
It seems that `tests/nested/manual/hybrid-fde-recovery-keys` stopped working silently some time ago, which explains why it didn't fail when the 25.10 gadget seed disk size was increased.

It started not working in https://github.com/canonical/snapd/pull/15711 because the 2510 variant was removed and switched as default env vars and it didn't run because there were no other variants that don't override the relevant env vars.

`tests/nested/manual/passphrase-support-on-hybrid/task.yaml` was updated for consistency and to avoid the same happening there.