### PR TITLE
cmd/snap, cmd/snap-exec, interfaces/apparmor: workarounds for Go 1.25 cgroup aware GOMAXPROCS

### DIFF
--- a/cmd/snap-exec/main.go
+++ b/cmd/snap-exec/main.go
@@ -191,6 +191,12 @@ func execApp(snapTarget, revision, command string, args []string) error {
 		return err
 	}
 
+	// Workaround for Go 1.25 runtime was applied.
+	if os.Getenv("GOMAXPROCS") != "" && os.Getenv("SNAPD_SET_GOMAXPROCS") != "" {
+		os.Unsetenv("SNAPD_SET_GOMAXPROCS")
+		os.Unsetenv("GOMAXPROCS")
+	}
+
 	// build the environment from the yaml, translating TMPDIR and
 	// similar variables back from where they were hidden when
 	// invoking the setuid snap-confine.

--- a/cmd/snap/cmd_run.go
+++ b/cmd/snap/cmd_run.go
@@ -31,6 +31,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -1503,6 +1504,20 @@ func (x *cmdRun) runSnapConfine(info *snap.Info, runner runnable, beforeExec fun
 	// We have a new location for the ticket, update the environment variable.
 	if len(krb5ccnamePath) > 0 {
 		env["KRB5CCNAME"] = krb5ccnamePath
+	}
+
+	// Workaround Go 1.25 changes, where the runtime attempts to probe
+	// /proc/self/mountinfo to find the cpu controller and raises a denial. In
+	// order to silence it we would need to grant access to
+	// /proc/self/mountinfo, which is only granted when mount-observe plug is
+	// connected. Setting GOMAXPROCS bypasses the runtime setup. As a
+	// workaround, when GOMAXPROCS isn't set, we explicitly set it and leave a
+	// flag indicating that workaround is in place. If the snap-exec which
+	// executes in snap mount namespace is unaware of the workaround, the value
+	// of GOMAXPROCS still makes reasonable sense.
+	if !needsClassic && os.Getenv("GOMAXPROCS") == "" {
+		os.Setenv("GOMAXPROCS", strconv.Itoa(runtime.NumCPU()))
+		os.Setenv("SNAPD_SET_GOMAXPROCS", "1")
 	}
 
 	// on each run variant path this will be used once to get

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -1012,6 +1012,9 @@ profile snap-update-ns.###SNAP_INSTANCE_NAME### (attach_disconnected) {
   # Allow reading own cgroups
   owner @{PROC}/@{pid}/cgroup r,
 
+  # Allow reading own mountinfo (Go runtime 1.25+)
+  owner @{PROC}/@{pid}/mountinfo r,
+
   # Allow reading somaxconn, required in newer distro releases
   @{PROC}/sys/net/core/somaxconn r,
   # but silence noisy denial of inet/inet6


### PR DESCRIPTION
This is a workaround for a change introduced in Go 1.25 in https://github.com/golang/go/commit/e6dacf91ffb0a356aa692ab5c46411e2eef913f3 which makes GOMAXPROCS cgroup aware.

There are 2 parts of the fix for binaries which are written in Go and execute under AppArmor profiles:
- snap-exec, and is executed under the target AppArmor profile, the probe raises an a denial unless the snap already plugs mount-observe
- snap-update-ns exected under a dedicated AppArmor profile, only requires the NS profile to be updated

