### PR TITLE
tests: revert workarounds for sbc#1245551

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -791,8 +791,6 @@ restore_suite() {
         # shellcheck source=tests/lib/pkgdb.sh
         . "$TESTSLIB"/pkgdb.sh
         distro_purge_package snapd
-        # On Tumbleweed, removing the package doesn't stop the snapd units so ensure they are stopped
-        systemctl stop snapd.socket snapd.service || true
         if [[ "$SPREAD_SYSTEM" != opensuse-* && "$SPREAD_SYSTEM" != arch-* ]]; then
             # A snap-confine package never existed on openSUSE or Arch
             distro_purge_package snap-confine

--- a/tests/main/snap-set-core-w-no-core/task.yaml
+++ b/tests/main/snap-set-core-w-no-core/task.yaml
@@ -21,7 +21,6 @@ execute: |
 
     echo "Ensure core is gone"
     distro_purge_package snapd
-    systemctl stop snapd.socket snapd.service || true
     distro_install_build_snapd
 
     echo "Check that we can set core config nevertheless"

--- a/tests/main/snapd-snap-auto-install/task.yaml
+++ b/tests/main/snapd-snap-auto-install/task.yaml
@@ -14,8 +14,6 @@ execute: |
     #shellcheck source=tests/lib/pkgdb.sh
     . "$TESTSLIB"/pkgdb.sh
     distro_purge_package snapd
-    # On Tumbleweed, removing the package doesn't stop the snapd units so stop them here
-    systemctl stop snapd.socket snapd.service || true
     distro_install_build_snapd
     snap wait system seed.loaded
 


### PR DESCRIPTION
Revert what appear to be multiple workarounds for https://bugzilla.suse.com/show_bug.cgi?id=1245551

Related: [SNAPDENG-35297](https://warthogs.atlassian.net/browse/SNAPDENG-35297)


[SNAPDENG-35297]: https://warthogs.atlassian.net/browse/SNAPDENG-35297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