### PR TITLE
o/i/apparmorprompting: implement methods to retrieve notices from backends

### DIFF
--- a/overlord/ifacestate/apparmorprompting/export_test.go
+++ b/overlord/ifacestate/apparmorprompting/export_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/prompting"
 	"github.com/snapcore/snapd/interfaces/prompting/requestprompts"
 	"github.com/snapcore/snapd/interfaces/prompting/requestrules"
+	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/sandbox/apparmor/notify"
 	"github.com/snapcore/snapd/sandbox/apparmor/notify/listener"
 	"github.com/snapcore/snapd/testutil"
@@ -163,6 +164,12 @@ func (nb *noticeBackends) RuleBackend() *noticeTypeBackend {
 
 func (ntb *noticeTypeBackend) AddNotice(userID uint32, id prompting.IDType, data map[string]string) error {
 	return ntb.addNotice(userID, id, data)
+}
+
+type NtbFilter = ntbFilter
+
+func (ntb *noticeTypeBackend) SimplifyFilter(filter *state.NoticeFilter) (simplified ntbFilter, matchPossible bool) {
+	return ntb.simplifyFilter(filter)
 }
 
 func (ntb *noticeTypeBackend) Save() error {

--- a/overlord/ifacestate/apparmorprompting/noticebackend.go
+++ b/overlord/ifacestate/apparmorprompting/noticebackend.go
@@ -362,7 +362,7 @@ func (f ntbFilter) filterNotices(notices []*state.Notice, now time.Time) []*stat
 	}
 	if len(filteredNotices) == 0 {
 		// Never found a non-expired notice matching After filter
-		return filteredNotices
+		return nil
 	}
 	// Discard notices with last repeated timestamp after f.BeforeOrAt (if given).
 	if !f.BeforeOrAt.IsZero() {
@@ -476,7 +476,6 @@ func (ntb *noticeTypeBackend) BackendNotice(id string) *state.Notice {
 func (ntb *noticeTypeBackend) BackendWaitNotices(ctx context.Context, filter *state.NoticeFilter) ([]*state.Notice, error) {
 	simplifiedFilter, matchPossible := ntb.simplifyFilter(filter)
 	if !matchPossible {
-		// A match is not possible, so return immediately
 		return nil, nil
 	}
 	ntb.rwmu.RLock()

--- a/overlord/ifacestate/apparmorprompting/noticebackend_test.go
+++ b/overlord/ifacestate/apparmorprompting/noticebackend_test.go
@@ -946,6 +946,9 @@ func (s *noticebackendSuite) TestBackendWaitNoticesNew(c *C) {
 	start := make(chan struct{})
 	go func() {
 		close(start)
+		// wait until notice backend mutex is held so we're sure cond.Wait()
+		// has been called before we add the new notice, so we're sure we're
+		// testing the waiting code and not returning an existing notice.
 		sawMutexHeld := apparmorprompting.WaitUntilMutexHeld(ruleBackend, 100*time.Millisecond)
 		c.Logf("sawMutexHeld: %b", sawMutexHeld)
 		ruleBackend.AddNotice(1000, 0x42, nil)
@@ -1052,6 +1055,9 @@ func (s *noticebackendSuite) TestBackendWaitNoticesBeforeOrAtFilter(c *C) {
 	start := make(chan struct{})
 	go func() {
 		close(start)
+		// wait until notice backend mutex is held so we're sure cond.Wait()
+		// has been called before we add the new notice, so we're sure we're
+		// testing the waiting code and not returning an existing notice.
 		sawMutexHeld := apparmorprompting.WaitUntilMutexHeld(promptBackend, 100*time.Millisecond)
 		c.Logf("sawMutexHeld: %b", sawMutexHeld)
 		promptBackend.AddNotice(1000, 7, nil)


### PR DESCRIPTION
This PR is based on #15932.

This is the second part of the notice backend implementation, split from #15768.

`BackendNotices` and `BackendWaitNotices` get real implementations here.

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-35196