### PR TITLE
github/workflows: swap core20 for core22 in fundamental systems

### DIFF
--- a/.github/workflows/data-fundamental-systems.json
+++ b/.github/workflows/data-fundamental-systems.json
@@ -41,10 +41,10 @@
         "rules": "main"
       },
       {
-        "group": "ubuntu-core-20 (fundamental)",
+        "group": "ubuntu-core-22 (fundamental)",
         "backend": "openstack-ps7",
         "alternative-backend": "google-core",
-        "systems": "ubuntu-core-20-64",
+        "systems": "ubuntu-core-22-64",
         "tasks": "tests/...",
         "rules": "main"
       },

--- a/.github/workflows/data-non-fundamental-systems.json
+++ b/.github/workflows/data-non-fundamental-systems.json
@@ -81,10 +81,10 @@
         "rules": "main"
       },
       {
-        "group": "ubuntu-core-22",
+        "group": "ubuntu-core-20",
         "backend": "openstack-ps7",
         "alternative-backend": "google-core",
-        "systems": "ubuntu-core-22-64",
+        "systems": "ubuntu-core-20-64",
         "tasks": "tests/...",
         "rules": "main"
       },


### PR DESCRIPTION
Move swap core20 for core22 in fundamental systems. At least unti we figure out why core20 prepare is failing in CI when accessing Ubuntu archive.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
