### PR TITLE
many: use notice backend for prompting notice types

### DIFF
--- a/daemon/api_debug_features_test.go
+++ b/daemon/api_debug_features_test.go
@@ -38,7 +38,7 @@ type featuresDebugSuite struct {
 func (s *featuresDebugSuite) SetUpTest(c *C) {
 	s.apiBaseSuite.SetUpTest(c)
 	s.daemonWithOverlordMock()
-	ifacemgr, err := ifacestate.Manager(s.d.Overlord().State(), s.d.Overlord().HookManager(), s.d.Overlord().TaskRunner(), []interfaces.Interface{}, []interfaces.SecurityBackend{})
+	ifacemgr, err := ifacestate.Manager(s.d.Overlord().State(), s.d.Overlord().HookManager(), s.d.Overlord().NoticeManager(), s.d.Overlord().TaskRunner(), []interfaces.Interface{}, []interfaces.SecurityBackend{})
 	c.Assert(err, IsNil)
 	s.d.Overlord().AddManager(ifacemgr)
 }

--- a/daemon/api_themes_test.go
+++ b/daemon/api_themes_test.go
@@ -380,7 +380,7 @@ func (s *themesSuite) daemonWithIfaceMgr(c *C) *daemon.Daemon {
 	hookMgr, err := hookstate.Manager(st, runner)
 	c.Assert(err, IsNil)
 	overlord.AddManager(hookMgr)
-	ifaceMgr, err := ifacestate.Manager(st, hookMgr, runner, nil, nil)
+	ifaceMgr, err := ifacestate.Manager(st, hookMgr, nil, runner, nil, nil)
 	c.Assert(err, IsNil)
 	overlord.AddManager(ifaceMgr)
 	overlord.AddManager(runner)

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -710,7 +710,7 @@ func (s *firstBoot16Suite) TestPopulateFromSeedMissingBootloader(c *C) {
 	c.Assert(err, IsNil)
 	o.AddManager(snapmgr)
 
-	ifacemgr, err := ifacestate.Manager(st, nil, o.TaskRunner(), nil, nil)
+	ifacemgr, err := ifacestate.Manager(st, nil, nil, o.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 	o.AddManager(ifacemgr)
 	c.Assert(o.StartUp(), IsNil)

--- a/overlord/ifacestate/apparmorprompting/export_test.go
+++ b/overlord/ifacestate/apparmorprompting/export_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/prompting"
 	"github.com/snapcore/snapd/interfaces/prompting/requestprompts"
 	"github.com/snapcore/snapd/interfaces/prompting/requestrules"
+	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/sandbox/apparmor/notify"
 	"github.com/snapcore/snapd/sandbox/apparmor/notify/listener"
 	"github.com/snapcore/snapd/testutil"
@@ -163,6 +164,12 @@ func (nb *noticeBackends) RuleBackend() *noticeTypeBackend {
 
 func (ntb *noticeTypeBackend) AddNotice(userID uint32, id prompting.IDType, data map[string]string) error {
 	return ntb.addNotice(userID, id, data)
+}
+
+type NtbFilter = ntbFilter
+
+func (ntb *noticeTypeBackend) SimplifyFilter(filter *state.NoticeFilter) (simplified ntbFilter, matchPossible bool) {
+	return ntb.simplifyFilter(filter)
 }
 
 func (ntb *noticeTypeBackend) Save() error {

--- a/overlord/ifacestate/apparmorprompting/export_test.go
+++ b/overlord/ifacestate/apparmorprompting/export_test.go
@@ -20,6 +20,7 @@
 package apparmorprompting
 
 import (
+	"github.com/snapcore/snapd/interfaces/prompting"
 	"github.com/snapcore/snapd/interfaces/prompting/requestprompts"
 	"github.com/snapcore/snapd/interfaces/prompting/requestrules"
 	"github.com/snapcore/snapd/sandbox/apparmor/notify"
@@ -145,4 +146,25 @@ func (m *InterfacesRequestsManager) PromptDB() *requestprompts.PromptDB {
 
 func (m *InterfacesRequestsManager) RuleDB() *requestrules.RuleDB {
 	return m.rules
+}
+
+var (
+	NewNoticeBackends   = newNoticeBackends
+	RegisterWithManager = (*noticeBackends).registerWithManager
+)
+
+func (nb *noticeBackends) PromptBackend() *noticeTypeBackend {
+	return nb.promptBackend
+}
+
+func (nb *noticeBackends) RuleBackend() *noticeTypeBackend {
+	return nb.ruleBackend
+}
+
+func (ntb *noticeTypeBackend) AddNotice(userID uint32, id prompting.IDType, data map[string]string) error {
+	return ntb.addNotice(userID, id, data)
+}
+
+func (ntb *noticeTypeBackend) Save() error {
+	return ntb.save()
 }

--- a/overlord/ifacestate/apparmorprompting/noticebackend.go
+++ b/overlord/ifacestate/apparmorprompting/noticebackend.go
@@ -1,0 +1,395 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package apparmorprompting
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces/prompting"
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/notices"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+const (
+	promptNoticeNamespace = "prompt"
+	ruleNoticeNamespace   = "rule"
+	defaultExpireAfter    = 24 * time.Hour
+)
+
+// noticeBackends manages notice backends related to prompting.
+type noticeBackends struct {
+	promptBackend *noticeTypeBackend
+	ruleBackend   *noticeTypeBackend
+}
+
+func newNoticeBackends(noticeMgr *notices.NoticeManager) (*noticeBackends, error) {
+	nextNoticeTimestamp := noticeMgr.NextNoticeTimestamp
+
+	now := time.Now()
+
+	if err := os.MkdirAll(dirs.SnapInterfacesRequestsRunDir, 0o755); err != nil {
+		return nil, fmt.Errorf("cannot create interfaces requests run directory: %w", err)
+	}
+
+	path := filepath.Join(dirs.SnapInterfacesRequestsRunDir, "prompt-notices.json")
+	promptNoticeBackend, err := newNoticeTypeBackend(now, nextNoticeTimestamp, path, state.InterfacesRequestsPromptNotice, promptNoticeNamespace)
+	if err != nil {
+		return nil, err
+	}
+
+	path = filepath.Join(dirs.SnapInterfacesRequestsRunDir, "rule-notices.json")
+	ruleNoticeBackend, err := newNoticeTypeBackend(now, nextNoticeTimestamp, path, state.InterfacesRequestsRuleUpdateNotice, ruleNoticeNamespace)
+	if err != nil {
+		return nil, err
+	}
+
+	backends := &noticeBackends{
+		promptBackend: promptNoticeBackend,
+		ruleBackend:   ruleNoticeBackend,
+	}
+
+	return backends, nil
+}
+
+func (nb *noticeBackends) registerWithManager(noticeMgr *notices.NoticeManager) error {
+	drainNotices := true
+	for _, bknd := range []*noticeTypeBackend{nb.promptBackend, nb.ruleBackend} {
+		// We don't use the validation closure, since notices are produced
+		// directly to satisfy validation.
+		_, drainedNotices, err := noticeMgr.RegisterBackend(bknd, bknd.noticeType, bknd.namespace, drainNotices)
+		if err != nil {
+			// This should never occur
+			return fmt.Errorf("cannot register prompting manager as a %s notice backend", bknd.namespace)
+		}
+		// Drained notices should only occur the first time snapd starts after
+		// refreshing to a new release which uses this notice backend. This is
+		// a migration to ensure no information is lost when state is no longer
+		// responsible for notices of this type.
+		for _, notice := range drainedNotices {
+			// Re-create each notice in the backend, so no data is lost before
+			// a client can receive it. The ID will be different, but the key
+			// will be the same.
+			userID, _ := notice.UserID() // prompting notices always have UserID
+			promptingID, err := prompting.IDFromString(notice.Key())
+			if err != nil {
+				// Should never occur, as all prompting notices had key set as
+				// promptID.String() or ruleID.String()
+				continue
+			}
+			if err = bknd.addNotice(userID, promptingID, notice.LastData()); err != nil {
+				// Should never occur, only error would be if two notices with
+				// the same key (prompt/rule ID) existed for different users,
+				// which should never happen. Or if there's an error saving.
+				logger.Noticef("WARNING: cannot migrate notice from state to %s notice backend: %v", bknd.noticeType, err)
+				continue
+			}
+		}
+	}
+	return nil
+}
+
+// noticeTypeBackend manages notices for a particular notice type.
+type noticeTypeBackend struct {
+	// rwmu must be held for writing when adding a notice and held for reading
+	// when reading notices.
+	rwmu sync.RWMutex
+	// cond is used to broadcast when a new notice is added.
+	cond *sync.Cond
+	// nextNoticeTimestamp is a closure derived from a notice manager which
+	// returns a unique and monotonically increasing next notice timestamp.
+	nextNoticeTimestamp func() time.Time
+	// filepath is the path where notices for this backend are stored on disk.
+	filepath string
+	// noticeType is the type of notice managed by this backend.
+	noticeType state.NoticeType
+	// namespace is the prefix for the IDs of notices managed by this backend.
+	namespace string
+	// userNotices maps from user ID to the list of notices managed by this
+	// backend which are associated with that user. The notices in each list
+	// must always remain sorted by last repeated timestamp.
+	//
+	// This is optimized for the prompting use-case: notice requests for only
+	// one user at a time, with the most recent notices being the ones most
+	// likely to re-occur.
+	userNotices map[uint32][]*state.Notice
+	// idToNotice maps from notice ID to the notice itself. This is used to
+	// efficiently look up the notice associated with a particular ID, and to
+	// ensure that no two notices for different users can have the same ID.
+	idToNotice map[string]*state.Notice
+}
+
+func newNoticeTypeBackend(now time.Time, nextNoticeTimestamp func() time.Time, path string, noticeType state.NoticeType, namespace string) (*noticeTypeBackend, error) {
+	ntb := &noticeTypeBackend{
+		nextNoticeTimestamp: nextNoticeTimestamp,
+		filepath:            path,
+		noticeType:          noticeType,
+		namespace:           namespace,
+	}
+	// Use ntb.rwmu.RLocker() as the cond locker, since that is the lock which
+	// is held during BackendWaitNotices(), and thus calling ntb.cond.Wait()
+	// will be able to release the lock.
+	ntb.cond = sync.NewCond(ntb.rwmu.RLocker())
+	if err := ntb.load(now); err != nil {
+		return nil, err
+	}
+	return ntb, nil
+}
+
+// addNotice records an occurrence of a notice with the specified user ID, a
+// key equal to the given prompt/rule ID, and the given data, with notice ID
+// and type derived from the receiver.
+func (ntb *noticeTypeBackend) addNotice(userID uint32, id prompting.IDType, data map[string]string) error {
+	ntb.rwmu.Lock()
+	defer ntb.rwmu.Unlock()
+	key := id.String()
+	noticeID := fmt.Sprintf("%s-%s", ntb.namespace, key)
+
+	userNotices, existingNotice, existingIndex, err := ntb.searchExistingNotices(userID, noticeID)
+	if err != nil {
+		return err
+	}
+
+	// Now that errors can't occur (other than save error), get a new unique
+	// timestamp from the state, which will bump the state's noticeLastTimestamp
+	timestamp := ntb.nextNoticeTimestamp()
+
+	// Check if any notices have expired relative to the new timestamp.
+	// Since they're sorted, as soon as we see a non-expired notice, bail out.
+	// Do this before potentially calling Reoccur on the existing notice, so we
+	// see its original timestamp in the sorted slice.
+	expiredCount := 0
+	for _, n := range userNotices {
+		if !n.Expired(timestamp) {
+			break
+		}
+		expiredCount++
+	}
+
+	var newNotice *state.Notice
+	if existingNotice != nil && !existingNotice.Expired(timestamp) {
+		newNotice = existingNotice.DeepCopy()
+		newNotice.Reoccur(timestamp, data, 0)
+	} else {
+		newNotice = state.NewNotice(noticeID, &userID, ntb.noticeType, key, timestamp, data, 0, defaultExpireAfter)
+	}
+
+	newUserNotices := assembleNewUserNotices(userNotices, expiredCount, newNotice, existingIndex)
+
+	ntb.userNotices[userID] = newUserNotices
+	ntb.idToNotice[noticeID] = newNotice
+
+	if err := ntb.save(); err != nil {
+		ntb.userNotices[userID] = userNotices
+		if existingNotice != nil {
+			ntb.idToNotice[noticeID] = existingNotice
+		} else {
+			delete(ntb.idToNotice, noticeID)
+		}
+		return fmt.Errorf("cannot add notice to prompting %s backend: %w", ntb.noticeType, err)
+	}
+
+	// Now that we've successfully saved, delete the expired notices
+	for _, expiredNotice := range userNotices[:expiredCount] {
+		delete(ntb.idToNotice, expiredNotice.ID())
+	}
+
+	ntb.cond.Broadcast()
+
+	return nil
+}
+
+// searchExistingNotice looks up the list of existing notices for the given
+// userID and checks whether a notice with the given noticeID already exists.
+//
+// Returns the slice of existing notices for the given userID. If the notice
+// does exist, a pointer to it is returned, along with the index at which it
+// occurs in the userNotices slice. If it does not exist, returns a nil
+// existingNotice and returns existingIndex of -1.
+//
+// The caller must ensure that the backend mutex is locked.
+func (ntb *noticeTypeBackend) searchExistingNotices(userID uint32, noticeID string) (userNotices []*state.Notice, notice *state.Notice, existingIndex int, err error) {
+	notice, ok := ntb.idToNotice[noticeID]
+	if !ok {
+		userNotices = ntb.userNotices[userID]
+		return userNotices, nil, -1, nil
+	}
+
+	if existingUserID, ok := notice.UserID(); !ok || existingUserID != userID {
+		// This should never occur, since prompting notices always have UserIDs
+		// and prompt/rule IDs are globally unique.
+		if !ok {
+			return nil, nil, -1, fmt.Errorf("cannot add %s notice with ID %s for user %d: notice with the same ID already exists without user", ntb.namespace, noticeID, userID)
+		}
+		return nil, nil, -1, fmt.Errorf("cannot add %s notice with ID %s for user %d: notice with the same ID already exists for user %d", ntb.namespace, noticeID, userID, existingUserID)
+	}
+
+	userNotices, ok = ntb.userNotices[userID]
+	if !ok {
+		// This should never occur.
+		return nil, nil, -1, fmt.Errorf("internal error: notice ID maps to notice with user which doesn't exist in user notices: %v", notice)
+	}
+
+	// Find the index of the existing notice with this ID.
+	// Since the user notices are sorted by LastRepeated timestamp, and
+	// each notice has a unique LastRepeated timestamp, we can use binary
+	// search by LastRepeated timestamp.
+	// XXX: maybe use slices.BinarySearchFunc instead once on go 1.21+
+	existingIndex = sort.Search(len(userNotices), func(i int) bool {
+		// Find first index which has a LastRepeated timestamp >= the
+		// existing notice, since we're binary searching for that notice.
+		return !userNotices[i].LastRepeated().Before(notice.LastRepeated())
+	})
+	if existingIndex >= len(userNotices) || userNotices[existingIndex] != notice {
+		// ID maps to a notice which doesn't actually exist in userNotices.
+		// This should never occur.
+		return nil, nil, -1, fmt.Errorf("internal error: notice ID maps to notice which doesn't exist in user notices: %v not in %v", notice, userNotices)
+	}
+
+	return userNotices, notice, existingIndex, nil
+}
+
+// assembleNewUserNotices returns a new slice of notices by discarding any
+// expired notices from the front of the given userNotices, copying non-expired
+// notices other than the existing notice, if it exists, and appending the given
+// new notice to the end of the slice. If the notice did not previously exist in
+// the userNotices slice, existingIndex should be -1.
+func assembleNewUserNotices(userNotices []*state.Notice, expiredCount int, newNotice *state.Notice, existingIndex int) []*state.Notice {
+	newUserNotices := make([]*state.Notice, 0, len(userNotices)-expiredCount+1)
+	for i := expiredCount; i < len(userNotices); i++ {
+		if i != existingIndex {
+			newUserNotices = append(newUserNotices, userNotices[i])
+		}
+	}
+	newUserNotices = append(newUserNotices, newNotice)
+	return newUserNotices
+}
+
+// BackendNotices returns the list of notices that match the filter (if any),
+// ordered by the last-repeated time.
+//
+// The caller must not mutate the data within the returned slice.
+func (ntb *noticeTypeBackend) BackendNotices(filter *state.NoticeFilter) []*state.Notice {
+	// just a naive stub, for now, which ignores much of the filter
+	ntb.rwmu.RLock()
+	defer ntb.rwmu.RUnlock()
+	now := time.Now()
+
+	// XXX: this is wrong, replace with a real implementation
+	var notices []*state.Notice
+	for userID, userNotices := range ntb.userNotices {
+		if filter != nil && filter.UserID != nil && *filter.UserID != userID {
+			continue
+		}
+		for _, notice := range userNotices {
+			if !notice.Expired(now) {
+				notices = append(notices, notice)
+			}
+		}
+	}
+	state.SortNotices(notices)
+	return notices
+}
+
+// BackendNotice returns a single notice by ID, or nil if not found.
+func (ntb *noticeTypeBackend) BackendNotice(id string) *state.Notice {
+	ntb.rwmu.RLock()
+	defer ntb.rwmu.RUnlock()
+	if noticeEntry, ok := ntb.idToNotice[id]; ok {
+		return noticeEntry
+	}
+	return nil
+}
+
+// BackendWaitNotices waits for notices that match the filter to exist or occur,
+// returning the list of matching notices ordered by last-repeated time.
+//
+// It waits till there is at least one matching notice, the context is
+// cancelled, or the timestamp of the BeforeOrAt filter has passed (if it is
+// nonzero). If there are existing notices that match the filter,
+// BackendWaitNotices will return them immediately.
+func (ntb *noticeTypeBackend) BackendWaitNotices(ctx context.Context, filter *state.NoticeFilter) ([]*state.Notice, error) {
+	// just a non-functional stub, for now
+	return nil, nil
+}
+
+type savedNotices struct {
+	UserNotices map[uint32][]*state.Notice `json:"user-notices"`
+}
+
+// Loads existing notices for this backend from disk.
+//
+// The caller must ensure that the lock is held for writing.
+func (ntb *noticeTypeBackend) load(now time.Time) error {
+	f, err := os.Open(ntb.filepath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			ntb.userNotices = make(map[uint32][]*state.Notice)
+			ntb.idToNotice = make(map[string]*state.Notice)
+			return nil
+		}
+		return fmt.Errorf("cannot open %s notices file: %w", ntb.namespace, err)
+	}
+	defer f.Close()
+	var saved savedNotices
+	if err = json.NewDecoder(f).Decode(&saved); err != nil {
+		return fmt.Errorf("cannot unmarshal %s notices file: %w", ntb.namespace, err)
+	}
+	ntb.userNotices = make(map[uint32][]*state.Notice)
+	ntb.idToNotice = make(map[string]*state.Notice)
+	// Prune expired notices
+	for user, notices := range saved.UserNotices {
+		ntb.userNotices[user] = notices[:0]
+		for i, n := range notices {
+			if !n.Expired(now) {
+				ntb.userNotices[user] = notices[i:]
+				break
+			}
+		}
+		// Construct ID mappings for these notices
+		for _, n := range ntb.userNotices[user] {
+			ntb.idToNotice[n.ID()] = n
+		}
+	}
+	return nil
+}
+
+// Save notices for this backend to disk.
+//
+// The caller must ensure that the lock is held.
+func (ntb *noticeTypeBackend) save() error {
+	b, err := json.Marshal(savedNotices{UserNotices: ntb.userNotices})
+	if err != nil {
+		// Should not occur, marshalling should always succeed
+		return fmt.Errorf("cannot marshal %s notices: %w", ntb.namespace, err)
+	}
+	return osutil.AtomicWriteFile(ntb.filepath, b, 0o600, 0)
+}

--- a/overlord/ifacestate/apparmorprompting/noticebackend.go
+++ b/overlord/ifacestate/apparmorprompting/noticebackend.go
@@ -293,29 +293,180 @@ func assembleNewUserNotices(userNotices []*state.Notice, expiredCount int, newNo
 	return newUserNotices
 }
 
+// ntbFilter is a simplified version of state.NoticeFilter which only contains
+// information relevant to a noticeTypeBackend.
+type ntbFilter struct {
+	UserID     *uint32
+	Keys       []string
+	After      time.Time
+	BeforeOrAt time.Time
+}
+
+// simplifyFilter creates a new simplified filter with only the information
+// relevant to this backend. If no notices can match this backend, returns false.
+func (ntb *noticeTypeBackend) simplifyFilter(filter *state.NoticeFilter) (simplified ntbFilter, matchPossible bool) {
+	if filter == nil {
+		return simplified, true
+	}
+	if len(filter.Types) > 0 && !slicesContains(filter.Types, ntb.noticeType) {
+		return simplified, false
+	}
+	if !filter.BeforeOrAt.IsZero() && !filter.After.IsZero() && !filter.After.Before(filter.BeforeOrAt) {
+		// No possible timestamp can satisfy both After and BeforeOrAt filters
+		return simplified, false
+	}
+	var keys []string
+	if len(filter.Keys) > 0 {
+		keys = make([]string, 0, len(filter.Keys))
+		for _, key := range filter.Keys {
+			if _, err := prompting.IDFromString(key); err != nil {
+				// Key is not a valid prompting ID, so it's impossible for
+				// there to be a notice matching it.
+				continue
+			}
+			keys = append(keys, key)
+		}
+		if len(keys) == 0 {
+			// There were keys specified in the original filter but none were
+			// viable, so it's impossible for notices to match this filter.
+			return simplified, false
+		}
+	}
+	simplified = ntbFilter{
+		UserID:     filter.UserID,
+		Keys:       keys,
+		After:      filter.After,
+		BeforeOrAt: filter.BeforeOrAt,
+	}
+	return simplified, true
+}
+
+// filterNotices filters the given slice of notices, returning only those which
+// match the filter. Requires that the notices are sorted by last repeated time.
+//
+// Assumes that all notices in the slice already apply to the UserID in the
+// filter.
+func (f ntbFilter) filterNotices(notices []*state.Notice, now time.Time) []*state.Notice {
+	var filteredNotices []*state.Notice
+	// Discard expired notices or those with last repeated timestamp before f.After (if given)
+	for i, notice := range notices {
+		if notice.Expired(now) {
+			continue
+		}
+		if !f.After.IsZero() && !notice.LastRepeated().After(f.After) {
+			continue
+		}
+		filteredNotices = notices[i:]
+		break
+	}
+	if len(filteredNotices) == 0 {
+		// Never found a non-expired notice matching After filter
+		return filteredNotices
+	}
+	// Discard notices with last repeated timestamp after f.BeforeOrAt (if given).
+	if !f.BeforeOrAt.IsZero() {
+		// Since this filter is not exported over the API, we only expect
+		// notices to occur after f.BeforeOrAt if they're racing with a
+		// request. So look from newest notice to oldest, and stop looking
+		// once we see a notice with timestamp before or at f.BeforeOrAt.
+		allAfter := true
+		for i := len(filteredNotices) - 1; i >= 0; i-- {
+			if filteredNotices[i].LastRepeated().After(f.BeforeOrAt) {
+				continue
+			}
+			allAfter = false
+			// Discard all notices with timestamps after this one
+			filteredNotices = filteredNotices[:i+1]
+			break
+		}
+		if allAfter {
+			// All notices had timestamps after f.BeforeOrAt
+			return nil
+		}
+	}
+
+	// Now have non-expired notices matching After/BeforeOrAt filters.
+	// If filter has no keys, we're done.
+	if len(f.Keys) == 0 {
+		return filteredNotices
+	}
+
+	// Look for the keys from the filter
+	keyNotices := make([]*state.Notice, 0, len(f.Keys))
+	for _, notice := range filteredNotices {
+		if !slicesContains(f.Keys, notice.Key()) {
+			continue
+		}
+		keyNotices = append(keyNotices, notice)
+		if len(keyNotices) == len(f.Keys) {
+			break
+		}
+	}
+	return keyNotices
+}
+
+// TODO: remove in favor of slices.Contains once we're on Go 1.21+
+func slicesContains[T comparable](haystack []T, needle T) bool {
+	for _, v := range haystack {
+		if v == needle {
+			return true
+		}
+	}
+	return false
+}
+
 // BackendNotices returns the list of notices that match the filter (if any),
 // ordered by the last-repeated time.
 //
 // The caller must not mutate the data within the returned slice.
 func (ntb *noticeTypeBackend) BackendNotices(filter *state.NoticeFilter) []*state.Notice {
-	// just a naive stub, for now, which ignores much of the filter
+	simplifiedFilter, matchPossible := ntb.simplifyFilter(filter)
+	if !matchPossible {
+		return nil
+	}
 	ntb.rwmu.RLock()
 	defer ntb.rwmu.RUnlock()
 	now := time.Now()
+	return ntb.doNotices(simplifiedFilter, now)
+}
 
-	// XXX: this is wrong, replace with a real implementation
+// The caller must hold the backend lock for reading and must not mutate the
+// data within the returned slice.
+func (ntb *noticeTypeBackend) doNotices(filter ntbFilter, now time.Time) []*state.Notice {
+	if filter.UserID != nil {
+		userNotices, ok := ntb.userNotices[*filter.UserID]
+		if !ok {
+			return nil
+		}
+		return filter.filterNotices(userNotices, now)
+	}
 	var notices []*state.Notice
-	for userID, userNotices := range ntb.userNotices {
-		if filter != nil && filter.UserID != nil && *filter.UserID != userID {
+	nonEmptyUserNotices := 0
+	for _, userNotices := range ntb.userNotices {
+		filtered := filter.filterNotices(userNotices, now)
+		if len(filtered) == 0 {
 			continue
 		}
-		for _, notice := range userNotices {
-			if !notice.Expired(now) {
-				notices = append(notices, notice)
-			}
+		nonEmptyUserNotices++
+		switch nonEmptyUserNotices {
+		case 1:
+			// Don't copy yet, we don't know if it will be necessary
+			notices = filtered
+		case 2:
+			// Need to copy to a new slice so we can safely append other user
+			// notices and sort the end result later.
+			newNotices := make([]*state.Notice, 0, len(notices)+len(filtered))
+			newNotices = append(newNotices, notices...)
+			newNotices = append(newNotices, filtered...)
+			notices = newNotices
+		default:
+			notices = append(notices, filtered...)
 		}
 	}
-	state.SortNotices(notices)
+	if nonEmptyUserNotices > 1 {
+		// Since we concatenated notices from multiple users, need to re-sort
+		state.SortNotices(notices)
+	}
 	return notices
 }
 
@@ -337,8 +488,82 @@ func (ntb *noticeTypeBackend) BackendNotice(id string) *state.Notice {
 // nonzero). If there are existing notices that match the filter,
 // BackendWaitNotices will return them immediately.
 func (ntb *noticeTypeBackend) BackendWaitNotices(ctx context.Context, filter *state.NoticeFilter) ([]*state.Notice, error) {
-	// just a non-functional stub, for now
-	return nil, nil
+	simplifiedFilter, matchPossible := ntb.simplifyFilter(filter)
+	if !matchPossible {
+		// A match is not possible, so return immediately
+		return nil, nil
+	}
+	ntb.rwmu.RLock()
+	defer ntb.rwmu.RUnlock()
+	now := time.Now()
+	notices := ntb.doNotices(simplifiedFilter, now)
+	if len(notices) > 0 {
+		return notices, nil
+	}
+
+	if !simplifiedFilter.BeforeOrAt.IsZero() && simplifiedFilter.BeforeOrAt.Before(now) {
+		// No new notices can be added with a timestamp before the BeforeOrAt filter
+		return nil, nil
+	}
+
+	// When the context is done/cancelled, wake up the waiters so that they can
+	// check their ctx.Err() and return if they're cancelled.
+	//
+	// TODO: replace this with context.AfterFunc once we're on Go 1.21.
+	stop := contextAfterFunc(ctx, func() {
+		// We need to acquire a lock mutually exclusive with the cond lock here
+		// to be sure that the Broadcast below won't occur before the call to
+		// Wait, which would result in a missed signal (and deadlock). Since
+		// the cond lock is ntb.rwmu.RLocker(), we need to acquire ntb.rwmu
+		// for *writing*, rather than locking ntb.cond.L.
+		ntb.rwmu.Lock()
+		defer ntb.rwmu.Unlock()
+
+		ntb.cond.Broadcast()
+	})
+	defer stop()
+
+	for {
+		// Wait until a new notice occurs or ctx is cancelled.
+		ntb.cond.Wait()
+
+		// If ctx was cancelled, return the error.
+		ctxErr := ctx.Err()
+		if ctxErr != nil {
+			return nil, ctxErr
+		}
+
+		now = time.Now()
+		// Otherwise, check if there are now matching notices.
+		notices = ntb.doNotices(simplifiedFilter, now)
+		if len(notices) > 0 {
+			return notices, nil
+		}
+
+		if !simplifiedFilter.BeforeOrAt.IsZero() && now.After(simplifiedFilter.BeforeOrAt) {
+			// Since we just checked with the now timestamp and there were no
+			// matching notices, and any new notices must have a later timestamp
+			// after simplifiedFilter.BeforeOrAt, it's impossible for a new
+			// notice to match the filter.
+			return nil, nil
+		}
+	}
+}
+
+// Remove this and just use context.AfterFunc once we're on Go 1.21.
+func contextAfterFunc(ctx context.Context, f func()) func() {
+	stopCh := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			f()
+		case <-stopCh:
+		}
+	}()
+	stop := func() {
+		close(stopCh)
+	}
+	return stop
 }
 
 type savedNotices struct {

--- a/overlord/ifacestate/apparmorprompting/noticebackend.go
+++ b/overlord/ifacestate/apparmorprompting/noticebackend.go
@@ -417,8 +417,6 @@ func slicesContains[T comparable](haystack []T, needle T) bool {
 
 // BackendNotices returns the list of notices that match the filter (if any),
 // ordered by the last-repeated time.
-//
-// The caller must not mutate the data within the returned slice.
 func (ntb *noticeTypeBackend) BackendNotices(filter *state.NoticeFilter) []*state.Notice {
 	simplifiedFilter, matchPossible := ntb.simplifyFilter(filter)
 	if !matchPossible {
@@ -430,38 +428,25 @@ func (ntb *noticeTypeBackend) BackendNotices(filter *state.NoticeFilter) []*stat
 	return ntb.doNotices(simplifiedFilter, now)
 }
 
-// The caller must hold the backend lock for reading and must not mutate the
-// data within the returned slice.
+// The caller must hold the backend lock for reading.
 func (ntb *noticeTypeBackend) doNotices(filter ntbFilter, now time.Time) []*state.Notice {
+	var notices []*state.Notice
 	if filter.UserID != nil {
 		userNotices, ok := ntb.userNotices[*filter.UserID]
 		if !ok {
 			return nil
 		}
-		return filter.filterNotices(userNotices, now)
+		notices = append(notices, filter.filterNotices(userNotices, now)...)
+		return notices
 	}
-	var notices []*state.Notice
 	nonEmptyUserNotices := 0
 	for _, userNotices := range ntb.userNotices {
 		filtered := filter.filterNotices(userNotices, now)
 		if len(filtered) == 0 {
 			continue
 		}
+		notices = append(notices, filtered...)
 		nonEmptyUserNotices++
-		switch nonEmptyUserNotices {
-		case 1:
-			// Don't copy yet, we don't know if it will be necessary
-			notices = filtered
-		case 2:
-			// Need to copy to a new slice so we can safely append other user
-			// notices and sort the end result later.
-			newNotices := make([]*state.Notice, 0, len(notices)+len(filtered))
-			newNotices = append(newNotices, notices...)
-			newNotices = append(newNotices, filtered...)
-			notices = newNotices
-		default:
-			notices = append(notices, filtered...)
-		}
 	}
 	if nonEmptyUserNotices > 1 {
 		// Since we concatenated notices from multiple users, need to re-sort

--- a/overlord/ifacestate/apparmorprompting/noticebackend_test.go
+++ b/overlord/ifacestate/apparmorprompting/noticebackend_test.go
@@ -1,0 +1,608 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package apparmorprompting_test
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces/prompting"
+	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting"
+	"github.com/snapcore/snapd/overlord/notices"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type noticebackendSuite struct {
+	testutil.BaseTest
+
+	st        *state.State
+	noticeMgr *notices.NoticeManager
+}
+
+var _ = Suite(&noticebackendSuite{})
+
+func (s *noticebackendSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+
+	dirs.SetRootDir(c.MkDir())
+	s.AddCleanup(func() { dirs.SetRootDir("") })
+
+	s.st = state.New(nil)
+	s.noticeMgr = notices.NewNoticeManager(s.st)
+}
+
+func (s *noticebackendSuite) TestNewNoticeBackends(c *C) {
+	noticeBackend, err := apparmorprompting.NewNoticeBackends(s.noticeMgr)
+	c.Assert(err, IsNil)
+	c.Check(noticeBackend, NotNil)
+}
+
+func (s *noticebackendSuite) TestRegisterWithManager(c *C) {
+	uid1 := uint32(1000)
+	uid2 := uint32(1001)
+	data1 := map[string]string{"foo": "bar"}
+	data2 := map[string]string{"baz": "qux", "fizz": "buzz"}
+	// Add some notices to state so that they are drained and added to the
+	// prompting backends during registration. Notice keys are expected to be
+	// the result of IDType.String(), so make sure these are that.
+	s.st.Lock()
+	id1, err := s.st.AddNotice(&uid1, state.InterfacesRequestsPromptNotice, prompting.IDType(0x123).String(), &state.AddNoticeOptions{Data: data1})
+	c.Assert(err, IsNil)
+	id2, err := s.st.AddNotice(&uid1, state.InterfacesRequestsRuleUpdateNotice, prompting.IDType(0x456).String(), &state.AddNoticeOptions{Data: data2})
+	c.Assert(err, IsNil)
+	id3, err := s.st.AddNotice(&uid2, state.InterfacesRequestsRuleUpdateNotice, prompting.IDType(0x789).String(), &state.AddNoticeOptions{Data: data1})
+	c.Assert(err, IsNil)
+	id4, err := s.st.AddNotice(&uid2, state.WarningNotice, "foo", &state.AddNoticeOptions{Data: data2})
+	c.Assert(err, IsNil)
+	// Add one prompting notice with a key which is not an IDType.String(), which will be dropped
+	id5, err := s.st.AddNotice(&uid2, state.InterfacesRequestsRuleUpdateNotice, "bar", &state.AddNoticeOptions{Data: data2})
+	c.Assert(err, IsNil)
+	s.st.Unlock()
+
+	// Check that all notices are retrievable from the manager
+	existingNotices := s.noticeMgr.Notices(nil)
+	c.Assert(existingNotices, HasLen, 5)
+	c.Check(existingNotices[0].ID(), Equals, id1)
+	c.Check(existingNotices[1].ID(), Equals, id2)
+	c.Check(existingNotices[2].ID(), Equals, id3)
+	c.Check(existingNotices[3].ID(), Equals, id4)
+	c.Check(existingNotices[4].ID(), Equals, id5)
+
+	// Create new prompting notice backends and check that they initially have no notices
+	noticeBackend, err := apparmorprompting.NewNoticeBackends(s.noticeMgr)
+	c.Check(err, IsNil)
+	c.Check(noticeBackend.PromptBackend().BackendNotices(nil), HasLen, 0)
+	c.Check(noticeBackend.RuleBackend().BackendNotices(nil), HasLen, 0)
+
+	// Creating backend has no effect on the notice manager yet
+	existingNotices = s.noticeMgr.Notices(nil)
+	c.Assert(existingNotices, HasLen, 5)
+
+	// Register the prompting backends with the notice manager
+	err = apparmorprompting.RegisterWithManager(noticeBackend, s.noticeMgr)
+	c.Check(err, IsNil)
+
+	// Check that the prompting backends have the expected notices now
+	promptNotices := noticeBackend.PromptBackend().BackendNotices(nil)
+	c.Assert(promptNotices, HasLen, 1)
+	ruleNotices := noticeBackend.RuleBackend().BackendNotices(nil)
+	c.Assert(ruleNotices, HasLen, 2)
+	// Check that the new notice IDs are namespaced as expected and key and data were preserved
+	c.Check(promptNotices[0].ID(), Equals, "prompt-0000000000000123")
+	c.Check(promptNotices[0].Key(), Equals, "0000000000000123")
+	c.Check(promptNotices[0].LastData(), DeepEquals, data1)
+	c.Check(ruleNotices[0].ID(), Equals, "rule-0000000000000456")
+	c.Check(ruleNotices[0].Key(), Equals, "0000000000000456")
+	c.Check(ruleNotices[0].LastData(), DeepEquals, data2)
+	c.Check(ruleNotices[1].ID(), Equals, "rule-0000000000000789")
+	c.Check(ruleNotices[1].Key(), Equals, "0000000000000789")
+	c.Check(ruleNotices[1].LastData(), DeepEquals, data1)
+
+	// Check that the state no longer has notices with prompting types
+	s.st.Lock()
+	stateNotices := s.st.Notices(nil)
+	s.st.Unlock()
+	c.Check(stateNotices, HasLen, 1)
+	c.Check(stateNotices[0].ID(), Equals, id4)
+	c.Check(stateNotices[0].Key(), Equals, "foo")
+
+	// Check that the notice manager can retrieve all expected notices
+	notices := s.noticeMgr.Notices(nil)
+	c.Check(notices, HasLen, 4)
+	c.Check(notices[0].ID(), Equals, id4)
+	c.Check(notices[0].Key(), Equals, "foo")
+	c.Check(notices[1].ID(), Equals, "prompt-0000000000000123")
+	c.Check(notices[1].Key(), Equals, "0000000000000123")
+	c.Check(notices[2].ID(), Equals, "rule-0000000000000456")
+	c.Check(notices[2].Key(), Equals, "0000000000000456")
+	c.Check(notices[3].ID(), Equals, "rule-0000000000000789")
+	c.Check(notices[3].Key(), Equals, "0000000000000789")
+}
+
+func (s *noticebackendSuite) TestAddNotice(c *C) {
+	noticeBackend, err := apparmorprompting.NewNoticeBackends(s.noticeMgr)
+	c.Assert(err, IsNil)
+	promptBackend := noticeBackend.PromptBackend()
+
+	notices := promptBackend.BackendNotices(nil)
+	c.Assert(notices, HasLen, 0)
+
+	userID := uint32(1000)
+
+	before1 := time.Now()
+
+	// We can add a new notice
+	c.Check(promptBackend.AddNotice(userID, 0x123, nil), IsNil)
+	notices = promptBackend.BackendNotices(nil)
+	c.Assert(notices, HasLen, 1)
+	c.Check(notices[0].Key(), Equals, prompting.IDType(0x123).String())
+	c.Check(notices[0].ID(), Equals, "prompt-"+prompting.IDType(0x123).String())
+	uid, ok := notices[0].UserID()
+	c.Check(ok, Equals, true)
+	c.Check(uid, Equals, userID)
+	c.Check(notices[0].LastRepeated().After(before1), Equals, true)
+
+	before2 := time.Now()
+	c.Check(notices[0].LastRepeated().Before(before2), Equals, true)
+
+	// We can add another notice for the same user
+	c.Check(promptBackend.AddNotice(userID, 0x456, nil), IsNil)
+	notices = promptBackend.BackendNotices(nil)
+	c.Assert(notices, HasLen, 2)
+	notices = promptBackend.BackendNotices(&state.NoticeFilter{UserID: &userID})
+	c.Assert(notices, HasLen, 2)
+	c.Check(notices[0].Key(), Equals, prompting.IDType(0x123).String())
+	c.Check(notices[1].Key(), Equals, prompting.IDType(0x456).String())
+	c.Check(notices[1].ID(), Equals, "prompt-"+prompting.IDType(0x456).String())
+	uid, ok = notices[1].UserID()
+	c.Check(ok, Equals, true)
+	c.Check(uid, Equals, userID)
+	c.Check(notices[0].LastRepeated().Before(before2), Equals, true)
+	c.Check(notices[1].LastRepeated().After(before2), Equals, true)
+
+	// We can add a notice for a different user
+	c.Check(promptBackend.AddNotice(1234, 0x789, nil), IsNil)
+	notices = promptBackend.BackendNotices(nil)
+	c.Assert(notices, HasLen, 3)
+	c.Check(notices[0].Key(), Equals, prompting.IDType(0x123).String())
+	c.Check(notices[1].Key(), Equals, prompting.IDType(0x456).String())
+	c.Check(notices[2].Key(), Equals, prompting.IDType(0x789).String())
+	c.Check(notices[2].ID(), Equals, "prompt-"+prompting.IDType(0x789).String())
+	uid, ok = notices[2].UserID()
+	c.Check(ok, Equals, true)
+	c.Check(uid, Equals, uint32(1234))
+
+	beforeReAdd := time.Now()
+
+	// If we re-add an existing notice, it ends up at the end of the list since
+	// it has the newest timestamp. This works even across multiple users.
+	c.Check(promptBackend.AddNotice(userID, 0x123, nil), IsNil)
+	notices = promptBackend.BackendNotices(nil)
+	c.Assert(notices, HasLen, 3)
+	c.Check(notices[0].Key(), Equals, prompting.IDType(0x456).String())
+	c.Check(notices[0].LastRepeated().Before(beforeReAdd), Equals, true)
+	c.Check(notices[1].Key(), Equals, prompting.IDType(0x789).String())
+	c.Check(notices[1].LastRepeated().Before(beforeReAdd), Equals, true)
+	c.Check(notices[2].Key(), Equals, prompting.IDType(0x123).String())
+	c.Check(notices[2].LastRepeated().After(beforeReAdd), Equals, true)
+	notices = promptBackend.BackendNotices(&state.NoticeFilter{UserID: &userID})
+	c.Assert(notices, HasLen, 2)
+	c.Check(notices[0].Key(), Equals, prompting.IDType(0x456).String())
+	c.Check(notices[1].Key(), Equals, prompting.IDType(0x123).String())
+}
+
+func (s *noticebackendSuite) TestAddNoticeData(c *C) {
+	noticeBackend, err := apparmorprompting.NewNoticeBackends(s.noticeMgr)
+	c.Assert(err, IsNil)
+	promptBackend := noticeBackend.PromptBackend()
+
+	userID := uint32(1000)
+
+	data1 := map[string]string{"foo": "bar", "baz": "qux"}
+	data2 := map[string]string{"fizz": "buzz"}
+
+	// Add notice with no data
+	c.Check(promptBackend.AddNotice(userID, 0x123, nil), IsNil)
+	notices := promptBackend.BackendNotices(&state.NoticeFilter{UserID: &userID})
+	c.Check(notices[0].LastData(), IsNil)
+
+	// Re-add notice with different data
+	c.Check(promptBackend.AddNotice(userID, 0x123, data1), IsNil)
+	notices = promptBackend.BackendNotices(&state.NoticeFilter{UserID: &userID})
+	c.Check(notices[0].LastData(), DeepEquals, data1)
+
+	// Re-add notice with same data
+	c.Check(promptBackend.AddNotice(userID, 0x123, data1), IsNil)
+	notices = promptBackend.BackendNotices(&state.NoticeFilter{UserID: &userID})
+	c.Check(notices[0].LastData(), DeepEquals, data1)
+
+	// Re-add notice with other different data
+	c.Check(promptBackend.AddNotice(userID, 0x123, data2), IsNil)
+	notices = promptBackend.BackendNotices(&state.NoticeFilter{UserID: &userID})
+	c.Check(notices[0].LastData(), DeepEquals, data2)
+
+	// Re-add notice with nil data
+	c.Check(promptBackend.AddNotice(userID, 0x123, nil), IsNil)
+	notices = promptBackend.BackendNotices(&state.NoticeFilter{UserID: &userID})
+	c.Check(notices[0].LastData(), IsNil)
+
+	// Re-add notice with some data again
+	c.Check(promptBackend.AddNotice(userID, 0x123, data1), IsNil)
+	notices = promptBackend.BackendNotices(&state.NoticeFilter{UserID: &userID})
+	c.Check(notices[0].LastData(), DeepEquals, data1)
+
+	// Add different notice with different data
+	c.Check(promptBackend.AddNotice(userID, 0x456, data2), IsNil)
+	notices = promptBackend.BackendNotices(&state.NoticeFilter{UserID: &userID})
+	c.Check(notices[0].LastData(), DeepEquals, data1)
+	c.Check(notices[1].LastData(), DeepEquals, data2)
+
+	// Re-add first notice with nil data again
+	c.Check(promptBackend.AddNotice(userID, 0x123, nil), IsNil)
+	notices = promptBackend.BackendNotices(&state.NoticeFilter{UserID: &userID})
+	c.Check(notices[0].LastData(), DeepEquals, data2)
+	c.Check(notices[1].LastData(), IsNil)
+}
+
+func (s *noticebackendSuite) TestAddNoticeSameKeyDifferentUser(c *C) {
+	noticeBackend, err := apparmorprompting.NewNoticeBackends(s.noticeMgr)
+	c.Assert(err, IsNil)
+	promptBackend := noticeBackend.PromptBackend()
+
+	// Add notice with one user
+	c.Check(promptBackend.AddNotice(1000, 0x123, nil), IsNil)
+
+	// Add notice with same ID but different user
+	result := promptBackend.AddNotice(1234, 0x123, nil)
+	c.Check(result, ErrorMatches, "cannot add prompt notice with ID prompt-0000000000000123 for user 1234: notice with the same ID already exists for user 1000")
+}
+
+func (s *noticebackendSuite) TestAddNoticeSomeExpired(c *C) {
+	userID := uint32(1000)
+	for i, testCase := range []struct {
+		record   prompting.IDType
+		expected []prompting.IDType
+	}{
+		{
+			record:   5, // a new notice
+			expected: []prompting.IDType{3, 4, 5},
+		},
+		{
+			record:   1, // the first existing expired notice
+			expected: []prompting.IDType{3, 4, 1},
+		},
+		{
+			record:   2, // the last existing expired notice
+			expected: []prompting.IDType{3, 4, 2},
+		},
+		{
+			record:   3, // the first non-expired notice
+			expected: []prompting.IDType{4, 3},
+		},
+		{
+			record:   4, // the last non-expired notice
+			expected: []prompting.IDType{3, 4},
+		},
+	} {
+		// Need a new root dir for each test case
+		dirs.SetRootDir(c.MkDir())
+		st := state.New(nil)
+		noticeMgr := notices.NewNoticeManager(st)
+
+		noticeBackend, err := apparmorprompting.NewNoticeBackends(noticeMgr)
+		c.Assert(err, IsNil)
+		ruleBackend := noticeBackend.RuleBackend()
+
+		c.Check(ruleBackend.AddNotice(userID, 1, nil), IsNil)
+		c.Check(ruleBackend.AddNotice(userID, 2, nil), IsNil)
+		c.Check(ruleBackend.AddNotice(userID, 3, nil), IsNil)
+		c.Check(ruleBackend.AddNotice(userID, 4, nil), IsNil)
+		origNotices := ruleBackend.BackendNotices(nil)
+		c.Check(origNotices, HasLen, 4, Commentf("testCase %d: %+v\norigNotices: %+v", i, testCase, origNotices))
+		// Expire the first two notices by re-recording them in the past
+		for _, notice := range origNotices[:2] {
+			notice.Reoccur(notice.LastRepeated().Add(-1000*time.Hour), nil, 0)
+		}
+
+		// Record the specified notice
+		c.Check(ruleBackend.AddNotice(userID, testCase.record, nil), IsNil)
+		notices := ruleBackend.BackendNotices(&state.NoticeFilter{UserID: &userID})
+		// Check that the expected notices are found
+		c.Check(notices, HasLen, len(testCase.expected), Commentf("testCase %d: %+v\nnotices: %+v", i, testCase, notices))
+		for i, promptID := range testCase.expected {
+			c.Check(notices[i].Key(), Equals, promptID.String())
+		}
+	}
+}
+
+func (s *noticebackendSuite) TestAddNoticeAllExpired(c *C) {
+	for _, id := range []prompting.IDType{1, 2, 3, 4} {
+		// Need a new root dir for each test case
+		dirs.SetRootDir(c.MkDir())
+		st := state.New(nil)
+		noticeMgr := notices.NewNoticeManager(st)
+
+		noticeBackend, err := apparmorprompting.NewNoticeBackends(noticeMgr)
+		c.Assert(err, IsNil)
+		promptBackend := noticeBackend.PromptBackend()
+
+		userID := uint32(1000)
+
+		c.Check(promptBackend.AddNotice(userID, 1, nil), IsNil)
+		c.Check(promptBackend.AddNotice(userID, 2, nil), IsNil)
+		c.Check(promptBackend.AddNotice(userID, 3, nil), IsNil)
+		origNotices := promptBackend.BackendNotices(&state.NoticeFilter{UserID: &userID})
+		c.Check(origNotices, HasLen, 3, Commentf("trying to add notice %s", id))
+		// Expire all existing notices by re-recording them in the past
+		for _, notice := range origNotices {
+			notice.Reoccur(notice.LastRepeated().Add(-1000*time.Hour), nil, 0)
+		}
+
+		// Record the specified notice
+		c.Check(promptBackend.AddNotice(userID, id, nil), IsNil)
+		notices := promptBackend.BackendNotices(&state.NoticeFilter{UserID: &userID})
+		// Check that the nesly (re-)recorded notice is the only one
+		c.Check(notices, HasLen, 1, Commentf("trying to add notice %s", id))
+		c.Check(notices[0].Key(), Equals, id.String())
+	}
+}
+
+func (s *noticebackendSuite) TestAddNoticeSaveFailureRollback(c *C) {
+	for _, id := range []prompting.IDType{1, 2, 3, 4, 5} {
+		// Need a new root dir for each test case
+		dirs.SetRootDir(c.MkDir())
+		st := state.New(nil)
+		noticeMgr := notices.NewNoticeManager(st)
+
+		noticeBackend, err := apparmorprompting.NewNoticeBackends(noticeMgr)
+		c.Assert(err, IsNil)
+		promptBackend := noticeBackend.PromptBackend()
+
+		userID := uint32(1000)
+
+		c.Check(promptBackend.AddNotice(userID, 1, nil), IsNil)
+		c.Check(promptBackend.AddNotice(userID, 2, nil), IsNil)
+		c.Check(promptBackend.AddNotice(userID, 3, nil), IsNil)
+		c.Check(promptBackend.AddNotice(userID, 4, nil), IsNil)
+		origNotices := promptBackend.BackendNotices(&state.NoticeFilter{UserID: &userID})
+		c.Assert(origNotices, HasLen, 4)
+		// Expire the first two notices by re-recording them in the past
+		for _, notice := range origNotices[:2] {
+			notice.Reoccur(notice.LastRepeated().Add(-1000*time.Hour), nil, 0)
+		}
+		beforeNotices := promptBackend.BackendNotices(&state.NoticeFilter{UserID: &userID})
+		c.Assert(beforeNotices, HasLen, 2)
+		c.Assert(beforeNotices[0].Key(), Equals, prompting.IDType(3).String())
+		c.Assert(beforeNotices[1].Key(), Equals, prompting.IDType(4).String())
+
+		// Check that the expired notices are still in the ID map.
+		// Technically, this check relies on internal implementation details
+		// which are not required to remain true.
+		c.Assert(promptBackend.BackendNotice("prompt-0000000000000001"), NotNil)
+		c.Assert(promptBackend.BackendNotice("prompt-0000000000000002"), NotNil)
+
+		// Cause a save error by writing a directory in place of the notices state file
+		path := filepath.Join(dirs.SnapInterfacesRequestsRunDir, "prompt-notices.json")
+		c.Assert(os.Remove(path), IsNil)
+		c.Assert(os.Mkdir(path, 0o700), IsNil)
+
+		// Add a notice with the ID from the test case
+		result := promptBackend.AddNotice(userID, id, nil)
+		c.Check(result, ErrorMatches, "cannot add notice to prompting interfaces-requests-prompt backend.*")
+
+		// Check that the new notice was not added
+		afterNotices := promptBackend.BackendNotices(&state.NoticeFilter{UserID: &userID})
+		c.Check(afterNotices, HasLen, 2, Commentf("after adding notice with ID %s, afterNotices: %+v", id, afterNotices))
+		if len(afterNotices) != 2 {
+			// continue so we can get information to debug from other cases
+			// without panicking.
+			continue
+		}
+		c.Check(afterNotices[0].Key(), Equals, prompting.IDType(3).String(), Commentf("after adding notice with ID %s", id))
+		c.Check(afterNotices[1].Key(), Equals, prompting.IDType(4).String(), Commentf("after adding notice with ID %s", id))
+
+		// Check that the expired notices are still in the ID map.
+		c.Check(promptBackend.BackendNotice("prompt-0000000000000001"), NotNil, Commentf("could not find expired notice with ID 1 after adding notice with ID %s", id))
+		c.Check(promptBackend.BackendNotice("prompt-0000000000000002"), NotNil, Commentf("could not find expired notice with ID 2 after adding notice with ID %s", id))
+	}
+}
+
+func (s *noticebackendSuite) TestLoad(c *C) {
+	noticeBackend, err := apparmorprompting.NewNoticeBackends(s.noticeMgr)
+	c.Assert(err, IsNil)
+
+	data1 := map[string]string{"foo": "bar"}
+	data2 := map[string]string{"baz": "qux", "fizz": "buzz"}
+
+	c.Check(noticeBackend.PromptBackend().AddNotice(123, 0x456, nil), IsNil)
+	c.Check(noticeBackend.PromptBackend().AddNotice(789, 0xabc, data1), IsNil)
+	// Rule with the same user ID and prompt/rule ID will not be repeated, since
+	// these are of different types and end up in different backends.
+	c.Check(noticeBackend.RuleBackend().AddNotice(123, 0x456, data1), IsNil)
+	c.Check(noticeBackend.RuleBackend().AddNotice(0xf00, 0xba4, nil), IsNil)
+	// Add another notice to the prompts backend
+	c.Check(noticeBackend.PromptBackend().AddNotice(123, 0xdef, data2), IsNil)
+
+	promptNotices := noticeBackend.PromptBackend().BackendNotices(nil)
+	c.Assert(promptNotices, HasLen, 3)
+	c.Check(promptNotices[0].Key(), Equals, "0000000000000456")
+	c.Check(promptNotices[1].Key(), Equals, "0000000000000ABC")
+	c.Check(promptNotices[2].Key(), Equals, "0000000000000DEF")
+
+	ruleNotices := noticeBackend.RuleBackend().BackendNotices(nil)
+	c.Assert(ruleNotices, HasLen, 2)
+	c.Check(ruleNotices[0].Key(), Equals, "0000000000000456")
+	c.Check(ruleNotices[1].Key(), Equals, "0000000000000BA4")
+
+	// Initialize a new backend and check that it loads the existing notices
+	newBackend, err := apparmorprompting.NewNoticeBackends(s.noticeMgr)
+	c.Check(err, IsNil)
+
+	promptNotices = newBackend.PromptBackend().BackendNotices(nil)
+	c.Check(promptNotices, HasLen, 3)
+	c.Check(promptNotices[0].Key(), Equals, "0000000000000456")
+	c.Check(promptNotices[0].LastData(), IsNil)
+	c.Check(promptNotices[1].Key(), Equals, "0000000000000ABC")
+	c.Check(promptNotices[1].LastData(), DeepEquals, data1)
+	c.Check(promptNotices[2].Key(), Equals, "0000000000000DEF")
+	c.Check(promptNotices[2].LastData(), DeepEquals, data2)
+	ruleNotices = newBackend.RuleBackend().BackendNotices(nil)
+	c.Check(ruleNotices, HasLen, 2)
+	c.Check(ruleNotices[0].Key(), Equals, "0000000000000456")
+	c.Check(ruleNotices[0].LastData(), DeepEquals, data1)
+	c.Check(ruleNotices[1].Key(), Equals, "0000000000000BA4")
+	c.Check(ruleNotices[1].LastData(), IsNil)
+}
+
+func (s *noticebackendSuite) TestLoadSomeExpired(c *C) {
+	noticeBackend, err := apparmorprompting.NewNoticeBackends(s.noticeMgr)
+	c.Assert(err, IsNil)
+	promptBackend := noticeBackend.PromptBackend()
+
+	userID := uint32(1000)
+
+	c.Check(promptBackend.AddNotice(userID, 1, nil), IsNil)
+	c.Check(promptBackend.AddNotice(userID, 2, nil), IsNil)
+	c.Check(promptBackend.AddNotice(userID, 3, nil), IsNil)
+	c.Check(promptBackend.AddNotice(userID, 4, nil), IsNil)
+	origNotices := promptBackend.BackendNotices(nil)
+	c.Assert(origNotices, HasLen, 4)
+	// Expire the first two notices by re-recording them in the past
+	for _, notice := range origNotices[:2] {
+		notice.Reoccur(notice.LastRepeated().Add(-1000*time.Hour), nil, 0)
+	}
+
+	// Manually save to disk to ensure the expired notices are written to disk.
+	// Notices are saved when adding a new notice, but that also drops expired
+	// notices, so we need to save manually here to ensure expired notices are
+	// not dropped.
+	c.Assert(promptBackend.Save(), IsNil)
+
+	// Initialize a new backend and check that it loads existing notices
+	newBackend, err := apparmorprompting.NewNoticeBackends(s.noticeMgr)
+	c.Check(err, IsNil)
+
+	afterNotices := newBackend.PromptBackend().BackendNotices(nil)
+	c.Check(afterNotices, HasLen, 2)
+	c.Check(afterNotices[0].Key(), Equals, "0000000000000003")
+	c.Check(afterNotices[1].Key(), Equals, "0000000000000004")
+	// Check that expired notices were not added
+	c.Check(newBackend.PromptBackend().BackendNotice("prompt-0000000000000001"), IsNil)
+	c.Check(newBackend.PromptBackend().BackendNotice("prompt-0000000000000002"), IsNil)
+	c.Check(newBackend.PromptBackend().BackendNotice("prompt-0000000000000003"), NotNil)
+	c.Check(newBackend.PromptBackend().BackendNotice("prompt-0000000000000004"), NotNil)
+
+	// Add a new notice and make sure everything is fine
+	c.Check(newBackend.PromptBackend().AddNotice(1000, 5, nil), IsNil)
+	finalNotices := newBackend.PromptBackend().BackendNotices(&state.NoticeFilter{UserID: &userID})
+	c.Check(finalNotices, HasLen, 3)
+	c.Check(finalNotices[0].Key(), Equals, "0000000000000003")
+	c.Check(finalNotices[1].Key(), Equals, "0000000000000004")
+	c.Check(finalNotices[2].Key(), Equals, "0000000000000005")
+}
+
+func (s *noticebackendSuite) TestLoadAllExpired(c *C) {
+	noticeBackend, err := apparmorprompting.NewNoticeBackends(s.noticeMgr)
+	c.Assert(err, IsNil)
+	promptBackend := noticeBackend.PromptBackend()
+
+	c.Check(promptBackend.AddNotice(1000, 1, nil), IsNil)
+	c.Check(promptBackend.AddNotice(1000, 2, nil), IsNil)
+	c.Check(promptBackend.AddNotice(1000, 3, nil), IsNil)
+	c.Check(promptBackend.AddNotice(1000, 4, nil), IsNil)
+	origNotices := promptBackend.BackendNotices(nil)
+	c.Assert(origNotices, HasLen, 4)
+	// Expire all the notices by re-recording them in the past
+	for _, notice := range origNotices {
+		notice.Reoccur(notice.LastRepeated().Add(-1000*time.Hour), nil, 0)
+	}
+
+	// Manually save to disk to ensure the expired notices are written to disk.
+	// Notices are saved when adding a new notice, but that also drops expired
+	// notices, so we need to save manually here to ensure expired notices are
+	// not dropped.
+	c.Assert(promptBackend.Save(), IsNil)
+
+	// Initialize a new backend and check that it loads existing notices
+	newBackend, err := apparmorprompting.NewNoticeBackends(s.noticeMgr)
+	c.Check(err, IsNil)
+
+	afterNotices := newBackend.PromptBackend().BackendNotices(nil)
+	c.Check(afterNotices, HasLen, 0)
+	// Check that expired notices were not added
+	c.Check(newBackend.PromptBackend().BackendNotice("prompt-0000000000000001"), IsNil)
+	c.Check(newBackend.PromptBackend().BackendNotice("prompt-0000000000000002"), IsNil)
+	c.Check(newBackend.PromptBackend().BackendNotice("prompt-0000000000000003"), IsNil)
+	c.Check(newBackend.PromptBackend().BackendNotice("prompt-0000000000000004"), IsNil)
+
+	// Add a new notice and make sure everything is fine
+	c.Check(newBackend.PromptBackend().AddNotice(1000, 5, nil), IsNil)
+	finalNotices := newBackend.PromptBackend().BackendNotices(nil)
+	c.Check(finalNotices, HasLen, 1)
+	c.Check(finalNotices[0].Key(), Equals, "0000000000000005")
+}
+
+func (s *noticebackendSuite) TestBackendNotice(c *C) {
+	noticeBackend, err := apparmorprompting.NewNoticeBackends(s.noticeMgr)
+	c.Assert(err, IsNil)
+	ruleBackend := noticeBackend.RuleBackend()
+
+	c.Check(ruleBackend.AddNotice(1234, 1, nil), IsNil)
+	c.Check(ruleBackend.AddNotice(1234, 2, nil), IsNil)
+	c.Check(ruleBackend.AddNotice(1234, 3, nil), IsNil)
+	c.Check(ruleBackend.AddNotice(1234, 4, nil), IsNil)
+	origNotices := ruleBackend.BackendNotices(nil)
+	c.Assert(origNotices, HasLen, 4)
+	// Expire the first two notices by re-recording them in the past
+	for _, notice := range origNotices[:2] {
+		notice.Reoccur(notice.LastRepeated().Add(-1000*time.Hour), nil, 0)
+	}
+
+	afterNotices := ruleBackend.BackendNotices(nil)
+	c.Assert(afterNotices, HasLen, 2)
+
+	// Check that non-expired notices can be found by ID
+	notice := ruleBackend.BackendNotice("rule-0000000000000003")
+	c.Assert(notice, NotNil)
+	c.Check(notice.Key(), Equals, "0000000000000003")
+	notice = ruleBackend.BackendNotice("rule-0000000000000004")
+	c.Assert(notice, NotNil)
+	c.Check(notice.Key(), Equals, "0000000000000004")
+
+	// Check that expired notices can still be found by ID
+	// XXX: we don't necessarily want to guarantee this, but test it for now
+	notice = ruleBackend.BackendNotice("rule-0000000000000001")
+	c.Assert(notice, NotNil)
+	c.Check(notice.Key(), Equals, "0000000000000001")
+	notice = ruleBackend.BackendNotice("rule-0000000000000002")
+	c.Assert(notice, NotNil)
+	c.Check(notice.Key(), Equals, "0000000000000002")
+
+	// Check that a nonexistent notice returns nil
+	notice = ruleBackend.BackendNotice("rule-0000000000000005")
+	c.Assert(notice, IsNil)
+	notice = ruleBackend.BackendNotice("foo")
+	c.Assert(notice, IsNil)
+}

--- a/overlord/ifacestate/apparmorprompting/prompting_test.go
+++ b/overlord/ifacestate/apparmorprompting/prompting_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/prompting/requestrules"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting"
+	"github.com/snapcore/snapd/overlord/notices"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/sandbox/apparmor/notify"
 	"github.com/snapcore/snapd/sandbox/apparmor/notify/listener"
@@ -50,7 +51,7 @@ func Test(t *testing.T) { TestingT(t) }
 type apparmorpromptingSuite struct {
 	testutil.BaseTest
 
-	st *state.State
+	noticeMgr *notices.NoticeManager
 
 	defaultUser uint32
 }
@@ -63,7 +64,9 @@ func (s *apparmorpromptingSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(c.MkDir())
 	s.AddCleanup(func() { dirs.SetRootDir("") })
 
-	s.st = state.New(nil)
+	st := state.New(nil)
+	s.noticeMgr = notices.NewNoticeManager(st)
+
 	s.defaultUser = 1000
 }
 
@@ -71,7 +74,7 @@ func (s *apparmorpromptingSuite) TestNew(c *C) {
 	_, _, _, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	err = mgr.Stop()
@@ -85,7 +88,7 @@ func (s *apparmorpromptingSuite) TestNewErrorListener(c *C) {
 	})
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, ErrorMatches, fmt.Sprintf("cannot register prompting listener: %v", registerFailure))
 	c.Assert(mgr, IsNil)
 }
@@ -102,7 +105,7 @@ func (s *apparmorpromptingSuite) TestNewErrorPromptDB(c *C) {
 	c.Assert(f.Chmod(0o400), IsNil)
 	defer f.Chmod(0o600)
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, ErrorMatches, "cannot open request prompts backend:.*")
 	c.Assert(mgr, IsNil)
 
@@ -131,7 +134,7 @@ func (s *apparmorpromptingSuite) TestNewErrorRuleDB(c *C) {
 	c.Assert(f.Chmod(0o400), IsNil)
 	defer f.Chmod(0o600)
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, ErrorMatches, "cannot open request rules backend:.*")
 	c.Assert(mgr, IsNil)
 
@@ -147,7 +150,7 @@ func (s *apparmorpromptingSuite) TestStop(c *C) {
 	_, reqChan, _, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	promptDB := mgr.PromptDB()
@@ -191,7 +194,7 @@ func (s *apparmorpromptingSuite) TestHandleListenerRequestInterfaceSelection(c *
 	logbuf, restore := logger.MockLogger()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Close readyChan so we can add rules
@@ -272,7 +275,7 @@ func (s *apparmorpromptingSuite) TestHandleListenerRequestDenyRoot(c *C) {
 	_, reqChan, replyChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Send request for root
@@ -297,7 +300,7 @@ func (s *apparmorpromptingSuite) TestHandleListenerRequestErrors(c *C) {
 	logbuf, restore := logger.MockLogger()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Close readyChan so we can check mgr.Prompts
@@ -354,8 +357,15 @@ func (s *apparmorpromptingSuite) TestHandleListenerRequestErrors(c *C) {
 			Permission: notify.AA_MAY_APPEND,
 		}
 		reqChan <- req
+		// Poke the prompts backend to ensure there's no timeout
+		_, err = mgr.Prompts(s.defaultUser, clientActivity)
+		c.Assert(err, IsNil)
 	}
-	time.Sleep(10 * time.Millisecond)
+	lastPromptID := prompting.IDType(1000).String()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	_, err = s.noticeMgr.WaitNotices(ctx, &state.NoticeFilter{Keys: []string{lastPromptID}})
+	c.Assert(err, IsNil)
 
 	prompts, err = mgr.Prompts(s.defaultUser, clientActivity)
 	c.Assert(err, IsNil)
@@ -375,7 +385,9 @@ func (s *apparmorpromptingSuite) TestHandleListenerRequestErrors(c *C) {
 		Permission: notify.AA_MAY_APPEND,
 	}
 	reqChan <- req
-	time.Sleep(10 * time.Millisecond)
+	resp, err = waitForReply(replyChan)
+	c.Assert(err, IsNil)
+	c.Check(resp.Request, Equals, req)
 	logger.WithLoggerLock(func() {
 		c.Check(logbuf.String(), testutil.Contains,
 			" WARNING: too many outstanding prompts for user 1000; auto-denying new one\n")
@@ -388,7 +400,7 @@ func (s *apparmorpromptingSuite) TestHandleReplySimple(c *C) {
 	readyChan, reqChan, replyChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// simulateRequest checks mgr.Prompts, so make sure we close readyChan first
@@ -441,14 +453,12 @@ func (s *apparmorpromptingSuite) simulateRequest(c *C, reqChan chan *listener.Re
 	logger.WithLoggerLock(func() { c.Assert(logbuf.String(), Equals, "") })
 
 	// which should generate a notice
-	s.st.Lock()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	n, err := s.st.WaitNotices(ctx, &state.NoticeFilter{
+	n, err := s.noticeMgr.WaitNotices(ctx, &state.NoticeFilter{
 		Types: []state.NoticeType{state.InterfacesRequestsPromptNotice},
 		After: whenSent,
 	})
-	s.st.Unlock()
 	c.Check(err, IsNil)
 	c.Check(n, HasLen, 1)
 
@@ -535,7 +545,7 @@ func (s *apparmorpromptingSuite) TestHandleReplyErrors(c *C) {
 	readyChan, reqChan, replyChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// simulateRequest checks mgr.Prompts, so make sure we close readyChan first
@@ -617,7 +627,7 @@ func (s *apparmorpromptingSuite) TestExistingRuleAllowsNewPrompt(c *C) {
 	readyChan, reqChan, replyChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// pretend that there are no pending requests to be re-sent
@@ -679,22 +689,18 @@ func (s *apparmorpromptingSuite) TestExistingRuleAllowsNewPrompt(c *C) {
 }
 
 func (s *apparmorpromptingSuite) checkRecordedPromptNotices(c *C, since time.Time, count int) {
-	s.st.Lock()
-	n := s.st.Notices(&state.NoticeFilter{
+	n := s.noticeMgr.Notices(&state.NoticeFilter{
 		Types: []state.NoticeType{state.InterfacesRequestsPromptNotice},
 		After: since,
 	})
-	s.st.Unlock()
 	c.Check(n, HasLen, count, Commentf("%+v", n))
 }
 
 func (s *apparmorpromptingSuite) checkRecordedRuleUpdateNotices(c *C, since time.Time, count int) {
-	s.st.Lock()
-	n := s.st.Notices(&state.NoticeFilter{
+	n := s.noticeMgr.Notices(&state.NoticeFilter{
 		Types: []state.NoticeType{state.InterfacesRequestsRuleUpdateNotice},
 		After: since,
 	})
-	s.st.Unlock()
 	c.Check(n, HasLen, count, Commentf("%+v", n))
 }
 
@@ -702,7 +708,7 @@ func (s *apparmorpromptingSuite) TestExistingRulePartiallyAllowsNewPrompt(c *C) 
 	readyChan, reqChan, _, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// pretend that there are no pending requests to be re-sent
@@ -739,7 +745,7 @@ func (s *apparmorpromptingSuite) TestExistingRulePartiallyDeniesNewPrompt(c *C) 
 	readyChan, reqChan, replyChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// pretend that there are no pending requests to be re-sent
@@ -791,7 +797,7 @@ func (s *apparmorpromptingSuite) TestExistingRulesMixedMatchNewPromptDenies(c *C
 	readyChan, reqChan, replyChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// pretend that there are no pending requests to be re-sent
@@ -861,7 +867,7 @@ func (s *apparmorpromptingSuite) TestNewRuleAllowExistingPrompt(c *C) {
 	readyChan, reqChan, replyChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// simulateRequest checks mgr.Prompts, so make sure we close readyChan first
@@ -943,7 +949,7 @@ func (s *apparmorpromptingSuite) TestNewRuleDenyExistingPrompt(c *C) {
 	readyChan, reqChan, replyChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// simulateRequest checks mgr.Prompts, so make sure we close readyChan first
@@ -1017,7 +1023,7 @@ func (s *apparmorpromptingSuite) TestReplyNewRuleHandlesExistingPrompt(c *C) {
 	readyChan, reqChan, replyChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Already tested HandleReply errors, and that applyRuleToOutstandingPrompts
@@ -1115,7 +1121,7 @@ func (s *apparmorpromptingSuite) testReplyRuleHandlesFuturePrompts(c *C, outcome
 	readyChan, reqChan, replyChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Already tested HandleReply errors, and that applyRuleToOutstandingPrompts
@@ -1216,7 +1222,7 @@ func (s *apparmorpromptingSuite) TestRequestMerged(c *C) {
 	readyChan, reqChan, _, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Requests with identical *original* abstract permissions are merged into
@@ -1300,7 +1306,7 @@ func (s *apparmorpromptingSuite) TestRules(c *C) {
 
 func (s *apparmorpromptingSuite) prepManagerWithRules(c *C) (mgr *apparmorprompting.InterfacesRequestsManager, rules []*requestrules.Rule) {
 	var err error
-	mgr, err = apparmorprompting.New(s.st)
+	mgr, err = apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	whenAdded := time.Now()
@@ -1453,7 +1459,7 @@ func (s *apparmorpromptingSuite) TestAddRuleWithIDPatchRemove(c *C) {
 	readyChan, reqChan, replyChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// simulateRequest checks mgr.Prompts, so make sure we close readyChan first
@@ -1560,7 +1566,7 @@ func (s *apparmorpromptingSuite) TestListenerReadyCausesPromptsHandleReadying(c 
 	})
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	mgr, err := apparmorprompting.New(s.noticeMgr)
 	c.Assert(err, IsNil)
 
 	// Check that the callback has not started yet
@@ -1647,7 +1653,11 @@ func (s *apparmorpromptingSuite) testReadyBlocks(c *C, f func(mgr *apparmorpromp
 	readyChan, _, _, restore := apparmorprompting.MockListener()
 	defer restore()
 
-	mgr, err := apparmorprompting.New(s.st)
+	// Need a new noticeMgr each time so we can re-register backends with the same types
+	st := state.New(nil)
+	noticeMgr := notices.NewNoticeManager(st)
+
+	mgr, err := apparmorprompting.New(noticeMgr)
 	c.Assert(err, IsNil)
 
 	startChan := make(chan time.Time)

--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting"
 	"github.com/snapcore/snapd/overlord/ifacestate/schema"
 	"github.com/snapcore/snapd/overlord/ifacestate/udevmonitor"
+	"github.com/snapcore/snapd/overlord/notices"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/snap"
@@ -128,7 +129,7 @@ func MockCreateUDevMonitor(new func(udevmonitor.DeviceAddedFunc, udevmonitor.Dev
 	}
 }
 
-func MockCreateInterfacesRequestsManager(new func(s *state.State) (*apparmorprompting.InterfacesRequestsManager, error)) (restore func()) {
+func MockCreateInterfacesRequestsManager(new func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error)) (restore func()) {
 	return testutil.Mock(&createInterfacesRequestsManager, new)
 }
 

--- a/overlord/ifacestate/helpers_test.go
+++ b/overlord/ifacestate/helpers_test.go
@@ -430,7 +430,7 @@ apps:
 	defer restore()
 
 	// Construct and start up the interface manager.
-	mgr, err := ifacestate.Manager(st, nil, ovld.TaskRunner(), nil, nil)
+	mgr, err := ifacestate.Manager(st, nil, nil, ovld.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 	err = mgr.StartUp()
 	c.Assert(err, IsNil)
@@ -499,7 +499,7 @@ func (s *helpersSuite) TestProfileRegenerationSetupMany(c *C) {
 	defer restore()
 
 	// Construct and start up the interface manager.
-	mgr, err := ifacestate.Manager(st, nil, ovld.TaskRunner(), nil, nil)
+	mgr, err := ifacestate.Manager(st, nil, nil, ovld.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 	err = mgr.StartUp()
 	c.Assert(err, IsNil)
@@ -547,7 +547,7 @@ func (s *helpersSuite) TestProfileRegenerationSetupManyFailsSystemKeyNotWritten(
 	defer restore()
 
 	// Construct and start up the interface manager.
-	mgr, err := ifacestate.Manager(st, nil, ovld.TaskRunner(), nil, nil)
+	mgr, err := ifacestate.Manager(st, nil, nil, ovld.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 	err = mgr.StartUp()
 	c.Assert(err, IsNil)
@@ -777,7 +777,7 @@ func (s *helpersSuite) TestDiscardLateBackendViaSnapstate(c *C) {
 	ovld := overlord.Mock()
 	st := ovld.State()
 	// manager
-	mgr, err := ifacestate.Manager(st, nil, ovld.TaskRunner(), nil, nil)
+	mgr, err := ifacestate.Manager(st, nil, nil, ovld.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 	// installs the ifacemgr helper
 	err = mgr.StartUp()

--- a/overlord/ifacestate/hotplug_test.go
+++ b/overlord/ifacestate/hotplug_test.go
@@ -183,7 +183,7 @@ func (s *hotplugSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 	s.o.AddManager(hookMgr)
 
-	s.mgr, err = ifacestate.Manager(s.state, hookMgr, s.o.TaskRunner(), nil, nil)
+	s.mgr, err = ifacestate.Manager(s.state, hookMgr, nil, s.o.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 
 	s.o.AddManager(s.mgr)

--- a/overlord/ifacestate/ifacemgr.go
+++ b/overlord/ifacestate/ifacemgr.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/ifacestate/udevmonitor"
+	"github.com/snapcore/snapd/overlord/notices"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/overlord/swfeats"
@@ -50,6 +51,9 @@ type deviceData struct {
 type InterfaceManager struct {
 	state *state.State
 	repo  *interfaces.Repository
+
+	// Notice Manager (because interfacesRequestsManager may be a notice backend)
+	noticeManager *notices.NoticeManager
 
 	udevMonMu           sync.Mutex
 	udevMon             udevmonitor.Interface
@@ -75,7 +79,7 @@ type InterfaceManager struct {
 
 // Manager returns a new InterfaceManager.
 // Extra interfaces can be provided for testing.
-func Manager(s *state.State, hookManager *hookstate.HookManager, runner *state.TaskRunner, extraInterfaces []interfaces.Interface, extraBackends []interfaces.SecurityBackend) (*InterfaceManager, error) {
+func Manager(s *state.State, hookManager *hookstate.HookManager, noticeManager *notices.NoticeManager, runner *state.TaskRunner, extraInterfaces []interfaces.Interface, extraBackends []interfaces.SecurityBackend) (*InterfaceManager, error) {
 	delayedCrossMgrInit()
 
 	// NOTE: hookManager is nil only when testing.
@@ -87,6 +91,8 @@ func Manager(s *state.State, hookManager *hookstate.HookManager, runner *state.T
 	m := &InterfaceManager{
 		state: s,
 		repo:  interfaces.NewRepository(),
+		// noticeManager is stored to register future notice backends
+		noticeManager: noticeManager,
 		// note: enumeratedDeviceKeys is reset to nil when enumeration is done
 		enumeratedDeviceKeys: make(map[string]map[snap.HotplugKey]bool),
 		hotplugDevicePaths:   make(map[string][]deviceData),
@@ -598,16 +604,16 @@ var interfacesRequestsControlHandlerServicePresent = func(m *InterfaceManager) (
 // initInterfacesRequestsManager initializes the prompting backends which make
 // up the interfaces requests manager.
 //
+// Pass the notice manager to the backends so that they can be registered as
+// providers of prompting-related notices.
+//
 // This function should only be called if prompting is supported and enabled,
 // and at least one installed snap has a "snap-interfaces-requests-control"
 // connection with the "handler-service" attribute declared.
-//
-// The state lock must not be held when this function is called, so that
-// notices can be recorded if necessary.
 func (m *InterfaceManager) initInterfacesRequestsManager() error {
 	m.interfacesRequestsManagerMu.Lock()
 	defer m.interfacesRequestsManagerMu.Unlock()
-	interfacesRequestsManager, err := createInterfacesRequestsManager(m.state)
+	interfacesRequestsManager, err := createInterfacesRequestsManager(m.noticeManager)
 	if err != nil {
 		return err
 	}

--- a/overlord/ifacestate/ifacestate_test.go
+++ b/overlord/ifacestate/ifacestate_test.go
@@ -52,6 +52,7 @@ import (
 	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/ifacestate/udevmonitor"
+	"github.com/snapcore/snapd/overlord/notices"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/sequence"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
@@ -177,6 +178,7 @@ type interfaceManagerSuite struct {
 	o              *overlord.Overlord
 	state          *state.State
 	se             *overlord.StateEngine
+	noticeMgr      *notices.NoticeManager
 	privateMgr     *ifacestate.InterfaceManager
 	privateHookMgr *hookstate.HookManager
 	extraIfaces    []interfaces.Interface
@@ -242,6 +244,8 @@ func (s *interfaceManagerSuite) SetUpTest(c *C) {
 	s.state = s.o.State()
 	s.se = s.o.StateEngine()
 
+	s.noticeMgr = notices.NewNoticeManager(s.state)
+
 	s.SetupAsserts(c, s.state, &s.BaseTest)
 
 	s.BaseTest.AddCleanup(snap.MockSanitizePlugsSlots(func(snapInfo *snap.Info) {}))
@@ -304,7 +308,7 @@ slots:
 	s.BaseTest.AddCleanup(ifacestate.MockInterfacesRequestsManagerStop(fakeInterfacesRequestsManagerStop))
 }
 
-var fakeCreateInterfacesRequestsManager = func(s *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
+var fakeCreateInterfacesRequestsManager = func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error) {
 	return nil, nil
 }
 
@@ -333,7 +337,7 @@ func addForeignTaskHandlers(runner *state.TaskRunner) {
 
 func (s *interfaceManagerSuite) manager(c *C) *ifacestate.InterfaceManager {
 	if s.privateMgr == nil {
-		mgr, err := ifacestate.Manager(s.state, s.hookManager(c), s.o.TaskRunner(), s.extraIfaces, s.extraBackends)
+		mgr, err := ifacestate.Manager(s.state, s.hookManager(c), s.noticeMgr, s.o.TaskRunner(), s.extraIfaces, s.extraBackends)
 		c.Assert(err, IsNil)
 		addForeignTaskHandlers(s.o.TaskRunner())
 		mgr.DisableUDevMonitor()
@@ -385,12 +389,8 @@ func (s *interfaceManagerSuite) TestSmokeAppArmorPromptingEnabled(c *C) {
 	defer restore()
 	createCount := 0
 	fakeManager := &apparmorprompting.InterfacesRequestsManager{}
-	restore = ifacestate.MockCreateInterfacesRequestsManager(func(s *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
+	restore = ifacestate.MockCreateInterfacesRequestsManager(func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error) {
 		createCount++
-		// InterfacesRequestsManager may record notices during creation, so
-		// simulate it acquiring the state lock to do so.
-		s.Lock()
-		defer s.Unlock()
 		return fakeManager, nil
 	})
 	defer restore()
@@ -435,7 +435,7 @@ func (s *interfaceManagerSuite) TestSmokeAppArmorPromptingDisabled(c *C) {
 	defer restore()
 	createCount := 0
 	fakeManager := &apparmorprompting.InterfacesRequestsManager{}
-	restore = ifacestate.MockCreateInterfacesRequestsManager(func(s *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
+	restore = ifacestate.MockCreateInterfacesRequestsManager(func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error) {
 		c.Errorf("unexpectedly called m.initInterfacesRequestsManager")
 		createCount++
 		return fakeManager, nil
@@ -7030,13 +7030,13 @@ func (s *interfaceManagerSuite) TestInterfacesRequestsManagerNoHandlerService(c 
 
 	createCount := 0
 	fakeManager := &apparmorprompting.InterfacesRequestsManager{}
-	restore = ifacestate.MockCreateInterfacesRequestsManager(func(s *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
+	restore = ifacestate.MockCreateInterfacesRequestsManager(func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error) {
 		createCount++
 		return fakeManager, nil
 	})
 	defer restore()
 
-	mgr, err := ifacestate.Manager(s.state, nil, s.o.TaskRunner(), nil, nil)
+	mgr, err := ifacestate.Manager(s.state, nil, nil, s.o.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 
 	logbuf, restore := logger.MockLogger()
@@ -7077,13 +7077,13 @@ func (s *interfaceManagerSuite) TestInterfacesRequestsManagerHandlerServicePrese
 
 	createCount := 0
 	fakeManager := &apparmorprompting.InterfacesRequestsManager{}
-	restore = ifacestate.MockCreateInterfacesRequestsManager(func(s *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
+	restore = ifacestate.MockCreateInterfacesRequestsManager(func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error) {
 		createCount++
 		return fakeManager, nil
 	})
 	defer restore()
 
-	mgr, err := ifacestate.Manager(s.state, nil, s.o.TaskRunner(), nil, nil)
+	mgr, err := ifacestate.Manager(s.state, nil, nil, s.o.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 
 	logbuf, restore := logger.MockLogger()
@@ -7118,12 +7118,12 @@ func (s *interfaceManagerSuite) TestInitInterfacesRequestsManagerError(c *C) {
 	defer restore()
 
 	createError := fmt.Errorf("custom error")
-	restore = ifacestate.MockCreateInterfacesRequestsManager(func(s *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
+	restore = ifacestate.MockCreateInterfacesRequestsManager(func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error) {
 		return nil, createError
 	})
 	defer restore()
 
-	mgr, err := ifacestate.Manager(s.state, nil, s.o.TaskRunner(), nil, nil)
+	mgr, err := ifacestate.Manager(s.state, nil, nil, s.o.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 
 	logbuf, restore := logger.MockLogger()
@@ -7155,7 +7155,7 @@ func (s *interfaceManagerSuite) TestStopInterfacesRequestsManagerError(c *C) {
 	})
 	defer restore()
 	fakeManager := &apparmorprompting.InterfacesRequestsManager{}
-	restore = ifacestate.MockCreateInterfacesRequestsManager(func(s *state.State) (*apparmorprompting.InterfacesRequestsManager, error) {
+	restore = ifacestate.MockCreateInterfacesRequestsManager(func(noticeMgr *notices.NoticeManager) (*apparmorprompting.InterfacesRequestsManager, error) {
 		return fakeManager, nil
 	})
 	defer restore()
@@ -8368,7 +8368,7 @@ func (s *interfaceManagerSuite) TestUDevMonitorInit(c *C) {
 	})
 	defer restoreCreate()
 
-	mgr, err := ifacestate.Manager(s.state, nil, s.o.TaskRunner(), nil, nil)
+	mgr, err := ifacestate.Manager(s.state, nil, nil, s.o.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 	s.o.AddManager(mgr)
 	c.Assert(s.o.StartUp(), IsNil)
@@ -8409,7 +8409,7 @@ func (s *interfaceManagerSuite) TestUDevMonitorInitErrors(c *C) {
 	})
 	defer restoreCreate()
 
-	mgr, err := ifacestate.Manager(s.state, nil, s.o.TaskRunner(), nil, nil)
+	mgr, err := ifacestate.Manager(s.state, nil, nil, s.o.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 	s.o.AddManager(mgr)
 	c.Assert(s.o.StartUp(), IsNil)
@@ -8445,7 +8445,7 @@ func (s *interfaceManagerSuite) TestUDevMonitorInitWaitsForCore(c *C) {
 	})
 	defer restoreCreate()
 
-	mgr, err := ifacestate.Manager(s.state, nil, s.o.TaskRunner(), nil, nil)
+	mgr, err := ifacestate.Manager(s.state, nil, nil, s.o.TaskRunner(), nil, nil)
 	c.Assert(err, IsNil)
 	s.o.AddManager(mgr)
 	c.Assert(s.o.StartUp(), IsNil)

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -173,7 +173,7 @@ func New(restartHandler restart.Handler) (*Overlord, error) {
 	}
 	o.addManager(assertMgr)
 
-	ifaceMgr, err := ifacestate.Manager(s, hookMgr, o.runner, nil, nil)
+	ifaceMgr, err := ifacestate.Manager(s, hookMgr, o.noticeMgr, o.runner, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/overlord/state/notices.go
+++ b/overlord/state/notices.go
@@ -128,6 +128,37 @@ func (n *Notice) Reoccur(now time.Time, data map[string]string, repeatAfter time
 	return repeated
 }
 
+// DeepCopy returns a deep copy of the receiver.
+func (n *Notice) DeepCopy() *Notice {
+	// Create deep copies of non-primitive fields (strings are fine)
+	var userID *uint32
+	if n.userID != nil {
+		userIDVal := *n.userID
+		userID = &userIDVal
+	}
+	var lastData map[string]string
+	if len(n.lastData) > 0 {
+		lastData = make(map[string]string, len(n.lastData))
+		for k, v := range n.lastData {
+			lastData[k] = v
+		}
+	}
+
+	return &Notice{
+		id:            n.id,
+		userID:        userID,
+		noticeType:    n.noticeType,
+		key:           n.key,
+		firstOccurred: n.firstOccurred,
+		lastOccurred:  n.lastOccurred,
+		lastRepeated:  n.lastRepeated,
+		occurrences:   n.occurrences,
+		lastData:      lastData,
+		repeatAfter:   n.repeatAfter,
+		expireAfter:   n.expireAfter,
+	}
+}
+
 func (n *Notice) String() string {
 	userIDStr := "public"
 	if n.userID != nil {

--- a/overlord/state/notices_test.go
+++ b/overlord/state/notices_test.go
@@ -139,6 +139,48 @@ func (s *noticesSuite) TestReoccur(c *C) {
 	c.Check(n["repeat-after"], IsNil)
 }
 
+func (s *noticesSuite) TestDeepCopy(c *C) {
+	id := "foo"
+	userID := uint32(123)
+	nType := state.NoticeType("bar")
+	key := "baz"
+	timestamp := time.Now()
+	data := map[string]string{"fizz": "buzz"}
+	repeatAfter := 10 * time.Second
+	expireAfter := 30 * time.Second
+
+	notice := state.NewNotice(id, &userID, nType, key, timestamp, data, repeatAfter, expireAfter)
+
+	duplicate := notice.DeepCopy()
+
+	c.Check(duplicate, DeepEquals, notice)
+	c.Check(duplicate, Not(Equals), notice)
+
+	origJSON, err := notice.MarshalJSON()
+	c.Assert(err, IsNil)
+
+	copyJSON, err := duplicate.MarshalJSON()
+	c.Assert(err, IsNil)
+
+	c.Check(string(origJSON), Equals, string(copyJSON))
+
+	// If we mutate the last-data map in the orig, check that they now differ
+	delete(notice.LastData(), "fizz")
+	c.Check(duplicate, Not(DeepEquals), notice)
+	// and "fizz" still exists in the duplicate map
+	c.Check(duplicate.LastData()["fizz"], Equals, "buzz")
+
+	// Check that we can copy a notice with nil fields
+	var nilUserID *uint32
+	var nilData map[string]string
+	notice = state.NewNotice(id, nilUserID, nType, key, timestamp, nilData, repeatAfter, expireAfter)
+
+	duplicate = notice.DeepCopy()
+
+	c.Check(duplicate, DeepEquals, notice)
+	c.Check(duplicate, Not(Equals), notice)
+}
+
 func (s *noticesSuite) TestMarshal(c *C) {
 	st := state.New(nil)
 


### PR DESCRIPTION
This PR is based on #15933.

This is the final part of the prompting notice backend PR chain, which wires up the new notice backend to handle notices for the prompting notice types.