### PR TITLE
tests/lib: setup-vm should also stop snapd.socket before changing proxy configuration

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -1493,7 +1493,7 @@ nested_setup_vm(){
 
         # Configure snapd to use the proxy
         remote.retry -n 10 --wait 3 "systemctl is-enabled snapd"
-        remote.exec "sudo systemctl stop snapd"
+        remote.exec "sudo systemctl stop snapd snapd.socket"
         remote.exec "sudo mkdir -p /etc/systemd/system/snapd.service.d"
         remote.exec "echo [Service] | sudo tee /etc/systemd/system/snapd.service.d/proxy.conf"
         remote.exec "echo Environment=HTTPS_PROXY=$HTTPS_PROXY HTTP_PROXY=$HTTP_PROXY https_proxy=$HTTPS_PROXY http_proxy=$HTTP_PROXY NO_PROXY=$nested_no_proxy no_proxy=$nested_no_proxy SNAPD_USE_PROXY=$SNAPD_USE_PROXY | sudo tee -a /etc/systemd/system/snapd.service.d/proxy.conf"

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -1493,12 +1493,12 @@ nested_setup_vm(){
 
         # Configure snapd to use the proxy
         remote.retry -n 10 --wait 3 "systemctl is-enabled snapd"
-        remote.exec "sudo systemctl stop snapd snapd.socket"
+        remote.exec "sudo systemctl stop snapd.service snapd.socket"
         remote.exec "sudo mkdir -p /etc/systemd/system/snapd.service.d"
         remote.exec "echo [Service] | sudo tee /etc/systemd/system/snapd.service.d/proxy.conf"
         remote.exec "echo Environment=HTTPS_PROXY=$HTTPS_PROXY HTTP_PROXY=$HTTP_PROXY https_proxy=$HTTPS_PROXY http_proxy=$HTTP_PROXY NO_PROXY=$nested_no_proxy no_proxy=$nested_no_proxy SNAPD_USE_PROXY=$SNAPD_USE_PROXY | sudo tee -a /etc/systemd/system/snapd.service.d/proxy.conf"
         remote.exec "sudo systemctl daemon-reload"
-        remote.exec "sudo systemctl start snapd"
+        remote.exec "sudo systemctl start snapd.service snapd.socket"
         remote.exec "sudo sync"
     fi
     if [ -n "${NTP_SERVER:-}" ]; then


### PR DESCRIPTION
Fix issue identified in https://github.com/canonical/snapd/actions/runs/17466738684/job/49690619454?pr=15921.

The issue relates to changes made in https://github.com/canonical/snapd/pull/15799.

openstack-ext-ps7:ubuntu-24.04-64:tests/nested/manual/recovery-system-reboot:recover failed with:

```
2025-09-05T13:38:32.1053457Z remote.wait-for: snap command ready
2025-09-05T13:38:32.1054198Z + tests.nested setup-vm
2025-09-05T13:38:32.1055229Z nameserver 10.151.11.5
2025-09-05T13:38:32.1055956Z nameserver 10.151.11.6
2025-09-05T13:38:32.1056262Z nameserver 10.151.11.7
2025-09-05T13:38:32.1057024Z HTTPS_PROXY=http://egress.ps7.internal:3128
2025-09-05T13:38:32.1057827Z https_proxy=http://egress.ps7.internal:3128
2025-09-05T13:38:32.1058263Z HTTP_PROXY=http://egress.ps7.internal:3128
2025-09-05T13:38:32.1058690Z http_proxy=http://egress.ps7.internal:3128
2025-09-05T13:38:32.1059102Z NO_PROXY=127.0.0.1,127.0.0.53,localhost,10.0.2.2
2025-09-05T13:38:32.1059503Z no_proxy=127.0.0.1,127.0.0.53,localhost,10.0.2.2
2025-09-05T13:38:32.1059871Z SNAPD_USE_PROXY=true
2025-09-05T13:38:32.1060145Z enabled
2025-09-05T13:38:32.1067705Z Warning: The unit file, source configuration file or drop-ins of snapd.service changed on disk. Run 'systemctl daemon-reload' to reload units.
2025-09-05T13:38:32.1069123Z Stopping 'snapd.service', but its triggering units are still active:  <-------
2025-09-05T13:38:32.1069586Z snapd.socket
2025-09-05T13:38:32.1069838Z [Service]
2025-09-05T13:38:32.1071069Z Environment=HTTPS_PROXY=http://egress.ps7.internal:3128 HTTP_PROXY=http://egress.ps7.internal:3128 https_proxy=http://egress.ps7.internal:3128 http_proxy=http://egress.ps7.internal:3128 NO_PROXY=127.0.0.1,127.0.0.53,localhost,10.0.2.2 no_proxy=127.0.0.1,127.0.0.53,localhost,10.0.2.2 SNAPD_USE_PROXY=true
2025-09-05T13:38:32.1074463Z Job for snapd.service failed because the control process exited with error code.
2025-09-05T13:38:32.1075823Z See "systemctl status snapd.service" and "journalctl -xeu snapd.service" for details.

```

It looks like the service was not successfully stopped, preventing correct application of the proxy environment...