### PR TITLE
tests: remove the kill-spread step from the ci execution

### DIFF
--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -85,8 +85,6 @@ jobs:
       run: |
           rm -rf "${{ github.workspace }}"
           mkdir "${{ github.workspace }}"
-          # Make sure there are not spread processes running
-          killall -s SIGQUIT spread || true
 
     - name: Checkout code
       uses: actions/checkout@v4
@@ -366,8 +364,6 @@ jobs:
     - name: Discard spread workers
       if: always()
       run: |
-        # Make sure there is not spread process running which locks the .spread-reuse.*.yaml files
-        killall -s SIGQUIT spread || true
         shopt -s nullglob;
         for r in .spread-reuse.*.yaml; do
           spread -discard -reuse-pid="$(echo "$r" | grep -o -E '[0-9]+')";


### PR DESCRIPTION
This steps were added to workaround the issue in the github actions runner when spread got stuck. The issue was already fixed and this workaround shouldn't be needed anymore.

