### PR TITLE
secboot, o/install: support secboot preinstall error actions

### DIFF
--- a/cmd/snap-bootstrap/cmd_initramfs_mounts.go
+++ b/cmd/snap-bootstrap/cmd_initramfs_mounts.go
@@ -487,7 +487,7 @@ func doInstall(mst *initramfsMountsState, model *asserts.Model, sysSnaps map[sna
 	}
 
 	if useEncryption {
-		if err := install.PrepareEncryptedSystemData(model, installedSystem.BootstrappedContainerForRole, nil, trustedInstallObserver); err != nil {
+		if err := install.PrepareEncryptedSystemData(model, installedSystem.BootstrappedContainerForRole, nil, nil, trustedInstallObserver); err != nil {
 			return err
 		}
 	}

--- a/gadget/device/encrypt.go
+++ b/gadget/device/encrypt.go
@@ -97,9 +97,14 @@ func FactoryResetFallbackSaveSealedKeyUnder(seedDeviceFDEDir string) string {
 	return filepath.Join(seedDeviceFDEDir, "ubuntu-save.recovery.sealed-key.factory-reset")
 }
 
-// TpmLockoutAuthUnder return the path of the tpm lockout authority key.
+// TpmLockoutAuthUnder returns the path of the tpm lockout authority key.
 func TpmLockoutAuthUnder(saveDeviceFDEDir string) string {
 	return filepath.Join(saveDeviceFDEDir, "tpm-lockout-auth")
+}
+
+// PreinstallCheckResultUnder returns the path of the preinstall check result.
+func PreinstallCheckResultUnder(deviceFDEDir string) string {
+	return filepath.Join(deviceFDEDir, "preinstall-check-result")
 }
 
 // ErrNoSealedKeys error if there are no sealed keys

--- a/gadget/device/encrypt_test.go
+++ b/gadget/device/encrypt_test.go
@@ -105,6 +105,9 @@ func (s *deviceSuite) TestLocations(c *C) {
 
 	c.Check(device.TpmLockoutAuthUnder(dirs.SnapFDEDirUnderSave(dirs.SnapSaveDir)), Equals,
 		"/var/lib/snapd/save/device/fde/tpm-lockout-auth")
+
+	c.Check(device.PreinstallCheckResultUnder(boot.InstallHostFDESaveDir), Equals,
+		"/run/mnt/ubuntu-save/device/fde/preinstall-check-result")
 }
 
 func (s *deviceSuite) TestStampSealedKeysRunthrough(c *C) {

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -313,7 +313,7 @@ func (m *DeviceManager) doSetupRunSystem(t *state.Task, _ *tomb.Tomb) error {
 	}
 
 	if useEncryption {
-		if err := installLogic.PrepareEncryptedSystemData(model, installedSystem.BootstrappedContainerForRole, nil, trustedInstallObserver); err != nil {
+		if err := installLogic.PrepareEncryptedSystemData(model, installedSystem.BootstrappedContainerForRole, nil, nil, trustedInstallObserver); err != nil {
 			return err
 		}
 	}
@@ -640,7 +640,7 @@ func (m *DeviceManager) doFactoryResetRunSystem(t *state.Task, _ *tomb.Tomb) err
 		}
 		installedSystem.BootstrappedContainerForRole[gadget.SystemSave] = saveBoostrapContainer
 
-		if err := installLogic.PrepareEncryptedSystemData(model, installedSystem.BootstrappedContainerForRole, nil, trustedInstallObserver); err != nil {
+		if err := installLogic.PrepareEncryptedSystemData(model, installedSystem.BootstrappedContainerForRole, nil, nil, trustedInstallObserver); err != nil {
 			return err
 		}
 	}
@@ -1173,7 +1173,7 @@ func (m *DeviceManager) doInstallFinish(t *state.Task, _ *tomb.Tomb) error {
 	if useEncryption {
 		bootstrappedContainersForRole := install.BootstrappedContainersForRole(encryptSetupData)
 		if trustedInstallObserver != nil {
-			if err := installLogic.PrepareEncryptedSystemData(systemAndSnaps.Model, bootstrappedContainersForRole, encryptSetupData.VolumesAuth(), trustedInstallObserver); err != nil {
+			if err := installLogic.PrepareEncryptedSystemData(systemAndSnaps.Model, bootstrappedContainersForRole, encryptSetupData.VolumesAuth(), nil, trustedInstallObserver); err != nil {
 				return err
 			}
 		}

--- a/secboot/export_sb_test.go
+++ b/secboot/export_sb_test.go
@@ -37,6 +37,8 @@ import (
 	"github.com/snapcore/snapd/testutil"
 )
 
+type ResealKeysWithTPMParams = resealKeysWithTPMParams
+
 var (
 	UnwrapPreinstallCheckError         = unwrapPreinstallCheckError
 	ConvertPreinstallCheckErrorType    = convertPreinstallCheckErrorType
@@ -49,7 +51,13 @@ var (
 	ResealKeysWithFDESetupHook = resealKeysWithFDESetupHook
 )
 
-type ResealKeysWithTPMParams = resealKeysWithTPMParams
+func ExtractSbRunChecksContext(checkContext *PreinstallCheckContext) *sb_preinstall.RunChecksContext {
+	return checkContext.sbRunChecksContext
+}
+
+func NewPreinstallChecksContext(sbRunChecksContext *sb_preinstall.RunChecksContext) *PreinstallCheckContext {
+	return &PreinstallCheckContext{sbRunChecksContext}
+}
 
 func MockSbPreinstallNewRunChecksContext(f func(initialFlags sb_preinstall.CheckFlags, loadedImages []sb_efi.Image, profileOpts sb_preinstall.PCRProfileOptionsFlags) *sb_preinstall.RunChecksContext) (restore func()) {
 	old := sbPreinstallNewRunChecksContext

--- a/secboot/preinstall.go
+++ b/secboot/preinstall.go
@@ -31,3 +31,10 @@ type PreinstallErrorDetails struct {
 	Args    map[string]json.RawMessage `json:"args,omitempty"`
 	Actions []string                   `json:"actions,omitempty"`
 }
+
+// PreinstallAction describes an action with optional arguments that may
+// be requested to resolve a preinstall check error.
+type PreinstallAction struct {
+	Action string                     `json:"action"`
+	Args   map[string]json.RawMessage `json:"args,omitempty"`
+}

--- a/secboot/preinstall_nosb.go
+++ b/secboot/preinstall_nosb.go
@@ -24,6 +24,16 @@ import (
 	"context"
 )
 
-func PreinstallCheck(ctx context.Context, bootImagePaths []string) ([]PreinstallErrorDetails, error) {
+type PreinstallCheckContext struct{}
+
+func PreinstallCheck(ctx context.Context, bootImagePaths []string) (*PreinstallCheckContext, []PreinstallErrorDetails, error) {
+	return nil, nil, errBuildWithoutSecboot
+}
+
+func (c *PreinstallCheckContext) PreinstallCheckAction(ctx context.Context, action *PreinstallAction) ([]PreinstallErrorDetails, error) {
 	return nil, errBuildWithoutSecboot
+}
+
+func (c *PreinstallCheckContext) SaveCheckResult(filename string) error {
+	return errBuildWithoutSecboot
 }

--- a/secboot/preinstall_sb.go
+++ b/secboot/preinstall_sb.go
@@ -22,14 +22,24 @@ package secboot
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	sb_efi "github.com/snapcore/secboot/efi"
 	sb_preinstall "github.com/snapcore/secboot/efi/preinstall"
 
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/systemd"
 )
+
+// PreinstallCheckContext wraps RunChecksContext to control access
+// and avoid exposing the secboot dependency to external packages.
+type PreinstallCheckContext struct {
+	sbRunChecksContext *sb_preinstall.RunChecksContext
+}
 
 var (
 	sbPreinstallNewRunChecksContext = sb_preinstall.NewRunChecksContext
@@ -47,7 +57,7 @@ var (
 //
 // To support testing, when the system is running in a Virtual Machine, the check
 // configuration is modified to permit this to avoid an error.
-func PreinstallCheck(ctx context.Context, bootImagePaths []string) ([]PreinstallErrorDetails, error) {
+func PreinstallCheck(ctx context.Context, bootImagePaths []string) (*PreinstallCheckContext, []PreinstallErrorDetails, error) {
 	// allow value-added-retailer drivers that are:
 	//  - listed as Driver#### load options
 	//  - referenced in the DriverOrder UEFI variable
@@ -68,10 +78,37 @@ func PreinstallCheck(ctx context.Context, bootImagePaths []string) ([]Preinstall
 		bootImages = append(bootImages, sb_efi.NewFileImage(image))
 	}
 
-	checksContext := sbPreinstallNewRunChecksContext(checkFlags, bootImages, profileOptionFlags)
+	checkContext := &PreinstallCheckContext{sbPreinstallNewRunChecksContext(checkFlags, bootImages, profileOptionFlags)}
 
 	// no actions or action args for preinstall checks
-	result, err := sbPreinstallRunChecks(checksContext, ctx, sb_preinstall.ActionNone)
+	result, err := sbPreinstallRunChecks(checkContext.sbRunChecksContext, ctx, sb_preinstall.ActionNone)
+	if err != nil {
+		errorDetails, err := unwrapPreinstallCheckError(err)
+		if err != nil {
+			return nil, errorDetails, err
+		}
+		return checkContext, errorDetails, err
+	}
+
+	if result.Warnings != nil {
+		for _, warn := range result.Warnings.Unwrap() {
+			logger.Noticef("preinstall check warning: %v", warn)
+		}
+	}
+
+	return checkContext, nil, nil
+}
+
+// PreinstallCheckAction runs a follow-up preinstall check using the specified
+// action to evaluate whether a previously reported issue can be resolved. It
+// reuses the check configuration and boot image state from the preinstall check
+// context. On success, it returns a list with details on all remaining errors
+// identified by secboot or nil if no errors were found. Any warnings contained
+// in the secboot result are logged. On failure, it returns the error
+// encountered while interpreting the secboot error.
+func (c *PreinstallCheckContext) PreinstallCheckAction(ctx context.Context, action *PreinstallAction) ([]PreinstallErrorDetails, error) {
+	//TODO:FDEM: Changes to secboot required to allow passing args in a more usable format
+	result, err := sbPreinstallRunChecks(c.sbRunChecksContext, ctx, sb_preinstall.Action(action.Action))
 	if err != nil {
 		return unwrapPreinstallCheckError(err)
 	}
@@ -82,6 +119,26 @@ func PreinstallCheck(ctx context.Context, bootImagePaths []string) ([]Preinstall
 		}
 	}
 	return nil, nil
+}
+
+// SaveCheckResult writes the serialized preinstall check result in the location
+// specified by the filename.
+func (c *PreinstallCheckContext) SaveCheckResult(filename string) error {
+	result := c.sbRunChecksContext.Result()
+	if result == nil {
+		errorCount := len(c.sbRunChecksContext.Errors())
+		return fmt.Errorf("preinstall check result unavailable: %d unresolved errors", errorCount)
+	}
+
+	bytes, err := json.Marshal(result)
+	if err != nil {
+		return fmt.Errorf("cannot serialize preinstall check result: %v", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(filename), 0755); err != nil {
+		return err
+	}
+	return osutil.AtomicWriteFile(filename, bytes, 0600, 0)
 }
 
 // unwrapPreinstallCheckError converts a single or compound preinstall check


### PR DESCRIPTION
Extend secboot wrapper and install code to support error actions.

This PR aim to complete part 1 of the [complete design](https://github.com/ernestl/snapd/pull/3)
It extends the snapd secboot preinstall wrapper and install code to cater for a preinstall check with an error recovery action whenever a check context is provided and stores the latest check context resulting from a successful preinstall check (with or without an action) as part of encryption information.

Spec: [Perform TPM/FDE pre-install check error recovery actions](https://docs.google.com/document/d/1Mbj7Ut0tgW0PCz8VWdhvBN52kHTxYqkZZKQODB1NlLk/edit?tab=t.0#heading=h.26porr595yii)

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-35035