### PR TITLE
tests: keep instances running  in ps6

### DIFF
--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -290,14 +290,13 @@ jobs:
       run: |
         echo KEEP_INSTANCES=true >> $GITHUB_ENV
         backend="${{ inputs.backend }}"
+        spread_lib_dir=tests/lib/spread
         for system in ${{ inputs.systems }}; do
             workers=$(yq '.backends["$backend"].systems[] | select(has("$system"))[].workers' < spread.yaml)
-            if [ "$workers" != null ]; then
-                cd tests/lib/spread
-                cp spread."$backend".yaml spread.yaml
-                spread -gc -collect "$workers"
-                rm spread.yaml
-                rm .spread-reuse.*.yaml
+            if [[ "$workers" =~ ^[0-9]+$ ]] && (( workers > 0 )); then
+                cp "$spread_lib_dir"/spread."$backend".yaml "$spread_lib_dir"/spread.yaml
+                ( cd "$spread_lib_dir" && spread -gc -collect "$workers" )
+                rm -f "$spread_lib_dir"/spread.yaml "$spread_lib_dir"/.spread-reuse.*.yaml
             fi
         done
 

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -285,6 +285,22 @@ jobs:
           mv -v "${snap}" "${snap}.keep"
         done
 
+    - name: Collect required instances
+      if: ${{ inputs.backend == 'openstack' }}
+      run: |
+        echo KEEP_INSTANCES=true >> $GITHUB_ENV
+        backend="${{ inputs.backend }}"
+        for system in ${{ inputs.systems }}; do
+            workers=$(yq '.backends["$backend"].systems[] | select(has("$system"))[].workers' < spread.yaml)
+            if [ "$workers" != null ]; then
+                cd tests/lib/spread
+                cp spread."$backend".yaml spread.yaml
+                spread -gc -collect "$workers"
+                rm spread.yaml
+                rm .spread-reuse.*.yaml
+            fi
+        done
+
     - name: Run spread tests
       if: ${{ env.SKIP_SPREAD_LABEL != 'true' }}
       env:
@@ -351,6 +367,12 @@ jobs:
             echo "ARTIFACTS_FOLDER=spread-artifacts" >> $GITHUB_ENV
           fi
 
+          if [ "${KEEP_INSTANCES:-}" = true ]; then
+            # Instances are not discarded when the KEEP_INSTANCES is true
+            # This is done to avoid lack of resources during the following runs
+            SPREAD_FLAGS="$SPREAD_FLAGS -reuse"
+          fi
+
           # Run spread tests
           # "pipefail" ensures that a non-zero status from the spread is
           # propagated; and we use a subshell as this option could trigger
@@ -366,6 +388,11 @@ jobs:
     - name: Discard spread workers
       if: always()
       run: |
+        # Workers are not discarded when KEEP_INSTANCES is true
+        if [ "${KEEP_INSTANCES:-}" = true ]; then
+          exit
+        fi
+
         # Make sure there is not spread process running which locks the .spread-reuse.*.yaml files
         killall -s SIGQUIT spread || true
         shopt -s nullglob;

--- a/spread.yaml
+++ b/spread.yaml
@@ -394,6 +394,7 @@ backends:
         halt-timeout: 2h
         wait-timeout: 5m
         groups: [default]
+        volume-auto-delete: true
         environment:
             HTTP_PROXY: "http://squid.internal:3128"
             HTTPS_PROXY: "http://squid.internal:3128"

--- a/tests/lib/spread/spread.openstack.yaml
+++ b/tests/lib/spread/spread.openstack.yaml
@@ -1,0 +1,16 @@
+project: snapd
+
+path: /root/spread
+
+backends:
+    openstack:
+        key: '$(HOST: echo "$OS_CREDENTIALS_AMD64_PS6")'
+        halt-timeout: 2h
+        groups: [default]
+        systems:
+            - fedora-42-64:
+                  image: snapd-spread/fedora-42-64
+
+suites: 
+    suite/:
+        summary: fake suite

--- a/tests/lib/spread/suite/task/task.yaml
+++ b/tests/lib/spread/suite/task/task.yaml
@@ -1,0 +1,2 @@
+summary: fake task
+execute: exit 0


### PR DESCRIPTION
Instances are not discarded when the backend is openstack

This is done to avoid lack of resources next test execution

The approach also includes the removal of the vms cleaner for that environment.

