### PR TITLE
many: support gpio-aggregator configfs kernel for gpio-chardev

### DIFF
--- a/cmd/snap-gpio-helper/cmd_export.go
+++ b/cmd/snap-gpio-helper/cmd_export.go
@@ -43,7 +43,7 @@ var gpioExportGadgetChardevChip = gpio.ExportGadgetChardevChip
 
 func (c *cmdExportChardev) Execute(args []string) error {
 	chipLabels := strings.Split(c.Args.ChipLabels, ",")
-	lines, err := strutil.ParseRange(c.Args.Lines)
+	sortedLines, err := strutil.ParseRange(c.Args.Lines)
 	if err != nil {
 		return fmt.Errorf("invalid lines argument: %w", err)
 	}
@@ -51,5 +51,5 @@ func (c *cmdExportChardev) Execute(args []string) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 
-	return gpioExportGadgetChardevChip(ctx, chipLabels, lines, c.Args.Gadget, c.Args.Slot)
+	return gpioExportGadgetChardevChip(ctx, chipLabels, sortedLines, c.Args.Gadget, c.Args.Slot)
 }

--- a/sandbox/gpio/common.go
+++ b/sandbox/gpio/common.go
@@ -120,6 +120,8 @@ var osChown = os.Chown
 var osWriteFile = os.WriteFile
 var syscallMknod = syscall.Mknod
 
