### PR TITLE
interfaces:  read access to ksm (Kernel Samepage Merging) added

### DIFF
--- a/interfaces/builtin/hardware_observe.go
+++ b/interfaces/builtin/hardware_observe.go
@@ -98,8 +98,8 @@ network netlink raw,
 @{PROC}/tty/driver/{,*} r,
 @{PROC}/sys/dev/cdrom/info r,
 
-# status of hugepages and transparent_hugepage, but not the pages themselves
-/sys/kernel/mm/{hugepages,transparent_hugepage}/{,**} r,
+# status of ksm (Kernel Samepage Merging), hugepages and transparent_hugepage, but not the pages themselves
+/sys/kernel/mm/{ksm,hugepages,transparent_hugepage}/{,**} r,
 
 # systemd-detect-virt
 /{,usr/}bin/systemd-detect-virt ixr,


### PR DESCRIPTION
This PR is a continuation of this [previous one](https://github.com/canonical/snapd/pull/15844), and its aim is to reduce the error logs in node-exporter running as a strictly confined snap. 

More info: https://forum.snapcraft.io/t/should-some-snapd-interfaces-be-modified/48242/11?u=abuelodelanada
