### PR TITLE
many: enable mocked camera prompts for testing

### DIFF
--- a/interfaces/builtin/camera.go
+++ b/interfaces/builtin/camera.go
@@ -31,10 +31,10 @@ const cameraBaseDeclarationSlots = `
 
 const cameraConnectedPlugAppArmor = `
 # Until we have proper device assignment, allow access to all cameras
-/dev/video[0-9]* rw,
+###PROMPT### /dev/video[0-9]* rw,
 
 # VideoCore cameras (shared device with VideoCore/EGL)
-/dev/vchiq rw,
+###PROMPT### /dev/vchiq rw,
 
 # Allow detection of cameras. Leaks plugged in USB device info
 /sys/bus/usb/devices/ r,

--- a/interfaces/builtin/camera_test.go
+++ b/interfaces/builtin/camera_test.go
@@ -82,7 +82,7 @@ func (s *CameraInterfaceSuite) TestAppArmorSpec(c *C) {
 	spec := apparmor.NewSpecification(appSet)
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "/dev/video[0-9]* rw")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "###PROMPT### /dev/video[0-9]* rw")
 }
 
 func (s *CameraInterfaceSuite) TestUDevSpec(c *C) {

--- a/interfaces/prompting/constraints.go
+++ b/interfaces/prompting/constraints.go
@@ -540,7 +540,8 @@ var (
 	// List of permissions available for each interface. This also defines the
 	// order in which the permissions should be presented.
 	interfacePermissionsAvailable = map[string][]string{
-		"home": {"read", "write", "execute"},
+		"home":   {"read", "write", "execute"},
+		"camera": {"access"},
 	}
 
 	// A mapping from interfaces which support AppArmor file permissions to
@@ -554,6 +555,9 @@ var (
 			"read":    notify.AA_MAY_READ | notify.AA_MAY_GETATTR,
 			"write":   notify.AA_MAY_WRITE | notify.AA_MAY_APPEND | notify.AA_MAY_CREATE | notify.AA_MAY_DELETE | notify.AA_MAY_RENAME | notify.AA_MAY_SETATTR | notify.AA_MAY_CHMOD | notify.AA_MAY_LOCK | notify.AA_MAY_LINK,
 			"execute": notify.AA_MAY_EXEC | notify.AA_EXEC_MMAP,
+		},
+		"camera": {
+			"access": notify.AA_MAY_READ | notify.AA_MAY_GETATTR | notify.AA_MAY_WRITE | notify.AA_MAY_APPEND,
 		},
 	}
 )

