### PR TITLE
o/snapstate: relax confdb change conflict checks

### DIFF
--- a/overlord/confdbstate/confdbmgr.go
+++ b/overlord/confdbstate/confdbmgr.go
@@ -49,7 +49,7 @@ func setupConfdbHook(st *state.State, snapName, hookName string, ignoreError boo
 type ConfdbManager struct{}
 
 func Manager(st *state.State, hookMgr *hookstate.HookManager, runner *state.TaskRunner) *ConfdbManager {
-	snapstate.ConfdbstateIsConfdbHookname = IsConfdbHookname
+	snapstate.IsConfdbHookname = IsConfdbHookname
 
 	m := &ConfdbManager{}
 

--- a/overlord/confdbstate/confdbmgr.go
+++ b/overlord/confdbstate/confdbmgr.go
@@ -29,6 +29,7 @@ import (
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/hookstate"
+	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"gopkg.in/tomb.v2"
 )
@@ -48,6 +49,8 @@ func setupConfdbHook(st *state.State, snapName, hookName string, ignoreError boo
 type ConfdbManager struct{}
 
 func Manager(st *state.State, hookMgr *hookstate.HookManager, runner *state.TaskRunner) *ConfdbManager {
+	snapstate.ConfdbstateIsConfdbHookname = IsConfdbHookname
+
 	m := &ConfdbManager{}
 
 	// no undo since if we commit there's no rolling back

--- a/overlord/confdbstate/confdbstate.go
+++ b/overlord/confdbstate/confdbstate.go
@@ -202,7 +202,7 @@ func GetTransactionToSet(ctx *hookstate.Context, st *state.State, view *confdb.V
 	account, schemaName := view.Schema().Account, view.Schema().Name
 
 	// check if we're already running in the context of a committing transaction
-	if IsConfdbHook(ctx) {
+	if IsConfdbHookCtx(ctx) {
 		// running in the context of a transaction, so if the referenced confdb schema
 		// doesn't match that tx, we only allow the caller to read through the other confdb schema
 		t, _ := ctx.Task()
@@ -524,14 +524,18 @@ func GetStoredTransaction(t *state.Task) (tx *Transaction, txTask *state.Task, s
 	return tx, ct, saveTxChanges, nil
 }
 
-// IsConfdbHook returns whether the hook context belongs to a confdb hook.
-func IsConfdbHook(ctx *hookstate.Context) bool {
-	return ctx != nil && !ctx.IsEphemeral() &&
-		(strings.HasPrefix(ctx.HookName(), "change-view-") ||
-			strings.HasPrefix(ctx.HookName(), "save-view-") ||
-			strings.HasPrefix(ctx.HookName(), "load-view-") ||
-			strings.HasPrefix(ctx.HookName(), "query-view-") ||
-			strings.HasPrefix(ctx.HookName(), "observe-view-"))
+// IsConfdbHookCtx returns whether the hook context belongs to a confdb hook.
+func IsConfdbHookCtx(ctx *hookstate.Context) bool {
+	return ctx != nil && !ctx.IsEphemeral() && IsConfdbHookname(ctx.HookName())
+}
+
+// IsConfdbHookname returns whether the hookname denotes a confdb hook.
+func IsConfdbHookname(name string) bool {
+	return strings.HasPrefix(name, "change-view-") ||
+		strings.HasPrefix(name, "save-view-") ||
+		strings.HasPrefix(name, "load-view-") ||
+		strings.HasPrefix(name, "query-view-") ||
+		strings.HasPrefix(name, "observe-view-")
 }
 
 // CanHookSetConfdb returns whether the hook context belongs to a confdb hook
@@ -551,7 +555,7 @@ func GetTransactionForSnapctlGet(ctx *hookstate.Context, view *confdb.View, path
 	st := ctx.State()
 	account, schemaName := view.Schema().Account, view.Schema().Name
 
-	if IsConfdbHook(ctx) {
+	if IsConfdbHookCtx(ctx) {
 		// running in the context of a transaction, so if the referenced confdb
 		// doesn't match that tx, we only allow the caller to read the other confdb
 		t, _ := ctx.Task()

--- a/overlord/confdbstate/confdbstate_test.go
+++ b/overlord/confdbstate/confdbstate_test.go
@@ -1079,7 +1079,7 @@ func (s *confdbTestSuite) mockConfdbHooks(c *C) (*[]string, func()) {
 			return nil, err
 		}
 
-		if !confdbstate.IsConfdbHook(ctx) {
+		if !confdbstate.IsConfdbHookCtx(ctx) {
 			// ignore non-confdb hooks
 			return nil, nil
 		}

--- a/overlord/hookstate/ctlcmd/set.go
+++ b/overlord/hookstate/ctlcmd/set.go
@@ -252,7 +252,7 @@ func setConfdbValues(ctx *hookstate.Context, plugName string, requests map[strin
 		return err
 	}
 
-	if confdbstate.IsConfdbHook(ctx) && !confdbstate.CanHookSetConfdb(ctx) {
+	if confdbstate.IsConfdbHookCtx(ctx) && !confdbstate.CanHookSetConfdb(ctx) {
 		return fmt.Errorf("cannot modify confdb in %q hook", ctx.HookName())
 	}
 

--- a/overlord/snapstate/autorefresh_gating_test.go
+++ b/overlord/snapstate/autorefresh_gating_test.go
@@ -91,7 +91,7 @@ func (s *autorefreshGatingSuite) SetUpTest(c *C) {
 	})
 	s.AddCleanup(restore)
 
-	snapstate.ConfdbstateIsConfdbHookname = confdbstate.IsConfdbHookname
+	snapstate.IsConfdbHookname = confdbstate.IsConfdbHookname
 }
 
 func (r *autoRefreshGatingStore) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, assertQuery store.AssertionQuery, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, []store.AssertionResult, error) {

--- a/overlord/snapstate/autorefresh_gating_test.go
+++ b/overlord/snapstate/autorefresh_gating_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/confdbstate"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
@@ -89,6 +90,8 @@ func (s *autorefreshGatingSuite) SetUpTest(c *C) {
 		return snapasserts.NewValidationSets(), nil
 	})
 	s.AddCleanup(restore)
+
+	snapstate.ConfdbstateIsConfdbHookname = confdbstate.IsConfdbHookname
 }
 
 func (r *autoRefreshGatingStore) SnapAction(ctx context.Context, currentSnaps []*store.CurrentSnap, actions []*store.SnapAction, assertQuery store.AssertionQuery, user *auth.UserState, opts *store.RefreshOptions) ([]store.SnapActionResult, []store.AssertionResult, error) {

--- a/overlord/snapstate/conflict.go
+++ b/overlord/snapstate/conflict.go
@@ -245,6 +245,13 @@ func isIrrelevantChange(chg *state.Change, ignoreChangeID string) bool {
 		return true
 	}
 	switch chg.Kind() {
+	case "get-confdb":
+		// confdb hooks can conflict with tasks unlinking custodian/base snaps but
+		// those are prevented using task blockers (before hooks/unlinking snaps).
+		// We also prevent concurrent accesses to the same confdb in confdbstate/
+		fallthrough
+	case "set-confdb":
+		fallthrough
 	case "pre-download":
 		// pre-download changes only have pre-download tasks
 		// which don't generate conflicts because they only

--- a/overlord/snapstate/refresh.go
+++ b/overlord/snapstate/refresh.go
@@ -38,6 +38,10 @@ import (
 // pidsOfSnap is a mockable version of PidsOfSnap
 var pidsOfSnap = cgroup.PidsOfSnap
 
+var ConfdbstateIsConfdbHookname = func(string) bool {
+	panic("internal error: confdbstate.IsConfdbHookname is unset")
+}
+
 // refreshAppsCheck returns an error if the snap has processes running that aren't
 // services and aren't marked to be ignored (refresh-mode: "ignore-running").
 var refreshAppsCheck = func(info *snap.Info) error {
@@ -51,11 +55,10 @@ var refreshAppsCheck = func(info *snap.Info) error {
 	var busyHookNames []string
 	var busyPIDs []int
 
-	// Currently there are no situations when hooks might be allowed to run
-	// during the refresh process. The function exists to make the next two
-	// chunks of code symmetric.
 	canHookRunDuringRefresh := func(hook *snap.HookInfo) bool {
-		return false
+		// refreshes and changes that unlink snaps can conflict with confdb accesses
+		// that run custodian hooks but those are dealt with before running hooks/unlinking
+		return ConfdbstateIsConfdbHookname(hook.Name)
 	}
 
 	for name, app := range info.Apps {

--- a/overlord/snapstate/refresh.go
+++ b/overlord/snapstate/refresh.go
@@ -38,7 +38,8 @@ import (
 // pidsOfSnap is a mockable version of PidsOfSnap
 var pidsOfSnap = cgroup.PidsOfSnap
 
-var ConfdbstateIsConfdbHookname = func(string) bool {
+// IsConfdbHookname is a hook set by confdbstate (see confdbstate.go).
+var IsConfdbHookname = func(string) bool {
 	panic("internal error: confdbstate.IsConfdbHookname is unset")
 }
 
@@ -56,9 +57,9 @@ var refreshAppsCheck = func(info *snap.Info) error {
 	var busyPIDs []int
 
 	canHookRunDuringRefresh := func(hook *snap.HookInfo) bool {
-		// refreshes and changes that unlink snaps can conflict with confdb accesses
-		// that run custodian hooks but those are dealt with before running hooks/unlinking
-		return ConfdbstateIsConfdbHookname(hook.Name)
+		// changes that unlink snaps can conflict with confdb accesses that run those
+		// snaps' hooks, but we deal with that in the unlink/run-hook tasks
+		return IsConfdbHookname(hook.Name)
 	}
 
 	for name, app := range info.Apps {

--- a/overlord/snapstate/refresh_test.go
+++ b/overlord/snapstate/refresh_test.go
@@ -72,7 +72,7 @@ hooks:
 	s.AddCleanup(func() { dirs.SetRootDir("") })
 	s.state = state.New(nil)
 
-	snapstate.ConfdbstateIsConfdbHookname = confdbstate.IsConfdbHookname
+	snapstate.IsConfdbHookname = confdbstate.IsConfdbHookname
 }
 
 func (s *refreshSuite) TestRefreshCheck(c *C) {

--- a/overlord/snapstate/refresh_test.go
+++ b/overlord/snapstate/refresh_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/snapcore/snapd/cmd/snaplock/runinhibit"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/confdbstate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
 	"github.com/snapcore/snapd/overlord/state"
@@ -70,6 +71,8 @@ hooks:
 	s.AddCleanup(restore)
 	s.AddCleanup(func() { dirs.SetRootDir("") })
 	s.state = state.New(nil)
+
+	snapstate.ConfdbstateIsConfdbHookname = confdbstate.IsConfdbHookname
 }
 
 func (s *refreshSuite) TestRefreshCheck(c *C) {
@@ -301,4 +304,22 @@ func (s *refreshSuite) TestDoHardRefreshFlowRefreshInhibitionTimeout(c *C) {
 	// In addition, the fake backend recorded that a lock was established.
 	op := backend.ops.MustFindOp(c, "run-inhibit-snap-for-unlink")
 	c.Check(op.inhibitHint, Equals, runinhibit.Hint("refresh"))
+}
+
+func (s *refreshSuite) TestRefreshCheckIgnoresConfdbHooks(c *C) {
+	s.pids = map[string][]int{
+		"snap.pkg.hook.change-view-setup":  {101},
+		"snap.pkg.hook.save-view-setup":    {102},
+		"snap.pkg.hook.load-view-setup":    {103},
+		"snap.pkg.hook.query-view-setup":   {104},
+		"snap.pkg.hook.observe-view-setup": {105},
+	}
+	err := snapstate.RefreshCheck(s.info)
+	c.Assert(err, IsNil)
+
+	s.pids["snap.pkg.hook.configure"] = []int{100}
+	err = snapstate.RefreshCheck(s.info)
+	c.Assert(err, NotNil)
+	c.Check(err.Error(), Equals, `snap "pkg" has running hooks (configure), pids: 100`)
+	c.Check(err.(*snapstate.BusySnapError).Pids(), DeepEquals, []int{100})
 }

--- a/tests/main/confdb/task.yaml
+++ b/tests/main/confdb/task.yaml
@@ -79,3 +79,30 @@ execute: |
   snap run --shell test-custodian-snap.sh -c 'snapctl get --view :manage-wifi ssid' 2>&1 | MATCH "error: snapctl: cannot access confdb through unconnected plug :manage-wifi"
   snap run --shell test-custodian-snap.sh -c 'snapctl set --view :manage-wifi ssid=foo' 2>&1 | MATCH "error: snapctl: cannot access confdb through unconnected plug :manage-wifi"
   snap run --shell test-custodian-snap.sh -c 'snapctl unset --view :manage-wifi ssid' 2>&1 | MATCH "error: snapctl: cannot access confdb through unconnected plug :manage-wifi"
+
+  snap remove --purge test-custodian-snap_other test-custodian-snap
+  "$TESTSTOOLS"/snaps-state install-local waiting-custodian
+  # we want to check that a refresh of a custodian waits for any running custodian
+  # hooks. A refresh starting after the hook will hang on the pre-refresh hook
+  # (only one can run at once), so we'll refresh here and revert so that no pre-refresh
+  # hook runs and we approximate a custodian hook starting mid-refresh
+  "$TESTSTOOLS"/snaps-state install-local waiting-custodian
+  snap connect waiting-custodian:wifi-setup
+
+  # access confdb triggering a custodian hook that hangs
+  OLD_CHG=$(snap changes | tail -n 2 | head -n 1 | awk '{print $1}')
+  snap get developer1/network/wifi-setup ssid &>/dev/null &
+  pid="$!"
+  GET_CHG="$((OLD_CHG+1))"
+
+  retry -n 5 sh -c "snap change $GET_CHG | grep "Doing.*Run hook load-view-wifi-setup""
+
+  # try to "refresh" the custodian and check it waits before unlinking
+  REVERT_CHG="$(snap revert waiting-custodian --no-wait)"
+  retry -n 5 sh -c "snap change $REVERT_CHG | MATCH ".*Do.*Make current revision for snap \"waiting-custodian\" unavailable""
+
+  # unblock the custodian hook and check that the revert finished
+  touch /var/snap/waiting-custodian/common/flag
+  wait "$pid"
+  retry -n 5 sh -c "snap changes | tail -n 4 | MATCH \"$GET_CHG.*Done.*Get confdb through.*\""
+  retry -n 5 sh -c "snap changes | tail -n 4 | MATCH \"$REVERT_CHG.*Done.*Revert .waiting-custodian. snap\""

--- a/tests/main/confdb/waiting-custodian/bin/sh
+++ b/tests/main/confdb/waiting-custodian/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /bin/sh "$@"

--- a/tests/main/confdb/waiting-custodian/meta/hooks/load-view-wifi-setup
+++ b/tests/main/confdb/waiting-custodian/meta/hooks/load-view-wifi-setup
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+until [ -e "$SNAP_COMMON"/flag ]; do
+	sleep 2
+done
+
+if val=$(snapctl get --view :wifi-setup ssid); then
+	snapctl set --view :wifi-setup ssid="prefix-$val"
+fi

--- a/tests/main/confdb/waiting-custodian/meta/snap.yaml
+++ b/tests/main/confdb/waiting-custodian/meta/snap.yaml
@@ -1,0 +1,12 @@
+name: waiting-custodian
+version: 1.0
+apps:
+  sh:
+    command: bin/sh
+base: core24
+plugs:
+  wifi-setup:
+    interface: confdb
+    account: developer1
+    view: network/wifi-setup
+    role: custodian


### PR DESCRIPTION
Since conflict checks between other changes and confdb hooks are dealt with at the points where we unlink relevant snaps or run hooks, we can relax the conflict checks to let confdb accesses run concurrently with other changes.
