### PR TITLE
many: add /v2/system-volumes action for replacing platform keys

### DIFF
--- a/client/system_volumes.go
+++ b/client/system_volumes.go
@@ -20,6 +20,8 @@
 package client
 
 import (
+	"time"
+
 	"github.com/snapcore/snapd/gadget/device"
 )
 
@@ -57,4 +59,13 @@ type SystemVolumesOptions struct {
 type ChangePassphraseOptions struct {
 	OldPassphrase string `json:"old-passphrase"`
 	NewPassphrase string `json:"new-passphrase"`
+}
+
+type PlatformKeyOptions struct {
+	Passphrase string `json:"passphrase,omitempty"`
+	PIN        string `json:"pin,omitempty"`
+
+	AuthMode device.AuthMode `json:"auth-mode,omitempty"`
+	KDFType  string          `json:"kdf-type,omitempty"`
+	KDFTime  time.Duration   `json:"kdf-time,omitempty"`
 }

--- a/daemon/api_system_volumes.go
+++ b/daemon/api_system_volumes.go
@@ -42,7 +42,7 @@ var systemVolumesCmd = &Command{
 	POST: postSystemVolumesAction,
 	Actions: []string{
 		"generate-recovery-key", "check-recovery-key", "replace-recovery-key",
-		"check-passphrase", "check-pin", "change-passphrase"},
+		"replace-platform-key", "check-passphrase", "check-pin", "change-passphrase"},
 	// anyone can enumerate key slots.
 	ReadAccess: interfaceOpenAccess{Interfaces: []string{"snap-fde-control"}},
 	WriteAccess: byActionAccess{
@@ -70,6 +70,10 @@ var systemVolumesCmd = &Command{
 				Interfaces: []string{"snap-fde-control"},
 				Polkit:     polkitActionManageFDE,
 			},
+			"replace-platform-key": interfaceRootAccess{
+				Interfaces: []string{"snap-fde-control"},
+				Polkit:     polkitActionManageFDE,
+			},
 		},
 		// by default, all actions are only allowed for root.
 		Default: rootAccess{},
@@ -77,13 +81,15 @@ var systemVolumesCmd = &Command{
 }
 
 var fdeReplaceRecoveryKeyChangeKind = swfeats.RegisterChangeKind("fde-replace-recovery-key")
+var fdeReplacePlatformKeyChangeKind = swfeats.RegisterChangeKind("fde-replace-platform-key")
 var fdeChangePassphraseChangeKind = swfeats.RegisterChangeKind("fde-change-passphrase")
 
 var (
-	fdestateReplaceRecoveryKey = fdestate.ReplaceRecoveryKey
-	fdestateChangeAuth         = fdestate.ChangeAuth
-	fdeMgrGenerateRecoveryKey  = (*fdestate.FDEManager).GenerateRecoveryKey
-	fdeMgrCheckRecoveryKey     = (*fdestate.FDEManager).CheckRecoveryKey
+	fdestateReplaceRecoveryKey  = fdestate.ReplaceRecoveryKey
+	fdestateReplaceProtectedKey = fdestate.ReplaceProtectedKey
+	fdestateChangeAuth          = fdestate.ChangeAuth
+	fdeMgrGenerateRecoveryKey   = (*fdestate.FDEManager).GenerateRecoveryKey
+	fdeMgrCheckRecoveryKey      = (*fdestate.FDEManager).CheckRecoveryKey
 
 	devicestateGetVolumeStructuresWithKeyslots = devicestate.GetVolumeStructuresWithKeyslots
 )
@@ -205,7 +211,7 @@ type systemVolumesActionRequest struct {
 	// KeyID is the recovery key id.
 	KeyID string `json:"key-id"`
 
-	client.QualityCheckOptions
+	client.PlatformKeyOptions
 	client.ChangePassphraseOptions
 }
 
@@ -248,6 +254,8 @@ func postSystemVolumesActionJSON(c *Command, r *http.Request) Response {
 		return postSystemVolumesActionCheckRecoveryKey(c, &req)
 	case "replace-recovery-key":
 		return postSystemVolumesActionReplaceRecoveryKey(c, &req)
+	case "replace-platform-key":
+		return postSystemVolumesActionReplacePlatformKey(c, &req)
 	case "check-passphrase":
 		return postSystemVolumesCheckPassphrase(&req)
 	case "check-pin":
@@ -312,6 +320,39 @@ func postSystemVolumesActionReplaceRecoveryKey(c *Command, req *systemVolumesAct
 	}
 
 	chg := newChange(st, fdeReplaceRecoveryKeyChangeKind, "Replace recovery key", []*state.TaskSet{ts}, nil)
+
+	st.EnsureBefore(0)
+
+	return AsyncResponse(nil, chg.ID())
+}
+
+func postSystemVolumesActionReplacePlatformKey(c *Command, req *systemVolumesActionRequest) Response {
+	// XXX: Only support passphrase auth mode for now?
+	if req.AuthMode == "" {
+		return BadRequest("system volume action requires auth-mode to be provided")
+	}
+
+	st := c.d.overlord.State()
+	st.Lock()
+	defer st.Unlock()
+
+	var volumesAuth *device.VolumesAuthOptions
+	if req.AuthMode != device.AuthModeNone {
+		volumesAuth = &device.VolumesAuthOptions{
+			Mode: req.AuthMode,
+			// TODO:FDEM: add PIN support
+			Passphrase: req.Passphrase,
+			KDFType:    req.KDFType,
+			KDFTime:    req.KDFTime,
+		}
+	}
+
+	ts, err := fdestateReplaceProtectedKey(st, volumesAuth, req.Keyslots)
+	if err != nil {
+		return errToResponse(err, nil, BadRequest, "cannot replace platform key: %v")
+	}
+
+	chg := newChange(st, fdeReplacePlatformKeyChangeKind, "Replace platform key", []*state.TaskSet{ts}, nil)
 
 	st.EnsureBefore(0)
 

--- a/daemon/api_system_volumes.go
+++ b/daemon/api_system_volumes.go
@@ -85,11 +85,11 @@ var fdeReplacePlatformKeyChangeKind = swfeats.RegisterChangeKind("fde-replace-pl
 var fdeChangePassphraseChangeKind = swfeats.RegisterChangeKind("fde-change-passphrase")
 
 var (
-	fdestateReplaceRecoveryKey  = fdestate.ReplaceRecoveryKey
-	fdestateReplaceProtectedKey = fdestate.ReplaceProtectedKey
-	fdestateChangeAuth          = fdestate.ChangeAuth
-	fdeMgrGenerateRecoveryKey   = (*fdestate.FDEManager).GenerateRecoveryKey
-	fdeMgrCheckRecoveryKey      = (*fdestate.FDEManager).CheckRecoveryKey
+	fdestateReplaceRecoveryKey = fdestate.ReplaceRecoveryKey
+	fdestateReplacePlatformKey = fdestate.ReplacePlatformKey
+	fdestateChangeAuth         = fdestate.ChangeAuth
+	fdeMgrGenerateRecoveryKey  = (*fdestate.FDEManager).GenerateRecoveryKey
+	fdeMgrCheckRecoveryKey     = (*fdestate.FDEManager).CheckRecoveryKey
 
 	devicestateGetVolumeStructuresWithKeyslots = devicestate.GetVolumeStructuresWithKeyslots
 )
@@ -350,7 +350,7 @@ func postSystemVolumesActionReplacePlatformKey(c *Command, req *systemVolumesAct
 	st.Lock()
 	defer st.Unlock()
 
-	ts, err := fdestateReplaceProtectedKey(st, volumesAuth, req.Keyslots)
+	ts, err := fdestateReplacePlatformKey(st, volumesAuth, req.Keyslots)
 	if err != nil {
 		return errToResponse(err, nil, BadRequest, "cannot replace platform key: %v")
 	}

--- a/daemon/api_system_volumes_test.go
+++ b/daemon/api_system_volumes_test.go
@@ -379,7 +379,7 @@ func (s *systemVolumesSuite) testSystemVolumesActionReplacePlatformKey(c *C, aut
 	defer d.Overlord().Stop()
 
 	called := 0
-	s.AddCleanup(daemon.MockFdestateReplaceProtectedKey(func(st *state.State, volumesAuth *device.VolumesAuthOptions, keyslotRefs []fdestate.KeyslotRef) (*state.TaskSet, error) {
+	s.AddCleanup(daemon.MockFdestateReplacePlatformKey(func(st *state.State, volumesAuth *device.VolumesAuthOptions, keyslotRefs []fdestate.KeyslotRef) (*state.TaskSet, error) {
 		called++
 		switch authMode {
 		case device.AuthModeNone:
@@ -397,6 +397,8 @@ func (s *systemVolumesSuite) testSystemVolumesActionReplacePlatformKey(c *C, aut
 				Mode:    device.AuthModePIN,
 				KDFTime: 1002,
 			})
+		default:
+			c.Errorf("unexpected auth-mode %q", authMode)
 		}
 		c.Check(keyslotRefs, DeepEquals, []fdestate.KeyslotRef{
 			{ContainerRole: "some-container-role", Name: "some-name"},
@@ -493,7 +495,7 @@ func (s *systemVolumesSuite) TestSystemVolumesActionReplacePlatformKeyError(c *C
 	c.Check(rsp.Message, Equals, "invalid platform key options: passphrase and pin cannot be set at the same time")
 
 	var mockErr error
-	s.AddCleanup(daemon.MockFdestateReplaceProtectedKey(func(st *state.State, volumesAuth *device.VolumesAuthOptions, keyslots []fdestate.KeyslotRef) (*state.TaskSet, error) {
+	s.AddCleanup(daemon.MockFdestateReplacePlatformKey(func(st *state.State, volumesAuth *device.VolumesAuthOptions, keyslots []fdestate.KeyslotRef) (*state.TaskSet, error) {
 		return nil, mockErr
 	}))
 

--- a/daemon/api_system_volumes_test.go
+++ b/daemon/api_system_volumes_test.go
@@ -70,6 +70,10 @@ func (s *systemVolumesSuite) SetUpTest(c *C) {
 				Interfaces: []string{"snap-fde-control"},
 				Polkit:     "io.snapcraft.snapd.manage-fde",
 			},
+			"replace-platform-key": daemon.InterfaceRootAccess{
+				Interfaces: []string{"snap-fde-control"},
+				Polkit:     "io.snapcraft.snapd.manage-fde",
+			},
 		},
 		Default: daemon.RootAccess{},
 	}
@@ -364,6 +368,155 @@ func (s *systemVolumesSuite) TestSystemVolumesActionReplaceRecoveryKeyMissingKey
 	rsp := s.errorReq(c, req, nil, actionIsExpected)
 	c.Assert(rsp.Status, Equals, 400)
 	c.Assert(rsp.Message, Equals, "system volume action requires key-id to be provided")
+}
+
+func (s *systemVolumesSuite) testSystemVolumesActionReplacePlatformKey(c *C, authMode device.AuthMode) {
+	d := s.daemon(c)
+	s.mockHybridSystem()
+	st := d.Overlord().State()
+
+	d.Overlord().Loop()
+	defer d.Overlord().Stop()
+
+	called := 0
+	s.AddCleanup(daemon.MockFdestateReplaceProtectedKey(func(st *state.State, volumesAuth *device.VolumesAuthOptions, keyslotRefs []fdestate.KeyslotRef) (*state.TaskSet, error) {
+		called++
+		switch authMode {
+		case device.AuthModeNone:
+			c.Check(volumesAuth, IsNil)
+		case device.AuthModePassphrase:
+			c.Check(*volumesAuth, DeepEquals, device.VolumesAuthOptions{
+				Mode:       device.AuthModePassphrase,
+				Passphrase: "passw0rd",
+				KDFType:    "argon2id",
+				KDFTime:    1001,
+			})
+		case device.AuthModePIN:
+			c.Check(*volumesAuth, DeepEquals, device.VolumesAuthOptions{
+				// TODO:FDEM: check PIN is passed
+				Mode:    device.AuthModePIN,
+				KDFTime: 1002,
+			})
+		}
+		c.Check(keyslotRefs, DeepEquals, []fdestate.KeyslotRef{
+			{ContainerRole: "some-container-role", Name: "some-name"},
+		})
+
+		return state.NewTaskSet(st.NewTask("some-task", "")), nil
+	}))
+
+	bodyTemplate := `
+{
+	"action": "replace-platform-key",
+	"keyslots": [
+		{"container-role": "some-container-role", "name": "some-name"}
+	],
+%s
+}`
+
+	var bodyRaw string
+	switch authMode {
+	case device.AuthModeNone:
+		bodyRaw = fmt.Sprintf(bodyTemplate, `
+	"auth-mode": "none"
+`)
+	case device.AuthModePassphrase:
+		bodyRaw = fmt.Sprintf(bodyTemplate, `
+	"auth-mode": "passphrase",
+	"passphrase": "passw0rd",
+	"kdf-type": "argon2id",
+	"kdf-time": 1001
+`)
+	case device.AuthModePIN:
+		bodyRaw = fmt.Sprintf(bodyTemplate, `
+	"auth-mode": "pin",
+	"pin": "p1n",
+	"kdf-time": 1002
+`)
+	}
+
+	body := strings.NewReader(bodyRaw)
+	req, err := http.NewRequest("POST", "/v2/system-volumes", body)
+	c.Assert(err, IsNil)
+	req.Header.Add("Content-Type", "application/json")
+
+	rsp := s.asyncReq(c, req, nil, actionIsExpected)
+	c.Assert(rsp.Status, Equals, 202)
+
+	st.Lock()
+	chg := st.Change(rsp.Change)
+	tsks := chg.Tasks()
+	st.Unlock()
+	c.Check(chg, NotNil)
+	c.Check(chg.ID(), Equals, "1")
+	c.Check(chg.Kind(), Equals, "fde-replace-platform-key")
+	c.Assert(tsks, HasLen, 1)
+	c.Check(tsks[0].Kind(), Equals, "some-task")
+	c.Check(called, Equals, 1)
+}
+
+func (s *systemVolumesSuite) TestSystemVolumesActionReplacePlatformKeyAuthModeNone(c *C) {
+	const authMode = device.AuthModeNone
+	s.testSystemVolumesActionReplacePlatformKey(c, authMode)
+}
+
+func (s *systemVolumesSuite) TestSystemVolumesActionReplacePlatformKeyAuthModePassphrase(c *C) {
+	const authMode = device.AuthModePassphrase
+	s.testSystemVolumesActionReplacePlatformKey(c, authMode)
+}
+
+func (s *systemVolumesSuite) TestSystemVolumesActionReplacePlatformKeyAuthModePIN(c *C) {
+	const authMode = device.AuthModePIN
+	s.testSystemVolumesActionReplacePlatformKey(c, authMode)
+}
+
+func (s *systemVolumesSuite) TestSystemVolumesActionReplacePlatformKeyError(c *C) {
+	s.daemon(c)
+	s.mockHybridSystem()
+
+	var mockErr error
+	s.AddCleanup(daemon.MockFdestateReplaceProtectedKey(func(st *state.State, volumesAuth *device.VolumesAuthOptions, keyslots []fdestate.KeyslotRef) (*state.TaskSet, error) {
+		return nil, mockErr
+	}))
+
+	// catch all, bad request error
+	body := strings.NewReader(`{"action": "replace-platform-key", "auth-mode": "none"}`)
+	req, err := http.NewRequest("POST", "/v2/system-volumes", body)
+	c.Assert(err, IsNil)
+	req.Header.Add("Content-Type", "application/json")
+
+	mockErr = errors.New("boom!")
+	rsp := s.errorReq(c, req, nil, actionIsExpected)
+	c.Assert(rsp.Status, Equals, 400)
+	c.Check(rsp.Message, Equals, "cannot replace platform key: boom!")
+
+	// typed conflict detection error kind
+	mockErr = &snapstate.ChangeConflictError{
+		Message: fmt.Sprintf("conflict error: boom!"),
+	}
+	body = strings.NewReader(`{"action": "replace-platform-key", "auth-mode": "none"}`)
+	req, err = http.NewRequest("POST", "/v2/system-volumes", body)
+	req.Header.Add("Content-Type", "application/json")
+
+	c.Assert(err, IsNil)
+	rsp = s.errorReq(c, req, nil, actionIsExpected)
+	c.Assert(rsp.Status, Equals, 409)
+	c.Check(rsp.Kind, Equals, client.ErrorKindSnapChangeConflict)
+	c.Check(rsp.Message, Equals, "conflict error: boom!")
+}
+
+func (s *systemVolumesSuite) TestSystemVolumesActionReplacePlatformKeyMissingAuthMode(c *C) {
+	s.daemon(c)
+	s.mockHybridSystem()
+
+	body := strings.NewReader(`{"action": "replace-platform-key"}`)
+	req, err := http.NewRequest("POST", "/v2/system-volumes", body)
+	c.Assert(err, IsNil)
+	req.Header.Add("Content-Type", "application/json")
+
+	rsp := s.errorReq(c, req, nil, actionIsExpected)
+	c.Assert(rsp.Status, Equals, 400)
+	c.Assert(rsp.Message, Equals, "system volume action requires auth-mode to be provided")
 }
 
 func (s *systemVolumesSuite) TestSystemVolumesActionChangePassphrase(c *C) {

--- a/daemon/export_api_system_volumes_test.go
+++ b/daemon/export_api_system_volumes_test.go
@@ -40,6 +40,10 @@ func MockFdestateReplaceRecoveryKey(f func(st *state.State, recoveryKeyID string
 	return testutil.Mock(&fdestateReplaceRecoveryKey, f)
 }
 
+func MockFdestateReplaceProtectedKey(f func(st *state.State, volumesAuth *device.VolumesAuthOptions, keyslotRefs []fdestate.KeyslotRef) (*state.TaskSet, error)) (restore func()) {
+	return testutil.Mock(&fdestateReplaceProtectedKey, f)
+}
+
 func MockFdestateChangeAuth(f func(st *state.State, authMode device.AuthMode, old string, new string, keyslotRefs []fdestate.KeyslotRef) (*state.TaskSet, error)) (restore func()) {
 	return testutil.Mock(&fdestateChangeAuth, f)
 }

--- a/daemon/export_api_system_volumes_test.go
+++ b/daemon/export_api_system_volumes_test.go
@@ -40,8 +40,8 @@ func MockFdestateReplaceRecoveryKey(f func(st *state.State, recoveryKeyID string
 	return testutil.Mock(&fdestateReplaceRecoveryKey, f)
 }
 
-func MockFdestateReplaceProtectedKey(f func(st *state.State, volumesAuth *device.VolumesAuthOptions, keyslotRefs []fdestate.KeyslotRef) (*state.TaskSet, error)) (restore func()) {
-	return testutil.Mock(&fdestateReplaceProtectedKey, f)
+func MockFdestateReplacePlatformKey(f func(st *state.State, volumesAuth *device.VolumesAuthOptions, keyslotRefs []fdestate.KeyslotRef) (*state.TaskSet, error)) (restore func()) {
+	return testutil.Mock(&fdestateReplacePlatformKey, f)
 }
 
 func MockFdestateChangeAuth(f func(st *state.State, authMode device.AuthMode, old string, new string, keyslotRefs []fdestate.KeyslotRef) (*state.TaskSet, error)) (restore func()) {

--- a/gadget/device/encrypt.go
+++ b/gadget/device/encrypt.go
@@ -169,10 +169,9 @@ const (
 
 // VolumesAuthOptions contains options for the volumes authentication
 // mechanism (e.g. passphrase authentication).
-//
-// TODO: Add PIN option when secboot support lands.
 type VolumesAuthOptions struct {
 	Mode       AuthMode      `json:"mode,omitempty"`
+	PIN        string        `json:"pin,omitempty"`
 	Passphrase string        `json:"passphrase,omitempty"`
 	KDFType    string        `json:"kdf-type,omitempty"`
 	KDFTime    time.Duration `json:"kdf-time,omitempty"`
@@ -184,12 +183,19 @@ func (o *VolumesAuthOptions) Validate() error {
 		return nil
 	}
 
+	if len(o.Passphrase) != 0 && len(o.PIN) != 0 {
+		return fmt.Errorf("passphrase and pin cannot be set at the same time")
+	}
+
 	switch o.Mode {
 	case AuthModePassphrase:
 		if len(o.Passphrase) == 0 {
 			return fmt.Errorf("passphrase cannot be empty")
 		}
 	case AuthModePIN:
+		if len(o.PIN) == 0 {
+			return fmt.Errorf("pin cannot be empty")
+		}
 		if o.KDFType != "" {
 			return fmt.Errorf("%q authentication mode does not support custom kdf types", AuthModePIN)
 		}

--- a/gadget/device/encrypt_test.go
+++ b/gadget/device/encrypt_test.go
@@ -184,11 +184,17 @@ func (s *deviceSuite) TestVolumesAuthOptionsValidateError(c *C) {
 	opts = &device.VolumesAuthOptions{Mode: device.AuthModePassphrase}
 	c.Assert(opts.Validate(), ErrorMatches, "passphrase cannot be empty")
 	// PIN mode not implemented yet
-	opts = &device.VolumesAuthOptions{Mode: device.AuthModePIN}
+	opts = &device.VolumesAuthOptions{Mode: device.AuthModePIN, PIN: "1234"}
 	c.Assert(opts.Validate(), ErrorMatches, `"pin" authentication mode is not implemented`)
 	// PIN mode + custom kdf type
-	opts = &device.VolumesAuthOptions{Mode: device.AuthModePIN, KDFType: "argon2i"}
+	opts = &device.VolumesAuthOptions{Mode: device.AuthModePIN, KDFType: "argon2i", PIN: "1234"}
 	c.Assert(opts.Validate(), ErrorMatches, `"pin" authentication mode does not support custom kdf types`)
+	// Empty PIN
+	opts = &device.VolumesAuthOptions{Mode: device.AuthModePIN}
+	c.Assert(opts.Validate(), ErrorMatches, `pin cannot be empty`)
+	// Passphrase and PIN cannot be set at the same time
+	opts = &device.VolumesAuthOptions{PIN: "1234", Passphrase: "1234"}
+	c.Assert(opts.Validate(), ErrorMatches, `passphrase and pin cannot be set at the same time`)
 	// Bad kdf type
 	opts = &device.VolumesAuthOptions{Mode: device.AuthModePassphrase, Passphrase: "1234", KDFType: "bad-type"}
 	c.Assert(opts.Validate(), ErrorMatches, `invalid kdf type "bad-type", only "argon2i", "argon2id" and "pbkdf2" are supported`)

--- a/overlord/fdestate/conflict.go
+++ b/overlord/fdestate/conflict.go
@@ -125,7 +125,7 @@ func checkDBXChangeConflicts(st *state.State) error {
 	return snapstate.CheckChangeConflictMany(st, snaps, "")
 }
 
-func addProtectedKeysAffectedSnaps(t *state.Task) ([]string, error) {
+func addPlatformKeysAffectedSnaps(t *state.Task) ([]string, error) {
 	// adding a TPM protected key requires populating the role parameters
 	// in the FDE state (ensureParametersLoaded), those parameters could
 	// be updated as a result of a reseal caused by a refresh of any snap

--- a/overlord/fdestate/conflict.go
+++ b/overlord/fdestate/conflict.go
@@ -48,13 +48,18 @@ func checkFDEChangeConflict(st *state.State) error {
 				ChangeKind: chg.Kind(),
 				ChangeID:   chg.ID(),
 			}
+		case "fde-replace-platform-key":
+			return &snapstate.ChangeConflictError{
+				Message:    "replacing platform key in progress, no other FDE changes allowed until this is done",
+				ChangeKind: chg.Kind(),
+				ChangeID:   chg.ID(),
+			}
 		case "fde-change-passphrase":
 			return &snapstate.ChangeConflictError{
 				Message:    "changing passphrase in progress, no other FDE changes allowed until this is done",
 				ChangeKind: chg.Kind(),
 				ChangeID:   chg.ID(),
 			}
-		// TODO:FDEM: add entry for passphrase reset when API lands
 		default:
 			// try to catch changes/tasks that could have been missed
 			// and log a warning.

--- a/overlord/fdestate/conflict_test.go
+++ b/overlord/fdestate/conflict_test.go
@@ -86,7 +86,7 @@ func (s *fdeMgrSuite) TestCheckFDEChangeConflict(c *C) {
 
 }
 
-func (s *fdeMgrSuite) TestAddProtectedKeysAffectedSnaps(c *C) {
+func (s *fdeMgrSuite) TestAddPlatformKeysAffectedSnaps(c *C) {
 	st := s.st
 	onClassic := true
 	s.startedManager(c, onClassic)
@@ -99,7 +99,7 @@ func (s *fdeMgrSuite) TestAddProtectedKeysAffectedSnaps(c *C) {
 
 	tsk := st.NewTask("foo", "foo task")
 
-	names, err := fdestate.AddProtectedKeysAffectedSnaps(tsk)
+	names, err := fdestate.AddPlatformKeysAffectedSnaps(tsk)
 	c.Assert(err, IsNil)
 	c.Check(names, DeepEquals, []string{
 		"pc",        // gadget

--- a/overlord/fdestate/conflict_test.go
+++ b/overlord/fdestate/conflict_test.go
@@ -38,6 +38,7 @@ func (s *fdeMgrSuite) TestCheckFDEChangeConflict(c *C) {
 	var chgToErr = map[string]string{
 		"fde-efi-secureboot-db-update": "external EFI DBX update in progress, no other FDE changes allowed until this is done",
 		"fde-replace-recovery-key":     "replacing recovery key in progress, no other FDE changes allowed until this is done",
+		"fde-replace-platform-key":     "replacing platform key in progress, no other FDE changes allowed until this is done",
 		"fde-change-passphrase":        "changing passphrase in progress, no other FDE changes allowed until this is done",
 		"some-fde-change":              "FDE change in progress, no other FDE changes allowed until this is done",
 

--- a/overlord/fdestate/export_test.go
+++ b/overlord/fdestate/export_test.go
@@ -48,8 +48,8 @@ var (
 	NotifyDBXUpdatePrepareDoneOK = notifyDBXUpdatePrepareDoneOK
 	DbxUpdatePreparedOKChan      = dbxUpdatePreparedOKChan
 
-	DbxUpdateAffectedSnaps        = dbxUpdateAffectedSnaps
-	AddProtectedKeysAffectedSnaps = addProtectedKeysAffectedSnaps
+	DbxUpdateAffectedSnaps       = dbxUpdateAffectedSnaps
+	AddPlatformKeysAffectedSnaps = addPlatformKeysAffectedSnaps
 
 	CheckFDEChangeConflict            = checkFDEChangeConflict
 	CheckFDEParametersChangeConflicts = checkFDEParametersChangeConflicts

--- a/overlord/fdestate/fdemgr.go
+++ b/overlord/fdestate/fdemgr.go
@@ -115,6 +115,8 @@ func Manager(st *state.State, runner *state.TaskRunner) (*FDEManager, error) {
 	// which is strange from a UX perspective but it is necessary to prevent
 	// conflicting reseal/seal operations from racing when reading/writing
 	// FDE state parameters.
+	//
+	// XXX: s/fde-add-protected-keys/fde-add-platform-keys?
 	snapstate.RegisterAffectedSnapsByKind("fde-add-protected-keys", addProtectedKeysAffectedSnaps)
 
 	runner.AddHandler("efi-secureboot-db-update-prepare",

--- a/overlord/fdestate/fdemgr.go
+++ b/overlord/fdestate/fdemgr.go
@@ -115,9 +115,7 @@ func Manager(st *state.State, runner *state.TaskRunner) (*FDEManager, error) {
 	// which is strange from a UX perspective but it is necessary to prevent
 	// conflicting reseal/seal operations from racing when reading/writing
 	// FDE state parameters.
-	//
-	// XXX: s/fde-add-protected-keys/fde-add-platform-keys?
-	snapstate.RegisterAffectedSnapsByKind("fde-add-protected-keys", addProtectedKeysAffectedSnaps)
+	snapstate.RegisterAffectedSnapsByKind("fde-add-platform-keys", addPlatformKeysAffectedSnaps)
 
 	runner.AddHandler("efi-secureboot-db-update-prepare",
 		m.doEFISecurebootDBUpdatePrepare, m.undoEFISecurebootDBUpdatePrepare)
@@ -136,7 +134,7 @@ func Manager(st *state.State, runner *state.TaskRunner) (*FDEManager, error) {
 	runner.AddHandler("fde-remove-keys", m.doRemoveKeys, nil)
 	runner.AddHandler("fde-rename-keys", m.doRenameKeys, nil)
 	runner.AddHandler("fde-change-auth", m.doChangeAuth, nil)
-	runner.AddHandler("fde-add-protected-keys", m.doAddProtectedKeys, nil)
+	runner.AddHandler("fde-add-platform-keys", m.doAddPlatformKeys, nil)
 	runner.AddBlocked(func(t *state.Task, running []*state.Task) bool {
 		if isFDETask(t) {
 			for _, tRunning := range running {

--- a/overlord/fdestate/fdemgr_test.go
+++ b/overlord/fdestate/fdemgr_test.go
@@ -1327,7 +1327,7 @@ func (s *fdeMgrSuite) TestEFIDBXUpdateTaskAffectedSnaps(c *C) {
 	c.Assert(snaps, DeepEquals, []string{"pc", "pc-kernel", "core20"})
 }
 
-func (s *fdeMgrSuite) TestAddProtectedKeysTaskAffectedSnaps(c *C) {
+func (s *fdeMgrSuite) TestAddPlatformKeysTaskAffectedSnaps(c *C) {
 	onClassic := true
 	s.startedManager(c, onClassic)
 
@@ -1337,7 +1337,7 @@ func (s *fdeMgrSuite) TestAddProtectedKeysTaskAffectedSnaps(c *C) {
 	s.st.Lock()
 	defer s.st.Unlock()
 
-	tsk := s.st.NewTask("fde-add-protected-keys", "")
+	tsk := s.st.NewTask("fde-add-platform-keys", "")
 	snaps, err := snapstate.SnapsAffectedByTask(tsk)
 	c.Assert(err, IsNil)
 	c.Assert(snaps, DeepEquals, []string{"pc", "pc-kernel", "core20"})

--- a/overlord/fdestate/fdestate.go
+++ b/overlord/fdestate/fdestate.go
@@ -646,6 +646,8 @@ type volumesAuthOptionsKey struct{}
 //   - container-role: system-data, name: default
 //   - container-role: system-data, name: default-fallback
 //   - container-role: system-save, name: default-fallback
+//
+// XXX: s/ReplaceProtectedKey/ReplacePlatformKey?
 func ReplaceProtectedKey(st *state.State, volumesAuth *device.VolumesAuthOptions, keyslotRefs []KeyslotRef) (*state.TaskSet, error) {
 	authMode := device.AuthModeNone
 	if volumesAuth != nil {

--- a/overlord/fdestate/fdestate.go
+++ b/overlord/fdestate/fdestate.go
@@ -639,16 +639,14 @@ func SystemEncryptedFromState(st *state.State) (bool, error) {
 
 type volumesAuthOptionsKey struct{}
 
-// ReplaceProtectedKey creates a taskset that replaces the
-// protected key for the specified target key slots.
+// ReplacePlatformKey creates a taskset that replaces the
+// platform protected key for the specified target key slots.
 //
 // If keyslotRefs is empty, the following key slots are targets:
 //   - container-role: system-data, name: default
 //   - container-role: system-data, name: default-fallback
 //   - container-role: system-save, name: default-fallback
-//
-// XXX: s/ReplaceProtectedKey/ReplacePlatformKey?
-func ReplaceProtectedKey(st *state.State, volumesAuth *device.VolumesAuthOptions, keyslotRefs []KeyslotRef) (*state.TaskSet, error) {
+func ReplacePlatformKey(st *state.State, volumesAuth *device.VolumesAuthOptions, keyslotRefs []KeyslotRef) (*state.TaskSet, error) {
 	authMode := device.AuthModeNone
 	if volumesAuth != nil {
 		if err := volumesAuth.Validate(); err != nil {
@@ -670,7 +668,7 @@ func ReplaceProtectedKey(st *state.State, volumesAuth *device.VolumesAuthOptions
 	}
 
 	if len(keyslotRefs) == 0 {
-		// by default, target protected keys that would have been added during installation.
+		// by default, target platform keys that would have been added during installation.
 		keyslotRefs = append(keyslotRefs,
 			KeyslotRef{ContainerRole: "system-data", Name: "default"},
 			KeyslotRef{ContainerRole: "system-data", Name: "default-fallback"},
@@ -756,7 +754,7 @@ func ReplaceProtectedKey(st *state.State, volumesAuth *device.VolumesAuthOptions
 
 	ts := state.NewTaskSet()
 
-	addTemporaryKeys := st.NewTask("fde-add-protected-keys", fmt.Sprintf("Add temporary %s key slots", keyType))
+	addTemporaryKeys := st.NewTask("fde-add-platform-keys", fmt.Sprintf("Add temporary %s key slots", keyType))
 	addTemporaryKeys.Set("keyslots", tmpKeyslotRefs)
 	addTemporaryKeys.Set("auth-mode", authMode)
 	addTemporaryKeys.Set("roles", tmpKeyslotRoles)

--- a/overlord/fdestate/fdestate_test.go
+++ b/overlord/fdestate/fdestate_test.go
@@ -477,7 +477,7 @@ func (s *fdeMgrSuite) TestSystemEncryptedFromStateNoEncryptedDisks(c *C) {
 	s.testSystemEncryptedFromState(c, hasEncryptedDisks)
 }
 
-func (s *fdeMgrSuite) testReplaceProtectedKey(c *C, authMode device.AuthMode, defaultKeyslots bool) {
+func (s *fdeMgrSuite) testReplacePlatformKey(c *C, authMode device.AuthMode, defaultKeyslots bool) {
 	keyslots := []fdestate.KeyslotRef{
 		{ContainerRole: "system-data", Name: "default"},
 	}
@@ -526,9 +526,9 @@ func (s *fdeMgrSuite) testReplaceProtectedKey(c *C, authMode device.AuthMode, de
 	var ts *state.TaskSet
 	var err error
 	if defaultKeyslots {
-		ts, err = fdestate.ReplaceProtectedKey(s.st, volumesAuth, nil)
+		ts, err = fdestate.ReplacePlatformKey(s.st, volumesAuth, nil)
 	} else {
-		ts, err = fdestate.ReplaceProtectedKey(s.st, volumesAuth, keyslots)
+		ts, err = fdestate.ReplacePlatformKey(s.st, volumesAuth, keyslots)
 	}
 	if authMode == device.AuthModePIN {
 		// this is expected to break when PIN support lands
@@ -542,7 +542,7 @@ func (s *fdeMgrSuite) testReplaceProtectedKey(c *C, authMode device.AuthMode, de
 	c.Check(tsks, HasLen, 3)
 
 	c.Check(tsks[0].Summary(), Matches, fmt.Sprintf("Add temporary %s key slots", keyType))
-	c.Check(tsks[0].Kind(), Equals, "fde-add-protected-keys")
+	c.Check(tsks[0].Kind(), Equals, "fde-add-platform-keys")
 	// check tmp key slots are passed to task
 	var tskKeyslots []fdestate.KeyslotRef
 	c.Assert(tsks[0].Get("keyslots", &tskKeyslots), IsNil)
@@ -597,31 +597,31 @@ func (s *fdeMgrSuite) testReplaceProtectedKey(c *C, authMode device.AuthMode, de
 	}
 }
 
-func (s *fdeMgrSuite) TestReplaceProtectedKeyAuthModeNone(c *C) {
+func (s *fdeMgrSuite) TestReplacePlatformKeyAuthModeNone(c *C) {
 	const defaultKeyslots = false
 	const authMode = device.AuthModeNone
-	s.testReplaceProtectedKey(c, authMode, defaultKeyslots)
+	s.testReplacePlatformKey(c, authMode, defaultKeyslots)
 }
 
-func (s *fdeMgrSuite) TestReplaceProtectedKeyAuthModePassphrase(c *C) {
+func (s *fdeMgrSuite) TestReplacePlatformKeyAuthModePassphrase(c *C) {
 	const defaultKeyslots = false
 	const authMode = device.AuthModePassphrase
-	s.testReplaceProtectedKey(c, authMode, defaultKeyslots)
+	s.testReplacePlatformKey(c, authMode, defaultKeyslots)
 }
 
-func (s *fdeMgrSuite) TestReplaceProtectedKeyAuthModePIN(c *C) {
+func (s *fdeMgrSuite) TestReplacePlatformKeyAuthModePIN(c *C) {
 	const defaultKeyslots = false
 	const authMode = device.AuthModePIN
-	s.testReplaceProtectedKey(c, authMode, defaultKeyslots)
+	s.testReplacePlatformKey(c, authMode, defaultKeyslots)
 }
 
-func (s *fdeMgrSuite) TestReplaceProtectedKeyDefaultKeyslots(c *C) {
+func (s *fdeMgrSuite) TestReplacePlatformKeyDefaultKeyslots(c *C) {
 	const defaultKeyslots = true
 	const authMode = device.AuthModeNone
-	s.testReplaceProtectedKey(c, authMode, defaultKeyslots)
+	s.testReplacePlatformKey(c, authMode, defaultKeyslots)
 }
 
-func (s *fdeMgrSuite) TestReplaceProtectedKeyErrors(c *C) {
+func (s *fdeMgrSuite) TestReplacePlatformKeyErrors(c *C) {
 	defer fdestate.MockSecbootReadContainerKeyData(func(devicePath, slotName string) (secboot.KeyData, error) {
 		switch fmt.Sprintf("%s:%s", devicePath, slotName) {
 		case "/dev/disk/by-uuid/data:default":
@@ -649,27 +649,27 @@ func (s *fdeMgrSuite) TestReplaceProtectedKeyErrors(c *C) {
 	defer s.st.Unlock()
 
 	// unsupported auth mode
-	_, err := fdestate.ReplaceProtectedKey(s.st, &device.VolumesAuthOptions{Mode: "unknown"}, nil)
+	_, err := fdestate.ReplacePlatformKey(s.st, &device.VolumesAuthOptions{Mode: "unknown"}, nil)
 	c.Assert(err, ErrorMatches, `invalid authentication mode "unknown", only "passphrase" and "pin" modes are supported`)
 
 	// invalid key slot reference
 	badKeyslot := fdestate.KeyslotRef{ContainerRole: "", Name: "some-name"}
-	_, err = fdestate.ReplaceProtectedKey(s.st, nil, []fdestate.KeyslotRef{badKeyslot})
+	_, err = fdestate.ReplacePlatformKey(s.st, nil, []fdestate.KeyslotRef{badKeyslot})
 	c.Assert(err, ErrorMatches, `invalid key slot reference \(container-role: "", name: "some-name"\): container role cannot be empty`)
 
 	// invalid key slot reference
 	badKeyslot = fdestate.KeyslotRef{ContainerRole: "system-data", Name: "default-recovery"}
-	_, err = fdestate.ReplaceProtectedKey(s.st, nil, []fdestate.KeyslotRef{badKeyslot})
+	_, err = fdestate.ReplacePlatformKey(s.st, nil, []fdestate.KeyslotRef{badKeyslot})
 	c.Assert(err, ErrorMatches, `invalid key slot reference \(container-role: "system-data", name: "default-recovery"\): unsupported name, expected "default" or "default-fallback"`)
 
 	// missing keyslot
 	badKeyslot = fdestate.KeyslotRef{ContainerRole: "system-save", Name: "default-fallback"}
-	_, err = fdestate.ReplaceProtectedKey(s.st, nil, []fdestate.KeyslotRef{badKeyslot})
+	_, err = fdestate.ReplacePlatformKey(s.st, nil, []fdestate.KeyslotRef{badKeyslot})
 	c.Assert(err, ErrorMatches, `key slot reference \(container-role: "system-save", name: "default-fallback"\) not found`)
 
 	// keyslot key data loading error
 	badKeyslot = fdestate.KeyslotRef{ContainerRole: "system-data", Name: "default-fallback"}
-	_, err = fdestate.ReplaceProtectedKey(s.st, nil, []fdestate.KeyslotRef{badKeyslot})
+	_, err = fdestate.ReplacePlatformKey(s.st, nil, []fdestate.KeyslotRef{badKeyslot})
 	c.Assert(err, ErrorMatches, `cannot read key data for \(container-role: "system-data", name: "default-fallback"\): cannot read key data for "default-fallback" from "/dev/disk/by-uuid/data": boom!`)
 
 	// bad keyslot type (recovery instead of platform)
@@ -677,7 +677,7 @@ func (s *fdeMgrSuite) TestReplaceProtectedKeyErrors(c *C) {
 	s.mockCurrentKeys(c, []fdestate.KeyslotRef{{ContainerRole: "system-data", Name: "default"}}, nil)
 	s.st.Lock()
 	badKeyslot = fdestate.KeyslotRef{ContainerRole: "system-data", Name: "default"}
-	_, err = fdestate.ReplaceProtectedKey(s.st, nil, []fdestate.KeyslotRef{badKeyslot})
+	_, err = fdestate.ReplacePlatformKey(s.st, nil, []fdestate.KeyslotRef{badKeyslot})
 	c.Assert(err, ErrorMatches, `invalid key slot reference \(container-role: "system-data", name: "default"\): unsupported type "recovery", expected "platform"`)
 
 	// recovery mode
@@ -685,7 +685,7 @@ func (s *fdeMgrSuite) TestReplaceProtectedKeyErrors(c *C) {
 		UbuntuData: boot.PartitionState{UnlockKey: "recovery"},
 	}
 	c.Assert(unlockState.WriteTo("unlocked.json"), IsNil)
-	_, err = fdestate.ReplaceProtectedKey(s.st, nil, nil)
+	_, err = fdestate.ReplacePlatformKey(s.st, nil, nil)
 	c.Assert(err, ErrorMatches, "system was unlocked with a recovery key during boot: reboot required")
 	// cleanup
 	c.Assert(os.RemoveAll(filepath.Join(dirs.SnapBootstrapRunDir, "unlocked.json")), IsNil)
@@ -694,7 +694,7 @@ func (s *fdeMgrSuite) TestReplaceProtectedKeyErrors(c *C) {
 	chg := s.st.NewChange("fde-change-passphrase", "")
 	task := s.st.NewTask("some-fde-task", "")
 	chg.AddTask(task)
-	_, err = fdestate.ReplaceProtectedKey(s.st, nil, nil)
+	_, err = fdestate.ReplacePlatformKey(s.st, nil, nil)
 	c.Assert(err, ErrorMatches, `changing passphrase in progress, no other FDE changes allowed until this is done`)
 	c.Check(err, testutil.ErrorIs, &snapstate.ChangeConflictError{})
 	// cleanup
@@ -733,14 +733,14 @@ type: base
 		c.Assert(err, IsNil)
 		chg = s.st.NewChange("install-essential-snap", "")
 		chg.AddAll(ts)
-		_, err = fdestate.ReplaceProtectedKey(s.st, nil, nil)
+		_, err = fdestate.ReplacePlatformKey(s.st, nil, nil)
 		c.Check(err, ErrorMatches, fmt.Sprintf(`snap %q has "install-essential-snap" change in progress`, sn.name))
 		// cleanup
 		chg.Abort()
 	}
 }
 
-func (s *fdeMgrSuite) TestReplaceProtectedKeyConflictSnaps(c *C) {
+func (s *fdeMgrSuite) TestReplacePlatformKeyConflictSnaps(c *C) {
 	defer fdestate.MockSecbootReadContainerKeyData(func(devicePath, slotName string) (secboot.KeyData, error) {
 		return &mockKeyData{authMode: device.AuthModeNone, platformName: "tpm2"}, nil
 	})()
@@ -760,7 +760,7 @@ func (s *fdeMgrSuite) TestReplaceProtectedKeyConflictSnaps(c *C) {
 	s.st.Set("seeded", true)
 
 	// mock change in progress
-	ts, err := fdestate.ReplaceProtectedKey(s.st, nil, nil)
+	ts, err := fdestate.ReplacePlatformKey(s.st, nil, nil)
 	c.Assert(err, IsNil)
 	chg := s.st.NewChange("fde-change", "")
 	chg.AddAll(ts)
@@ -812,7 +812,7 @@ type: app
 	}
 }
 
-func (s *fdeMgrSuite) TestReplaceProtectedKeySecbootPlatforms(c *C) {
+func (s *fdeMgrSuite) TestReplacePlatformKeySecbootPlatforms(c *C) {
 	// initialize fde manager
 	onClassic := true
 	s.startedManager(c, onClassic)
@@ -832,7 +832,7 @@ func (s *fdeMgrSuite) TestReplaceProtectedKeySecbootPlatforms(c *C) {
 			return &mockKeyData{authMode: device.AuthModeNone, platformName: platform}, nil
 		})()
 
-		ts, err := fdestate.ReplaceProtectedKey(s.st, nil, []fdestate.KeyslotRef{{ContainerRole: "system-data", Name: "default"}})
+		ts, err := fdestate.ReplacePlatformKey(s.st, nil, []fdestate.KeyslotRef{{ContainerRole: "system-data", Name: "default"}})
 		switch platform {
 		case "tpm2":
 			// only supported platform currently is "tpm2"

--- a/overlord/fdestate/fdestate_test.go
+++ b/overlord/fdestate/fdestate_test.go
@@ -498,7 +498,7 @@ func (s *fdeMgrSuite) testReplaceProtectedKey(c *C, authMode device.AuthMode, de
 		volumesAuth = &device.VolumesAuthOptions{Mode: device.AuthModePassphrase, Passphrase: "password"}
 		keyType = "passphrase"
 	case device.AuthModePIN:
-		volumesAuth = &device.VolumesAuthOptions{Mode: device.AuthModePIN}
+		volumesAuth = &device.VolumesAuthOptions{Mode: device.AuthModePIN, PIN: "1234"}
 		keyType = "pin"
 	}
 

--- a/overlord/fdestate/handlers.go
+++ b/overlord/fdestate/handlers.go
@@ -214,7 +214,7 @@ func (m *FDEManager) doRenameKeys(t *state.Task, tomb *tomb.Tomb) error {
 	return nil
 }
 
-func (m *FDEManager) doAddProtectedKeys(t *state.Task, _ *tomb.Tomb) (err error) {
+func (m *FDEManager) doAddPlatformKeys(t *state.Task, _ *tomb.Tomb) (err error) {
 	m.state.Lock()
 	defer m.state.Unlock()
 
@@ -265,7 +265,7 @@ func (m *FDEManager) doAddProtectedKeys(t *state.Task, _ *tomb.Tomb) (err error)
 	if unlockedWithRecoveryKey {
 		// primary key might be missing from kernel keyring if disk was
 		// unlocked with recovery key during boot.
-		return errors.New("cannot add protected keys if the system was unlocked with a recovery key during boot")
+		return errors.New("cannot add platform keys if the system was unlocked with a recovery key during boot")
 	}
 
 	containers, err := m.GetEncryptedContainers()
@@ -346,7 +346,7 @@ func (m *FDEManager) doAddProtectedKeys(t *state.Task, _ *tomb.Tomb) (err error)
 		}
 		// TODO:FDEM: support FDE hook setup
 		if err := secbootAddContainerTPMProtectedKey(devicePath, ref.Name, &params); err != nil {
-			return fmt.Errorf("cannot add protected key slot %s: %v", ref.String(), err)
+			return fmt.Errorf("cannot add platform key slot %s: %v", ref.String(), err)
 		}
 
 		addedKeyslots = append(addedKeyslots, ref)

--- a/overlord/fdestate/handlers_test.go
+++ b/overlord/fdestate/handlers_test.go
@@ -967,8 +967,11 @@ func (s *fdeMgrSuite) TestDoAddProtectedKeys(c *C) {
 		var volumesAuth *device.VolumesAuthOptions
 		if !tc.noVolumesAuth {
 			volumesAuth = &device.VolumesAuthOptions{Mode: tc.authMode}
-			if tc.authMode == device.AuthModePassphrase {
+			switch tc.authMode {
+			case device.AuthModePassphrase:
 				volumesAuth.Passphrase = "password"
+			case device.AuthModePIN:
+				volumesAuth.PIN = "1234"
 			}
 			s.st.Cache(fdestate.VolumesAuthOptionsKey(), volumesAuth)
 		}

--- a/overlord/fdestate/handlers_test.go
+++ b/overlord/fdestate/handlers_test.go
@@ -850,7 +850,7 @@ func (s *fdeMgrSuite) TestDoChangeAuthKeysNoop(c *C) {
 	c.Check(chg.Status(), Equals, state.DoneStatus)
 }
 
-func (s *fdeMgrSuite) TestDoAddProtectedKeys(c *C) {
+func (s *fdeMgrSuite) TestDoAddPlatformKeys(c *C) {
 	const onClassic = true
 	s.startedManager(c, onClassic)
 
@@ -899,7 +899,7 @@ func (s *fdeMgrSuite) TestDoAddProtectedKeys(c *C) {
 		},
 		{
 			authMode: device.AuthModePassphrase, recoveryMode: true,
-			expectedErr: "cannot add protected keys if the system was unlocked with a recovery key during boot",
+			expectedErr: "cannot add platform keys if the system was unlocked with a recovery key during boot",
 		},
 		{
 			authMode:    device.AuthModePassphrase,
@@ -929,7 +929,7 @@ func (s *fdeMgrSuite) TestDoAddProtectedKeys(c *C) {
 				"/dev/disk/by-uuid/data:tmp-default-1",
 				"/dev/disk/by-uuid/data:tmp-default-2",
 			},
-			expectedErr: `cannot add protected key slot \(container-role: "system-data", name: "tmp-default-3"\): add error on /dev/disk/by-uuid/data:tmp-default-3`,
+			expectedErr: `cannot add platform key slot \(container-role: "system-data", name: "tmp-default-3"\): add error on /dev/disk/by-uuid/data:tmp-default-3`,
 		},
 		{
 			keyslots: []fdestate.KeyslotRef{{ContainerRole: "system-data", Name: "default"}},
@@ -1008,7 +1008,7 @@ func (s *fdeMgrSuite) TestDoAddProtectedKeys(c *C) {
 
 		c.Assert(device.StampSealedKeys(dirs.GlobalRootDir, device.SealingMethodTPM), IsNil)
 
-		task := s.st.NewTask("fde-add-protected-keys", "test")
+		task := s.st.NewTask("fde-add-platform-keys", "test")
 		task.Set("keyslots", tc.keyslots)
 		task.Set("auth-mode", tc.authMode)
 		task.Set("roles", roles)
@@ -1058,7 +1058,7 @@ func (s *fdeMgrSuite) TestDoAddProtectedKeys(c *C) {
 	}
 }
 
-func (s *fdeMgrSuite) TestDoAddProtectedKeysIdempotence(c *C) {
+func (s *fdeMgrSuite) TestDoAddPlatformKeysIdempotence(c *C) {
 	const onClassic = true
 	s.startedManager(c, onClassic)
 
@@ -1120,7 +1120,7 @@ func (s *fdeMgrSuite) TestDoAddProtectedKeysIdempotence(c *C) {
 	chg := s.st.NewChange("sample", "...")
 
 	for i := 1; i <= 3; i++ {
-		t := s.st.NewTask("fde-add-protected-keys", "test")
+		t := s.st.NewTask("fde-add-platform-keys", "test")
 		t.Set("keyslots", keyslotRefs)
 		t.Set("auth-mode", device.AuthModeNone)
 		t.Set("roles", roles)

--- a/tests/nested/manual/passphrase-support-on-hybrid/task.yaml
+++ b/tests/nested/manual/passphrase-support-on-hybrid/task.yaml
@@ -39,15 +39,6 @@ environment:
   STORE_ADDR: localhost:11028
   STORE_DIR: $(pwd)/fake-store-blobdir
 
-debug: |
-  if [ -f containers.out ]; then
-    echo "Last system-volumes value (containers.out)"
-    cat containers.out
-  fi
-
-  echo "Current system-volumes"
-  remote.exec sudo snap debug api /v2/system-volumes
-
 prepare: |
   if [ "$TRUST_TEST_KEYS" = "false" ]; then
       echo "This test needs test keys to be trusted"
@@ -138,6 +129,15 @@ prepare: |
 restore: |
   "$TESTSTOOLS"/store-state teardown-fake-store "$STORE_DIR"
   rm -rf pc-kernel.* pc.* initrd* linux* kernel* tmp* pc-gadget
+
+debug: |
+  if [ -f containers.out ]; then
+    echo "Last system-volumes value (containers.out)"
+    cat containers.out
+  fi
+
+  echo "Current system-volumes"
+  remote.exec sudo snap debug api /v2/system-volumes
 
 execute: |
   # the APIs tested here shouldn't be available on anything before 25.10

--- a/tests/nested/manual/passphrase-support-on-hybrid/task.yaml
+++ b/tests/nested/manual/passphrase-support-on-hybrid/task.yaml
@@ -247,12 +247,34 @@ execute: |
 
   reboot_with_passphrase "ubuntu-1"
 
-  # Let's change the passphrase one more time for good measure
-  remote_action_request '{"action": "change-passphrase", "old-passphrase": "ubuntu-1", "new-passphrase": "ubuntu-2"}'
+  # Let's reset the passphrase as root (without providing old passphrase)
+  remote_action_request '{"action": "replace-platform-key", "auth-mode": "passphrase", "passphrase": "ubuntu-2"}'
   change_id="$(gojq --raw-output .change < resp)"
   remote.exec sudo snap watch "$change_id"
 
   reboot_with_passphrase "ubuntu-2"
+
+  # Let's remove passphrase protection completely
+  remote_action_request '{"action": "replace-platform-key", "auth-mode": "none"}'
+  change_id="$(gojq --raw-output .change < resp)"
+  remote.exec sudo snap watch "$change_id"
+
+  reboot_with_passphrase ""
+
+  # And bring it back i.e. adding a passphrase even for
+  # systems not installed with a passphrase.
+  remote_action_request '{"action": "replace-platform-key", "auth-mode": "passphrase", "passphrase": "ubuntu-3"}'
+  change_id="$(gojq --raw-output .change < resp)"
+  remote.exec sudo snap watch "$change_id"
+
+  reboot_with_passphrase "ubuntu-3"
+
+  # Let's change the passphrase one more time for good measure
+  remote_action_request '{"action": "change-passphrase", "old-passphrase": "ubuntu-3", "new-passphrase": "ubuntu-4"}'
+  change_id="$(gojq --raw-output .change < resp)"
+  remote.exec sudo snap watch "$change_id"
+
+  reboot_with_passphrase "ubuntu-4"
 
   # Check encryption again for good measure
   remote.exec sudo snap debug api /v2/system-volumes > containers.out
@@ -270,10 +292,3 @@ execute: |
   gojq '.keyslots | length' < container.out | MATCH "^2$"
   gojq --raw-output '.keyslots.default."auth-mode"' < container.out | MATCH "^none$"
   gojq --raw-output '.keyslots."default-fallback"."auth-mode"' < container.out | MATCH "^passphrase$"
-
-  # TODO: 4. Test resetting passphrases.
-
-  # TODO: 5. Try refreshing to an unsupported kernel when snapd-info files
-  # are available.
-
-  # TODO: 6. Remodelling?

--- a/tests/nested/manual/passphrase-support-on-hybrid/task.yaml
+++ b/tests/nested/manual/passphrase-support-on-hybrid/task.yaml
@@ -39,6 +39,15 @@ environment:
   STORE_ADDR: localhost:11028
   STORE_DIR: $(pwd)/fake-store-blobdir
 
+debug: |
+  if [ -f containers.out ]; then
+    echo "Last system-volumes value (containers.out)"
+    cat containers.out
+  fi
+
+  echo "Current system-volumes"
+  remote.exec sudo snap debug api /v2/system-volumes
+
 prepare: |
   if [ "$TRUST_TEST_KEYS" = "false" ]; then
       echo "This test needs test keys to be trusted"


### PR DESCRIPTION
This PR enables platform protected key replacement.

The new `/v2/system-volumes` action `replace-platform-key` action is needed to currently implement root passphrase reset without providing the old passphrase but the implementation is generic enough that it can be used for more use cases like:
- Reset a passphrase/PIN without providing the old value
- Change key authentication mode, for example:
  - Switch from passphrase to PIN authentication
  - Switch from PIN to passphrase authentication
  - Switch from no authentication to PIN or Passphrase authentication
  - Switch from PIN or Passphrase authentication to no authentication
 - Change key authentication options, i.e. KDF options

API spec: [SD201](https://docs.google.com/document/d/1Mbj7Ut0tgW0PCz8VWdhvBN52kHTxYqkZZKQODB1NlLk/edit?tab=t.0#bookmark=id.pnbbojaglhu2)

JIRA ticket: SNAPDENG-35302