### PR TITLE
snapcraft: bump FIPS toolchain to 1.23

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -289,7 +289,7 @@ parts:
     override-build: |
       # this should be passed through build environment, but we're already
       # anchoring dynamic linker env variables
-      GO_TOOLCHAIN_FIPS_CHANNEL="1.21-fips/stable"
+      GO_TOOLCHAIN_FIPS_CHANNEL="1.23-fips/stable"
 
       VERSION="$(craftctl get version)"
       if [ -f fips-build ] ; then


### PR DESCRIPTION
Bump the version of FIPS Go toolchain to 1.23, same version we use for other builds.

Related: [SNAPDENG-35096](https://warthogs.atlassian.net/browse/SNAPDENG-35096)

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?


[SNAPDENG-35096]: https://warthogs.atlassian.net/browse/SNAPDENG-35096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