### PR TITLE
spread, github: add Ubuntu Pro 24.04 FIPS variant

### DIFF
--- a/.github/workflows/data-non-fundamental-systems.json
+++ b/.github/workflows/data-non-fundamental-systems.json
@@ -108,7 +108,7 @@
         "group": "ubuntu-fips",
         "backend": "google-pro",
         "alternative-backend": "google-pro",
-        "systems": "ubuntu-fips-22.04-64",
+        "systems": "ubuntu-fips-22.04-64 ubuntu-fips-24.04-64",
         "tasks": "tests/fips/...",
         "rules": "fips"
       }

--- a/spread.yaml
+++ b/spread.yaml
@@ -228,6 +228,11 @@ backends:
                   workers: 1
                   attach-service-account: true
 
+            - ubuntu-fips-24.04-64:
+                  image: ubuntu-os-pro-cloud/ubuntu-pro-2404-lts-amd64
+                  workers: 1
+                  attach-service-account: true
+
     google-distro-1:
         type: google
         key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'


### PR DESCRIPTION
Add Ubuntu Pro 24.04 and a corresponding FIPS flavor test target.