### PR TITLE
interfaces/compatibility: implement parser for compatibility expressions

### DIFF
--- a/interfaces/compatibility/compatibility.go
+++ b/interfaces/compatibility/compatibility.go
@@ -45,6 +45,24 @@ type CompatField struct {
 	Dimensions []CompatDimension
 }
 
+func (cf *CompatField) String() string {
+	var sb strings.Builder
+	for _, d := range cf.Dimensions {
+		if sb.Len() > 0 {
+			sb.WriteRune('-')
+		}
+		sb.WriteString(d.Tag)
+		for _, vals := range d.Values {
+			if vals.Min == vals.Max {
+				sb.WriteString(fmt.Sprintf("-%d", vals.Min))
+			} else {
+				sb.WriteString(fmt.Sprintf("-(%d..%d)", vals.Min, vals.Max))
+			}
+		}
+	}
+	return sb.String()
+}
+
 // CompatSpec specifies valid values for a compatibility field, this can be
 // used to further restrict these fields for a given interface. The number of
 // dimensions, tags, and number of values per dimension must match the ones in

--- a/interfaces/compatibility/compatibility_test.go
+++ b/interfaces/compatibility/compatibility_test.go
@@ -77,6 +77,9 @@ func (s *CompatSuite) TestValidCompatFields(c *C) {
 		cfield, err := compatibility.DecodeCompatField(tc.compat, nil)
 		c.Assert(err, IsNil)
 		c.Check(cfield, DeepEquals, tc.cfield)
+		cfield, err = compatibility.DecodeCompatField(cfield.String(), nil)
+		c.Assert(err, IsNil)
+		c.Check(cfield, DeepEquals, tc.cfield)
 	}
 }
 

--- a/interfaces/compatibility/export_test.go
+++ b/interfaces/compatibility/export_test.go
@@ -1,0 +1,25 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package compatibility
+
+var (
+	Items = items
+	Parse = parse
+)

