### PR TITLE
packaging/ubuntu-16.04/source/options: ignore .image-garden content

### DIFF
--- a/packaging/ubuntu-16.04/source/options
+++ b/packaging/ubuntu-16.04/source/options
@@ -1,2 +1,3 @@
 tar-ignore = "tests/lib/cache/*"
 tar-ignore = ".git/"
+tar-ignore = ".image-garden/"


### PR DESCRIPTION
Ignore the contents of .image-garden.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
