### PR TITLE
i/builtin: fix gpio-aggregator module not being loaded in the right order

### DIFF
--- a/interfaces/builtin/gpio_chardev.go
+++ b/interfaces/builtin/gpio_chardev.go
@@ -59,7 +59,7 @@ const gpioChardevBaseDeclarationSlots = `
     deny-auto-connection: true
 `
 
-var gpioChardevPermanentPlugKmod = []string{
+var gpioChardevPermanentSlotKmod = []string{
 	"gpio-aggregator",
 }
 
@@ -206,7 +206,7 @@ func init() {
 			name:                     "gpio-chardev",
 			summary:                  gpioChardevSummary,
 			baseDeclarationSlots:     gpioChardevBaseDeclarationSlots,
-			permanentPlugKModModules: gpioChardevPermanentPlugKmod,
+			permanentSlotKModModules: gpioChardevPermanentSlotKmod,
 			serviceSnippets:          gpioChardevPlugServiceSnippets,
 		},
 	})

--- a/interfaces/builtin/gpio_chardev.go
+++ b/interfaces/builtin/gpio_chardev.go
@@ -59,7 +59,7 @@ const gpioChardevBaseDeclarationSlots = `
     deny-auto-connection: true
 `
 
-var gpioChardevConnectedSlotKmod = []string{
+var gpioChardevPermanentPlugKmod = []string{
 	"gpio-aggregator",
 }
 
@@ -206,7 +206,7 @@ func init() {
 			name:                     "gpio-chardev",
 			summary:                  gpioChardevSummary,
 			baseDeclarationSlots:     gpioChardevBaseDeclarationSlots,
-			connectedSlotKModModules: gpioChardevConnectedSlotKmod,
+			permanentPlugKModModules: gpioChardevPermanentPlugKmod,
 			serviceSnippets:          gpioChardevPlugServiceSnippets,
 		},
 	})

--- a/interfaces/builtin/gpio_chardev_test.go
+++ b/interfaces/builtin/gpio_chardev_test.go
@@ -247,7 +247,7 @@ func (s *GpioChardevInterfaceSuite) TestSystemdConnectedPlug(c *C) {
 
 func (s *GpioChardevInterfaceSuite) TestKModPermanentPlug(c *C) {
 	spec := &kmod.Specification{}
-	c.Assert(spec.AddPermanentPlug(s.iface, s.plugInfo), IsNil)
+	c.Assert(spec.AddPermanentSlot(s.iface, s.slotInfo), IsNil)
 	c.Assert(spec.Modules(), DeepEquals, map[string]bool{
 		"gpio-aggregator": true,
 	})

--- a/interfaces/builtin/gpio_chardev_test.go
+++ b/interfaces/builtin/gpio_chardev_test.go
@@ -245,9 +245,9 @@ func (s *GpioChardevInterfaceSuite) TestSystemdConnectedPlug(c *C) {
 	})
 }
 
-func (s *GpioChardevInterfaceSuite) TestKModConnectedSlot(c *C) {
+func (s *GpioChardevInterfaceSuite) TestKModPermanentPlug(c *C) {
 	spec := &kmod.Specification{}
-	c.Assert(spec.AddConnectedSlot(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.AddPermanentPlug(s.iface, s.plugInfo), IsNil)
 	c.Assert(spec.Modules(), DeepEquals, map[string]bool{
 		"gpio-aggregator": true,
 	})


### PR DESCRIPTION
`BeforeConnectPlug` under the `gpio-chardev` interface is called before the kmod backend loads the `gpio-aggregator` module so it will always be reported as not supported.

To fix it, now load the module if a snap that plugs `gpio-chardev` is detected without being connected.
