### PR TITLE
github: use pull_request_target instead of pull_request

### DIFF
--- a/.github/workflows/ready-for-review-checker.yaml
+++ b/.github/workflows/ready-for-review-checker.yaml
@@ -1,7 +1,7 @@
 name: Remove Run-only-one-system label and trigger read-systems job
 
 on:
-  pull_request:
+  pull_request_target:
     types: [ready_for_review]
 
 jobs:


### PR DESCRIPTION
I chose the wrong event for the label-remover. `pull_request` runs in the context of the merge commit, which in our case since we use forks, does not have write permissions to remove the label, comment on the workflow, and trigger the job. The `pull_request_target` event instead runs in the context of the base, and so has those permissions. Here's the relevant bit in the documentation from https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target:

> This event runs in the context of the base of the pull request, rather than in the context of the merge commit, as the pull_request event does. This prevents execution of unsafe code from the head of the pull request that could alter your repository or steal any secrets you use in your workflow. This event allows your workflow to do things like label or comment on pull requests from forks. Avoid using this event if you need to build or run code from the pull request.
