### PR TITLE
cmd/user-support: Update $HOME outside /home documentation link

### DIFF
--- a/cmd/snap-confine/user-support.c
+++ b/cmd/snap-confine/user-support.c
@@ -40,8 +40,8 @@ void setup_user_data(void) {
             // clear errno or it will be displayed in die()
             errno = 0;
             // XXX: may point to the right config option here?
-            die("Sorry, home directories outside of /home needs configuration.\nSee https://forum.snapcraft.io/t/11209 "
-                "for details.");
+            die("Sorry, home directories outside of /home needs configuration.\n"
+                "See https://snapcraft.io/docs/home-outside-home for details.");
         }
         die("cannot create user data directory: %s", user_data);
     };


### PR DESCRIPTION
The current/old link to the forums isn't helpful for users due to the amount of noise on the thread, especially with it being so old.
This replaces it with the direct documentation related to the problem.