### PR TITLE
tests/lib/prepare.sh: Mount snap as squashfs

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -280,7 +280,7 @@ update_core_snap_for_classic_reexec() {
 
     # Now mount the new core snap, first discarding the old mount namespace
     snapd.tool exec snap-discard-ns core
-    mount "$snap" "$core"
+    mount -t squashfs "$snap" "$core"
 
     check_file() {
         if ! cmp "$1" "$2" ; then


### PR DESCRIPTION
It seems detection of squashfs format is broken on some platforms and fails the spread tests. Forcing squashfs should help.