### PR TITLE
tests: fix snap-model test

### DIFF
--- a/tests/main/snap-model/task.yaml
+++ b/tests/main/snap-model/task.yaml
@@ -5,6 +5,10 @@ details: |
   model and serial assertions.
 
 execute: |
+  echo "Wait for device initialization to be done"
+  . "$TESTSLIB"/core-config.sh
+  wait_for_device_initialized_change
+
   knownCmdAssertion=$(snap known model)
   modelCmdAssertion=$(snap model --assertion)
   echo "Check that model assertion from \"snap known\" matches \"snap model\""


### PR DESCRIPTION
It is required to wait until the device is initialized before requesting the model assetion, otherwise the command `snap model --assertion` returns an error.

error:
++ snap model --serial --assertion
error: device not ready yet (no assertions found)