### PR TITLE
store: skip icon download when using a proxy store

### DIFF
--- a/store/devicenauthctx.go
+++ b/store/devicenauthctx.go
@@ -38,7 +38,10 @@ type DeviceAndAuthContext interface {
 	StoreID(fallback string) (string, error)
 
 	DeviceSessionRequestParams(nonce string) (*DeviceSessionRequestParams, error)
-	ProxyStoreParams(defaultURL *url.URL) (proxyStoreID string, proxySroreURL *url.URL, err error)
+	// ProxyStoreParams returns the parameters of a proxy store. If one is set
+	// up in the system, the returned URL points to the proxy store and its ID
+	// is non-empty. Otherwise returns the fallback defaultURL.
+	ProxyStoreParams(defaultURL *url.URL) (proxyStoreID string, proxyStoreURL *url.URL, err error)
 
 	CloudInfo() (*auth.CloudInfo, error)
 

--- a/store/store_download.go
+++ b/store/store_download.go
@@ -331,9 +331,9 @@ func (s *Store) DownloadIcon(ctx context.Context, name string, targetPath string
 	if s.dauthCtx != nil {
 		// custom proxy store, which historically had not supported icon
 		// downloads through its APIs
-		_, u, err := s.dauthCtx.ProxyStoreParams(s.baseURL(s.cfg.StoreBaseURL))
-		if err == nil && u != nil {
-			if !strings.HasPrefix(downloadURL, u.String()) {
+		psID, psU, err := s.dauthCtx.ProxyStoreParams(s.baseURL(s.cfg.StoreBaseURL))
+		if err == nil && psID != "" && psU != nil {
+			if !strings.HasPrefix(downloadURL, psU.String()) {
 				return ErrProxyStoreIconDownloadUnsupported
 			}
 		}

--- a/store/store_download.go
+++ b/store/store_download.go
@@ -332,7 +332,7 @@ func (s *Store) DownloadIcon(ctx context.Context, name string, targetPath string
 		// custom proxy store, which historically had not supported icon
 		// downloads through its APIs
 		psID, psU, err := s.dauthCtx.ProxyStoreParams(s.baseURL(s.cfg.StoreBaseURL))
-		if err == nil && psID != "" && psU != nil {
+		if err == nil && psID != "" {
 			if !strings.HasPrefix(downloadURL, psU.String()) {
 				return ErrProxyStoreIconDownloadUnsupported
 			}

--- a/store/store_download_test.go
+++ b/store/store_download_test.go
@@ -1580,7 +1580,6 @@ func (s *storeDownloadSuite) TestDownloadIconInfiniteRedirect(c *C) {
 
 func (s *storeDownloadSuite) TestDownloadIconProxyStoreUnsupported(c *C) {
 	const expectedName = "foo"
-	const expectedURL = "URL"
 	expectedContent := []byte("I was downloaded")
 
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
When proxy store is configured in snapd, we are expecting all communication to be carried out to the proxy rather than directly to snapcraft.io or any of its CDN endpoints. The patch makes attempts to download the icons fail with explicit error when a proxy store is in place and the icon download URL does not match the store's URL.

Related: SNAPDENG-35400

Supersedes: #15884