+// This helper does not perform any cleanup, caller may want to call
+// removeAggregatedChip in case of an error.
 func addAggregatedChip(sourceChipLabel string, lines strutil.Range, instanceName, slotName string) (chipName string, err error) {
 	configfsBaseDir := snapConfigfsDir(instanceName, slotName)
 	if err = osMkdir(configfsBaseDir, 0755); err != nil {
@@ -172,6 +174,8 @@ func aggregatedChipUdevRulePath(instanceName, slotName string) string {
 	return filepath.Join(filepath.Join(dirs.GlobalRootDir, ephemeralUdevRulesDir), fname)
 }
 
+// This helper does not perform any cleanup, caller may want to call
+// removeEphemeralUdevTaggingRule in case of an error.
 func addEphemeralUdevTaggingRule(ctx context.Context, chipName string, instanceName, slotName string) error {
 	if err := os.MkdirAll(filepath.Join(dirs.GlobalRootDir, ephemeralUdevRulesDir), 0755); err != nil {
 		return err
@@ -200,6 +204,8 @@ func addEphemeralUdevTaggingRule(ctx context.Context, chipName string, instanceN
 	return nil
 }
 
+// This helper does not perform any cleanup, caller may want to call
+// removeGadgetSlotDevice in case of an error.
 func addGadgetSlotDevice(chipName, instanceName, slotName string) (err error) {
 	fi, err := osStat(filepath.Join(dirs.DevDir, chipName))
 	if err != nil {

--- a/sandbox/gpio/common.go
+++ b/sandbox/gpio/common.go
@@ -223,13 +223,6 @@ func addGadgetSlotDevice(chipName, instanceName, slotName string) (err error) {
 		return err
 	}
 
-	defer func() {
-		if err != nil {
-			// cleanup created device node
-			os.RemoveAll(devPath)
-		}
-	}()
-
 	// restore ownership
 	if err := osChown(devPath, int(stat.Uid), int(stat.Gid)); err != nil {
 		return err

--- a/sandbox/gpio/export_test.go
+++ b/sandbox/gpio/export_test.go
@@ -21,13 +21,23 @@ package gpio
 import (
 	"io/fs"
 	"syscall"
-	"time"
 
 	"github.com/snapcore/snapd/testutil"
 )
 
+type ChardevChip = chardevChip
+
+func (c *ChardevChip) Path() string   { return c.path }
+func (c *ChardevChip) Name() string   { return c.name }
+func (c *ChardevChip) Label() string  { return c.label }
+func (c *ChardevChip) NumLines() uint { return c.numLines }
+
+func MockChardevChip(path, name, label string, numLines uint) *chardevChip {
+	return &chardevChip{path, name, label, numLines}
+}
+
 var IoctlGetChipInfo = ioctlGetChipInfo
-var ChardevChipInfo = chardevChipInfo
+var GetChardevChipInfo = getChardevChipInfo
 
 func MockUnixSyscall(f func(trap uintptr, a1 uintptr, a2 uintptr, a3 uintptr) (r1 uintptr, r2 uintptr, err syscall.Errno)) (restore func()) {
 	return testutil.Mock(&unixSyscall, f)
@@ -40,8 +50,12 @@ func MockIoctlGetChipInfo(f func(path string) (name, label [32]byte, lines uint3
 	})
 }
 
-func MockChardevChipInfo(f func(path string) (*ChardevChip, error)) (restore func()) {
-	return testutil.Mock(&chardevChipInfo, f)
+func MockGetChardevChipInfo(f func(path string) (*chardevChip, error)) (restore func()) {
+	return testutil.Mock(&getChardevChipInfo, f)
+}
+
+func MockOsMkdir(f func(path string, perm fs.FileMode) error) (restore func()) {
+	return testutil.Mock(&osMkdir, f)
 }
 
 func MockOsStat(f func(path string) (fs.FileInfo, error)) (restore func()) {
@@ -56,16 +70,12 @@ func MockOsChown(f func(path string, uid int, gid int) error) (restore func()) {
 	return testutil.Mock(&osChown, f)
 }
 
+func MockOsWriteFile(f func(name string, data []byte, perm fs.FileMode) error) (restore func()) {
+	return testutil.Mock(&osWriteFile, f)
+}
+
 func MockSyscallMknod(f func(path string, mode uint32, dev int) (err error)) (restore func()) {
 	return testutil.Mock(&syscallMknod, f)
-}
-
-func MockAggregatorCreationTimeout(t time.Duration) (restore func()) {
-	return testutil.Mock(&aggregatorCreationTimeout, t)
-}
-
-func MockLockAggregator(f func() (unlocker func(), err error)) (restore func()) {
-	return testutil.Mock(&lockAggregator, f)
 }
 
 func MockKmodLoadModule(f func(module string, options []string) error) (restore func()) {

--- a/sandbox/gpio/gpio_chardev.go
+++ b/sandbox/gpio/gpio_chardev.go
@@ -41,11 +41,11 @@ func SnapChardevPath(instanceName, plugOrSlot string) string {
 // gpio aggregator for a given gadget gpio-chardev interface slot.
 //
 // Note: chipLabels must match exactly one chip.
-func ExportGadgetChardevChip(ctx context.Context, chipLabels []string, lines strutil.Range, gadgetName, slotName string) error {
+func ExportGadgetChardevChip(ctx context.Context, chipLabels []string, lines strutil.Range, instanceName, slotName string) error {
 	// The filtering is quadratic, but we only expect a few chip
 	// labels, so it is fine.
-	filter := func(chip *ChardevChip) bool {
-		return strutil.ListContains(chipLabels, chip.Label)
+	filter := func(chip *chardevChip) bool {
+		return strutil.ListContains(chipLabels, chip.label)
 	}
 	chips, err := findChips(filter)
 	if err != nil {
@@ -55,9 +55,9 @@ func ExportGadgetChardevChip(ctx context.Context, chipLabels []string, lines str
 		return errors.New("no matching gpio chips found matching chip labels")
 	}
 	if len(chips) > 1 {
-		concat := chips[0].Label
+		concat := chips[0].label
 		for _, chip := range chips[1:] {
-			concat += " " + chip.Label
+			concat += " " + chip.label
 		}
 		return fmt.Errorf("more than one gpio chips were found matching chip labels (%s)", concat)
 	}
@@ -71,27 +71,27 @@ func ExportGadgetChardevChip(ctx context.Context, chipLabels []string, lines str
 	// aggregator device doesn't have enough metadata for udev to match in
 	// advance. Instead, We use the dynamically generated chip name is used
 	// for matching e.g. `SUBSYSTEM=="gpio", KERNEL=="gpiochip3"`.
-	aggregatedChip, err := addAggregatedChip(ctx, chip, lines)
+	aggregatedChipName, err := addAggregatedChip(chip.label, lines, instanceName, slotName)
 	if err != nil {
 		return err
 	}
-	if err := addEphemeralUdevTaggingRule(ctx, aggregatedChip, gadgetName, slotName); err != nil {
+	if err := addEphemeralUdevTaggingRule(ctx, aggregatedChipName, instanceName, slotName); err != nil {
 		return err
 	}
-	return addGadgetSlotDevice(aggregatedChip, gadgetName, slotName)
+	return addGadgetSlotDevice(aggregatedChipName, instanceName, slotName)
 }
 
 // UnexportGadgetChardevChip unexports previously exported gpio chip lines
 // for a given gadget gpio-chardev interface slot.
-func UnexportGadgetChardevChip(gadgetName, slotName string) error {
-	aggregatedChip, err := removeGadgetSlotDevice(gadgetName, slotName)
-	if err != nil {
+func UnexportGadgetChardevChip(instanceName, slotName string) error {
+	// XXX: make removal best effort and ignore errors?
+	if err := removeGadgetSlotDevice(instanceName, slotName); err != nil {
 		return err
 	}
-	if err := removeEphemeralUdevTaggingRule(gadgetName, slotName); err != nil {
+	if err := removeEphemeralUdevTaggingRule(instanceName, slotName); err != nil {
 		return err
 	}
-	return removeAggregatedChip(aggregatedChip)
+	return removeAggregatedChip(instanceName, slotName)
 }
 
 var kmodLoadModule = kmod.LoadModule
@@ -103,7 +103,7 @@ func EnsureAggregatorDriver() error {
 	_, err := os.Stat(filepath.Join(dirs.GlobalRootDir, aggregatorDriverDir))
 	if errors.Is(err, os.ErrNotExist) {
 		if err := kmodLoadModule("gpio-aggregator", nil); err != nil {
-			return err
+			return fmt.Errorf("cannot load gpio-aggregator module: %v", err)
 		}
 	}
 
@@ -113,11 +113,8 @@ func EnsureAggregatorDriver() error {
 // CheckConfigfsSupport checks if the configfs interface for
 // gpio-aggregator is available.
 func CheckConfigfsSupport() error {
-	// GPIO chardev support is hidden until kernel configfs gpio-aggregator interface
-	// makes it to the 24.04 kernel AND the snap-gpio-helper is updated to use the
-	// new configfs interface.
-	// https://bugs.launchpad.net/ubuntu/+source/linux/+bug/2103496
-
-	// The check should be as simple as checking that /sys/kernel/config/gpio-aggregator exists.
-	return errors.New("gpio-aggregator configfs support is missing")
+	if _, err := os.Stat(filepath.Join(dirs.GlobalRootDir, aggregatorConfigfsDir)); err != nil {
+		return fmt.Errorf("gpio-aggregator configfs support is missing: %v", err)
+	}
+	return nil
 }

--- a/sandbox/gpio/gpio_chardev.go
+++ b/sandbox/gpio/gpio_chardev.go
@@ -74,7 +74,7 @@ func ExportGadgetChardevChip(ctx context.Context, chipLabels []string, lines str
 		}
 		// Best effort cleanup
 		if err := UnexportGadgetChardevChip(instanceName, slotName); err != nil {
-			logger.Noticef("cannot cleanup exported gpio chip: %v", err)
+			logger.Noticef("cannot cleanup exported gpio chip: %v (while handling error: %v)", err, retErr)
 		}
 	}()
 

--- a/sandbox/gpio/gpio_chardev_test.go
+++ b/sandbox/gpio/gpio_chardev_test.go
@@ -462,8 +462,16 @@ func (s *exportUnexportTestSuite) TestExportGadgetChardevChipAddGadgetDeviceErro
 
 	err := gpio.ExportGadgetChardevChip(context.TODO(), []string{"label-0"}, strutil.Range{{Start: 0, End: 0}}, "gadget-name", "slot-name")
 	c.Check(err, ErrorMatches, "boom!")
-	// device node is cleaned on error
+
+	// Cleanup is triggered on error
+
+	// Virtual device is removed
 	c.Check(filepath.Join(s.rootdir, "/dev/snap/gpio-chardev/gadget-name/slot-name"), testutil.FileAbsent)
+	// Udev rule is removed
+	c.Check(filepath.Join(s.rootdir, "/run/udev/rules.d/69-snap.gadget-name.interface.gpio-chardev-slot-name.rules"), testutil.FileAbsent)
+	// Aggregator device is deleted
+	c.Check(s.mockChipInfos[filepath.Join(s.rootdir, "/dev/gpiochip3")], IsNil)
+	c.Check(s.mockChipInfos[filepath.Join(s.rootdir, "/dev/snap/gpio-chardev/gadget-name/slot-name")], IsNil)
 }
 
 func (s *exportUnexportTestSuite) TestExportGadgetChardevChipAggregatedChipsSkipped(c *C) {

--- a/tests/core/interfaces-gpio-chardev/task.yaml
+++ b/tests/core/interfaces-gpio-chardev/task.yaml
@@ -55,74 +55,97 @@ prepare: |
     snap install test-snapd-gpio-chardev
     tests.cleanup defer snap remove --purge test-snapd-gpio-chardev
 
+    snap install test-snapd-gpio-control
+    tests.cleanup defer snap remove --purge test-snapd-gpio-control
+
+    snap connect test-snapd-gpio-control:gpio-control
+
 execute: |
-    # TODO: remove when gpio-aggregator configfs support lands in kernel
-    # and snapd. This test should fail automatically when support lands.
-    not snap connect test-snapd-gpio-chardev:gpio-chardev-0 pc:gpio-chardev-0 2> out
-    MATCH "gpio-aggregator configfs support is missing" < out
-    exit 0
+    if [ "$SPREAD_REBOOT" = 0 ]; then
+        # Check number of gpiochips before connection
+        find /dev/gpiochip* | wc -l | MATCH '^2$'
 
-    # if [ "$SPREAD_REBOOT" = 0 ]; then
-    #     # Check number of gpiochips before connection
-    #     find /dev/gpiochip* | wc -l | MATCH '^2$'
+        echo "Connect to gadget slots"
+        snap connect test-snapd-gpio-chardev:gpio-chardev-0 pc:gpio-chardev-0
+        snap connect test-snapd-gpio-chardev:gpio-chardev-1 pc:gpio-chardev-1
 
-    #     echo "Connect to gadget slots"
-    #     snap connect test-snapd-gpio-chardev:gpio-chardev-0 pc:gpio-chardev-0
-    #     snap connect test-snapd-gpio-chardev:gpio-chardev-1 pc:gpio-chardev-1
-        
-    #     # Check number of gpiochips after connection
-    #     find /dev/gpiochip* | wc -l | MATCH '^4$'
+        # Check number of gpiochips after connection
+        find /dev/gpiochip* | wc -l | MATCH '^4$'
 
-    #     echo "The gpio chips are exported for the gadget slot"
-    #     test -c /dev/snap/gpio-chardev/pc/gpio-chardev-0
-    #     test -c /dev/snap/gpio-chardev/pc/gpio-chardev-1
-    #     echo "And symlinks created on the consumer plug side"
-    #     readlink /dev/snap/gpio-chardev/test-snapd-gpio-chardev/gpio-chardev-0 | MATCH /dev/snap/gpio-chardev/pc/gpio-chardev-0
-    #     readlink /dev/snap/gpio-chardev/test-snapd-gpio-chardev/gpio-chardev-1 | MATCH /dev/snap/gpio-chardev/pc/gpio-chardev-1
+        echo "The gpio chips are exported for the gadget slot"
+        test -c /dev/snap/gpio-chardev/pc/gpio-chardev-0
+        test -c /dev/snap/gpio-chardev/pc/gpio-chardev-1
+        echo "And symlinks created on the consumer plug side"
+        readlink /dev/snap/gpio-chardev/test-snapd-gpio-chardev/gpio-chardev-0 | MATCH /dev/snap/gpio-chardev/pc/gpio-chardev-0
+        readlink /dev/snap/gpio-chardev/test-snapd-gpio-chardev/gpio-chardev-1 | MATCH /dev/snap/gpio-chardev/pc/gpio-chardev-1
 
-    #     echo "And gpio-chardev setup dependency was injected into snap service"
-    #     systemctl show --property=After snap.test-snapd-gpio-chardev.svc.service | grep "gpio-chardev-setup.target"
-    #     systemctl show --property=Wants snap.test-snapd-gpio-chardev.svc.service | grep "gpio-chardev-setup.target"
+        echo "and the right lines are being exported"
+        # lines 0-7 are exported
+        test-snapd-gpio-control.gpioinfo --chip /dev/gpiochip0 | MATCH "line.*0:.*consumer=gpio-aggregator.0"
+        test-snapd-gpio-control.gpioinfo --chip /dev/gpiochip0 | MATCH "line.*1:.*consumer=gpio-aggregator.0"
+        test-snapd-gpio-control.gpioinfo --chip /dev/gpiochip0 | MATCH "line.*2:.*consumer=gpio-aggregator.0"
+        test-snapd-gpio-control.gpioinfo --chip /dev/gpiochip0 | MATCH "line.*3:.*consumer=gpio-aggregator.0"
+        test-snapd-gpio-control.gpioinfo --chip /dev/gpiochip0 | MATCH "line.*4:.*consumer=gpio-aggregator.0"
+        test-snapd-gpio-control.gpioinfo --chip /dev/gpiochip0 | MATCH "line.*5:.*consumer=gpio-aggregator.0"
+        test-snapd-gpio-control.gpioinfo --chip /dev/gpiochip0 | MATCH "line.*6:.*consumer=gpio-aggregator.0"
+        test-snapd-gpio-control.gpioinfo --chip /dev/gpiochip0 | MATCH "line.*7:.*consumer=gpio-aggregator.0"
+        # lines 0 and 6 only are exported
+        test-snapd-gpio-control.gpioinfo --chip /dev/gpiochip1 | MATCH "line.*0:.*consumer=gpio-aggregator.1"
+        test-snapd-gpio-control.gpioinfo --chip /dev/gpiochip1 | NOMATCH "line.*1:.*consumer=gpio-aggregator.1"
+        test-snapd-gpio-control.gpioinfo --chip /dev/gpiochip1 | NOMATCH "line.*2:.*consumer=gpio-aggregator.1"
+        test-snapd-gpio-control.gpioinfo --chip /dev/gpiochip1 | NOMATCH "line.*3:.*consumer=gpio-aggregator.1"
+        test-snapd-gpio-control.gpioinfo --chip /dev/gpiochip1 | NOMATCH "line.*4:.*consumer=gpio-aggregator.1"
+        test-snapd-gpio-control.gpioinfo --chip /dev/gpiochip1 | NOMATCH "line.*5:.*consumer=gpio-aggregator.1"
+        test-snapd-gpio-control.gpioinfo --chip /dev/gpiochip1 | MATCH "line.*6:.*consumer=gpio-aggregator.1"
+        test-snapd-gpio-control.gpioinfo --chip /dev/gpiochip1 | NOMATCH "line.*7:.*consumer=gpio-aggregator.1"
 
-    #     mkdir -p /var/snap/test-snapd-gpio-chardev/common/gpiochips
-    #     printf "0\n1\n0\n0\n0\n1\n0\n1\n" > /var/snap/test-snapd-gpio-chardev/common/gpiochips/gpio-chardev-0
-    #     printf "1\n1\n" > /var/snap/test-snapd-gpio-chardev/common/gpiochips/gpio-chardev-1
-    #     REBOOT
-    # elif [ "$SPREAD_REBOOT" = 1 ]; then
-    #     echo "Snap service should have properly set the gpio lines for each chip"
+        echo "And gpio-chardev setup dependency was injected into snap service"
+        systemctl show --property=After snap.test-snapd-gpio-chardev.svc.service | MATCH "gpio-chardev-setup.target"
+        systemctl show --property=Wants snap.test-snapd-gpio-chardev.svc.service | MATCH "gpio-chardev-setup.target"
 
-    #     chip=/dev/snap/gpio-chardev/pc/gpio-chardev-0
-    #     test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 0 | MATCH '^"0"=inactive$'
-    #     test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 1 | MATCH '^"1"=active$'
-    #     test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 2 | MATCH '^"2"=inactive$'
-    #     test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 3 | MATCH '^"3"=inactive$'
-    #     test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 4 | MATCH '^"4"=inactive$'
-    #     test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 5 | MATCH '^"5"=active$'
-    #     test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 6 | MATCH '^"6"=inactive$'
-    #     test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 7 | MATCH '^"7"=active$'
+        mkdir -p /var/snap/test-snapd-gpio-chardev/common/gpiochips
+        printf "0\n1\n0\n0\n0\n1\n0\n1\n" > /var/snap/test-snapd-gpio-chardev/common/gpiochips/gpio-chardev-0
+        printf "1\n1\n" > /var/snap/test-snapd-gpio-chardev/common/gpiochips/gpio-chardev-1
+        REBOOT
+    elif [ "$SPREAD_REBOOT" = 1 ]; then
+        echo "Snap service should have properly set the gpio lines for each chip"
 
-    #     chip=/dev/snap/gpio-chardev/pc/gpio-chardev-1
-    #     test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 0 | MATCH '^"0"=active$'
-    #     test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 1 | MATCH '^"1"=active$'
+        chip=/dev/snap/gpio-chardev/pc/gpio-chardev-0
+        test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 0 | MATCH '^"0"=inactive$'
+        test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 1 | MATCH '^"1"=active$'
+        test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 2 | MATCH '^"2"=inactive$'
+        test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 3 | MATCH '^"3"=inactive$'
+        test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 4 | MATCH '^"4"=inactive$'
+        test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 5 | MATCH '^"5"=active$'
+        test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 6 | MATCH '^"6"=inactive$'
+        test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 7 | MATCH '^"7"=active$'
 
-    #     echo "Disconnecting unexports the aggregated devices"
-    #     snap disconnect test-snapd-gpio-chardev:gpio-chardev-0 pc:gpio-chardev-0
-    #     snap disconnect test-snapd-gpio-chardev:gpio-chardev-1 pc:gpio-chardev-1
-    #     not test -e /dev/snap/gpio-chardev/pc/gpio-chardev-0
-    #     not test -e /dev/snap/gpio-chardev/pc/gpio-chardev-1
-    #     not test -e /dev/snap/gpio-chardev/test-snapd-gpio-chardev/gpio-chardev-0
-    #     not test -e /dev/snap/gpio-chardev/test-snapd-gpio-chardev/gpio-chardev-1
+        chip=/dev/snap/gpio-chardev/pc/gpio-chardev-1
+        test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 0 | MATCH '^"0"=active$'
+        test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 1 | MATCH '^"1"=active$'
 
-    #     # Reboot one last time to make sure services run normally even when disconnected
-    #     rm -rf /var/snap/test-snapd-gpio-chardev/common/gpiochips
-    #     REBOOT
-    # elif [ "$SPREAD_REBOOT" = 2 ]; then
-    #     echo "Snap service runs"
-    #     retry -n 20 --wait 2 sh -c 'journalctl -u snap.test-snapd-gpio-chardev.svc | MATCH "no chips found under /var/snap/test-snapd-gpio-chardev/common/gpiochips, exiting..."'
+        echo "Disconnecting unexports the aggregated devices"
+        snap disconnect test-snapd-gpio-chardev:gpio-chardev-0 pc:gpio-chardev-0
+        snap disconnect test-snapd-gpio-chardev:gpio-chardev-1 pc:gpio-chardev-1
+        not test -e /dev/snap/gpio-chardev/pc/gpio-chardev-0
+        not test -e /dev/snap/gpio-chardev/pc/gpio-chardev-1
+        not test -e /dev/snap/gpio-chardev/test-snapd-gpio-chardev/gpio-chardev-0
+        not test -e /dev/snap/gpio-chardev/test-snapd-gpio-chardev/gpio-chardev-1
 
-    #     echo "And aggregated devices are still unexported"
-    #     not test -e /dev/snap/gpio-chardev/pc/gpio-chardev-0
-    #     not test -e /dev/snap/gpio-chardev/pc/gpio-chardev-1
-    #     not test -e /dev/snap/gpio-chardev/test-snapd-gpio-chardev/gpio-chardev-0
-    #     not test -e /dev/snap/gpio-chardev/test-snapd-gpio-chardev/gpio-chardev-1
-    # fi
+        # Check number of gpiochips
+        find /dev/gpiochip* | wc -l | MATCH '^2$'
+
+        # Reboot one last time to make sure services run normally even when disconnected
+        rm -rf /var/snap/test-snapd-gpio-chardev/common/gpiochips
+        REBOOT
+    elif [ "$SPREAD_REBOOT" = 2 ]; then
+        echo "Snap service runs"
+        retry -n 20 --wait 2 sh -c 'journalctl -u snap.test-snapd-gpio-chardev.svc | MATCH "no chips found under /var/snap/test-snapd-gpio-chardev/common/gpiochips, exiting..."'
+
+        echo "And aggregated devices are still unexported"
+        find /dev/gpiochip* | wc -l | MATCH '^2$'
+        not test -e /dev/snap/gpio-chardev/pc/gpio-chardev-0
+        not test -e /dev/snap/gpio-chardev/pc/gpio-chardev-1
+        not test -e /dev/snap/gpio-chardev/test-snapd-gpio-chardev/gpio-chardev-0
+        not test -e /dev/snap/gpio-chardev/test-snapd-gpio-chardev/gpio-chardev-1
+    fi

--- a/tests/core/interfaces-gpio-chardev/task.yaml
+++ b/tests/core/interfaces-gpio-chardev/task.yaml
@@ -65,6 +65,8 @@ execute: |
         # Check number of gpiochips before connection
         find /dev/gpiochip* | wc -l | MATCH '^2$'
 
+        # TODO: check conflict detection works with connected "gpio" plugs.
+
         echo "Connect to gadget slots"
         snap connect test-snapd-gpio-chardev:gpio-chardev-0 pc:gpio-chardev-0
         snap connect test-snapd-gpio-chardev:gpio-chardev-1 pc:gpio-chardev-1
@@ -106,6 +108,24 @@ execute: |
         mkdir -p /var/snap/test-snapd-gpio-chardev/common/gpiochips
         printf "0\n1\n0\n0\n0\n1\n0\n1\n" > /var/snap/test-snapd-gpio-chardev/common/gpiochips/gpio-chardev-0
         printf "1\n1\n" > /var/snap/test-snapd-gpio-chardev/common/gpiochips/gpio-chardev-1
+
+        # Restart service for values to take effect
+        snap restart test-snapd-gpio-chardev.svc
+
+        chip=/dev/snap/gpio-chardev/pc/gpio-chardev-0
+        test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 0 | MATCH '^"0"=inactive$'
+        test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 1 | MATCH '^"1"=active$'
+        test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 2 | MATCH '^"2"=inactive$'
+        test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 3 | MATCH '^"3"=inactive$'
+        test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 4 | MATCH '^"4"=inactive$'
+        test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 5 | MATCH '^"5"=active$'
+        test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 6 | MATCH '^"6"=inactive$'
+        test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 7 | MATCH '^"7"=active$'
+
+        chip=/dev/snap/gpio-chardev/pc/gpio-chardev-1
+        test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 0 | MATCH '^"0"=active$'
+        test-snapd-gpio-chardev.cmd gpioget --chip "$chip" 1 | MATCH '^"1"=active$'
+
         REBOOT
     elif [ "$SPREAD_REBOOT" = 1 ]; then
         echo "Snap service should have properly set the gpio lines for each chip"


### PR DESCRIPTION
This PR re-enables the `gpio-chardev` interface now with the more robust `gpio-aggregator` configfs kernel interface.

Note: This PR builds on top of the fix from https://github.com/canonical/snapd/pull/15848 and should be rebased
For context, Check the SD201 spec.