### PR TITLE
tests: have curl save tar to home directory in docker-smoke and lp-1910456

### DIFF
--- a/tests/main/docker-smoke/task.yaml
+++ b/tests/main/docker-smoke/task.yaml
@@ -29,7 +29,9 @@ prepare: |
     else
       IMAGE_URL=$IMAGE_URL_X86
     fi
-    curl -sL "$IMAGE_URL" -o hello-world.tar
+    # Save to the home directory to get around apparmor denials
+    curl -sL "$IMAGE_URL" -o "$HOME"/hello-world.tar
+    mv "$HOME"/hello-world.tar .
     # retry until docker is ready lo load images
     retry -n 30 --wait 1 docker load -i hello-world.tar  
   fi

--- a/tests/regression/lp-1910456/task.yaml
+++ b/tests/regression/lp-1910456/task.yaml
@@ -151,7 +151,9 @@ execute: |
         else
             IMAGE_URL=$IMAGE_URL_X86
         fi  
-        curl -sL "$IMAGE_URL" -o ubuntu-24.04.tar
+        # Save to the home directory to get around apparmor denials
+        curl -sL "$IMAGE_URL" -o "$HOME"/ubuntu-24.04.tar
+        mv "$HOME"/ubuntu-24.04.tar .
         retry -n 30 --wait 1 docker load -i ubuntu-24.04.tar
     fi
 


### PR DESCRIPTION
In Questing, the new curl profile prevents saving a file in the current directory in spread. This saves it to the home directory and moves it back to the testing directory to get around the profile's restrictions.