### PR TITLE
store: skip icon download if proxy is in use

### DIFF
--- a/store/errors.go
+++ b/store/errors.go
@@ -68,6 +68,9 @@ var (
 
 	// ErrNoUpdateAvailable is returned when an update is attempted for a snap that has no update available.
 	ErrNoUpdateAvailable = errors.New("snap has no updates available")
+
+	// ErrSkipIconDownload is returned when snap icon download is skipped because the store is using a proxy.
+	ErrSkipIconDownload = errors.New("skipping icon download as store is using proxy")
 )
 
 // RevisionNotAvailableError is returned when an install is attempted for a snap but the/a revision is not available (given install constraints).

--- a/store/export_test.go
+++ b/store/export_test.go
@@ -186,6 +186,10 @@ func (sto *Store) MockCacher(obs downloadCache) (restore func()) {
 	}
 }
 
+func (sto *Store) MockProxy(f func(*http.Request) (*url.URL, error)) (restore func()) {
+	return testutil.Mock(&sto.cfg.Proxy, f)
+}
+
 func MockHttputilNewHTTPClient(f func(opts *httputil.ClientOptions) *http.Client) (restore func()) {
 	old := httputilNewHTTPClient
 	httputilNewHTTPClient = f

--- a/store/store.go
+++ b/store/store.go
@@ -166,7 +166,7 @@ type Store struct {
 
 	cacher downloadCache
 
-	proxy              func(*http.Request) (*url.URL, error)
+	proxy              func(*http.Request) (*url.URL, error) // XXX: this is unused; s.cfg.Proxy is always used instead
 	proxyConnectHeader http.Header
 
 	userAgent string
@@ -470,7 +470,7 @@ func (s *Store) newHTTPClient(opts *httputil.ClientOptions) *http.Client {
 	if opts == nil {
 		opts = &httputil.ClientOptions{}
 	}
-	opts.Proxy = s.cfg.Proxy
+	opts.Proxy = s.cfg.Proxy // XXX: why is s.proxy not used here?
 	opts.ProxyConnectHeader = s.proxyConnectHeader
 	opts.ExtraSSLCerts = &httputil.ExtraSSLCertsFromDir{
 		Dir: dirs.SnapdStoreSSLCertsDir,

--- a/store/store_download.go
+++ b/store/store_download.go
@@ -323,6 +323,10 @@ const (
 // authentication or user state, nor a progress bar. They are also not revision-
 // specific, and do not use a download cache.
 func (s *Store) DownloadIcon(ctx context.Context, name string, targetPath string, downloadURL string) error {
+	if s.cfg.Proxy != nil {
+		// If there's a proxy in use, skip snap icon download
+		return ErrSkipIconDownload
+	}
 	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
 		return err
 	}


### PR DESCRIPTION
If a store proxy is being used during snap installation, then skip downloading the snap icon. As downloading an icon involves simply getting a file from a fileserver (typically dashboard.snapcraft.io), the store proxy is not designed to mediate this download. However, when a proxy is in use, the expectation is that all snapd traffic should go through the proxy. Thus, the icon download should be skipped.

Prior to this change, in airgapped environments using the store proxy, it was possible that the icon download would hang for 15 minutes before failing, thus delaying all snap install/refresh tasks dramatically. This commit prevents this issue from occurring.

This is an alternative to #15876 which addresses the root cause rather than waiting for a timeout (which will be retried several times). This work is tracked by https://warthogs.atlassian.net/browse/SNAPDENG-35400

Ideally, we would have a way to know whether the system is airgapped in addition to checking whether a proxy is in use.