--- a/interfaces/compatibility/lex.go
+++ b/interfaces/compatibility/lex.go
@@ -1,0 +1,319 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Based on go's text/template lexer. See https://www.youtube.com/watch?v=HxaD_trXwRE&t=2s
+// for ideas behind this implementation.
+package compatibility
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// ItemType identifies the type of lex items.
+type ItemType int
+
+const (
+	ItemError ItemType = iota // error occurred; ErrMsg is text of error
+	ItemLabel
+	ItemAND
+	ItemOR
+	ItemLeftParen
+	ItemRightParen
+	ItemEOF
+)
+
+// Values for the different item types
+var itemVal = [...]string{
+	"error", "label", "AND", "OR", "(", ")", "EOF"}
+
+func (typ ItemType) String() string {
+	return fmt.Sprintf("%s", itemVal[typ])
+}
+
+const eof = -1
+
+// Item represents a token or text string returned from the scanner.
+type Item struct {
+	Typ    ItemType    // The type of this item.
+	ErrMsg string      // Set if an error
+	Label  CompatField // Set for ItemLabel type
+}
+
+func (i Item) String() string {
+	msg := ""
+	switch i.Typ {
+	case ItemLabel:
+		msg = i.Label.String()
+	case ItemError:
+		msg = i.ErrMsg
+	default:
+		return fmt.Sprintf("%q", itemVal[i.Typ])
+	}
+	if len(msg) > 20 {
+		return fmt.Sprintf(`"%s: %.20s..."`, itemVal[i.Typ], msg)
+	} else {
+		return fmt.Sprintf(`"%s: %s"`, itemVal[i.Typ], msg)
+	}
+}
+
+// lexer holds the state of the scanner.
+type lexer struct {
+	input  string // the string being scanned
+	pos    int
+	tokens []Item
+}
+
+// stateFn represents the state of the scanner as a function that performs an
+// action returns the next state.
+type stateFn func(*lexer) stateFn
+
+// Ancillary methods
+
+// next returns the next rune in the input.
+func (l *lexer) next() rune {
+	if l.pos >= len(l.input) {
+		return eof
+	}
+	r, w := utf8.DecodeRuneInString(l.input[l.pos:])
+	l.pos += w
+	return r
+}
+
+// peek returns but does not consume the next rune in the input.
+func (l *lexer) peek() rune {
+	if l.pos >= len(l.input) {
+		return eof
+	}
+	r, _ := utf8.DecodeRuneInString(l.input[l.pos:])
+	return r
+}
+
+// items returns tokens from the input. Called by the parser.
+// TODO implement instead nextItem to make this concurrent. Note that we are
+// using ItemError in preparation for this: we return such an error as the last
+// item to adapt to a future stream processing.
+func items(input string) []Item {
+	l := &lexer{input: input}
+	state := lexSpace
+	for state != nil {
+		state = state(l)
+	}
+	return l.tokens
+}
+
+func (l *lexer) finishWithError(errMsg string) stateFn {
+	l.tokens = append(l.tokens, Item{Typ: ItemError, ErrMsg: errMsg})
+	return nil
+}
+
+// isSpace returns true for the usual spaces. We avoid using isSpace as
+// we prefer to error out if more esoteric space runes are found.
+func isSpace(r rune) bool {
+	switch r {
+	case '\t', '\n', '\r', ' ':
+		return true
+	}
+	return false
+}
+
+func (l *lexer) eatSpaces() rune {
+	var r rune
+	for {
+		r = l.peek()
+		if !isSpace(r) {
+			break
+		}
+		l.next()
+	}
+	return r
+}
+
+func (l *lexer) testAhead(str string) bool {
+	return strings.HasPrefix(l.input[l.pos:], str)
+}
+
+//
+// Definition of the lexer states
+//
+
+func lexSpace(l *lexer) stateFn {
+	r := l.eatSpaces()
+	switch {
+	case l.testAhead("AND"):
+		return lexAND
+	case l.testAhead("OR"):
+		return lexOR
+	case unicode.IsLower(r):
+		return lexLabel
+	case r == '(':
+		return lexLeftParen
+	case r == ')':
+		return lexRightParen
+	case r == eof:
+		return nil
+	}
+	return l.finishWithError(fmt.Sprintf("unexpected rune: %c", r))
+}
+
+func lexAND(l *lexer) stateFn {
+	return lexSimpleType(l, ItemAND)
+}
+
+func lexOR(l *lexer) stateFn {
+	return lexSimpleType(l, ItemOR)
+}
+
+func lexLeftParen(l *lexer) stateFn {
+	return lexSimpleType(l, ItemLeftParen)
+}
+
+func lexRightParen(l *lexer) stateFn {
+	return lexSimpleType(l, ItemRightParen)
+}
+
+func lexSimpleType(l *lexer, itemTyp ItemType) stateFn {
+	l.tokens = append(l.tokens, Item{Typ: itemTyp})
+	l.pos += len(itemVal[itemTyp])
+	return lexSpace
+}
+
+func lexLabel(l *lexer) stateFn {
+	compatLabel := &CompatField{}
+	var currDim *CompatDimension
+	tags := map[string]bool{}
+
+intLoop:
+	for {
+		r := l.peek()
+		switch {
+		case unicode.IsLower(r):
+			start := l.pos
+			// After a lowercase character we can have digits in the string
+			for unicode.IsLower(l.peek()) || unicode.IsDigit(l.peek()) {
+				l.next()
+			}
+			// Append the previous dimension
+			appendDimensionToLabel(compatLabel, currDim)
+
+			tag := l.input[start:l.pos]
+			if len(tag) > 32 {
+				return l.finishWithError(
+					fmt.Sprintf("string is longer than 32 characters: %s", tag))
+			}
+			if _, ok := tags[tag]; ok {
+				return l.finishWithError(
+					fmt.Sprintf("repeated string in label: %s", tag))
+			}
+			currDim = &CompatDimension{Tag: l.input[start:l.pos]}
+			tags[tag] = true
+		case r == '-':
+			l.next()
+			if !unicode.IsLower(l.peek()) && !unicode.IsDigit(l.peek()) && l.peek() != '(' {
+				return l.finishWithError(
+					fmt.Sprintf("unexpected character after hyphen: %s", errorRune(l)))
+			}
+			if l.peek() == '(' {
+				intRange, err := readLabelRange(l)
+				if err != nil {
+					return l.finishWithError(err.Error())
+				}
+				currDim.Values = append(currDim.Values, intRange)
+			}
+		case unicode.IsDigit(r):
+			singleInt, err := readInteger(l)
+			if err != nil {
+				return l.finishWithError(err.Error())
+			}
+			currDim.Values = append(currDim.Values,
+				CompatRange{Min: singleInt, Max: singleInt})
+		default:
+			break intLoop
+		}
+	}
+	appendDimensionToLabel(compatLabel, currDim)
+	l.tokens = append(l.tokens, Item{Typ: ItemLabel, Label: *compatLabel})
+	return lexSpace
+}
+
+func appendDimensionToLabel(label *CompatField, dim *CompatDimension) {
+	if dim != nil {
+		if len(dim.Values) == 0 {
+			dim.Values = append(dim.Values, CompatRange{Min: 0, Max: 0})
+		}
+		label.Dimensions = append(label.Dimensions, *dim)
+	}
+}
+
+func errorRune(l *lexer) string {
+	if l.peek() == eof {
+		return "EOF"
+	}
+	return string(l.peek())
+}
+
+func readLabelRange(l *lexer) (CompatRange, error) {
+	// Skip '('
+	l.next()
+	leftInt, err := readInteger(l)
+	if err != nil {
+		return CompatRange{}, err
+	}
+	if !l.testAhead("..") {
+		return CompatRange{}, fmt.Errorf("no dots in integer range")
+	}
+	l.pos += 2
+	rightInt, err := readInteger(l)
+	if err != nil {
+		return CompatRange{}, err
+	}
+	if rightInt < leftInt {
+		return CompatRange{}, fmt.Errorf("negative range specified: (%d..%d)", leftInt, rightInt)
+	}
+	if l.peek() != ')' {
+		return CompatRange{}, fmt.Errorf("range missing closing parenthesis")
+	}
+	l.next()
+	return CompatRange{Min: leftInt, Max: rightInt}, nil
+}
+
+func readInteger(l *lexer) (uint, error) {
+	start := l.pos
+	for unicode.IsDigit(l.peek()) {
+		l.next()
+	}
+	if start == l.pos {
+		return 0, fmt.Errorf("not an integer: %s", errorRune(l))
+	}
+	intStr := l.input[start:l.pos]
+	if len(intStr) > 1 && intStr[0] == '0' {
+		return 0, fmt.Errorf("integers not allowed to start with 0: %s", intStr)
+	}
+	if len(intStr) > 8 {
+		return 0, fmt.Errorf("integer with more than 8 digits: %s", intStr)
+	}
+	integer, err := strconv.ParseUint(intStr, 10, 0)
+	if err != nil {
+		return 0, fmt.Errorf("cannot convert to an integer: %v", err)
+	}
+	return uint(integer), nil
+}

