### PR TITLE
o/hookstate: block run-hook while the snap is inactive

### DIFF
--- a/overlord/hookstate/hookmgr.go
+++ b/overlord/hookstate/hookmgr.go
@@ -108,29 +108,7 @@ type HookSetup struct {
 // Manager returns a new HookManager.
 func Manager(s *state.State, runner *state.TaskRunner) (*HookManager, error) {
 	// Make sure we only run 1 hook task for given snap at a time
-	runner.AddBlocked(func(thisTask *state.Task, running []*state.Task) bool {
-		// check if we're a hook task
-		if thisTask.Kind() != "run-hook" {
-			return false
-		}
-		var hooksup HookSetup
-		if thisTask.Get("hook-setup", &hooksup) != nil {
-			return false
-		}
-		thisSnapName := hooksup.Snap
-		// examine all hook tasks, block thisTask if we find any other hook task affecting same snap
-		for _, t := range running {
-			if t.Kind() != "run-hook" || t.Get("hook-setup", &hooksup) != nil {
-				continue // ignore errors and continue checking remaining tasks
-			}
-			if hooksup.Snap == thisSnapName {
-				// found hook task affecting same snap, block thisTask.
-				return true
-			}
-		}
-		return false
-	})
-
+	runner.AddBlocked(snapIsRunningHook)
 	// ensure hooks can't run concurrently with snap unlinking (can happen during
 	// confdb operations that trigger hooks)
 	runner.AddBlocked(snapIsInactive)
@@ -156,6 +134,31 @@ func Manager(s *state.State, runner *state.TaskRunner) (*HookManager, error) {
 	snapstate.RegisterAffectedSnapsByAttr("hook-setup", manager.hookAffectedSnaps)
 
 	return manager, nil
+}
+
+// snapIsRunningHook returns true if hook's snap already has other running hooks.
+func snapIsRunningHook(cand *state.Task, running []*state.Task) bool {
+	if cand.Kind() != "run-hook" {
+		return false
+	}
+	var hooksup HookSetup
+	if cand.Get("hook-setup", &hooksup) != nil {
+		return false
+	}
+
+	candSnapName := hooksup.Snap
+	// block cand if we find any other hook task affecting same snap
+	for _, t := range running {
+		if t.Kind() != "run-hook" || t.Get("hook-setup", &hooksup) != nil {
+			continue // ignore errors and continue checking remaining tasks
+		}
+		if hooksup.Snap == candSnapName {
+			// found hook task affecting same snap, block candidate task
+			return true
+		}
+	}
+
+	return false
 }
 
 // snapIsInactive returns true if the hook's snap is inactive.

--- a/overlord/hookstate/hookstate_test.go
+++ b/overlord/hookstate/hookstate_test.go
@@ -1451,8 +1451,6 @@ func (s *componentHookManagerSuite) TestComponentHookTaskEnsureInstance(c *C) {
 		"snap", "run", "--hook", "install", "-r", "1", "test-snap_instance+standard-component",
 	}})
 
-	fmt.Println(s.change.Err())
-
 	c.Check(s.task.Kind(), Equals, "run-hook")
 	c.Check(s.task.Status(), Equals, state.DoneStatus)
 	c.Check(s.change.Status(), Equals, state.DoneStatus)


### PR DESCRIPTION
This prevents hooks from running while the hook's snap is unlinked. This used to be possible but very unusual because hooks ran at the end of changes. This is no longer unusual since confdb operations can trigger custodian hook runs at any time.
