### PR TITLE
interfaces/builtin: add Cano Key to u2f devices list

### DIFF
--- a/interfaces/builtin/u2f_devices.go
+++ b/interfaces/builtin/u2f_devices.go
@@ -212,6 +212,11 @@ var u2fDevices = []u2fDevice{
 		VendorIDPattern:  "3752",
 		ProductIDPattern: "0001",
 	},
+	{
+		Name:             "Cano Key",
+		VendorIDPattern:  "20a0",
+		ProductIDPattern: "42d4",
+	},
 }
 
 const u2fDevicesConnectedPlugAppArmor = `

--- a/interfaces/builtin/u2f_devices_test.go
+++ b/interfaces/builtin/u2f_devices_test.go
@@ -93,7 +93,7 @@ func (s *u2fDevicesInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(err, IsNil)
 	spec := udev.NewSpecification(appSet)
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 35)
+	c.Assert(spec.Snippets(), HasLen, 36)
 	c.Assert(spec.Snippets(), testutil.Contains, `# u2f-devices
 # Yubico YubiKey
 SUBSYSTEM=="hidraw", KERNEL=="hidraw*", ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0113|0114|0115|0116|0120|0121|0200|0402|0403|0406|0407|0410", TAG+="snap_consumer_app"`)


### PR DESCRIPTION
This adds the [Cano Key](https://www.canokeys.org/) device to the u2f_devices.go list. 

The VendorId and ProductID can be verified at 

https://docs.canokeys.org/userguide/setup/#31-udev 


https://github.com/canokeys/canokey-core/blob/049465e58846b036fcf03991ae55a1337c9f7431/interfaces/USB/device/usbd_desc.h

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
