### PR TITLE
many: include request cgroup in prompt

### DIFF
--- a/interfaces/prompting/prompting.go
+++ b/interfaces/prompting/prompting.go
@@ -40,6 +40,9 @@ type Metadata struct {
 	// PID is the PID of the process which triggered a request.
 	// For rules, PID should be unset/ignored.
 	PID int32
+	// PGID is the process group ID of the process which triggered a request.
+	// For rules, PGID should be unset/ignored.
+	PGID int32
 	// Interface is the interface for which the prompt or rule applies.
 	Interface string
 }

--- a/interfaces/prompting/prompting.go
+++ b/interfaces/prompting/prompting.go
@@ -40,9 +40,9 @@ type Metadata struct {
 	// PID is the PID of the process which triggered a request.
 	// For rules, PID should be unset/ignored.
 	PID int32
-	// PGID is the process group ID of the process which triggered a request.
-	// For rules, PGID should be unset/ignored.
-	PGID int32
+	// Cgroup is the cgroup path of the process which triggered a request.
+	// For rules, Cgroup should be unset/ignored.
+	Cgroup string
 	// Interface is the interface for which the prompt or rule applies.
 	Interface string
 }

--- a/interfaces/prompting/requestprompts/requestprompts.go
+++ b/interfaces/prompting/requestprompts/requestprompts.go
@@ -67,7 +67,7 @@ type Prompt struct {
 	Timestamp    time.Time
 	Snap         string
 	PID          int32
-	PGID         int32
+	Cgroup       string
 	Interface    string
 	Constraints  *promptConstraints
 	listenerReqs []*listener.Request
@@ -79,7 +79,7 @@ type jsonPrompt struct {
 	Timestamp   time.Time              `json:"timestamp"`
 	Snap        string                 `json:"snap"`
 	PID         int32                  `json:"pid"`
-	PGID        int32                  `json:"pgid"`
+	Cgroup      string                 `json:"cgroup"`
 	Interface   string                 `json:"interface"`
 	Constraints *jsonPromptConstraints `json:"constraints"`
 }
@@ -104,7 +104,7 @@ func (p *Prompt) MarshalJSON() ([]byte, error) {
 		Timestamp:   p.Timestamp,
 		Snap:        p.Snap,
 		PID:         p.PID,
-		PGID:        p.PGID,
+		Cgroup:      p.Cgroup,
 		Interface:   p.Interface,
 		Constraints: constraints,
 	}
@@ -116,10 +116,10 @@ func (p *Prompt) MarshalJSON() ([]byte, error) {
 func (p *Prompt) matchesRequestContents(metadata *prompting.Metadata, constraints *promptConstraints) bool {
 	// We treat requests and prompts with different PIDs as distinct so that
 	// if there are multiple requests which are otherwise identical but have
-	// different PIDs or PGIDs, the client can present the modal dialog on
-	// any/all windows associated with the requests. If PIDs matche, PGIDs
+	// different PIDs or Cgroups, the client can present the modal dialog on
+	// any/all windows associated with the requests. If PIDs match, Cgroups
 	// should also match, but check them anyway for completeness.
-	return p.Snap == metadata.Snap && p.PID == metadata.PID && p.PGID == metadata.PGID && p.Interface == metadata.Interface && p.Constraints.equals(constraints)
+	return p.Snap == metadata.Snap && p.PID == metadata.PID && p.Cgroup == metadata.Cgroup && p.Interface == metadata.Interface && p.Constraints.equals(constraints)
 }
 
 // addListenerRequest adds the given listener request to the list of requests
@@ -742,7 +742,7 @@ func (pdb *PromptDB) AddOrMerge(metadata *prompting.Metadata, path string, reque
 		Timestamp:    timestamp,
 		Snap:         metadata.Snap,
 		PID:          metadata.PID,
-		PGID:         metadata.PGID,
+		Cgroup:       metadata.Cgroup,
 		Interface:    metadata.Interface,
 		Constraints:  constraints,
 		listenerReqs: []*listener.Request{listenerReq},

--- a/interfaces/prompting/requestprompts/requestprompts.go
+++ b/interfaces/prompting/requestprompts/requestprompts.go
@@ -67,6 +67,7 @@ type Prompt struct {
 	Timestamp    time.Time
 	Snap         string
 	PID          int32
+	PGID         int32
 	Interface    string
 	Constraints  *promptConstraints
 	listenerReqs []*listener.Request
@@ -78,6 +79,7 @@ type jsonPrompt struct {
 	Timestamp   time.Time              `json:"timestamp"`
 	Snap        string                 `json:"snap"`
 	PID         int32                  `json:"pid"`
+	PGID        int32                  `json:"pgid"`
 	Interface   string                 `json:"interface"`
 	Constraints *jsonPromptConstraints `json:"constraints"`
 }
@@ -102,6 +104,7 @@ func (p *Prompt) MarshalJSON() ([]byte, error) {
 		Timestamp:   p.Timestamp,
 		Snap:        p.Snap,
 		PID:         p.PID,
+		PGID:        p.PGID,
 		Interface:   p.Interface,
 		Constraints: constraints,
 	}
@@ -113,9 +116,10 @@ func (p *Prompt) MarshalJSON() ([]byte, error) {
 func (p *Prompt) matchesRequestContents(metadata *prompting.Metadata, constraints *promptConstraints) bool {
 	// We treat requests and prompts with different PIDs as distinct so that
 	// if there are multiple requests which are otherwise identical but have
-	// different PIDs, the client can present the modal dialog on any/all
-	// windows associated with the requests.
-	return p.Snap == metadata.Snap && p.PID == metadata.PID && p.Interface == metadata.Interface && p.Constraints.equals(constraints)
+	// different PIDs or PGIDs, the client can present the modal dialog on
+	// any/all windows associated with the requests. If PIDs matche, PGIDs
+	// should also match, but check them anyway for completeness.
+	return p.Snap == metadata.Snap && p.PID == metadata.PID && p.PGID == metadata.PGID && p.Interface == metadata.Interface && p.Constraints.equals(constraints)
 }
 
 // addListenerRequest adds the given listener request to the list of requests
@@ -738,6 +742,7 @@ func (pdb *PromptDB) AddOrMerge(metadata *prompting.Metadata, path string, reque
 		Timestamp:    timestamp,
 		Snap:         metadata.Snap,
 		PID:          metadata.PID,
+		PGID:         metadata.PGID,
 		Interface:    metadata.Interface,
 		Constraints:  constraints,
 		listenerReqs: []*listener.Request{listenerReq},

--- a/interfaces/prompting/requestprompts/requestprompts_test.go
+++ b/interfaces/prompting/requestprompts/requestprompts_test.go
@@ -319,7 +319,7 @@ func (s *requestpromptsSuite) TestAddOrMergeNonMerges(c *C) {
 		User:      s.defaultUser,
 		Snap:      "nextcloud",
 		PID:       1234,
-		PGID:      5678,
+		Cgroup:    "some-cgroup-name",
 		Interface: "home",
 	}
 	path := "/home/test/Documents/foo.txt"
@@ -349,7 +349,7 @@ func (s *requestpromptsSuite) TestAddOrMergeNonMerges(c *C) {
 
 	c.Check(prompt1.Snap, Equals, metadata.Snap)
 	c.Check(prompt1.PID, Equals, metadata.PID)
-	c.Check(prompt1.PGID, Equals, metadata.PGID)
+	c.Check(prompt1.Cgroup, Equals, metadata.Cgroup)
 	c.Check(prompt1.Interface, Equals, metadata.Interface)
 	c.Check(prompt1.Constraints.Path(), Equals, path)
 	c.Check(prompt1.Constraints.OutstandingPermissions(), DeepEquals, permissions)
@@ -386,7 +386,7 @@ func (s *requestpromptsSuite) TestAddOrMergeNonMerges(c *C) {
 
 	c.Check(prompt2.Snap, Equals, metadata.Snap)
 	c.Check(prompt2.PID, Equals, metadata.PID)
-	c.Check(prompt2.PGID, Equals, metadata.PGID)
+	c.Check(prompt2.Cgroup, Equals, metadata.Cgroup)
 	c.Check(prompt2.Interface, Equals, metadata.Interface)
 	c.Check(prompt2.Constraints.Path(), Equals, path)
 	c.Check(prompt2.Constraints.OutstandingPermissions(), DeepEquals, permissions)
@@ -416,7 +416,7 @@ func (s *requestpromptsSuite) TestAddOrMergeNonMerges(c *C) {
 	// Looking up prompt should not record notice
 	s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)
 
-	// Add third prompt, this time with different PID but same PGID
+	// Add third prompt, this time with different PID but same Cgroup
 
 	metadata = metadataTemplate
 	metadata.PID = 1337
@@ -428,7 +428,7 @@ func (s *requestpromptsSuite) TestAddOrMergeNonMerges(c *C) {
 
 	c.Check(prompt3.Snap, Equals, metadata.Snap)
 	c.Check(prompt3.PID, Equals, metadata.PID)
-	c.Check(prompt3.PGID, Equals, metadata.PGID)
+	c.Check(prompt3.Cgroup, Equals, metadata.Cgroup)
 	c.Check(prompt3.Interface, Equals, metadata.Interface)
 	c.Check(prompt3.Constraints.Path(), Equals, path)
 	c.Check(prompt3.Constraints.OutstandingPermissions(), DeepEquals, permissions)
@@ -457,10 +457,10 @@ func (s *requestpromptsSuite) TestAddOrMergeNonMerges(c *C) {
 	// Looking up prompt should not record notice
 	s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)
 
-	// Add fourth prompt, this time with different PGID but same PID
+	// Add fourth prompt, this time with different Cgroup but same PID
 
 	metadata = metadataTemplate
-	metadata.PGID = 1337
+	metadata.Cgroup = "another/cgroup"
 	prompt4, merged, err := pdb.AddOrMerge(&metadata, path, permissions, permissions, listenerReq4)
 	c.Assert(err, IsNil)
 	c.Check(merged, Equals, false)
@@ -470,7 +470,7 @@ func (s *requestpromptsSuite) TestAddOrMergeNonMerges(c *C) {
 
 	c.Check(prompt4.Snap, Equals, metadata.Snap)
 	c.Check(prompt4.PID, Equals, metadata.PID)
-	c.Check(prompt4.PGID, Equals, metadata.PGID)
+	c.Check(prompt4.Cgroup, Equals, metadata.Cgroup)
 	c.Check(prompt4.Interface, Equals, metadata.Interface)
 	c.Check(prompt4.Constraints.Path(), Equals, path)
 	c.Check(prompt4.Constraints.OutstandingPermissions(), DeepEquals, permissions)
@@ -514,7 +514,7 @@ func (s *requestpromptsSuite) TestAddOrMergeNonMerges(c *C) {
 
 	c.Check(prompt5.Snap, Equals, metadata.Snap)
 	c.Check(prompt5.PID, Equals, metadata.PID)
-	c.Check(prompt5.PGID, Equals, metadata.PGID)
+	c.Check(prompt5.Cgroup, Equals, metadata.Cgroup)
 	c.Check(prompt5.Interface, Equals, metadata.Interface)
 	c.Check(prompt5.Constraints.Path(), Equals, path)
 	c.Check(prompt5.Constraints.OutstandingPermissions(), DeepEquals, permissions)
@@ -561,7 +561,7 @@ func (s *requestpromptsSuite) TestAddOrMergeNonMerges(c *C) {
 
 	c.Check(prompt6.Snap, Equals, metadata.Snap)
 	c.Check(prompt6.PID, Equals, metadata.PID)
-	c.Check(prompt6.PGID, Equals, metadata.PGID)
+	c.Check(prompt6.Cgroup, Equals, metadata.Cgroup)
 	c.Check(prompt6.Interface, Equals, metadata.Interface)
 	c.Check(prompt6.Constraints.Path(), Equals, path)
 	c.Check(prompt6.Constraints.OutstandingPermissions(), DeepEquals, permissions)
@@ -609,7 +609,7 @@ func (s *requestpromptsSuite) TestAddOrMergeMerges(c *C) {
 		User:      s.defaultUser,
 		Snap:      "nextcloud",
 		PID:       1234,
-		PGID:      5678,
+		Cgroup:    "some/cgroup/path",
 		Interface: "home",
 	}
 	path := "/home/test/Documents/foo.txt"
@@ -665,7 +665,7 @@ func (s *requestpromptsSuite) TestAddOrMergeMerges(c *C) {
 
 	c.Check(prompt1.Snap, Equals, metadata.Snap)
 	c.Check(prompt1.PID, Equals, metadata.PID)
-	c.Check(prompt1.PGID, Equals, metadata.PGID)
+	c.Check(prompt1.Cgroup, Equals, metadata.Cgroup)
 	c.Check(prompt1.Interface, Equals, metadata.Interface)
 	c.Check(prompt1.Constraints.Path(), Equals, path)
 	c.Check(prompt1.Constraints.OutstandingPermissions(), DeepEquals, permissions)
@@ -717,7 +717,7 @@ func (s *requestpromptsSuite) TestAddOrMergeDuplicateRequests(c *C) {
 		User:      s.defaultUser,
 		Snap:      "nextcloud",
 		PID:       1234,
-		PGID:      5678,
+		Cgroup:    "some-cgroup-path",
 		Interface: "home",
 	}
 	path := "/home/test/Documents/foo.txt"
@@ -848,7 +848,7 @@ func (s *requestpromptsSuite) TestAddOrMergeTooMany(c *C) {
 		User:      s.defaultUser,
 		Snap:      "nextcloud",
 		PID:       42,
-		PGID:      33,
+		Cgroup:    "some-cgroup",
 		Interface: "home",
 	}
 
@@ -921,7 +921,7 @@ func (s *requestpromptsSuite) TestPromptWithIDErrors(c *C) {
 		User:      s.defaultUser,
 		Snap:      "nextcloud",
 		PID:       1337,
-		PGID:      1001,
+		Cgroup:    "0::/user.slice/user-1000.slice/user@1000.service/app.slice/foo.scope",
 		Interface: "home",
 	}
 	path := "/home/test/Documents/foo.txt"
@@ -970,7 +970,7 @@ func (s *requestpromptsSuite) TestReply(c *C) {
 		User:      s.defaultUser,
 		Snap:      "nextcloud",
 		PID:       123,
-		PGID:      123,
+		Cgroup:    "0::/user.slice/user-1000.slice/user@1000.service/app.slice/foo.scope",
 		Interface: "home",
 	}
 	path := "/home/test/Documents/foo.txt"
@@ -1103,7 +1103,7 @@ func (s *requestpromptsSuite) TestReplyTimedOut(c *C) {
 		User:      s.defaultUser,
 		Snap:      "nextcloud",
 		PID:       123,
-		PGID:      123,
+		Cgroup:    "0::/user.slice/user-1000.slice/user@1000.service/app.slice/some-cgroup-id.scope",
 		Interface: "home",
 	}
 	path := "/home/test/Documents/foo.txt"
@@ -1168,7 +1168,7 @@ func (s *requestpromptsSuite) TestReplyErrors(c *C) {
 		User:      s.defaultUser,
 		Snap:      "nextcloud",
 		PID:       123,
-		PGID:      456,
+		Cgroup:    "some-cgroup-path",
 		Interface: "home",
 	}
 	path := "/home/test/Documents/foo.txt"
@@ -1220,7 +1220,7 @@ func (s *requestpromptsSuite) TestHandleNewRule(c *C) {
 		User:      s.defaultUser,
 		Snap:      "nextcloud",
 		PID:       123,
-		PGID:      111,
+		Cgroup:    "some-cgroup-path",
 		Interface: "home",
 	}
 	path := "/home/test/Documents/foo.txt"
@@ -1274,9 +1274,9 @@ func (s *requestpromptsSuite) TestHandleNewRule(c *C) {
 		},
 	}
 
-	// For completeness, set PID and PGID to 0 since it would not be populated for rules
+	// For completeness, set PID and Cgroup to empty since they would not be populated for rules
 	metadata.PID = 0
-	metadata.PGID = 0
+	metadata.Cgroup = ""
 
 	satisfied, err := pdb.HandleNewRule(metadata, constraints)
 	c.Assert(err, IsNil)
@@ -1379,7 +1379,7 @@ func (s *requestpromptsSuite) TestHandleNewRuleNonMatches(c *C) {
 		User:      user,
 		Snap:      snap,
 		PID:       123,
-		PGID:      456,
+		Cgroup:    "0::/user.slice/user-1000.slice/user@1000.service/app.slice/some-cgroup.scope",
 		Interface: iface,
 	}
 	path := "/home/test/Documents/foo.txt"
@@ -1391,9 +1391,9 @@ func (s *requestpromptsSuite) TestHandleNewRuleNonMatches(c *C) {
 
 	s.checkNewNoticesSimple(c, []prompting.IDType{prompt.ID}, nil)
 
-	// For completeness, set PID and PGID to 0 since it would not be populated for rules
+	// For completeness, set PID and Cgroup to empty since they would not be populated for rules
 	metadata.PID = 0
-	metadata.PGID = 0
+	metadata.Cgroup = ""
 
 	pathPattern, err := patterns.ParsePathPattern("/home/test/Documents/**")
 	c.Assert(err, IsNil)
@@ -1517,7 +1517,7 @@ func (s *requestpromptsSuite) TestClose(c *C) {
 		User:      s.defaultUser,
 		Snap:      "nextcloud",
 		PID:       1234,
-		PGID:      1123,
+		Cgroup:    "0::/user.slice/user-1000.slice/user@1000.service/app.slice/some-cgroup.scope",
 		Interface: "home",
 	}
 	permissions := []string{"read", "write", "execute"}
@@ -1662,7 +1662,7 @@ func (s *requestpromptsSuite) TestIDMappingAcrossRestarts(c *C) {
 		User:      s.defaultUser,
 		Snap:      "nextcloud",
 		PID:       1234,
-		PGID:      1123,
+		Cgroup:    "0::/user.slice/user-1000.slice/user@1000.service/app.slice/some-cgroup.scope",
 		Interface: "home",
 	}
 	path := "/home/test/Documents/foo.txt"
@@ -1694,7 +1694,7 @@ func (s *requestpromptsSuite) TestIDMappingAcrossRestarts(c *C) {
 	c.Check(prompt3, Not(Equals), prompt2)
 	c.Check(prompt3.ID, Equals, prompting.IDType(1))
 
-	// Add fourth request, this time with different PID but same PGID
+	// Add fourth request, this time with different PID but same Cgroup
 	metadata = metadataTemplate
 	metadata.PID = 5000
 	prompt4, merged, err := pdb.AddOrMerge(&metadata, path, permissions, permissions, listenerReq4)
@@ -1772,7 +1772,7 @@ func (s *requestpromptsSuite) TestHandleReadying(c *C) {
 		User:      s.defaultUser,
 		Snap:      "nextcloud",
 		PID:       1234,
-		PGID:      1111,
+		Cgroup:    "0::/user.slice/user-1000.slice/user@1000.service/app.slice/some-cgroup.scope",
 		Interface: "home",
 	}
 	path := "/home/test/Documents/foo.txt"
@@ -1850,7 +1850,7 @@ func (s *requestpromptsSuite) TestPromptMarshalJSON(c *C) {
 		User:      s.defaultUser,
 		Snap:      "firefox",
 		PID:       1234,
-		PGID:      5678,
+		Cgroup:    "0::/user.slice/user-1000.slice/user@1000.service/app.slice/some-cgroup.scope",
 		Interface: "home",
 	}
 	path := "/home/test/foo"
@@ -1870,7 +1870,7 @@ func (s *requestpromptsSuite) TestPromptMarshalJSON(c *C) {
 	prompt.Timestamp, err = time.Parse(time.RFC3339Nano, timeStr)
 	c.Assert(err, IsNil)
 
-	expectedJSON := `{"id":"0000000000000001","timestamp":"2024-08-14T09:47:03.350324989-05:00","snap":"firefox","pid":1234,"pgid":5678,"interface":"home","constraints":{"path":"/home/test/foo","requested-permissions":["write","execute"],"available-permissions":["read","write","execute"]}}`
+	expectedJSON := `{"id":"0000000000000001","timestamp":"2024-08-14T09:47:03.350324989-05:00","snap":"firefox","pid":1234,"cgroup":"0::/user.slice/user-1000.slice/user@1000.service/app.slice/some-cgroup.scope","interface":"home","constraints":{"path":"/home/test/foo","requested-permissions":["write","execute"],"available-permissions":["read","write","execute"]}}`
 
 	marshalled, err := json.Marshal(prompt)
 	c.Assert(err, IsNil)
@@ -1902,7 +1902,7 @@ func (s *requestpromptsSuite) TestPromptExpiration(c *C) {
 		User:      s.defaultUser,
 		Snap:      "firefox",
 		PID:       1234,
-		PGID:      1123,
+		Cgroup:    "0::/user.slice/user-1000.slice/user@1000.service/app.slice/some-cgroup.scope",
 		Interface: "home",
 	}
 	path := "/home/test/foo"
@@ -2068,7 +2068,7 @@ func (s *requestpromptsSuite) TestPromptExpirationRace(c *C) {
 		User:      s.defaultUser,
 		Snap:      "firefox",
 		PID:       123,
-		PGID:      123,
+		Cgroup:    "0::/user.slice/user-1000.slice/user@1000.service/app.slice/some-cgroup.scope",
 		Interface: "home",
 	}
 	path := "/home/test/foo"

--- a/interfaces/prompting/requestprompts/requestprompts_test.go
+++ b/interfaces/prompting/requestprompts/requestprompts_test.go
@@ -319,6 +319,7 @@ func (s *requestpromptsSuite) TestAddOrMergeNonMerges(c *C) {
 		User:      s.defaultUser,
 		Snap:      "nextcloud",
 		PID:       1234,
+		PGID:      5678,
 		Interface: "home",
 	}
 	path := "/home/test/Documents/foo.txt"
@@ -329,6 +330,7 @@ func (s *requestpromptsSuite) TestAddOrMergeNonMerges(c *C) {
 	listenerReq3 := &listener.Request{ID: 3}
 	listenerReq4 := &listener.Request{ID: 4}
 	listenerReq5 := &listener.Request{ID: 5}
+	listenerReq6 := &listener.Request{ID: 6}
 
 	clientActivity := false // doesn't matter if it's true or false for this test
 	stored, err := pdb.Prompts(metadataTemplate.User, clientActivity)
@@ -347,6 +349,7 @@ func (s *requestpromptsSuite) TestAddOrMergeNonMerges(c *C) {
 
 	c.Check(prompt1.Snap, Equals, metadata.Snap)
 	c.Check(prompt1.PID, Equals, metadata.PID)
+	c.Check(prompt1.PGID, Equals, metadata.PGID)
 	c.Check(prompt1.Interface, Equals, metadata.Interface)
 	c.Check(prompt1.Constraints.Path(), Equals, path)
 	c.Check(prompt1.Constraints.OutstandingPermissions(), DeepEquals, permissions)
@@ -383,6 +386,7 @@ func (s *requestpromptsSuite) TestAddOrMergeNonMerges(c *C) {
 
 	c.Check(prompt2.Snap, Equals, metadata.Snap)
 	c.Check(prompt2.PID, Equals, metadata.PID)
+	c.Check(prompt2.PGID, Equals, metadata.PGID)
 	c.Check(prompt2.Interface, Equals, metadata.Interface)
 	c.Check(prompt2.Constraints.Path(), Equals, path)
 	c.Check(prompt2.Constraints.OutstandingPermissions(), DeepEquals, permissions)
@@ -412,7 +416,7 @@ func (s *requestpromptsSuite) TestAddOrMergeNonMerges(c *C) {
 	// Looking up prompt should not record notice
 	s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)
 
-	// Add third prompt, this time with different PID
+	// Add third prompt, this time with different PID but same PGID
 
 	metadata = metadataTemplate
 	metadata.PID = 1337
@@ -424,6 +428,7 @@ func (s *requestpromptsSuite) TestAddOrMergeNonMerges(c *C) {
 
 	c.Check(prompt3.Snap, Equals, metadata.Snap)
 	c.Check(prompt3.PID, Equals, metadata.PID)
+	c.Check(prompt3.PGID, Equals, metadata.PGID)
 	c.Check(prompt3.Interface, Equals, metadata.Interface)
 	c.Check(prompt3.Constraints.Path(), Equals, path)
 	c.Check(prompt3.Constraints.OutstandingPermissions(), DeepEquals, permissions)
@@ -452,10 +457,10 @@ func (s *requestpromptsSuite) TestAddOrMergeNonMerges(c *C) {
 	// Looking up prompt should not record notice
 	s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)
 
-	// Add fourth prompt, this time with different path
+	// Add fourth prompt, this time with different PGID but same PID
 
 	metadata = metadataTemplate
-	path = "/home/test/Documents/other.txt"
+	metadata.PGID = 1337
 	prompt4, merged, err := pdb.AddOrMerge(&metadata, path, permissions, permissions, listenerReq4)
 	c.Assert(err, IsNil)
 	c.Check(merged, Equals, false)
@@ -465,6 +470,7 @@ func (s *requestpromptsSuite) TestAddOrMergeNonMerges(c *C) {
 
 	c.Check(prompt4.Snap, Equals, metadata.Snap)
 	c.Check(prompt4.PID, Equals, metadata.PID)
+	c.Check(prompt4.PGID, Equals, metadata.PGID)
 	c.Check(prompt4.Interface, Equals, metadata.Interface)
 	c.Check(prompt4.Constraints.Path(), Equals, path)
 	c.Check(prompt4.Constraints.OutstandingPermissions(), DeepEquals, permissions)
@@ -494,12 +500,11 @@ func (s *requestpromptsSuite) TestAddOrMergeNonMerges(c *C) {
 	// Looking up prompt should not record notice
 	s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)
 
-	// Add fifth prompt, this time with different requested permissions
+	// Add fifth prompt, this time with different path
 
 	metadata = metadataTemplate
-	path = "/home/test/Documents/foo.txt"
-	requestedPermissions := permissions[:2]
-	prompt5, merged, err := pdb.AddOrMerge(&metadata, path, requestedPermissions, permissions, listenerReq5)
+	path = "/home/test/Documents/other.txt"
+	prompt5, merged, err := pdb.AddOrMerge(&metadata, path, permissions, permissions, listenerReq5)
 	c.Assert(err, IsNil)
 	c.Check(merged, Equals, false)
 	c.Check(prompt5, Not(Equals), prompt1)
@@ -509,6 +514,7 @@ func (s *requestpromptsSuite) TestAddOrMergeNonMerges(c *C) {
 
 	c.Check(prompt5.Snap, Equals, metadata.Snap)
 	c.Check(prompt5.PID, Equals, metadata.PID)
+	c.Check(prompt5.PGID, Equals, metadata.PGID)
 	c.Check(prompt5.Interface, Equals, metadata.Interface)
 	c.Check(prompt5.Constraints.Path(), Equals, path)
 	c.Check(prompt5.Constraints.OutstandingPermissions(), DeepEquals, permissions)
@@ -538,6 +544,54 @@ func (s *requestpromptsSuite) TestAddOrMergeNonMerges(c *C) {
 
 	// Looking up prompt should not record notice
 	s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)
+
+	// Add sixth prompt, this time with different requested permissions
+
+	metadata = metadataTemplate
+	path = "/home/test/Documents/foo.txt"
+	requestedPermissions := permissions[:2]
+	prompt6, merged, err := pdb.AddOrMerge(&metadata, path, requestedPermissions, permissions, listenerReq6)
+	c.Assert(err, IsNil)
+	c.Check(merged, Equals, false)
+	c.Check(prompt6, Not(Equals), prompt1)
+	c.Check(prompt6, Not(Equals), prompt2)
+	c.Check(prompt6, Not(Equals), prompt3)
+	c.Check(prompt6, Not(Equals), prompt4)
+	c.Check(prompt6, Not(Equals), prompt5)
+
+	c.Check(prompt6.Snap, Equals, metadata.Snap)
+	c.Check(prompt6.PID, Equals, metadata.PID)
+	c.Check(prompt6.PGID, Equals, metadata.PGID)
+	c.Check(prompt6.Interface, Equals, metadata.Interface)
+	c.Check(prompt6.Constraints.Path(), Equals, path)
+	c.Check(prompt6.Constraints.OutstandingPermissions(), DeepEquals, permissions)
+	c.Assert(prompt6.ListenerReqs(), HasLen, 1)
+	c.Check(prompt6.ListenerReqs()[0].ID, Equals, uint64(6))
+
+	// New prompts should record notice
+	s.checkNewNoticesSimple(c, []prompting.IDType{prompt6.ID}, nil)
+	// New prompts should advance the max ID
+	expectedID++
+	expectedMap[6] = requestprompts.IDMapEntry{PromptID: 6, UserID: s.defaultUser}
+	s.checkWrittenMaxID(c, expectedID)
+	s.checkWrittenIDMap(c, expectedMap)
+
+	storedPrompt, err = pdb.PromptWithID(metadata.User, prompt6.ID, clientActivity)
+	c.Check(err, IsNil)
+	c.Check(storedPrompt, Equals, prompt6)
+
+	stored, err = pdb.Prompts(metadata.User, clientActivity)
+	c.Assert(err, IsNil)
+	c.Assert(stored, HasLen, 6)
+	c.Check(stored[0], Equals, prompt1)
+	c.Check(stored[1], Equals, prompt2)
+	c.Check(stored[2], Equals, prompt3)
+	c.Check(stored[3], Equals, prompt4)
+	c.Check(stored[4], Equals, prompt5)
+	c.Check(stored[5], Equals, prompt6)
+
+	// Looking up prompt should not record notice
+	s.checkNewNoticesSimple(c, []prompting.IDType{}, nil)
 }
 
 func (s *requestpromptsSuite) TestAddOrMergeMerges(c *C) {
@@ -555,6 +609,7 @@ func (s *requestpromptsSuite) TestAddOrMergeMerges(c *C) {
 		User:      s.defaultUser,
 		Snap:      "nextcloud",
 		PID:       1234,
+		PGID:      5678,
 		Interface: "home",
 	}
 	path := "/home/test/Documents/foo.txt"
@@ -610,6 +665,7 @@ func (s *requestpromptsSuite) TestAddOrMergeMerges(c *C) {
 
 	c.Check(prompt1.Snap, Equals, metadata.Snap)
 	c.Check(prompt1.PID, Equals, metadata.PID)
+	c.Check(prompt1.PGID, Equals, metadata.PGID)
 	c.Check(prompt1.Interface, Equals, metadata.Interface)
 	c.Check(prompt1.Constraints.Path(), Equals, path)
 	c.Check(prompt1.Constraints.OutstandingPermissions(), DeepEquals, permissions)
@@ -661,6 +717,7 @@ func (s *requestpromptsSuite) TestAddOrMergeDuplicateRequests(c *C) {
 		User:      s.defaultUser,
 		Snap:      "nextcloud",
 		PID:       1234,
+		PGID:      5678,
 		Interface: "home",
 	}
 	path := "/home/test/Documents/foo.txt"
@@ -791,6 +848,7 @@ func (s *requestpromptsSuite) TestAddOrMergeTooMany(c *C) {
 		User:      s.defaultUser,
 		Snap:      "nextcloud",
 		PID:       42,
+		PGID:      33,
 		Interface: "home",
 	}
 
@@ -863,6 +921,7 @@ func (s *requestpromptsSuite) TestPromptWithIDErrors(c *C) {
 		User:      s.defaultUser,
 		Snap:      "nextcloud",
 		PID:       1337,
+		PGID:      1001,
 		Interface: "home",
 	}
 	path := "/home/test/Documents/foo.txt"
@@ -911,6 +970,7 @@ func (s *requestpromptsSuite) TestReply(c *C) {
 		User:      s.defaultUser,
 		Snap:      "nextcloud",
 		PID:       123,
+		PGID:      123,
 		Interface: "home",
 	}
 	path := "/home/test/Documents/foo.txt"
@@ -1043,6 +1103,7 @@ func (s *requestpromptsSuite) TestReplyTimedOut(c *C) {
 		User:      s.defaultUser,
 		Snap:      "nextcloud",
 		PID:       123,
+		PGID:      123,
 		Interface: "home",
 	}
 	path := "/home/test/Documents/foo.txt"
@@ -1107,6 +1168,7 @@ func (s *requestpromptsSuite) TestReplyErrors(c *C) {
 		User:      s.defaultUser,
 		Snap:      "nextcloud",
 		PID:       123,
+		PGID:      456,
 		Interface: "home",
 	}
 	path := "/home/test/Documents/foo.txt"
@@ -1158,6 +1220,7 @@ func (s *requestpromptsSuite) TestHandleNewRule(c *C) {
 		User:      s.defaultUser,
 		Snap:      "nextcloud",
 		PID:       123,
+		PGID:      111,
 		Interface: "home",
 	}
 	path := "/home/test/Documents/foo.txt"
@@ -1211,8 +1274,9 @@ func (s *requestpromptsSuite) TestHandleNewRule(c *C) {
 		},
 	}
 
-	// For completeness, set metadata.PID to 0 since it would not be populated for rules
+	// For completeness, set PID and PGID to 0 since it would not be populated for rules
 	metadata.PID = 0
+	metadata.PGID = 0
 
 	satisfied, err := pdb.HandleNewRule(metadata, constraints)
 	c.Assert(err, IsNil)
@@ -1315,6 +1379,7 @@ func (s *requestpromptsSuite) TestHandleNewRuleNonMatches(c *C) {
 		User:      user,
 		Snap:      snap,
 		PID:       123,
+		PGID:      456,
 		Interface: iface,
 	}
 	path := "/home/test/Documents/foo.txt"
@@ -1326,8 +1391,9 @@ func (s *requestpromptsSuite) TestHandleNewRuleNonMatches(c *C) {
 
 	s.checkNewNoticesSimple(c, []prompting.IDType{prompt.ID}, nil)
 
-	// For completeness, set metadata.PID to 0 since it would not be populated for rules
+	// For completeness, set PID and PGID to 0 since it would not be populated for rules
 	metadata.PID = 0
+	metadata.PGID = 0
 
 	pathPattern, err := patterns.ParsePathPattern("/home/test/Documents/**")
 	c.Assert(err, IsNil)
@@ -1451,6 +1517,7 @@ func (s *requestpromptsSuite) TestClose(c *C) {
 		User:      s.defaultUser,
 		Snap:      "nextcloud",
 		PID:       1234,
+		PGID:      1123,
 		Interface: "home",
 	}
 	permissions := []string{"read", "write", "execute"}
@@ -1595,6 +1662,7 @@ func (s *requestpromptsSuite) TestIDMappingAcrossRestarts(c *C) {
 		User:      s.defaultUser,
 		Snap:      "nextcloud",
 		PID:       1234,
+		PGID:      1123,
 		Interface: "home",
 	}
 	path := "/home/test/Documents/foo.txt"
@@ -1626,7 +1694,7 @@ func (s *requestpromptsSuite) TestIDMappingAcrossRestarts(c *C) {
 	c.Check(prompt3, Not(Equals), prompt2)
 	c.Check(prompt3.ID, Equals, prompting.IDType(1))
 
-	// Add fourth request, this time with different PID
+	// Add fourth request, this time with different PID but same PGID
 	metadata = metadataTemplate
 	metadata.PID = 5000
 	prompt4, merged, err := pdb.AddOrMerge(&metadata, path, permissions, permissions, listenerReq4)
@@ -1704,6 +1772,7 @@ func (s *requestpromptsSuite) TestHandleReadying(c *C) {
 		User:      s.defaultUser,
 		Snap:      "nextcloud",
 		PID:       1234,
+		PGID:      1111,
 		Interface: "home",
 	}
 	path := "/home/test/Documents/foo.txt"
@@ -1781,6 +1850,7 @@ func (s *requestpromptsSuite) TestPromptMarshalJSON(c *C) {
 		User:      s.defaultUser,
 		Snap:      "firefox",
 		PID:       1234,
+		PGID:      5678,
 		Interface: "home",
 	}
 	path := "/home/test/foo"
@@ -1800,7 +1870,7 @@ func (s *requestpromptsSuite) TestPromptMarshalJSON(c *C) {
 	prompt.Timestamp, err = time.Parse(time.RFC3339Nano, timeStr)
 	c.Assert(err, IsNil)
 
-	expectedJSON := `{"id":"0000000000000001","timestamp":"2024-08-14T09:47:03.350324989-05:00","snap":"firefox","pid":1234,"interface":"home","constraints":{"path":"/home/test/foo","requested-permissions":["write","execute"],"available-permissions":["read","write","execute"]}}`
+	expectedJSON := `{"id":"0000000000000001","timestamp":"2024-08-14T09:47:03.350324989-05:00","snap":"firefox","pid":1234,"pgid":5678,"interface":"home","constraints":{"path":"/home/test/foo","requested-permissions":["write","execute"],"available-permissions":["read","write","execute"]}}`
 
 	marshalled, err := json.Marshal(prompt)
 	c.Assert(err, IsNil)
@@ -1832,6 +1902,7 @@ func (s *requestpromptsSuite) TestPromptExpiration(c *C) {
 		User:      s.defaultUser,
 		Snap:      "firefox",
 		PID:       1234,
+		PGID:      1123,
 		Interface: "home",
 	}
 	path := "/home/test/foo"
@@ -1997,6 +2068,7 @@ func (s *requestpromptsSuite) TestPromptExpirationRace(c *C) {
 		User:      s.defaultUser,
 		Snap:      "firefox",
 		PID:       123,
+		PGID:      123,
 		Interface: "home",
 	}
 	path := "/home/test/foo"

--- a/overlord/ifacestate/apparmorprompting/prompting.go
+++ b/overlord/ifacestate/apparmorprompting/prompting.go
@@ -322,7 +322,7 @@ func (m *InterfacesRequestsManager) handleListenerReq(req *listener.Request) err
 		User:      userID,
 		Snap:      snap,
 		PID:       req.PID,
-		PGID:      req.PGID,
+		Cgroup:    req.Cgroup,
 		Interface: iface,
 	}
 

--- a/overlord/ifacestate/apparmorprompting/prompting.go
+++ b/overlord/ifacestate/apparmorprompting/prompting.go
@@ -322,6 +322,7 @@ func (m *InterfacesRequestsManager) handleListenerReq(req *listener.Request) err
 		User:      userID,
 		Snap:      snap,
 		PID:       req.PID,
+		PGID:      req.PGID,
 		Interface: iface,
 	}
 

--- a/overlord/ifacestate/apparmorprompting/prompting_test.go
+++ b/overlord/ifacestate/apparmorprompting/prompting_test.go
@@ -347,7 +347,7 @@ func (s *apparmorpromptingSuite) TestHandleListenerRequestErrors(c *C) {
 	for i := 0; i < maxOutstandingPromptsPerUser; i++ {
 		req := &listener.Request{
 			PID:        1234,
-			PGID:       5678,
+			Cgroup:     "0::/user.slice/user-1000.slice/user@1000.service/app.slice/some-cgroup.scope",
 			Label:      "snap.firefox.firefox",
 			SubjectUID: s.defaultUser,
 			Path:       fmt.Sprintf("/home/test/%d", i),
@@ -369,7 +369,7 @@ func (s *apparmorpromptingSuite) TestHandleListenerRequestErrors(c *C) {
 
 	req = &listener.Request{
 		PID:        1234,
-		PGID:       5678,
+		Cgroup:     "0::/user.slice/user-1000.slice/user@1000.service/app.slice/some-cgroup.scope",
 		Label:      "snap.firefox.firefox",
 		SubjectUID: s.defaultUser,
 		Path:       fmt.Sprintf("/home/test/%d", maxOutstandingPromptsPerUser),
@@ -481,7 +481,7 @@ func (s *apparmorpromptingSuite) simulateRequest(c *C, reqChan chan *listener.Re
 
 	c.Check(prompt.Snap, Equals, expectedSnap)
 	c.Check(prompt.PID, Equals, req.PID)
-	c.Check(prompt.PGID, Equals, req.PGID)
+	c.Check(prompt.Cgroup, Equals, req.Cgroup)
 	c.Check(prompt.Interface, Equals, "home") // assumes InterfaceFromTagsets returns "home" or ErrNoInterfaceTags
 	c.Check(prompt.Constraints.Path(), Equals, req.Path)
 
@@ -500,8 +500,8 @@ func (s *apparmorpromptingSuite) fillInPartialRequest(req *listener.Request) {
 	if req.PID == 0 {
 		req.PID = 1234
 	}
-	if req.PGID == 0 {
-		req.PGID = 5678
+	if req.Cgroup == "" {
+		req.Cgroup = "0::/user.slice/user-1000.slice/user@1000.service/app.slice/some-cgroup.scope"
 	}
 	if req.Label == "" {
 		req.Label = "snap.firefox.firefox"

--- a/overlord/ifacestate/apparmorprompting/prompting_test.go
+++ b/overlord/ifacestate/apparmorprompting/prompting_test.go
@@ -347,6 +347,7 @@ func (s *apparmorpromptingSuite) TestHandleListenerRequestErrors(c *C) {
 	for i := 0; i < maxOutstandingPromptsPerUser; i++ {
 		req := &listener.Request{
 			PID:        1234,
+			PGID:       5678,
 			Label:      "snap.firefox.firefox",
 			SubjectUID: s.defaultUser,
 			Path:       fmt.Sprintf("/home/test/%d", i),
@@ -368,6 +369,7 @@ func (s *apparmorpromptingSuite) TestHandleListenerRequestErrors(c *C) {
 
 	req = &listener.Request{
 		PID:        1234,
+		PGID:       5678,
 		Label:      "snap.firefox.firefox",
 		SubjectUID: s.defaultUser,
 		Path:       fmt.Sprintf("/home/test/%d", maxOutstandingPromptsPerUser),
@@ -479,6 +481,7 @@ func (s *apparmorpromptingSuite) simulateRequest(c *C, reqChan chan *listener.Re
 
 	c.Check(prompt.Snap, Equals, expectedSnap)
 	c.Check(prompt.PID, Equals, req.PID)
+	c.Check(prompt.PGID, Equals, req.PGID)
 	c.Check(prompt.Interface, Equals, "home") // assumes InterfaceFromTagsets returns "home" or ErrNoInterfaceTags
 	c.Check(prompt.Constraints.Path(), Equals, req.Path)
 
@@ -496,6 +499,9 @@ func (s *apparmorpromptingSuite) simulateRequest(c *C, reqChan chan *listener.Re
 func (s *apparmorpromptingSuite) fillInPartialRequest(req *listener.Request) {
 	if req.PID == 0 {
 		req.PID = 1234
+	}
+	if req.PGID == 0 {
+		req.PGID = 5678
 	}
 	if req.Label == "" {
 		req.Label = "snap.firefox.firefox"

--- a/sandbox/apparmor/notify/listener/export_test.go
+++ b/sandbox/apparmor/notify/listener/export_test.go
@@ -33,8 +33,7 @@ import (
 )
 
 var (
-	ReadyTimeout   = readyTimeout
-	ReadCgroupPath = readCgroupPath
+	ReadyTimeout = readyTimeout
 )
 
 func ExitOnError() (restore func()) {
@@ -54,10 +53,6 @@ func FakeRequestWithIDVersionClassAllowDeny(id uint64, version notify.ProtocolVe
 		AaAllowed:  aaAllow,
 		listener:   listener,
 	}
-}
-
-func MockOsReadFile(f func(name string) ([]byte, error)) (restore func()) {
-	return testutil.Mock(&osReadFile, f)
 }
 
 func MockOsOpen(f func(name string) (*os.File, error)) (restore func()) {
@@ -176,10 +171,12 @@ func SynchronizeNotifyIoctl() (ioctlDone <-chan notify.IoctlRequest, restore fun
 	return ioctlDoneRW, restore
 }
 
+func MockCgroupProcessPathInTrackingCgroup(f func(pid int) (string, error)) (restore func()) {
+	return testutil.Mock(&cgroupProcessPathInTrackingCgroup, f)
+}
+
 func MockEncodeAndSendResponse(f func(l *Listener, resp *notify.MsgNotificationResponse) error) (restore func()) {
-	restore = testutil.Backup(&encodeAndSendResponse)
-	encodeAndSendResponse = f
-	return restore
+	return testutil.Mock(&encodeAndSendResponse, f)
 }
 
 func (l *Listener) EpollIsClosed() bool {

--- a/sandbox/apparmor/notify/listener/export_test.go
+++ b/sandbox/apparmor/notify/listener/export_test.go
@@ -55,6 +55,10 @@ func FakeRequestWithIDVersionClassAllowDeny(id uint64, version notify.ProtocolVe
 	}
 }
 
+func MockUnixGetpgid(f func(pid int) (pgid int, err error)) (restore func()) {
+	return testutil.Mock(&unixGetpgid, f)
+}
+
 func MockOsOpen(f func(name string) (*os.File, error)) (restore func()) {
 	restore = testutil.Backup(&osOpen)
 	osOpen = f

--- a/sandbox/apparmor/notify/listener/export_test.go
+++ b/sandbox/apparmor/notify/listener/export_test.go
@@ -33,7 +33,8 @@ import (
 )
 
 var (
-	ReadyTimeout = readyTimeout
+	ReadyTimeout   = readyTimeout
+	ReadCgroupPath = readCgroupPath
 )
 
 func ExitOnError() (restore func()) {
@@ -55,14 +56,12 @@ func FakeRequestWithIDVersionClassAllowDeny(id uint64, version notify.ProtocolVe
 	}
 }
 
-func MockUnixGetpgid(f func(pid int) (pgid int, err error)) (restore func()) {
-	return testutil.Mock(&unixGetpgid, f)
+func MockOsReadFile(f func(name string) ([]byte, error)) (restore func()) {
+	return testutil.Mock(&osReadFile, f)
 }
 
 func MockOsOpen(f func(name string) (*os.File, error)) (restore func()) {
-	restore = testutil.Backup(&osOpen)
-	osOpen = f
-	return restore
+	return testutil.Mock(&osOpen, f)
 }
 
 // Mocks os.Open to instead create a socket, wrap it in a os.File, and return

--- a/sandbox/apparmor/notify/listener/listener_test.go
+++ b/sandbox/apparmor/notify/listener/listener_test.go
@@ -67,14 +67,11 @@ func (s *listenerSuite) SetUpTest(c *C) {
 	})
 	s.AddCleanup(restore)
 
-	restoreGetpgid := listener.MockUnixGetpgid(func(pid int) (pgid int, err error) {
-		// newMsgNotificationFile sets PID to be 1234
-		if pid == 1234 {
-			return 5678, nil
-		}
-		return 0, fmt.Errorf("unexpected pid: %d", pid)
+	restoreOsReadFile := listener.MockOsReadFile(func(name string) ([]byte, error) {
+		c.Assert(name, Matches, `\/proc\/[1-9][0-9]*\/cgroup`)
+		return []byte("0::/user.slice/user-1000.slice/user@1000.service/app.slice/some-cgroup.scope"), nil
 	})
-	s.AddCleanup(restoreGetpgid)
+	s.AddCleanup(restoreOsReadFile)
 }
 
 func (*listenerSuite) TestReply(c *C) {
@@ -1792,4 +1789,33 @@ func (*listenerSuite) TestRunConcurrency(c *C) {
 	c.Check(requestsSent > 1, Equals, true, Commentf("should have sent more than one request"))
 	c.Check(replyCount > 1, Equals, true, Commentf("should have replied to more than one request"))
 	c.Check(responseCount > 1, Equals, true, Commentf("should have received more than one response"))
+}
+
+func (*listenerSuite) TestReadCgroupPathHappy(c *C) {
+	pid := int32(1234)
+	expected := "some-cgroup-path"
+	restore := listener.MockOsReadFile(func(name string) ([]byte, error) {
+		c.Check(name, Equals, fmt.Sprintf("/proc/%d/cgroup", pid))
+		return []byte(expected), nil
+	})
+	defer restore()
+
+	result, err := listener.ReadCgroupPath(pid)
+	c.Check(result, Equals, expected)
+	c.Check(err, IsNil)
+}
+
+func (*listenerSuite) TestReadCgroupPathUnhappy(c *C) {
+	pid := int32(1234)
+	expectedErr := errors.New("something bad happened")
+	restore := listener.MockOsReadFile(func(name string) ([]byte, error) {
+		c.Check(name, Equals, fmt.Sprintf("/proc/%d/cgroup", pid))
+		return nil, expectedErr
+	})
+	defer restore()
+
+	result, err := listener.ReadCgroupPath(pid)
+	c.Check(result, Equals, "")
+	c.Check(err, ErrorMatches, "cannot read cgroup path for request process with PID 1234: something bad happened")
+	c.Check(errors.Is(err, expectedErr), Equals, true)
 }

--- a/sandbox/apparmor/notify/listener/listener_test.go
+++ b/sandbox/apparmor/notify/listener/listener_test.go
@@ -66,6 +66,15 @@ func (s *listenerSuite) SetUpTest(c *C) {
 		return v != 0
 	})
 	s.AddCleanup(restore)
+
+	restoreGetpgid := listener.MockUnixGetpgid(func(pid int) (pgid int, err error) {
+		// newMsgNotificationFile sets PID to be 1234
+		if pid == 1234 {
+			return 5678, nil
+		}
+		return 0, fmt.Errorf("unexpected pid: %d", pid)
+	})
+	s.AddCleanup(restoreGetpgid)
 }
 
 func (*listenerSuite) TestReply(c *C) {


### PR DESCRIPTION
Include the cgroup path in prompts so that prompts related to different processes of the same application instance can be identified as belonging to that same instance.

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-35444