### PR TITLE
tests: fix apparmor-prompting-snapd-startup by using tests.pkgs to install

### DIFF
--- a/tests/main/apparmor-prompting-snapd-startup/task.yaml
+++ b/tests/main/apparmor-prompting-snapd-startup/task.yaml
@@ -26,7 +26,7 @@ prepare: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-prompt-handler
     snap connect test-snapd-prompt-handler:snap-interfaces-requests-control
 
-    apt install attr
+    tests.pkgs install attr
 
 restore: |
     tests.exec is-skipped && exit 0


### PR DESCRIPTION


Avoid using apt without -y

This prevents thie error:

Upgrading:
  libattr1

Installing:
  attr

Summary:
  Upgrading: 1, Installing: 1, Removing: 0, Not Upgrading: 75
  Download size: 35.7 kB
  Space needed: 152 kB / 12.5 GB available

Continue? [Y/n] Abort.
