### PR TITLE
tests: new nigthly workflow execution in google backend

### DIFF
--- a/.github/workflows/nightly-spread.yaml
+++ b/.github/workflows/nightly-spread.yaml
@@ -60,19 +60,19 @@ jobs:
           - group: google
             backend: google
             systems: 'ALL'
-            tasks: 'tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap:lxd'
+            tasks: 'tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap:lxd tests/main/apparmor-prompting-support tests/main/proxy'
           - group: google-core
             backend: google-core
             systems: 'ALL'
-            tasks: 'tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap:lxd'
+            tasks: 'tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap:lxd tests/main/apparmor-prompting-support tests/main/proxy'
           - group: google-distro
             backend: google-distro
             systems: 'ALL'
-            tasks: 'tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap:lxd'
+            tasks: 'tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap:lxd tests/main/apparmor-prompting-support tests/main/proxy'
           - group: google-arm
             backend: google-distro
             systems: 'ubuntu-22.04-arm-64 ubuntu-core-24-arm-64'
-            tasks: 'tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap:lxd'
+            tasks: 'tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap:lxd tests/main/apparmor-prompting-support tests/main/proxy'
 
   spread-test-build-from-current:
     if: ${{ github.event.schedule == '0 6 * * *' || (github.event_name == 'workflow_dispatch' && inputs.job == 'spread-test-build-from-current') }}

--- a/.github/workflows/nightly-spread.yaml
+++ b/.github/workflows/nightly-spread.yaml
@@ -16,6 +16,7 @@ on:
         description: Job to run
         options:
           - spread-nightly
+          - spread-nightly-google
           - spread-test-build-from-current
           - spread-test-experimental
           - spread-test-openstack
@@ -37,8 +38,8 @@ jobs:
       rules: ''
       use-snapd-snap-from-master: true
 
-  spread-google-nightly:
-    if: ${{ github.event.schedule == '0 3 * * *' || (github.event_name == 'workflow_dispatch' && inputs.job == 'spread-google-nightly') }}
+  spread-nightly-google:
+    if: ${{ github.event.schedule == '0 3 * * *' || (github.event_name == 'workflow_dispatch' && inputs.job == 'spread-nightly-google') }}
     uses: ./.github/workflows/spread-tests.yaml
     with:
       runs-on: '["self-hosted", "spread-enabled"]'

--- a/.github/workflows/nightly-spread.yaml
+++ b/.github/workflows/nightly-spread.yaml
@@ -37,6 +37,42 @@ jobs:
       rules: ''
       use-snapd-snap-from-master: true
 
+  spread-google-nightly:
+    if: ${{ github.event.schedule == '0 3 * * *' || (github.event_name == 'workflow_dispatch' && inputs.job == 'spread-google-nightly') }}
+    uses: ./.github/workflows/spread-tests.yaml
+    with:
+      runs-on: '["self-hosted", "spread-enabled"]'
+      group: ${{ matrix.group }}
+      backend: ${{ matrix.backend }}
+      systems: ${{ matrix.systems }}
+      tasks: ${{ matrix.tasks }}
+      rules: ''
+      use-snapd-snap-from-master: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - group: jammy
+            backend: google
+            systems: 'ubuntu-22.04-64'
+            tasks: 'tests/main/apparmor-prompting-integration-tests tests/main/interfaces-requests-activates-handlers'
+          - group: google
+            backend: google
+            systems: 'ALL'
+            tasks: 'tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap:lxd'
+          - group: google-core
+            backend: google-core
+            systems: 'ALL'
+            tasks: 'tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap:lxd'
+          - group: google-distro
+            backend: google-distro
+            systems: 'ALL'
+            tasks: 'tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap:lxd'
+          - group: google-arm
+            backend: google-distro
+            systems: 'ubuntu-22.04-arm-64 ubuntu-core-24-arm-64'
+            tasks: 'tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap:lxd'
+
   spread-test-build-from-current:
     if: ${{ github.event.schedule == '0 6 * * *' || (github.event_name == 'workflow_dispatch' && inputs.job == 'spread-test-build-from-current') }}
     uses: ./.github/workflows/spread-tests.yaml

--- a/spread.yaml
+++ b/spread.yaml
@@ -228,7 +228,7 @@ backends:
                   workers: 1
                   attach-service-account: true
 
-    google-distro-1:
+    google-distro:
         type: google
         key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
         location: snapd-spread/europe-west3-b
@@ -248,12 +248,6 @@ backends:
                   workers: 6
                   storage: preserve-size
 
-    google-distro-2:
-        type: google
-        key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
-        location: snapd-spread/europe-west4-b
-        halt-timeout: 2h
-        systems:
             - arch-linux-64:
                   workers: 6
                   storage: 20G


### PR DESCRIPTION
This workflow is executed nightly and runs some tests which cannot be executed in openstack due to proxy/other restrictions.

Also in spread.yaml the google-distro-1 and google-distro-2 have been unified in google-distro backend, as it is not needed to have separated backends anymore.
