### PR TITLE
many: extend post v2 system with error actions

### DIFF
--- a/client/systems.go
+++ b/client/systems.go
@@ -360,9 +360,11 @@ type QualityCheckOptions struct {
 	PIN        string `json:"pin,omitempty"`
 }
 
-// FixEncryptionSupportOptions specifies an action to perform along with its
-// associated arguments.
+// FixEncryptionSupportOptions specifies the fix action to perform and its
+// optional arguments. FixAction is a pointer so the code can distinguish an
+// omitted field (nil) from the empty string (""), which maps to secboot
+// constant ActionNone.
 type FixEncryptionSupportOptions struct {
-	FixAction string                     `json:"fix-action"`
+	FixAction *string                    `json:"fix-action",omitempty`
 	Args      map[string]json.RawMessage `json:"args,omitempty"`
 }

--- a/client/systems.go
+++ b/client/systems.go
@@ -359,3 +359,10 @@ type QualityCheckOptions struct {
 	Passphrase string `json:"passphrase,omitempty"`
 	PIN        string `json:"pin,omitempty"`
 }
+
+// FixEncryptionSupportOptions specifies an action to perform along with its
+// associated arguments.
+type FixEncryptionSupportOptions struct {
+	FixAction string                     `json:"fix-action"`
+	Args      map[string]json.RawMessage `json:"args,omitempty"`
+}

