### PR TITLE
interfaces/builtin: add Thetis FIDO2 BioFP+ Security Key to U2F list

### DIFF
--- a/interfaces/builtin/u2f_devices.go
+++ b/interfaces/builtin/u2f_devices.go
@@ -95,7 +95,7 @@ var u2fDevices = []u2fDevice{
 	{
 		Name:             "Thetis Key",
 		VendorIDPattern:  "1ea8",
-		ProductIDPattern: "f025|f825",
+		ProductIDPattern: "f025|f825|fc26",
 	},
 	{
 		Name:             "Nitrokey FIDO U2F",


### PR DESCRIPTION
This PR adds Thetis FIDO2 BioFP+ Security Key, to the U2F allow list.

The security key is also known as ExcelSecu FIDO2 Security Key, which is shown by lsusb and can be seen in probes of two computers at https://linux-hardware.org/?id=usb:1ea8-fc26

Other relevant web pages:

- Thetis: https://thetis.io/products/fido2-fingerprint-key
- Excelsecu: https://www.excelsecu.com/productdetail/esecufido2secu.html

I have used a Thetis FIDO2 BioFP+ Security Key successfully with Firefox (141.0.3-1) and a modified /etc/udev/rules.d/70-snap.firefox.rules.