### PR TITLE
cmd/snap: add system architecture to snap version output

### DIFF
--- a/cmd/snap/cmd_version.go
+++ b/cmd/snap/cmd_version.go
@@ -68,6 +68,10 @@ func printVersions(cli *client.Client) error {
 		fmt.Fprintf(w, "kernel\t%s\n", sv.KernelVersion)
 	}
 
+	if sv.Architecture != "" {
+		fmt.Fprintf(w, "architecture\t%s\n", sv.Architecture)
+	}
+
 	w.Flush()
 
 	return nil

--- a/cmd/snap/cmd_version_linux.go
+++ b/cmd/snap/cmd_version_linux.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"runtime"
 
+	"github.com/snapcore/snapd/arch"
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/osutil"
@@ -37,6 +38,7 @@ func serverVersion(cli *client.Client) *client.ServerVersion {
 			OSID:          "Windows Subsystem for Linux",
 			OnClassic:     true,
 			KernelVersion: fmt.Sprintf("%s (%s)", osutil.KernelVersion(), runtime.GOARCH),
+			Architecture:  arch.DpkgArchitecture(),
 		}
 	}
 	sv, err := cli.ServerVersion()

--- a/cmd/snap/cmd_version_test.go
+++ b/cmd/snap/cmd_version_test.go
@@ -42,7 +42,12 @@ func (s *SnapSuite) TestVersionCommandOnClassic(c *C) {
 
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"version"})
 	c.Assert(err, IsNil)
-	c.Assert(s.Stdout(), Equals, "snap    4.56\nsnapd   7.89\nseries  56\nubuntu  12.34\n")
+	c.Assert(s.Stdout(), Equals, ""+
+		"snap          4.56\n"+
+		"snapd         7.89\n"+
+		"series        56\n"+
+		"ubuntu        12.34\n"+
+		"architecture  ia64\n")
 	c.Assert(s.Stderr(), Equals, "")
 }
 
@@ -57,7 +62,11 @@ func (s *SnapSuite) TestVersionCommandOnAllSnap(c *C) {
 
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"version"})
 	c.Assert(err, IsNil)
-	c.Assert(s.Stdout(), Equals, "snap    4.56\nsnapd   7.89\nseries  56\n")
+	c.Assert(s.Stdout(), Equals, ""+
+		"snap          4.56\n"+
+		"snapd         7.89\n"+
+		"series        56\n"+
+		"architecture  powerpc\n")
 	c.Assert(s.Stderr(), Equals, "")
 }
 
@@ -72,7 +81,11 @@ func (s *SnapSuite) TestVersionCommandOnClassicNoOsVersion(c *C) {
 
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"version"})
 	c.Assert(err, IsNil)
-	c.Assert(s.Stdout(), Equals, "snap    4.56\nsnapd   7.89\nseries  56\narch    -\n")
+	c.Assert(s.Stdout(), Equals, ""+
+		"snap    4.56\n"+
+		"snapd   7.89\n"+
+		"series  56\n"+
+		"arch    -\n")
 	c.Assert(s.Stderr(), Equals, "")
 }
 

--- a/tests/smoke/versioning/task.yaml
+++ b/tests/smoke/versioning/task.yaml
@@ -1,6 +1,8 @@
-summary: Check that the version is not dirty
+summary: Check version content.
 
 details: |
+    Check that snap version output is as expected.
+
     Snapd has a script that generates the version string based on the Debian
     changelog file or on Git history, and the status of the git repository. When
     Git-based version is computed, it could contain the word "dirty" if the
@@ -9,10 +11,31 @@ details: |
     modified the code in unintended ways.
 
 execute: |
-    tests.exec is-skipped && exit 0
+    snap version > version.out
 
     # TODO: fix dirty version number on riscv
     echo "Ensure the version number is not 'dirty'"
     if not uname -m | MATCH riscv64; then
-        snap version | NOMATCH dirty
+        NOMATCH dirty < version.out
     fi
+
+    echo "Ensure both version of snapd and the snap command is reported"
+    # repository package
+    MATCH '^snapd *.*2.*' < version.out
+    MATCH '^snap *.*2.*' < version.out
+
+    echo "Versions of snapd and snap are identical"
+    vers_snapd="$(awk '/snapd / { print $2 }' < version.out)"
+    vers_snap="$(awk '/snap / { print $2 }' < version.out)"
+    test "$vers_snapd" = "$vers_snap"
+
+    if ! os.query is-core; then
+        echo "Ensure distribution information is included in the output"
+        distro_id="$( . /etc/os-release; echo "$ID" )"
+        # distro_id better not contain any characters that may be treated as regex
+        # operators
+        MATCH "$distro_id *" < version.out
+    fi
+
+    echo "Ensure version output includes architecture"
+    MATCH "architecture *(amd64|arm64|armel|armhf|i386|ppc64el|riscv64|s390x)" < version.out


### PR DESCRIPTION
Include information on system architecture in output of snap version.

Related: [SNAPDENG-35305](https://warthogs.atlassian.net/browse/SNAPDENG-35305)
Fixes: [LP#2043406](https://bugs.launchpad.net/snapd/+bug/2043406)

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?


[SNAPDENG-35305]: https://warthogs.atlassian.net/browse/SNAPDENG-35305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