### PR TITLE
Enable access to the TPM over the /sys/class/tpm directory

### DIFF
--- a/interfaces/builtin/tpm.go
+++ b/interfaces/builtin/tpm.go
@@ -35,6 +35,7 @@ const tpmConnectedPlugAppArmor = `
 
 /dev/tpm[0-9]* rw,
 /dev/tpmrm[0-9]* rw,
+/sys/class/tpm/*/ppi/request
 `
 
 var tpmConnectedPlugUDev = []string{


### PR DESCRIPTION
We need to access the TPM to clear it before we do a factory reset. To do it, we do:
```
echo 5 > /sys/class/tpm/tpm0/ppi/request
```

But the current security setup doesn't allow us to do it. 

Reading those paths should be enabled. Even write access to TPM could be allowed. 


Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
