### PR TITLE
interfaces/kmod: fix comment to mention kmod rather than mount

### DIFF
--- a/interfaces/kmod/spec.go
+++ b/interfaces/kmod/spec.go
@@ -113,7 +113,7 @@ func (spec *Specification) AddConnectedPlug(iface interfaces.Interface, plug *in
 	return nil
 }
 
-// AddConnectedSlot records mount-specific side-effects of having a connected slot.
+// AddConnectedSlot records kmod-specific side-effects of having a connected slot.
 func (spec *Specification) AddConnectedSlot(iface interfaces.Interface, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	type definer interface {
 		KModConnectedSlot(spec *Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
@@ -124,7 +124,7 @@ func (spec *Specification) AddConnectedSlot(iface interfaces.Interface, plug *in
 	return nil
 }
 
-// AddPermanentPlug records mount-specific side-effects of having a plug.
+// AddPermanentPlug records kmod-specific side-effects of having a plug.
 func (spec *Specification) AddPermanentPlug(iface interfaces.Interface, plug *snap.PlugInfo) error {
 	type definer interface {
 		KModPermanentPlug(spec *Specification, plug *snap.PlugInfo) error
@@ -135,7 +135,7 @@ func (spec *Specification) AddPermanentPlug(iface interfaces.Interface, plug *sn
 	return nil
 }
 
-// AddPermanentSlot records mount-specific side-effects of having a slot.
+// AddPermanentSlot records kmod-specific side-effects of having a slot.
 func (spec *Specification) AddPermanentSlot(iface interfaces.Interface, slot *snap.SlotInfo) error {
 	type definer interface {
 		KModPermanentSlot(spec *Specification, slot *snap.SlotInfo) error


### PR DESCRIPTION
Fix copied comments.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
