### PR TITLE
tests: move nightly executions to openstack

### DIFF
--- a/.github/workflows/data-nested-systems.json
+++ b/.github/workflows/data-nested-systems.json
@@ -34,7 +34,7 @@
       },
       {
         "group": "nested-ubuntu-24.04-arm64",
-        "backend": "google-nested-arm",
+        "backend": "openstack-arm-ext-ps7",
         "alternative-backend": "google-nested-arm",
         "systems": "ubuntu-24.04-arm-64",
         "tasks": "tests/nested/core/core20-basic tests/nested/manual/optee-fde",

--- a/.github/workflows/nightly-cross-build.yml
+++ b/.github/workflows/nightly-cross-build.yml
@@ -23,6 +23,5 @@ jobs:
 
       - name: build-snapd
         run: |
-          # TODO: Move to openstack-arm-ext-ps7 when https://github.com/canonical/snapcraft/issues/5635 is fixed
-          spread google-nested-arm:ubuntu-22.04-arm-64:tests/utils/cross-build/suite/build-snapd-armhf:jammy
+          spread openstack-arm-ext-ps7:ubuntu-22.04-arm-64:tests/utils/cross-build/suite/build-snapd-armhf:jammy
 

--- a/.github/workflows/nightly-spread.yaml
+++ b/.github/workflows/nightly-spread.yaml
@@ -30,8 +30,8 @@ jobs:
     uses: ./.github/workflows/spread-tests.yaml
     with:
       runs-on: '["self-hosted", "spread-enabled"]'
-      group: google
-      backend: google
+      group: openstack-ps7
+      backend: openstack-ps7
       systems: 'ALL'
       tasks: 'tests/nightly/...'
       rules: ''
@@ -53,21 +53,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - group: google
-            backend: google
-            systems: 'ubuntu-18.04-64 ubuntu-20.04-64 ubuntu-22.04-64 ubuntu-24.04-64'
-          - group: debian-not-req
-            backend: google-distro-1
-            systems: 'debian-12-64 debian-sid-64'
+          - group: openstack-ps7
+            backend: openstack-ps7
+            systems: 'ubuntu-18.04-64 ubuntu-20.04-64 ubuntu-22.04-64 ubuntu-24.04-64 debian-12-64'
+          - group: openstack
+            backend: openstack
+            systems: 'debian-sid-64'
 
   spread-test-experimental:
     if: ${{ github.event.schedule == '0 3 * * *' || (github.event_name == 'workflow_dispatch' && inputs.job == 'spread-test-experimental') }}
     uses: ./.github/workflows/spread-tests.yaml
     with:
       runs-on: '["self-hosted", "spread-enabled"]'
-      group: 'google'
-      backend: 'google'
-      systems: 'ubuntu-18.04-64 ubuntu-20.04-64 ubuntu-21.10-64 ubuntu-core-20-64'
+      group: 'openstack-ps7'
+      backend: 'openstack-ps7'
+      systems: 'ubuntu-20.04-64 ubuntu-22.04-64 ubuntu-24.04-64 ubuntu-core-24-64'
       tasks: 'tests/...'
       rules: ''
       use-snapd-snap-from-master: true


### PR DESCRIPTION
Run nightly executions in openstack instead of google