--- a/interfaces/compatibility/lex_test.go
+++ b/interfaces/compatibility/lex_test.go
@@ -1,0 +1,246 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package compatibility_test
+
+import (
+	"github.com/snapcore/snapd/interfaces/compatibility"
+	. "gopkg.in/check.v1"
+)
+
+// TestItemString
+func (s *CompatSuite) TestItemString(c *C) {
+	for i, tc := range []struct {
+		item compatibility.Item
+		str  string
+	}{
+		{compatibility.Item{Typ: compatibility.ItemError, ErrMsg: "tokenizer error"},
+			`"error: tokenizer error"`},
+		{compatibility.Item{Typ: compatibility.ItemError, ErrMsg: "very long tokenizer error"},
+			`"error: very long tokenizer ..."`},
+		{compatibility.Item{Typ: compatibility.ItemLabel,
+			Label: compatibility.CompatField{[]compatibility.CompatDimension{
+				{"foo", []compatibility.CompatRange{{0, 0}}}}}},
+			`"label: foo-0"`},
+		{compatibility.Item{Typ: compatibility.ItemLabel,
+			Label: compatibility.CompatField{[]compatibility.CompatDimension{
+				{"foo01234567890123456789", []compatibility.CompatRange{{0, 0}}}}}},
+			`"label: foo01234567890123456..."`},
+		{compatibility.Item{Typ: compatibility.ItemOR}, `"OR"`},
+	} {
+		c.Logf("tc %d: %+v", i, tc)
+		c.Check(tc.item.String(), Equals, tc.str)
+	}
+}
+
+func (s *CompatSuite) TestLexValidExpressions(c *C) {
+	for i, tc := range []struct {
+		expression string
+		tokens     []compatibility.Item
+	}{
+		{"", nil},
+		{"   ", nil},
+		{"  foo", []compatibility.Item{
+			{compatibility.ItemLabel, "",
+				compatibility.CompatField{[]compatibility.CompatDimension{
+					{"foo", []compatibility.CompatRange{{0, 0}}}}}},
+		}},
+		{"foo\n\t", []compatibility.Item{
+			{compatibility.ItemLabel, "",
+				compatibility.CompatField{[]compatibility.CompatDimension{
+					{"foo", []compatibility.CompatRange{{0, 0}}}}}},
+		}},
+		{"(foo)", []compatibility.Item{
+			{compatibility.ItemLeftParen, "", compatibility.CompatField{}},
+			{compatibility.ItemLabel, "",
+				compatibility.CompatField{[]compatibility.CompatDimension{
+					{"foo", []compatibility.CompatRange{{0, 0}}}}}},
+			{compatibility.ItemRightParen, "", compatibility.CompatField{}},
+		}},
+		{"bar AND(foo OR baz)", []compatibility.Item{
+			{compatibility.ItemLabel, "",
+				compatibility.CompatField{[]compatibility.CompatDimension{
+					{"bar", []compatibility.CompatRange{{0, 0}}}}}},
+			{compatibility.ItemAND, "", compatibility.CompatField{}},
+			{compatibility.ItemLeftParen, "", compatibility.CompatField{}},
+			{compatibility.ItemLabel, "",
+				compatibility.CompatField{[]compatibility.CompatDimension{
+					{"foo", []compatibility.CompatRange{{0, 0}}}}}},
+			{compatibility.ItemOR, "", compatibility.CompatField{}},
+			{compatibility.ItemLabel, "",
+				compatibility.CompatField{[]compatibility.CompatDimension{
+					{"baz", []compatibility.CompatRange{{0, 0}}}}}},
+			{compatibility.ItemRightParen, "", compatibility.CompatField{}},
+		}},
+		{")bar AND ( OR ) xx  ", []compatibility.Item{
+			{compatibility.ItemRightParen, "", compatibility.CompatField{}},
+			{compatibility.ItemLabel, "",
+				compatibility.CompatField{[]compatibility.CompatDimension{
+					{"bar", []compatibility.CompatRange{{0, 0}}}}}},
+			{compatibility.ItemAND, "", compatibility.CompatField{}},
+			{compatibility.ItemLeftParen, "", compatibility.CompatField{}},
+			{compatibility.ItemOR, "", compatibility.CompatField{}},
+			{compatibility.ItemRightParen, "", compatibility.CompatField{}},
+			{compatibility.ItemLabel, "",
+				compatibility.CompatField{[]compatibility.CompatDimension{
+					{"xx", []compatibility.CompatRange{{0, 0}}}}}},
+		}},
+	} {
+		c.Logf("tc %d: %+v", i, tc)
+		c.Check(compatibility.Items(tc.expression), DeepEquals, tc.tokens)
+	}
+}
+
+func (s *CompatSuite) TestLexValidExpressionsDashes(c *C) {
+	for i, tc := range []struct {
+		expression string
+		tokens     []compatibility.Item
+	}{
+		{"foo-bar-1", []compatibility.Item{
+			{compatibility.ItemLabel, "",
+				compatibility.CompatField{
+					[]compatibility.CompatDimension{
+						{"foo", []compatibility.CompatRange{{0, 0}}},
+						{"bar", []compatibility.CompatRange{{1, 1}}},
+					}},
+			},
+		}},
+		{"foo-(1..4)-bar-(8..22)", []compatibility.Item{
+			{compatibility.ItemLabel, "",
+				compatibility.CompatField{
+					[]compatibility.CompatDimension{
+						{"foo", []compatibility.CompatRange{{1, 4}}},
+						{"bar", []compatibility.CompatRange{{8, 22}}},
+					}},
+			},
+		}},
+		{"(foo-2-0)", []compatibility.Item{
+			{compatibility.ItemLeftParen, "", compatibility.CompatField{}},
+			{compatibility.ItemLabel, "",
+				compatibility.CompatField{
+					[]compatibility.CompatDimension{
+						{"foo", []compatibility.CompatRange{{2, 2}, {0, 0}}},
+					}},
+			},
+			{compatibility.ItemRightParen, "", compatibility.CompatField{}},
+		}},
+		{"( foo )", []compatibility.Item{
+			{compatibility.ItemLeftParen, "", compatibility.CompatField{}},
+			{compatibility.ItemLabel, "",
+				compatibility.CompatField{
+					[]compatibility.CompatDimension{
+						{"foo", []compatibility.CompatRange{{0, 0}}},
+					}},
+			},
+			{compatibility.ItemRightParen, "", compatibility.CompatField{}},
+		}},
+		{"(foo)", []compatibility.Item{
+			{compatibility.ItemLeftParen, "", compatibility.CompatField{}},
+			{compatibility.ItemLabel, "",
+				compatibility.CompatField{
+					[]compatibility.CompatDimension{
+						{"foo", []compatibility.CompatRange{{0, 0}}},
+					}},
+			},
+			{compatibility.ItemRightParen, "", compatibility.CompatField{}},
+		}},
+		{"(foo-2-(3..7))", []compatibility.Item{
+			{compatibility.ItemLeftParen, "", compatibility.CompatField{}},
+			{compatibility.ItemLabel, "",
+				compatibility.CompatField{
+					[]compatibility.CompatDimension{
+						{"foo", []compatibility.CompatRange{{2, 2}, {3, 7}}},
+					}},
+			},
+			{compatibility.ItemRightParen, "", compatibility.CompatField{}},
+		}},
+		{" foo-2-(3..7) AND (b1a2r3 OR boo-(5..9)-7-(1..33))", []compatibility.Item{
+			{compatibility.ItemLabel, "",
+				compatibility.CompatField{
+					[]compatibility.CompatDimension{
+						{"foo", []compatibility.CompatRange{{2, 2}, {3, 7}}},
+					}},
+			},
+			{compatibility.ItemAND, "", compatibility.CompatField{}},
+			{compatibility.ItemLeftParen, "", compatibility.CompatField{}},
+			{compatibility.ItemLabel, "",
+				compatibility.CompatField{
+					[]compatibility.CompatDimension{
+						{"b1a2r3", []compatibility.CompatRange{{0, 0}}},
+					}},
+			},
+			{compatibility.ItemOR, "", compatibility.CompatField{}},
+			{compatibility.ItemLabel, "",
+				compatibility.CompatField{
+					[]compatibility.CompatDimension{
+						{"boo", []compatibility.CompatRange{{5, 9}, {7, 7}, {1, 33}}},
+					}},
+			},
+			{compatibility.ItemRightParen, "", compatibility.CompatField{}},
+		}},
+	} {
+		c.Logf("tc %d: %+v", i, tc)
+		c.Check(compatibility.Items(tc.expression), DeepEquals, tc.tokens)
+	}
+}
+
+func (s *CompatSuite) TestLexInvalidExpressions(c *C) {
+	for i, tc := range []struct {
+		expression string
+		err        string
+	}{
+		{" _foo", "unexpected rune: _"},
+		{"foo AN", "unexpected rune: A"},
+		{"fooX", "unexpected rune: X"},
+		{"foo-1#", "unexpected rune: #"},
+		{"foo-(1..2)_", "unexpected rune: _"},
+		{"foo-(13__15)", "no dots in integer range"},
+		{"foo-(13..15#", "range missing closing parenthesis"},
+	} {
+		c.Logf("tc %d: %+v", i, tc)
+		tokens := compatibility.Items(tc.expression)
+		c.Check(len(tokens) > 0, Equals, true)
+		c.Check(tokens[len(tokens)-1], DeepEquals,
+			compatibility.Item{compatibility.ItemError, tc.err, compatibility.CompatField{}})
+	}
+}
+
+func (s *CompatSuite) TestLexInvalidExpressionsDashes(c *C) {
+	for i, tc := range []struct {
+		expression string
+		err        string
+	}{
+		{"foo-", "unexpected character after hyphen: EOF"},
+		{"foo-(", "not an integer: EOF"},
+		{"foo-(2", "no dots in integer range"},
+		{"foo-(2..", "not an integer: EOF"},
+		{"foo-(2..3", "range missing closing parenthesis"},
+		{"foo-(a..b)", "not an integer: a"},
+		{"foo-)", "unexpected character after hyphen: )"},
+		{"foo-(2..x)", "not an integer: x"},
+		{"foo-01", "integers not allowed to start with 0: 01"},
+		{"foo-123456789", "integer with more than 8 digits: 123456789"},
+	} {
+		c.Logf("tc %d: %+v", i, tc)
+		tokens := compatibility.Items(tc.expression)
+		c.Check(len(tokens) > 0, Equals, true)
+		c.Check(tokens[len(tokens)-1], DeepEquals,
+			compatibility.Item{compatibility.ItemError, tc.err, compatibility.CompatField{}})
+	}
+}

