### PR TITLE
store: add timeout to http client when downloading snap icon

### DIFF
--- a/store/export_test.go
+++ b/store/export_test.go
@@ -158,6 +158,10 @@ func MockMaxIconFilesize(maxSize int64) (restore func()) {
 	return testutil.Mock(&maxIconFilesize, maxSize)
 }
 
+func MockDownloadIconTimeout(timeout time.Duration) (restore func()) {
+	return testutil.Mock(&downloadIconTimeout, timeout)
+}
+
 func MockDownloadIcon(f func(ctx context.Context, name, etag, downloadURL string, w ReadWriteSeekTruncater) (string, error)) (restore func()) {
 	return testutil.Mock(&downloadIcon, f)
 }

--- a/store/store_download.go
+++ b/store/store_download.go
@@ -681,6 +681,20 @@ type ReadWriteSeekTruncater interface {
 var (
 	maxIconFilesize int64 = 300000
 	downloadIcon          = downloadIconImpl
+	// downloadIconTimeout is the duration of time to wait when attempting to
+	// download a snap icon. Most icons are <100kB, and we limit the max size
+	// to 300kB. If the machine is behind a firewall which blocks connections
+	// aside from the store proxy, we want to more quickly abort, as this will
+	// otherwise hang until the 15 minute request timeout expires. Unfortunately,
+	// the request will retry 5 times total on request cancellation (e.g. by
+	// timeout), so we'll really wait 5x this value. But on very slow internet
+	// we still need to be able to download icons up to several hundred kB
+	// within this time limit.
+	// XXX: The http.Transport used by the NewHTTPClient sets ResponseHeaderTimeout
+	// to 15 seconds, so why doesn't that timer fire instead of waiting for the
+	// 15 minute request timeout? Is it blocked on DNS and never even gets to
+	// make the request?
+	downloadIconTimeout = 10 * time.Second
 )
 
 // downloadIconImpl writes an http.Request which does not require authentication
@@ -698,7 +712,7 @@ func downloadIconImpl(ctx context.Context, name, etag, downloadURL string, w Rea
 		httputil.MaybeLogRetryAttempt(iconURL.String(), attempt, startTime)
 
 		err = func() error {
-			clientOpts := &httputil.ClientOptions{} // XXX: should this have a timeout?
+			clientOpts := &httputil.ClientOptions{Timeout: downloadIconTimeout}
 			cli := httputil.NewHTTPClient(clientOpts)
 			reqOptions := iconRequestOptions{
 				url:  iconURL,


### PR DESCRIPTION
If the system is behind a firewall which prevents internet access outside of the store proxy, then snap icon requests will be blocked. However, rather than exiting quickly, the request hangs until the snapd API request timeout fires, which takes 15 minutes. This is a bad UX.

There is a 15 *second* timeout defined in the default `http.Transport` created by `httputil.NewHTTPClient`, but it appears that that timeout never fires, presumably because the transport never actually begins.

Thus, set a reasonably short timeout in the `http.Client` itself, so that users should be able to download snap icons even on a slow internet connection (though 60s would be required for a 300kB icon on 40kb/s dial-up).

A complication is that the request is retried five times in total, so the actual wait time when behind a firewall is 5x the client timeout. This means we really want to lower this timeout as much as possible, or else be more explicitly check for a complete connection failure. None of the current `http.Transport` timeouts appear to do anything in this scenario.