### PR TITLE
cmd/snap-bootstrap: robustness in terms of scanning disks

### DIFF
--- a/cmd/snap-bootstrap/blkid/mock_blkid.go
+++ b/cmd/snap-bootstrap/blkid/mock_blkid.go
@@ -63,6 +63,11 @@ func BuildFakeProbe(values map[string]string) *FakeBlkidProbe {
 	return &FakeBlkidProbe{values, &FakeBlkidPartlist{}}
 }
 
+func (p *FakeBlkidProbe) AddEmptyPartitionProbe(start int64) *FakeBlkidProbe {
+	p.partlist.partitions = append(p.partlist.partitions, &FakeBlkidPartition{"", "", start})
+	return BuildFakeProbe(make(map[string]string))
+}
+
 func (p *FakeBlkidProbe) AddPartitionProbe(name, uuid string, start int64) *FakeBlkidProbe {
 	p.partlist.partitions = append(p.partlist.partitions, &FakeBlkidPartition{name, uuid, start})
 


### PR DESCRIPTION
When installing from initramfs using a preseeded image on the rpi, two issues where observed in the logs.

One, udev can become retriggered during installation (when creating partitions), which causes retriggering scan-disk command.

Scan-disk then fails because LABEL is not available as the partition has not been formatted. Because this fails, udev then proceeds to remove the disk again, making the main snap-bootstrap process die.

The second issue is that loop devices created from snap mounts can make scan-disk crash as well, as no partitions are returned.


Fix has been manually verified on my Raspberry Pi 4 with a repacked initramfs and a preseeded image.