### PR TITLE
tests/lib/prepare-restore: try to catch the test which breaks ssh keys

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -892,6 +892,13 @@ restore_project_each() {
             find /var/snap -printf '%Z\t%H/%P\n' | grep -c -v snappy_var_t  | MATCH "0"
             ;;
     esac
+
+    case "$SPREAD_SYSTEM" in
+        ubuntu-core-*)
+            # TODO fishing for the test which broke the keys
+            stat --format %A /etc/ssh/ssh_host_rsa_key | MATCH -e '-rw-------'
+            ;;
+    esac
 }
 
 restore_project() {


### PR DESCRIPTION
Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
