### PR TITLE
i/systemd: move WantedBy option to [Install] section

### DIFF
--- a/interfaces/systemd/service.go
+++ b/interfaces/systemd/service.go
@@ -38,7 +38,7 @@ type Service struct {
 }
 
 func (s *Service) unitSectionNeeded() bool {
-	return s.Description != "" || s.Wants != "" || s.WantedBy != "" || s.After != "" || s.Before != ""
+	return s.Description != "" || s.Wants != "" || s.After != "" || s.Before != ""
 }
 
 func (s *Service) String() string {
@@ -51,9 +51,6 @@ func (s *Service) String() string {
 	}
 	if s.Wants != "" {
 		fmt.Fprintf(&buf, "Wants=%s\n", s.Wants)
-	}
-	if s.WantedBy != "" {
-		fmt.Fprintf(&buf, "WantedBy=%s\n", s.WantedBy)
 	}
 	if s.After != "" {
 		fmt.Fprintf(&buf, "After=%s\n", s.After)
@@ -76,5 +73,8 @@ func (s *Service) String() string {
 		fmt.Fprintf(&buf, "ExecStop=%s\n", s.ExecStop)
 	}
 	fmt.Fprintf(&buf, "\n[Install]\nWantedBy=multi-user.target\n")
+	if s.WantedBy != "" {
+		fmt.Fprintf(&buf, "WantedBy=%s\n", s.WantedBy)
+	}
 	return buf.String()
 }

--- a/interfaces/systemd/service_test.go
+++ b/interfaces/systemd/service_test.go
@@ -45,7 +45,7 @@ func (s *serviceSuite) TestString(c *C) {
 	service7 := systemd.Service{Wants: "snapd.mounts.target"}
 	c.Assert(service7.String(), Equals, "[Unit]\nWants=snapd.mounts.target\n[Service]\n\n[Install]\nWantedBy=multi-user.target\n")
 	service8 := systemd.Service{WantedBy: "snapd.mounts.target"}
-	c.Assert(service8.String(), Equals, "[Unit]\nWantedBy=snapd.mounts.target\n[Service]\n\n[Install]\nWantedBy=multi-user.target\n")
+	c.Assert(service8.String(), Equals, "[Service]\n\n[Install]\nWantedBy=multi-user.target\nWantedBy=snapd.mounts.target\n")
 	service9 := systemd.Service{After: "snapd.mounts.target"}
 	c.Assert(service9.String(), Equals, "[Unit]\nAfter=snapd.mounts.target\n[Service]\n\n[Install]\nWantedBy=multi-user.target\n")
 	service10 := systemd.Service{Before: "snapd.mounts.target"}


### PR DESCRIPTION
`WantedBy` is not supported under `[Unit]` and was giving the following warning:
> Unknown key name 'WantedBy' in section 'Unit', ignoring
