### PR TITLE
debug-tools/snap-debug-info.sh: do not exit with error if no DENIED

### DIFF
--- a/debug-tools/snap-debug-info.sh
+++ b/debug-tools/snap-debug-info.sh
@@ -65,4 +65,4 @@ h1 "SNAPD.SERVICE STATUS"; sudo systemctl --no-pager status snapd
 h1 "UPTIME"; uptime
 h1 "DATE (IN UTC)"; date --utc
 h1 "DISK SPACE"; df -h
-h1 "DENIED MESSAGES"; sudo journalctl --no-pager | grep DENIED
+h1 "DENIED MESSAGES"; sudo journalctl --no-pager | grep DENIED || true


### PR DESCRIPTION
Make sure that we do not end up the script with error if there are no apparmor denials in the journal.