--- a/interfaces/compatibility/parse.go
+++ b/interfaces/compatibility/parse.go
@@ -1,0 +1,218 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// This implements a parser for compatibility expressions (SD211), which is a
+// combination of compatibility labels with AND and OR operators, with the
+// possibility of grouping expressions using parenthesis. The grammar we have
+// for this parser is:
+//
+// Expr ::= AndExpr | OrExpr
+// AndExpr ::= AndExpr 'AND' Atom | Atom
+// OrExpr ::= OrExpr 'OR' Atom | Atom
+// Atom ::= '(' Expr ')' | LABEL
+//
+// With lexical tokens:
+//
+// LABEL = [a-z][a-z0-9]*(-([0-9]+|[(][0-9]+[.][.][0-9]+[)]))*([a-z][a-z0-9]*(-([0-9]+|[(][0-9]+[.][.][0-9]+[)]))*)*
+//
+//
+// To make it recursive LL(1), we can break left recursion, and break conflicts:
+//
+// Expr ::= Atom ExprR
+// ExprR ::= OrExprR | AndExprR | ε
+// OrExprR ::= 'OR' Atom OrExprROpt
+// OrExprROpt ::= OrExprR | ε
+// AndExprR ::= 'AND' Atom AndExprROpt
+// AndExprROpt ::= AndExprR | ε
+// Atom ::= '(' Expr ')' | Label
+//
+// We end up with the first and follow sets (with FIRST in respective order of the rules):
+//
+//              First         Follow
+// Expr         '(',Label     EOF,')'
+// ExprR        'OR','AND',ε  EOF,')'
+// OrExprR      'OR'          EOF,')'
+// OrExprROpt   'OR',ε        EOF,')'
+// AndExprR     'AND'         EOF,')'
+// AndExprROpt  'AND',ε       EOF,')'
+// Atom         '(',Label     EOF,')','OR','AND'
+//
+// And no conflicts.
+//
+// Note that it will be parsed as right associative, but as we do not mix OR and
+// AND, we can just ignore it and keep the AST with right priority.
+//
+// For each non-terminal, we have a method (note though that methods that
+// handle AND and OR are almost identical and have been fused in one to avoid
+// code duplication, so (And|Or)ExprR are implemented in parseOpExprR, and
+// (And|Or)ExprROpt are implemented in parseOpExprROpt). The parser starts by
+// calling Expr. FIRST is used to decide the next method to take. If ε is in
+// FIRST, then we have to look also at what is in FOLLOW.
+//
+// For more details look at https://en.wikipedia.org/wiki/LL_parser
+//
+// Thanks to Valentin David for suggesting this grammar.
+
+package compatibility
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Expression needs to be fulfilled by values of nodes in the tree. We can have
+// here either a CompatField or an Operator struct.
+type Expression interface {
+	String() string
+}
+
+// Node for abstract syntax tree of compatibility expressions.
+type Node struct {
+	Left  *Node
+	Right *Node
+	Exp   Expression
+}
+
+// parser for compatibility expressions
+type parser struct {
+	tokens []Item
+	pos    int
+	labels []CompatField
+}
+
+// Operator can be AND or OR.
+type Operator struct {
+	// Type ItemAND or ItemOR
+	Oper Item
+}
+
+func (op *Operator) String() string {
+	return op.Oper.String()
+}
+
+func (p *parser) nextToken() Item {
+	if p.pos >= len(p.tokens) {
+		return Item{Typ: ItemEOF}
+	}
+	t := p.tokens[p.pos]
+	p.pos++
+	return t
+}
+
+func (p *parser) peekToken() Item {
+	if p.pos >= len(p.tokens) {
+		return Item{Typ: ItemEOF}
+	}
+	return p.tokens[p.pos]
+}
+
+// parse parses a compatibility expression and returns an AST and a slice with
+// all compatibility labels found while building it.
+func parse(input string) (*Node, []CompatField, error) {
+	tokens := items(input)
+	if len(tokens) == 0 {
+		return nil, nil, errors.New("empty compatibility string")
+	}
+	lastItem := tokens[len(tokens)-1]
+	if lastItem.Typ == ItemError {
+		return nil, nil, fmt.Errorf("while parsing: %s", lastItem.ErrMsg)
+	}
+	p := parser{tokens: tokens}
+	root, err := p.parseExpr()
+	if err != nil {
+		return nil, nil, err
+	}
+	if p.peekToken().Typ != ItemEOF {
+		return nil, nil, fmt.Errorf("unexpected string at the end: %s", p.peekToken())
+	}
+	return root, p.labels, nil
+}
+
+func (p *parser) parseExpr() (*Node, error) {
+	left, err := p.parseAtom()
+	if err != nil {
+		return nil, err
+	}
+
+	return p.parseExprR(left)
+}
+
+func (p *parser) parseAtom() (*Node, error) {
+	switch p.peekToken().Typ {
+	case ItemLabel:
+		itLab := p.nextToken()
+		p.labels = append(p.labels, itLab.Label)
+		return &Node{Exp: &itLab.Label}, nil
+	case ItemLeftParen:
+		// Consume '('
+		p.nextToken()
+		node, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		// Consume ')'
+		if p.nextToken().Typ != ItemRightParen {
+			return nil, fmt.Errorf("expected right parenthesis, found %s", p.peekToken())
+		}
+		return node, nil
+	default:
+		return nil, fmt.Errorf("unexpected token %s", p.peekToken())
+	}
+}
+
+func (p *parser) parseExprR(left *Node) (*Node, error) {
+	t := p.peekToken()
+	switch t.Typ {
+	case ItemOR:
+		return p.parseOpExprR(ItemOR, left)
+	case ItemAND:
+		return p.parseOpExprR(ItemAND, left)
+	case ItemEOF, ItemRightParen:
+		return left, nil
+	default:
+		return nil, fmt.Errorf("unexpected token %s", p.peekToken())
+	}
+}
+
+func (p *parser) parseOpExprR(oper ItemType, left *Node) (*Node, error) {
+	operToken := p.nextToken()
+	if operToken.Typ != oper {
+		return nil, fmt.Errorf("expected %s, found %s", oper, p.peekToken())
+	}
+
+	right, err := p.parseAtom()
+	if err != nil {
+		return nil, err
+	}
+
+	opNode := &Node{Exp: &Operator{Oper: operToken}, Left: left, Right: right}
+	return p.parseOpExprROpt(oper, opNode)
+}
+
+func (p *parser) parseOpExprROpt(oper ItemType, left *Node) (*Node, error) {
+	t := p.peekToken()
+	switch t.Typ {
+	case oper:
+		return p.parseOpExprR(oper, left)
+	case ItemRightParen, ItemEOF:
+		return left, nil
+	default:
+		return nil, fmt.Errorf("unexpected item after %s expression: %s", oper, t)
+	}
+}

