### PR TITLE
tests/main/snap-user-service: skip more systems

### DIFF
--- a/tests/main/snap-user-service/task.yaml
+++ b/tests/main/snap-user-service/task.yaml
@@ -9,13 +9,13 @@ systems:
     - -ubuntu-14.04-*
     # Ubuntu 16 is too old for the user services
     - -ubuntu-16.04-*
-    # The following distros do not the user agent running
+    # The following distros do not have the user agent running by default
     - -amazon-linux-2-*
     - -amazon-linux-2023-*
-    - -opensuse-15.6-*
+    - -opensuse-*
     - -arch-linux-*
     - -centos-9-*
-    - -fedora-42-*
+    - -fedora-*
 
 kill-timeout: 10m
 


### PR DESCRIPTION
On openSUSE/Fedora/Arch, the snapd.session-agent.socket is not enabled by default during package installation. Make sure those systems are skipped.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
