### PR TITLE
i/b/xilinx-dma: support Multi Queue DMA (QDMA) IP

### DIFF
--- a/interfaces/builtin/xilinx_dma.go
+++ b/interfaces/builtin/xilinx_dma.go
@@ -47,13 +47,24 @@ const xilinxDmaConnectedPlugAppArmor = `
 # If multiple cards are detected, nodes are created under
 /dev/xdma/card[0-9]*/** rw,
 
+# Access to the device nodes created by the Xilinx QDMA driver
+/dev/qdma{,vf}[0-9]*-{MM,ST}-[0-9]* rw,
+
 # View XDMA driver module parameters
 /sys/module/xdma/parameters/* r,
+
+# View QDMA driver module parameters
+/sys/module/qdma/parameters/* r,
+
+# Access to QDMA driver configurations
+/sys/devices/pci*/**/qdma/* rw,
 `
 
 // The xdma subsystem alone should serve as a unique identifier for all relevant devices
 var xilinxDmaConnectedPlugUDev = []string{
 	`SUBSYSTEM=="xdma"`,
+	`SUBSYSTEM=="qdma-pf"`,
+	`SUBSYSTEM=="qdma-vf"`,
 }
 
 func init() {

--- a/interfaces/builtin/xilinx_dma_test.go
+++ b/interfaces/builtin/xilinx_dma_test.go
@@ -86,6 +86,9 @@ func (s *XilinxDmaInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/xdma/card[0-9]*/** rw,`)
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/xdma[0-9]*_{control,user,xvc} rw,`)
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/sys/module/xdma/parameters/* r,`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/qdma{,vf}[0-9]*-{MM,ST}-[0-9]* rw,`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/sys/module/qdma/parameters/* r,`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/sys/devices/pci*/**/qdma/* rw,`)
 }
 
 func (s *XilinxDmaInterfaceSuite) TestUDevSpec(c *C) {
@@ -93,9 +96,13 @@ func (s *XilinxDmaInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(err, IsNil)
 	spec := udev.NewSpecification(appSet)
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.coreSlot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 2)
+	c.Assert(spec.Snippets(), HasLen, 4)
 	c.Assert(spec.Snippets(), testutil.Contains, `# xilinx-dma
 SUBSYSTEM=="xdma", TAG+="snap_consumer_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains, `# xilinx-dma
+SUBSYSTEM=="qdma-pf", TAG+="snap_consumer_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains, `# xilinx-dma
+SUBSYSTEM=="qdma-vf", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(
 		`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
 }


### PR DESCRIPTION
Support both qdma-pf and qdma-vf modes

When a queue is created and started, the driver will create a device entry (such as `/dev/qdma01000-MM-0`) dynamically for applications to use.
The configuration entries will be in the PCIe device entries of sysfs. For instance:
`/sys/devices/pci0000:00/0000:00:01.1/0000:01:00.0/qdma/`.

The hardware-observe interface may also be required for an application to gather hardware information before accessing the actual QDMA device.