--- a/interfaces/compatibility/parse_test.go
+++ b/interfaces/compatibility/parse_test.go
@@ -1,0 +1,257 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package compatibility_test
+
+import (
+	"github.com/snapcore/snapd/interfaces/compatibility"
+	. "gopkg.in/check.v1"
+)
+
+func (s *CompatSuite) TestOperatorString(c *C) {
+	var exp compatibility.Expression
+	op := &compatibility.Operator{Oper: compatibility.Item{compatibility.ItemOR, "", compatibility.CompatField{}}}
+	exp = op
+	c.Check(exp.String(), Equals, `"OR"`)
+	op = &compatibility.Operator{Oper: compatibility.Item{compatibility.ItemAND, "", compatibility.CompatField{}}}
+	exp = op
+	c.Check(exp.String(), Equals, `"AND"`)
+}
+
+func (s *CompatSuite) TestParserValidExpressions(c *C) {
+	for i, tc := range []struct {
+		expression string
+		tree       *compatibility.Node
+		labels     []compatibility.CompatField
+	}{
+		{"foo",
+			&compatibility.Node{Exp: &compatibility.CompatField{
+				[]compatibility.CompatDimension{{"foo", []compatibility.CompatRange{{0, 0}}}}}},
+			[]compatibility.CompatField{{Dimensions: []compatibility.CompatDimension{{Tag: "foo", Values: []compatibility.CompatRange{{Min: 0, Max: 0}}}}}},
+		},
+		{"foo-7-4 OR bar",
+			&compatibility.Node{
+				Exp: &compatibility.Operator{compatibility.Item{compatibility.ItemOR, "", compatibility.CompatField{}}},
+				Left: &compatibility.Node{
+					Exp: &compatibility.CompatField{
+						Dimensions: []compatibility.CompatDimension{
+							{Tag: "foo", Values: []compatibility.CompatRange{{7, 7}, {4, 4}}}},
+					},
+				},
+				Right: &compatibility.Node{
+					Exp: &compatibility.CompatField{
+						Dimensions: []compatibility.CompatDimension{
+							{Tag: "bar", Values: []compatibility.CompatRange{{0, 0}}}},
+					},
+				},
+			},
+			[]compatibility.CompatField{
+				{Dimensions: []compatibility.CompatDimension{
+					{Tag: "foo", Values: []compatibility.CompatRange{{Min: 7, Max: 7}, {Min: 4, Max: 4}}},
+				}},
+				{Dimensions: []compatibility.CompatDimension{
+					{Tag: "bar", Values: []compatibility.CompatRange{{Min: 0, Max: 0}}},
+				}},
+			},
+		},
+		{"((foo AND bar-(1..10)))",
+			&compatibility.Node{
+				Exp: &compatibility.Operator{compatibility.Item{compatibility.ItemAND, "", compatibility.CompatField{}}},
+				Left: &compatibility.Node{
+					Exp: &compatibility.CompatField{
+						Dimensions: []compatibility.CompatDimension{
+							{Tag: "foo", Values: []compatibility.CompatRange{{0, 0}}}},
+					},
+				},
+				Right: &compatibility.Node{
+					Exp: &compatibility.CompatField{
+						Dimensions: []compatibility.CompatDimension{
+							{Tag: "bar", Values: []compatibility.CompatRange{{1, 10}}}},
+					},
+				},
+			},
+			[]compatibility.CompatField{
+				{Dimensions: []compatibility.CompatDimension{
+					{Tag: "foo", Values: []compatibility.CompatRange{{Min: 0, Max: 0}}},
+				}},
+				{Dimensions: []compatibility.CompatDimension{
+					{Tag: "bar", Values: []compatibility.CompatRange{{Min: 1, Max: 10}}},
+				}},
+			},
+		},
+		{"(foo AND bar) OR baz-(5..6)-(5..56)",
+			&compatibility.Node{
+				Exp: &compatibility.Operator{compatibility.Item{compatibility.ItemOR, "", compatibility.CompatField{}}},
+				Left: &compatibility.Node{
+					Exp: &compatibility.Operator{compatibility.Item{compatibility.ItemAND, "", compatibility.CompatField{}}},
+					Left: &compatibility.Node{
+						Exp: &compatibility.CompatField{
+							Dimensions: []compatibility.CompatDimension{
+								{Tag: "foo", Values: []compatibility.CompatRange{{0, 0}}}},
+						},
+					},
+					Right: &compatibility.Node{
+						Exp: &compatibility.CompatField{
+							Dimensions: []compatibility.CompatDimension{
+								{Tag: "bar", Values: []compatibility.CompatRange{{0, 0}}}},
+						},
+					}},
+				Right: &compatibility.Node{
+					Exp: &compatibility.CompatField{
+						Dimensions: []compatibility.CompatDimension{
+							{Tag: "baz", Values: []compatibility.CompatRange{{5, 6}, {5, 56}}}},
+					},
+				},
+			},
+			[]compatibility.CompatField{
+				{Dimensions: []compatibility.CompatDimension{
+					{Tag: "foo", Values: []compatibility.CompatRange{{Min: 0, Max: 0}}},
+				}},
+				{Dimensions: []compatibility.CompatDimension{
+					{Tag: "bar", Values: []compatibility.CompatRange{{Min: 0, Max: 0}}},
+				}},
+				{Dimensions: []compatibility.CompatDimension{
+					{Tag: "baz", Values: []compatibility.CompatRange{{Min: 5, Max: 6}, {Min: 5, Max: 56}}},
+				}},
+			},
+		},
+		{"foo-0-blah-5 AND (bar OR baz)",
+			&compatibility.Node{
+				Exp: &compatibility.Operator{compatibility.Item{compatibility.ItemAND, "", compatibility.CompatField{}}},
+				Left: &compatibility.Node{
+					Exp: &compatibility.CompatField{
+						Dimensions: []compatibility.CompatDimension{
+							{Tag: "foo", Values: []compatibility.CompatRange{{0, 0}}},
+							{Tag: "blah", Values: []compatibility.CompatRange{{5, 5}}},
+						},
+					},
+				},
+				Right: &compatibility.Node{
+					Exp: &compatibility.Operator{compatibility.Item{compatibility.ItemOR, "", compatibility.CompatField{}}},
+					Left: &compatibility.Node{
+						Exp: &compatibility.CompatField{
+							Dimensions: []compatibility.CompatDimension{
+								{Tag: "bar", Values: []compatibility.CompatRange{{0, 0}}}},
+						},
+					},
+					Right: &compatibility.Node{
+						Exp: &compatibility.CompatField{
+							Dimensions: []compatibility.CompatDimension{
+								{Tag: "baz", Values: []compatibility.CompatRange{{0, 0}}}},
+						},
+					}},
+			},
+			[]compatibility.CompatField{
+				{Dimensions: []compatibility.CompatDimension{
+					{Tag: "foo", Values: []compatibility.CompatRange{{Min: 0, Max: 0}}},
+					{Tag: "blah", Values: []compatibility.CompatRange{{Min: 5, Max: 5}}},
+				}},
+				{Dimensions: []compatibility.CompatDimension{
+					{Tag: "bar", Values: []compatibility.CompatRange{{Min: 0, Max: 0}}},
+				}},
+				{Dimensions: []compatibility.CompatDimension{
+					{Tag: "baz", Values: []compatibility.CompatRange{{Min: 0, Max: 0}}},
+				}},
+			},
+		},
+		{"foo OR bar OR baz",
+			&compatibility.Node{
+				Exp: &compatibility.Operator{compatibility.Item{compatibility.ItemOR, "", compatibility.CompatField{}}},
+				Left: &compatibility.Node{
+					Exp: &compatibility.Operator{compatibility.Item{compatibility.ItemOR, "", compatibility.CompatField{}}},
+					Left: &compatibility.Node{
+						Exp: &compatibility.CompatField{
+							Dimensions: []compatibility.CompatDimension{
+								{Tag: "foo", Values: []compatibility.CompatRange{{0, 0}}}},
+						},
+					},
+					Right: &compatibility.Node{
+						Exp: &compatibility.CompatField{
+							Dimensions: []compatibility.CompatDimension{
+								{Tag: "bar", Values: []compatibility.CompatRange{{0, 0}}}},
+						},
+					}},
+				Right: &compatibility.Node{
+					Exp: &compatibility.CompatField{
+						Dimensions: []compatibility.CompatDimension{
+							{Tag: "baz", Values: []compatibility.CompatRange{{0, 0}}}},
+					},
+				},
+			},
+			[]compatibility.CompatField{
+				{Dimensions: []compatibility.CompatDimension{
+					{Tag: "foo", Values: []compatibility.CompatRange{{Min: 0, Max: 0}}},
+				}},
+				{Dimensions: []compatibility.CompatDimension{
+					{Tag: "bar", Values: []compatibility.CompatRange{{Min: 0, Max: 0}}},
+				}},
+				{Dimensions: []compatibility.CompatDimension{
+					{Tag: "baz", Values: []compatibility.CompatRange{{Min: 0, Max: 0}}},
+				}},
+			},
+		},
+	} {
+		c.Logf("tc %d: %+v", i, tc)
+		node, labels, err := compatibility.Parse(tc.expression)
+		c.Check(err, IsNil)
+		c.Check(node, DeepEquals, tc.tree)
+		c.Check(labels, DeepEquals, tc.labels)
+	}
+}
+
+func (s *CompatSuite) TestParserInvalidExpressions(c *C) {
+	for i, tc := range []struct {
+		expression string
+		errMsg     string
+	}{
+		{"", "empty compatibility string"},
+		{"()", `unexpected token "\)"`},
+		{"(foo", `expected right parenthesis, found "EOF"`},
+		{"foo)", `unexpected string at the end: "\)"`},
+		{"foo(", `unexpected token "\("`},
+		{"foo (", `unexpected token "\("`},
+		{"foo bar", `unexpected token "label: bar-0"`},
+		{"foo OR OR bar", `unexpected token "OR"`},
+		{"AND", `unexpected token "AND"`},
+		{"OR", `unexpected token "OR"`},
+		{"foo OR", `unexpected token "EOF"`},
+		{"OR foo", `unexpected token "OR"`},
+		{"(OR foo)", `unexpected token "OR"`},
+		{"foo-", "while parsing: unexpected character after hyphen: EOF"},
+		{"foo-1-foo-2", "while parsing: repeated string in label: foo"},
+		{"a12345678901234567890123456789012", "while parsing: string is longer than 32 characters: a12345678901234567890123456789012"},
+		{"foo-(1..)", `while parsing: not an integer: \)`},
+		{"foo-(55..1)", `while parsing: negative range specified: \(55\.\.1\)`},
+		{"foo OR bar AND baz", `unexpected item after OR expression: "AND"`},
+		{"blah AND (foo OR bar AND baz)", `unexpected item after OR expression: "AND"`},
+		{"(blah AND foo OR bar) AND baz", `unexpected item after AND expression: "OR"`},
+		{"foo OR xx (", `unexpected item after OR expression: "\("`},
+		{"AND)", `unexpected token "AND"`},
+		{"OR)", `unexpected token "OR"`},
+		{"foo(bar)", `unexpected token "\("`},
+		{"foo-1(bar)", `unexpected token "\("`},
+		{"foo-(1..2)(", `unexpected token "\("`},
+	} {
+		c.Logf("tc %d: %+v", i, tc)
+		node, labels, err := compatibility.Parse(tc.expression)
+		c.Check(err, ErrorMatches, tc.errMsg)
+		c.Check(node, IsNil)
+		c.Check(len(labels), Equals, 0)
+	}
+}


### PR DESCRIPTION
This implements a parser for compatibility expressions (SD211), which is a combination of compatibility labels with AND and OR operators, with the possibility of grouping expressions using parenthesis.

The lexer is loosely based on on go's text/template lexer. See https://www.youtube.com/watch?v=HxaD_trXwRE&t=2s for ideas behind this.