--- a/interfaces/prompting/requestprompts/requestprompts.go
+++ b/interfaces/prompting/requestprompts/requestprompts.go
@@ -85,6 +85,8 @@ type jsonPrompt struct {
 // jsonPromptConstraints defines the marshalled json structure of promptConstraints.
 type jsonPromptConstraints struct {
 	Path                 string   `json:"path"`
+	Name                 string   `json:"name,omitempty"`
+	Subsystem            string   `json:"subsystem,omitempty"`
 	RequestedPermissions []string `json:"requested-permissions"`
 	AvailablePermissions []string `json:"available-permissions"`
 }
@@ -96,6 +98,10 @@ func (p *Prompt) MarshalJSON() ([]byte, error) {
 		Path:                 p.Constraints.path,
 		RequestedPermissions: p.Constraints.outstandingPermissions,
 		AvailablePermissions: p.Constraints.availablePermissions,
+	}
+	if p.Interface == "camera" {
+		constraints.Name = "Imaginary HD Camera"
+		constraints.Subsystem = "video4linux"
 	}
 	toMarshal := &jsonPrompt{
 		ID:          p.ID,

--- a/interfaces/prompting/requestprompts/requestprompts_test.go
+++ b/interfaces/prompting/requestprompts/requestprompts_test.go
@@ -1766,7 +1766,7 @@ func (s *requestpromptsSuite) TestHandleReadying(c *C) {
 	s.checkWrittenIDMap(c, expectedMap)
 }
 
-func (s *requestpromptsSuite) TestPromptMarshalJSON(c *C) {
+func (s *requestpromptsSuite) TestPromptMarshalJSONHome(c *C) {
 	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, allowedPermission notify.AppArmorPermission) error {
 		c.Fatalf("should not have called sendReply")
 		return nil
@@ -1801,6 +1801,48 @@ func (s *requestpromptsSuite) TestPromptMarshalJSON(c *C) {
 	c.Assert(err, IsNil)
 
 	expectedJSON := `{"id":"0000000000000001","timestamp":"2024-08-14T09:47:03.350324989-05:00","snap":"firefox","pid":1234,"interface":"home","constraints":{"path":"/home/test/foo","requested-permissions":["write","execute"],"available-permissions":["read","write","execute"]}}`
+
+	marshalled, err := json.Marshal(prompt)
+	c.Assert(err, IsNil)
+
+	c.Assert(string(marshalled), Equals, string(expectedJSON))
+}
+
+func (s *requestpromptsSuite) TestPromptMarshalJSONCamera(c *C) {
+	restore := requestprompts.MockSendReply(func(listenerReq *listener.Request, allowedPermission notify.AppArmorPermission) error {
+		c.Fatalf("should not have called sendReply")
+		return nil
+	})
+	defer restore()
+
+	pdb, err := requestprompts.New(s.defaultNotifyPrompt)
+	c.Assert(err, IsNil)
+	defer pdb.Close()
+
+	metadata := &prompting.Metadata{
+		User:      s.defaultUser,
+		Snap:      "firefox",
+		PID:       1234,
+		Interface: "camera",
+	}
+	path := "/dev/video1"
+	requestedPermissions := []string{"access"}
+	outstandingPermissions := []string{"access"}
+
+	fakeRequest := listener.Request{
+		ID: 0x1234,
+	}
+
+	prompt, merged, err := pdb.AddOrMerge(metadata, path, requestedPermissions, outstandingPermissions, &fakeRequest)
+	c.Assert(err, IsNil)
+	c.Assert(merged, Equals, false)
+
+	// Set timestamp to a known time
+	timeStr := "2024-08-14T09:47:03.350324989-05:00"
+	prompt.Timestamp, err = time.Parse(time.RFC3339Nano, timeStr)
+	c.Assert(err, IsNil)
+
+	expectedJSON := `{"id":"0000000000000001","timestamp":"2024-08-14T09:47:03.350324989-05:00","snap":"firefox","pid":1234,"interface":"camera","constraints":{"path":"/dev/video1","name":"Imaginary HD Camera","subsystem":"video4linux","requested-permissions":["access"],"available-permissions":["access"]}}`
 
 	marshalled, err := json.Marshal(prompt)
 	c.Assert(err, IsNil)

--- a/overlord/ifacestate/apparmorprompting/prompting.go
+++ b/overlord/ifacestate/apparmorprompting/prompting.go
@@ -22,6 +22,7 @@ package apparmorprompting
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 
 	"gopkg.in/tomb.v2"
@@ -272,8 +273,12 @@ func (m *InterfacesRequestsManager) handleListenerReq(req *listener.Request) err
 	if err != nil {
 		if errors.Is(err, prompting_errors.ErrNoInterfaceTags) {
 			// There were no tags registered with a snapd interface, so we
-			// default to the "home" interface.
-			iface = "home"
+			// look at the path to decide whether it's "home" or "camera".
+			if strings.HasPrefix(req.Path, "/dev/video") || req.Path == "/dev/vchiq" {
+				iface = "camera"
+			} else {
+				iface = "home"
+			}
 		} else {
 			// There was either more than one interface associated with tags, or
 			// none which applied to all requested permissions. Since we can't

--- a/overlord/ifacestate/apparmorprompting/prompting_test.go
+++ b/overlord/ifacestate/apparmorprompting/prompting_test.go
@@ -221,37 +221,76 @@ func (s *apparmorpromptingSuite) TestHandleListenerRequestInterfaceSelection(c *
 	c.Check(prompts[0].Interface, Equals, "home")
 	restore()
 
-	// Return ErrNoInterfaceTags and check that the manager defaults to "home"
+	// Explicitly set "camera" interface based on tags
 	restore = apparmorprompting.MockPromptingInterfaceFromTagsets(func(notify.TagsetMap) (string, error) {
-		return "", prompting_errors.ErrNoInterfaceTags
+		return "camera", nil
 	})
 	req = &listener.Request{
 		// Most fields don't matter here
 		ID:         2,
 		Label:      "snap2",
 		SubjectUID: s.defaultUser,
-		Permission: notify.AA_MAY_EXEC,
+		Permission: notify.AA_MAY_OPEN,
 	}
 	reqChan <- req
 	time.Sleep(10 * time.Millisecond)
 	prompts, err = mgr.Prompts(s.defaultUser, clientActivity)
 	c.Check(err, IsNil)
-	c.Check(prompts, HasLen, 2, Commentf("%+v", prompts[0]))
+	c.Check(prompts, HasLen, 2)
 	c.Check(prompts[0].Interface, Equals, "home")
-	c.Check(prompts[1].Interface, Equals, "home")
+	c.Check(prompts[1].Interface, Equals, "camera")
 	restore()
 
-	// Explicitly set some other interface based on tags.
-	// Currently only "home" is supported, so we expect a later error in order
-	// to see that the given interface was used when mapping permissions.
-	// TODO: when other interfaces are supported, use one here instead.
+	// Return ErrNoInterfaceTags and check that the manager defaults to "home" or "camera"
 	restore = apparmorprompting.MockPromptingInterfaceFromTagsets(func(notify.TagsetMap) (string, error) {
-		return "foo", nil
+		return "", prompting_errors.ErrNoInterfaceTags
 	})
 	req = &listener.Request{
 		// Most fields don't matter here
 		ID:         3,
 		Label:      "snap3",
+		SubjectUID: s.defaultUser,
+		Permission: notify.AA_MAY_EXEC,
+		Path:       "/home/test/foo",
+	}
+	reqChan <- req
+	time.Sleep(10 * time.Millisecond)
+	prompts, err = mgr.Prompts(s.defaultUser, clientActivity)
+	c.Check(err, IsNil)
+	c.Check(prompts, HasLen, 3, Commentf("%+v", prompts[0]))
+	c.Check(prompts[0].Interface, Equals, "home")
+	c.Check(prompts[1].Interface, Equals, "camera")
+	c.Check(prompts[2].Interface, Equals, "home")
+	req = &listener.Request{
+		// Most fields don't matter here
+		ID:         4,
+		Label:      "snap4",
+		SubjectUID: s.defaultUser,
+		Permission: notify.AA_MAY_WRITE,
+		Path:       "/dev/video1",
+	}
+	reqChan <- req
+	time.Sleep(10 * time.Millisecond)
+	prompts, err = mgr.Prompts(s.defaultUser, clientActivity)
+	c.Check(err, IsNil)
+	c.Check(prompts, HasLen, 4, Commentf("%+v", prompts[0]))
+	c.Check(prompts[0].Interface, Equals, "home")
+	c.Check(prompts[1].Interface, Equals, "camera")
+	c.Check(prompts[2].Interface, Equals, "home")
+	c.Check(prompts[3].Interface, Equals, "camera")
+	restore()
+
+	// Explicitly set some other interface based on tags.
+	// Currently only "home" and "camera" are supported, so we expect a later
+	// error in order to see that the given interface was used when mapping
+	// permissions.
+	restore = apparmorprompting.MockPromptingInterfaceFromTagsets(func(notify.TagsetMap) (string, error) {
+		return "foo", nil
+	})
+	req = &listener.Request{
+		// Most fields don't matter here
+		ID:         5,
+		Label:      "snap5",
 		SubjectUID: s.defaultUser,
 		Permission: notify.AA_MAY_OPEN,
 	}


### PR DESCRIPTION
Wire up the minimum necessary components to enable prompting for the `camera` interface, so that the Desktop team can test handling `camera` prompts.

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-35464

This PR should build a snap file artifact which should be able to be installed for testing. Alternatively, this branch can be cloned and a snapd snap can be built manually using `snapcraft`.