--- a/client/systems.go
+++ b/client/systems.go
@@ -365,6 +365,6 @@ type QualityCheckOptions struct {
 // omitted field (nil) from the empty string (""), which maps to secboot
 // constant ActionNone.
 type FixEncryptionSupportOptions struct {
-	FixAction *string                    `json:"fix-action",omitempty`
+	FixAction *string                    `json:"fix-action,omitempty"`
 	Args      map[string]json.RawMessage `json:"args,omitempty"`
 }

--- a/daemon/api_systems.go
+++ b/daemon/api_systems.go
@@ -743,16 +743,20 @@ func postSystemActionFixEncryptionSupport(c *Command, systemLabel string, req *s
 		return BadRequest("system action requires the system label to be provided")
 	}
 
-	if req.FixAction == "" {
+	// FixAction set to "" is valid and maps to secboot constant ActionNone.
+	// Omission of FixAction is not allowed.
+	if req.FixAction == nil {
 		return BadRequest("fix action must be provided in request body for action %q", req.Action)
 	}
 
-	if req.Args == nil {
-		return BadRequest("fix action args must be provided in request body for action %q", req.Action)
+	// Args is optional, but when specified it must contain at least one
+	// argument entry.
+	if req.Args != nil && len(req.Args) == 0 {
+		return BadRequest("optional fix action args, when provided, must contain one or more arguments %q", req.Action)
 	}
 
 	checkAction := &secboot.PreinstallAction{
-		Action: req.FixAction,
+		Action: *req.FixAction,
 		Args:   req.Args,
 	}
 

--- a/daemon/api_systems.go
+++ b/daemon/api_systems.go
@@ -124,14 +124,14 @@ func getAllSystems(c *Command, r *http.Request, user *auth.UserState) Response {
 }
 
 // wrapped for unit tests
-var deviceManagerSystemAndGadgetAndEncryptionInfo = func(
+var deviceManagerSystemAndGadgetAndEncryptionInfo func(
 	dm *devicestate.DeviceManager,
 	systemLabel string,
 	checkAction *secboot.PreinstallAction,
 	encInfoFromCache bool,
-) (*devicestate.System, *gadget.Info, *install.EncryptionSupportInfo, error) {
-	return dm.SystemAndGadgetAndEncryptionInfo(systemLabel, checkAction, encInfoFromCache)
-}
+) (
+	*devicestate.System, *gadget.Info, *install.EncryptionSupportInfo, error,
+) = (*devicestate.DeviceManager).SystemAndGadgetAndEncryptionInfo
 
 func storageEncryption(encInfo *install.EncryptionSupportInfo) *client.StorageEncryption {
 	if encInfo.Disabled {
@@ -750,7 +750,6 @@ func postSystemActionFixEncryptionSupport(c *Command, systemLabel string, req *s
 	details, err := getSystemDetailsWithOptionalFixAction(deviceMgr, systemLabel, checkAction)
 	if err != nil {
 		return InternalError(err.Error())
-
 	}
 
 	return SyncResponse(*details)

--- a/daemon/api_systems_test.go
+++ b/daemon/api_systems_test.go
@@ -1975,13 +1975,13 @@ func (s *systemsSuite) TestSystemActionFixEncryptionSupportErrors(c *check.C) {
 			expectedStatus: 400, expectedErrMsg: "system action requires the system label to be provided",
 		},
 		{
-			fixAction:      "",
+			fixAction:      "omit", // omit instructs the test logic to not populate the fix action
 			expectedStatus: 400, expectedErrMsg: "fix action must be provided in request body for action \"fix-encryption-support\"",
 		},
 		{
 			fixAction:      "action-1",
-			args:           nil,
-			expectedStatus: 400, expectedErrMsg: "fix action args must be provided in request body for action \"fix-encryption-support\"",
+			args:           map[string]json.RawMessage{},
+			expectedStatus: 400, expectedErrMsg: "optional fix action args, when provided, must contain one or more arguments \"fix-encryption-support\"",
 		},
 		{
 			fixAction: "action-1",
@@ -1994,9 +1994,12 @@ func (s *systemsSuite) TestSystemActionFixEncryptionSupportErrors(c *check.C) {
 		},
 	} {
 		body := map[string]any{
-			"action":     "fix-encryption-support",
-			"fix-action": tc.fixAction,
-			"args":       tc.args,
+			"action": "fix-encryption-support",
+			"args":   tc.args,
+		}
+
+		if tc.fixAction != "omit" {
+			body["fix-action"] = tc.fixAction
 		}
 
 		route := "/v2/systems/20191119"

--- a/daemon/export_api_systems_test.go
+++ b/daemon/export_api_systems_test.go
@@ -48,33 +48,23 @@ func MockDeviceManagerSystemAndGadgetAndEncryptionInfo(f func(
 	*secboot.PreinstallAction,
 	bool,
 ) (*devicestate.System, *gadget.Info, *install.EncryptionSupportInfo, error)) (restore func()) {
-	restore = testutil.Backup(&deviceManagerSystemAndGadgetAndEncryptionInfo)
-	deviceManagerSystemAndGadgetAndEncryptionInfo = f
-	return restore
+	return testutil.Mock(&deviceManagerSystemAndGadgetAndEncryptionInfo, f)
 }
 
 func MockDevicestateInstallFinish(f func(*state.State, string, map[string]*gadget.Volume, *devicestate.OptionalContainers) (*state.Change, error)) (restore func()) {
-	restore = testutil.Backup(&devicestateInstallFinish)
-	devicestateInstallFinish = f
-	return restore
+	return testutil.Mock(&devicestateInstallFinish, f)
 }
 
 func MockDevicestateInstallSetupStorageEncryption(f func(*state.State, string, map[string]*gadget.Volume, *device.VolumesAuthOptions) (*state.Change, error)) (restore func()) {
-	restore = testutil.Backup(&devicestateInstallSetupStorageEncryption)
-	devicestateInstallSetupStorageEncryption = f
-	return restore
+	return testutil.Mock(&devicestateInstallSetupStorageEncryption, f)
 }
 
 func MockDevicestateCreateRecoverySystem(f func(*state.State, string, devicestate.CreateRecoverySystemOptions) (*state.Change, error)) (restore func()) {
-	restore = testutil.Backup(&devicestateCreateRecoverySystem)
-	devicestateCreateRecoverySystem = f
-	return restore
+	return testutil.Mock(&devicestateCreateRecoverySystem, f)
 }
 
 func MockDevicestateRemoveRecoverySystem(f func(*state.State, string) (*state.Change, error)) (restore func()) {
-	restore = testutil.Backup(&devicestateRemoveRecoverySystem)
-	devicestateRemoveRecoverySystem = f
-	return restore
+	return testutil.Mock(&devicestateRemoveRecoverySystem, f)
 }
 
 func MockDevicestateGeneratePreInstallRecoveryKey(f func(st *state.State, label string) (rkey keys.RecoveryKey, err error)) (restore func()) {

--- a/daemon/export_api_systems_test.go
+++ b/daemon/export_api_systems_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/install"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/secboot/keys"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -41,7 +42,12 @@ type (
 	SystemsResponse = systemsResponse
 )
 
-func MockDeviceManagerSystemAndGadgetAndEncryptionInfo(f func(*devicestate.DeviceManager, string) (*devicestate.System, *gadget.Info, *install.EncryptionSupportInfo, error)) (restore func()) {
+func MockDeviceManagerSystemAndGadgetAndEncryptionInfo(f func(
+	*devicestate.DeviceManager,
+	string,
+	*secboot.PreinstallAction,
+	bool,
+) (*devicestate.System, *gadget.Info, *install.EncryptionSupportInfo, error)) (restore func()) {
 	restore = testutil.Backup(&deviceManagerSystemAndGadgetAndEncryptionInfo)
 	deviceManagerSystemAndGadgetAndEncryptionInfo = f
 	return restore
@@ -77,8 +83,4 @@ func MockDevicestateGeneratePreInstallRecoveryKey(f func(st *state.State, label 
 
 func MockDeviceValidatePassphrase(f func(mode device.AuthMode, passphrase string) (device.AuthQuality, error)) (restore func()) {
 	return testutil.Mock(&deviceValidatePassphrase, f)
-}
-
-func ClearCachedEncryptionSupportInfoForLabel(st *state.State, systemLabel string) {
-	st.Cache(encryptionSupportInfoKey{systemLabel}, nil)
 }

--- a/daemon/export_api_systems_test.go
+++ b/daemon/export_api_systems_test.go
@@ -45,10 +45,17 @@ type (
 func MockDeviceManagerSystemAndGadgetAndEncryptionInfo(f func(
 	*devicestate.DeviceManager,
 	string,
-	*secboot.PreinstallAction,
 	bool,
 ) (*devicestate.System, *gadget.Info, *install.EncryptionSupportInfo, error)) (restore func()) {
 	return testutil.Mock(&deviceManagerSystemAndGadgetAndEncryptionInfo, f)
+}
+
+func MockDeviceManagerApplyActionOnSystemAndGadgetAndEncryptionInfo(f func(
+	*devicestate.DeviceManager,
+	string,
+	*secboot.PreinstallAction,
+) (*devicestate.System, *gadget.Info, *install.EncryptionSupportInfo, error)) (restore func()) {
+	return testutil.Mock(&deviceManagerApplyActionOnSystemAndGadgetAndEncryptionInfo, f)
 }
 
 func MockDevicestateInstallFinish(f func(*state.State, string, map[string]*gadget.Volume, *devicestate.OptionalContainers) (*state.Change, error)) (restore func()) {

--- a/gadget/install/install.go
+++ b/gadget/install/install.go
@@ -681,13 +681,19 @@ func SaveStorageTraits(model gadget.Model, vols map[string]*gadget.Volume, encry
 }
 
 func EncryptPartitions(
-	onVolumes map[string]*gadget.Volume, volumesAuth *device.VolumesAuthOptions,
-	encryptionType device.EncryptionType, model *asserts.Model,
-	gadgetRoot, kernelRoot string, perfTimings timings.Measurer,
+	onVolumes map[string]*gadget.Volume,
+	volumesAuth *device.VolumesAuthOptions,
+	encryptionType device.EncryptionType,
+	checkContext *secboot.PreinstallCheckContext,
+	model *asserts.Model,
+	gadgetRoot,
+	kernelRoot string,
+	perfTimings timings.Measurer,
 ) (*EncryptionSetupData, error) {
 	setupData := &EncryptionSetupData{
-		parts:       make(map[string]partEncryptionData),
-		volumesAuth: volumesAuth,
+		parts:                  make(map[string]partEncryptionData),
+		volumesAuth:            volumesAuth,
+		preinstallCheckContext: checkContext,
 	}
 	for volName, vol := range onVolumes {
 		onDiskVol, err := gadget.OnDiskVolumeFromGadgetVol(vol)

--- a/gadget/install/install_dummy.go
+++ b/gadget/install/install_dummy.go
@@ -51,9 +51,14 @@ func SaveStorageTraits(model gadget.Model, vols map[string]*gadget.Volume, encry
 }
 
 func EncryptPartitions(
-	onVolumes map[string]*gadget.Volume, volumesAuth *device.VolumesAuthOptions,
-	encryptionType device.EncryptionType, model *asserts.Model,
-	gadgetRoot, kernelRoot string, perfTimings timings.Measurer,
+	onVolumes map[string]*gadget.Volume,
+	volumesAuth *device.VolumesAuthOptions,
+	encryptionType device.EncryptionType,
+	checkContext *secboot.PreinstallCheckContext,
+	model *asserts.Model,
+	gadgetRoot,
+	kernelRoot string,
+	perfTimings timings.Measurer,
 ) (*EncryptionSetupData, error) {
 	return nil, fmt.Errorf("build without secboot support")
 }

--- a/gadget/install/install_test.go
+++ b/gadget/install/install_test.go
@@ -1448,7 +1448,7 @@ func (s *installSuite) testWriteContent(c *C, opts writeContentOpts) {
 				EncryptedDevice: "/dev/mapper/ubuntu-data",
 			},
 		}
-		esd = install.MockEncryptionSetupData(labelToEncData, "", nil)
+		esd = install.MockEncryptionSetupData(labelToEncData, "", nil, nil)
 	}
 	onDiskVols, err := install.WriteContent(ginfo.Volumes, allLaidOutVols, esd, nil, nil, timings.New(nil))
 	c.Assert(err, IsNil)
@@ -1537,10 +1537,13 @@ func (s *installSuite) testEncryptPartitions(c *C, opts encryptPartitionsOpts) {
 		return nil
 	})()
 
-	encryptSetup, err := install.EncryptPartitions(ginfo.Volumes, opts.volumesAuth, opts.encryptType, model, gadgetRoot, "", timings.New(nil))
+	checkContext := &secboot.PreinstallCheckContext{}
+
+	encryptSetup, err := install.EncryptPartitions(ginfo.Volumes, opts.volumesAuth, opts.encryptType, checkContext, model, gadgetRoot, "", timings.New(nil))
 	c.Assert(err, IsNil)
 	c.Assert(encryptSetup, NotNil)
 	c.Assert(encryptSetup.VolumesAuth(), Equals, opts.volumesAuth)
+	c.Assert(encryptSetup.PreinstallCheckContext(), Equals, checkContext)
 	err = install.CheckEncryptionSetupData(encryptSetup, map[string]string{
 		"ubuntu-save": "/dev/mapper/ubuntu-save",
 		"ubuntu-data": "/dev/mapper/ubuntu-data",
@@ -1574,7 +1577,7 @@ func (s *installSuite) TestInstallEncryptPartitionsNoDeviceSet(c *C) {
 	c.Assert(err, IsNil)
 	defer restore()
 
-	encryptSetup, err := install.EncryptPartitions(ginfo.Volumes, nil, device.EncryptionTypeLUKS, model, gadgetRoot, "", timings.New(nil))
+	encryptSetup, err := install.EncryptPartitions(ginfo.Volumes, nil, device.EncryptionTypeLUKS, nil, model, gadgetRoot, "", timings.New(nil))
 
 	c.Check(err.Error(), Equals, `volume "pc" has no device assigned`)
 	c.Check(encryptSetup, IsNil)
@@ -1681,7 +1684,7 @@ func (s *installSuite) testMountVolumes(c *C, opts mountVolumesOpts) {
 				EncryptedDevice: "/dev/mapper/ubuntu-data",
 			},
 		}
-		esd = install.MockEncryptionSetupData(labelToEncData, "", nil)
+		esd = install.MockEncryptionSetupData(labelToEncData, "", nil, nil)
 	}
 
 	// 10 million mocks later ...

--- a/gadget/install/params.go
+++ b/gadget/install/params.go
@@ -126,7 +126,7 @@ func MockEncryptionSetupData(
 		//this is still used in place where LegacyKeptKey will be
 		//called to write the save key to a file in
 		//overlord/install/install.go. Once we have removed that call,
-		//we can use mock object instead.
+		// we can use mock object instead.
 		bootstrapKey := secboot.CreateMockBootstrappedContainer()
 		esd.parts[label] = partEncryptionData{
 			role:                encryptData.Role,

--- a/gadget/install/params.go
+++ b/gadget/install/params.go
@@ -68,6 +68,10 @@ type EncryptionSetupData struct {
 	// corresponding recovery key should be used for all relevant
 	// volumes during installation.
 	recoveryKeyID string
+	// optional preinstall check context that includes the check result that
+	// reflects the outcome of the most recent check and contains information
+	// required for optimum PCR configuration and reseal post install
+	preinstallCheckContext *secboot.PreinstallCheckContext
 }
 
 // EncryptedDevices returns a map partition role -> LUKS mapper device.
@@ -92,6 +96,10 @@ func (esd *EncryptionSetupData) RecoveryKeyID() string {
 	return esd.recoveryKeyID
 }
 
+func (esd *EncryptionSetupData) PreinstallCheckContext() *secboot.PreinstallCheckContext {
+	return esd.preinstallCheckContext
+}
+
 // MockEncryptedDeviceAndRole is meant to be used for unit tests from other
 // packages.
 type MockEncryptedDeviceAndRole struct {
@@ -101,18 +109,24 @@ type MockEncryptedDeviceAndRole struct {
 
 // MockEncryptionSetupData is meant to be used for unit tests from other
 // packages.
-func MockEncryptionSetupData(labelToEncDevice map[string]*MockEncryptedDeviceAndRole, recoveryKeyID string, volumesAuth *device.VolumesAuthOptions) *EncryptionSetupData {
+func MockEncryptionSetupData(
+	labelToEncDevice map[string]*MockEncryptedDeviceAndRole,
+	recoveryKeyID string,
+	volumesAuth *device.VolumesAuthOptions,
+	checkContext *secboot.PreinstallCheckContext,
+) *EncryptionSetupData {
 	esd := &EncryptionSetupData{
-		parts:         map[string]partEncryptionData{},
-		volumesAuth:   volumesAuth,
-		recoveryKeyID: recoveryKeyID,
+		parts:                  map[string]partEncryptionData{},
+		volumesAuth:            volumesAuth,
+		recoveryKeyID:          recoveryKeyID,
+		preinstallCheckContext: checkContext,
 	}
 	for label, encryptData := range labelToEncDevice {
 		//TODO:FDEM: we should use a mock for the bootstrap key. However,
 		//this is still used in place where LegacyKeptKey will be
 		//called to write the save key to a file in
 		//overlord/install/install.go. Once we have removed that call,
-		// we can use mock object instead.
+		//we can use mock object instead.
 		bootstrapKey := secboot.CreateMockBootstrappedContainer()
 		esd.parts[label] = partEncryptionData{
 			role:                encryptData.Role,

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -441,7 +441,16 @@ func MockInstallMountVolumes(f func(onVolumes map[string]*gadget.Volume, encSetu
 	}
 }
 
-func MockInstallEncryptPartitions(f func(onVolumes map[string]*gadget.Volume, volumesAuth *device.VolumesAuthOptions, encryptionType device.EncryptionType, model *asserts.Model, gadgetRoot, kernelRoot string, perfTimings timings.Measurer) (*install.EncryptionSetupData, error)) (restore func()) {
+func MockInstallEncryptPartitions(f func(
+	onVolumes map[string]*gadget.Volume,
+	volumesAuth *device.VolumesAuthOptions,
+	encryptionType device.EncryptionType,
+	checkContext *secboot.PreinstallCheckContext,
+	model *asserts.Model,
+	gadgetRoot,
+	kernelRoot string,
+	perfTimings timings.Measurer,
+) (*install.EncryptionSetupData, error)) (restore func()) {
 	old := installEncryptPartitions
 	installEncryptPartitions = f
 	return func() {
@@ -576,7 +585,13 @@ func MockCreateAllKnownSystemUsers(createAllUsers func(state *state.State, asser
 	return restore
 }
 
-func MockEncryptionSetupDataInCache(st *state.State, label string, recoveryKeyID string, volumesAuth *device.VolumesAuthOptions) (restore func()) {
+func MockEncryptionSetupDataInCache(
+	st *state.State,
+	label string,
+	recoveryKeyID string,
+	volumesAuth *device.VolumesAuthOptions,
+	checkContext *secboot.PreinstallCheckContext,
+) (restore func()) {
 	st.Lock()
 	defer st.Unlock()
 	var esd *install.EncryptionSetupData
@@ -590,7 +605,7 @@ func MockEncryptionSetupDataInCache(st *state.State, label string, recoveryKeyID
 			EncryptedDevice: "/dev/mapper/ubuntu-data",
 		},
 	}
-	esd = install.MockEncryptionSetupData(labelToEncData, recoveryKeyID, volumesAuth)
+	esd = install.MockEncryptionSetupData(labelToEncData, recoveryKeyID, volumesAuth, checkContext)
 	st.Cache(encryptionSetupDataKey{label}, esd)
 	return func() { CleanUpEncryptionSetupDataInCache(st, label) }
 }

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -995,6 +995,8 @@ func (m *DeviceManager) doInstallFinish(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
+	// cache is used to transport encryptionSetupData between install steps
+	// "install-setup-storage-encryption" and "install-finish"
 	var encryptSetupData *install.EncryptionSetupData
 	cached := st.Cached(encryptionSetupDataKey{systemLabel})
 	if cached != nil {
@@ -1173,8 +1175,13 @@ func (m *DeviceManager) doInstallFinish(t *state.Task, _ *tomb.Tomb) error {
 	if useEncryption {
 		bootstrappedContainersForRole := install.BootstrappedContainersForRole(encryptSetupData)
 		if trustedInstallObserver != nil {
-			// TODO:FDEM: pass preinstall check context that we get from encryptSetupData that is cached during install step install-setup-storage-encryption
-			if err := installLogic.PrepareEncryptedSystemData(systemAndSnaps.Model, bootstrappedContainersForRole, encryptSetupData.VolumesAuth(), nil, trustedInstallObserver); err != nil {
+			if err := installLogic.PrepareEncryptedSystemData(
+				systemAndSnaps.Model,
+				bootstrappedContainersForRole,
+				encryptSetupData.VolumesAuth(),
+				encryptSetupData.PreinstallCheckContext(),
+				trustedInstallObserver,
+			); err != nil {
 				return err
 			}
 		}
@@ -1250,7 +1257,7 @@ func (m *DeviceManager) doInstallFinish(t *state.Task, _ *tomb.Tomb) error {
 	return nil
 }
 
-func checkVolumesAuth(volumesAuth *device.VolumesAuthOptions, encryptInfo installLogic.EncryptionSupportInfo) error {
+func checkVolumesAuth(volumesAuth *device.VolumesAuthOptions, encryptInfo *installLogic.EncryptionSupportInfo) error {
 	if volumesAuth == nil {
 		return nil
 	}
@@ -1331,7 +1338,8 @@ func (m *DeviceManager) doInstallSetupStorageEncryption(t *state.Task, _ *tomb.T
 		SnapdVersions: systemAndSeeds.SystemSnapdVersions,
 	}
 
-	encryptInfo, err := m.encryptionSupportInfo(constraints)
+	const encInfoFromCache = false
+	encryptInfo, err := m.encryptionSupportInfoLocked(constraints, encInfoFromCache)
 	if err != nil {
 		return err
 	}
@@ -1350,7 +1358,16 @@ func (m *DeviceManager) doInstallSetupStorageEncryption(t *state.Task, _ *tomb.T
 
 	// TODO:ICE: support device.EncryptionTypeLUKSWithICE in the API
 	encType := device.EncryptionTypeLUKS
-	encryptionSetupData, err := installEncryptPartitions(onVolumes, volumesAuth, encType, systemAndSeeds.Model, mntPtForType[snap.TypeGadget], mntPtForType[snap.TypeKernel], perfTimings)
+	encryptionSetupData, err := installEncryptPartitions(
+		onVolumes,
+		volumesAuth,
+		encType,
+		encryptInfo.CheckContext(),
+		systemAndSeeds.Model,
+		mntPtForType[snap.TypeGadget],
+		mntPtForType[snap.TypeKernel],
+		perfTimings,
+	)
 	if err != nil {
 		return err
 	}
@@ -1362,6 +1379,8 @@ func (m *DeviceManager) doInstallSetupStorageEncryption(t *state.Task, _ *tomb.T
 	chg := t.Change()
 	chg.Set("api-data", apiData)
 
+	// cache is used to transport encryptionSetupData between install steps
+	// "install-setup-storage-encryption" and "install-finish"
 	st.Cache(encryptionSetupDataKey{systemLabel}, encryptionSetupData)
 
 	return nil

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -1338,6 +1338,8 @@ func (m *DeviceManager) doInstallSetupStorageEncryption(t *state.Task, _ *tomb.T
 		SnapdVersions: systemAndSeeds.SystemSnapdVersions,
 	}
 
+	// do not use cached encryption information; perform a fresh encryption
+	// availability check
 	const encInfoFromCache = false
 	encryptInfo, err := m.encryptionSupportInfoLocked(systemLabel, constraints, encInfoFromCache)
 	if err != nil {

--- a/overlord/devicestate/handlers_install.go
+++ b/overlord/devicestate/handlers_install.go
@@ -1339,7 +1339,7 @@ func (m *DeviceManager) doInstallSetupStorageEncryption(t *state.Task, _ *tomb.T
 	}
 
 	const encInfoFromCache = false
-	encryptInfo, err := m.encryptionSupportInfoLocked(constraints, encInfoFromCache)
+	encryptInfo, err := m.encryptionSupportInfoLocked(systemLabel, constraints, encInfoFromCache)
 	if err != nil {
 		return err
 	}

--- a/overlord/install/install.go
+++ b/overlord/install/install.go
@@ -265,7 +265,6 @@ func checkPassphraseSupportedByTargetSystem(sysVer SystemSnapdVersions) (bool, e
 // [GetEncryptionSupportInfo] must consider when deciding how to encrypt the
 // system.
 type EncryptionConstraints struct {
-	SystemLabel   string
 	Model         *asserts.Model
 	Kernel        *snap.Info
 	Gadget        *gadget.Info

--- a/overlord/install/install.go
+++ b/overlord/install/install.go
@@ -191,12 +191,13 @@ func BuildKernelBootInfo(kernInfo *snap.Info, compSeedInfos []ComponentSeedInfo,
 
 // SetAvailabilityCheckContext is a test only helper for populating EncryptionSupportInfo field availabilityCheckContext.
 func (esi *EncryptionSupportInfo) SetAvailabilityCheckContext(checkContext *secboot.PreinstallCheckContext) {
-	osutil.MustBeTestBinary("secbootPreinstallCheck can only be mocked in tests")
+	osutil.MustBeTestBinary("secbootPreinstallCheck can only be used in tests")
 	esi.availabilityCheckContext = checkContext
 }
 
 // MockSecbootCheckTPMKeySealingSupported mocks secbootCheckTPMKeySealingSupported usage by the package for testing.
 func MockSecbootCheckTPMKeySealingSupported(f func(tpmMode secboot.TPMProvisionMode) error) (restore func()) {
+	osutil.MustBeTestBinary("secbootCheckTPMKeySealingSupported can only be mocked in tests")
 	old := secbootCheckTPMKeySealingSupported
 	secbootCheckTPMKeySealingSupported = f
 	return func() {
@@ -264,6 +265,7 @@ func checkPassphraseSupportedByTargetSystem(sysVer SystemSnapdVersions) (bool, e
 // [GetEncryptionSupportInfo] must consider when deciding how to encrypt the
 // system.
 type EncryptionConstraints struct {
+	SystemLabel   string
 	Model         *asserts.Model
 	Kernel        *snap.Info
 	Gadget        *gadget.Info
@@ -658,7 +660,7 @@ func PrepareEncryptedSystemData(
 	if checkContext != nil {
 		// write check result containing information required
 		// for optimum PCR configuration and resealing
-		if err := saveCheckInfo(checkContext); err != nil {
+		if err := saveCheckResult(checkContext); err != nil {
 			return err
 		}
 	}
@@ -674,9 +676,9 @@ func PrepareEncryptedSystemData(
 	return nil
 }
 
-func saveCheckInfo(checkContext *secboot.PreinstallCheckContext) error {
-	saveCheckInfoPath := device.PreinstallCheckResultUnder(boot.InstallHostFDESaveDir)
-	return secbootSaveCheckResult(checkContext, saveCheckInfoPath)
+func saveCheckResult(checkContext *secboot.PreinstallCheckContext) error {
+	saveCheckResultPath := device.PreinstallCheckResultUnder(boot.InstallHostFDESaveDir)
+	return secbootSaveCheckResult(checkContext, saveCheckResultPath)
 }
 
 // writeMarkers writes markers containing the same secret to pair data and save.


### PR DESCRIPTION
Extend post /v2/system for error actions

This PR aim to complete part 2 based on [the complete POC](https://github.com/ernestl/snapd/pull/3)

The concept of caching encryption information existed at a daemon/api_systems.go level to avoid expensive preinstall check when only required to check if passphrase or pin is supported. This is now moved into devicestate, because the preinstall check context that is hidden in the encryption information structure also needs to be cached to enable follow-up preinstall checks with a specific action.

The preinstall check result needs to be stored in the save partition to configure optimum PCR configuration and enable resealing post install. The existing mechanism that transports encryption setup information between install steps "install-setup-storage-encryption" and "install-finish" was extended to also contain the preinstall check context from which the result is extracted for saving to disk when preparing encrypted system data during the "install-finish" step.

Spec: [Perform TPM/FDE pre-install check error recovery actions](https://docs.google.com/document/d/1Mbj7Ut0tgW0PCz8VWdhvBN52kHTxYqkZZKQODB1NlLk/edit?tab=t.0#heading=h.26porr595yii)

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-35035