### PR TITLE
data: tweak polkit message for FDE

### DIFF
--- a/data/polkit/io.snapcraft.snapd.policy
+++ b/data/polkit/io.snapcraft.snapd.policy
@@ -48,8 +48,8 @@
   </action>
 
   <action id="io.snapcraft.snapd.manage-fde">
-    <description gettext-domain="snappy">Manage FDE setup</description>
-    <message gettext-domain="snappy">Authentication is required to manage FDE setup</message>
+    <description gettext-domain="snappy">Manage disk encryption</description>
+    <message gettext-domain="snappy">Authentication is required to manage disk encryption setup</message>
     <defaults>
       <allow_any>auth_admin</allow_any>
       <allow_inactive>auth_admin</allow_inactive>


### PR DESCRIPTION
We don't use the FDE acronym, but refer to "Disk Encryption" instead. FDE is a rather obscure acronym, even more so than TPM. Suggesting to tweak for consistency and clarity.