### PR TITLE
cmd/snap-update-ns: add opt-in logging support

### DIFF
--- a/cmd/snap-update-ns/bootstrap.go
+++ b/cmd/snap-update-ns/bootstrap.go
@@ -108,7 +108,7 @@ func validateInstanceName(instanceName string) int {
 	return int(C.validate_instance_name(cStr))
 }
 
-// processArguments parses commnad line arguments.
+// processArguments parses command line arguments.
 // The argument cmdline is a string with embedded
 // NUL bytes, separating particular arguments.
 //

--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -136,7 +136,7 @@ func (c *Change) createPath(path string, pokeHoles bool, as *Assumptions) ([]*Ch
 	if needsMimic, mimicPath := mimicRequired(err); needsMimic && pokeHoles {
 		// If the error can be recovered by using a writable mimic
 		// then construct one and try again.
-		logger.Debugf("need to create writable mimic needed to create path %q (mount entry id: %q) (original error: %v)", path, c.Entry.XSnapdEntryID(), err)
+		logger.Debugf("need to create writable mimic in order to create path %q (mount entry id: %q) (original error: %v)", path, c.Entry.XSnapdEntryID(), err)
 		changes, err = createWritableMimic(mimicPath, c.Entry.XSnapdEntryID(), as)
 		if err != nil {
 			err = fmt.Errorf("cannot create writable mimic over %q: %s", mimicPath, err)

--- a/cmd/snap-update-ns/change.go
+++ b/cmd/snap-update-ns/change.go
@@ -313,8 +313,10 @@ func (c *Change) lowLevelPerform(as *Assumptions) error {
 	var err error
 
 	kind := c.Entry.XSnapdKind()
-	// ensure-dir mounts attempts to create a potentially missing target directory during the ensureTarget step
-	// and does not require any low-level actions. Directories created with ensure-dir mounts should never be removed.
+	// ensure-dir mounts attempts to create a potentially missing target
+	// directory during the ensureTarget step and does not require any
+	// low-level actions. Directories created with ensure-dir mounts should
+	// never be removed.
 	if kind == "ensure-dir" {
 		return nil
 	}

--- a/cmd/snap-update-ns/main.go
+++ b/cmd/snap-update-ns/main.go
@@ -109,6 +109,17 @@ func run() error {
 	return executeMountProfileUpdate(upCtx)
 }
 
+// setupOptInLogging configures the logger to log to an existing file.
+//
+// Developers or users assisting in a debug session may be asked to touch empty
+// files at /run/snapd/ns/snap.$SNAP_NAME.log and
+// /run/snapd/ns/snap.$SNAP_NAME.user.$UID.log.
+//
+// Presence of either file activates verbose debug logging of mount namespace
+// operations of the specific snap, and snap-uid pair.
+//
+// Nothing in snapd creates or removes those files. The content may be attached
+// to bug reports to be investigated by snapd developers.
 func setupOptInLogging(snapName string, userMounts bool) {
 	var path string
 	if userMounts {

--- a/cmd/snap-update-ns/main.go
+++ b/cmd/snap-update-ns/main.go
@@ -86,6 +86,8 @@ func run() error {
 	}
 
 	setupOptInLogging(opts.Positionals.SnapName, opts.UserMounts)
+	logger.Debugf("snap-update-ns invoked snap:%s, fromSnapConfine:%v, userMounts:%v",
+		opts.Positionals.SnapName, opts.FromSnapConfine, opts.UserMounts)
 
 	// Explicitly set the umask to 0 to prevent permission bits
 	// being masked out when creating files and directories.

--- a/cmd/snap-update-ns/main.go
+++ b/cmd/snap-update-ns/main.go
@@ -20,12 +20,17 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"io"
+	"io/fs"
 	"os"
+	"path/filepath"
 	"syscall"
 
 	"github.com/jessevdk/go-flags"
 
+	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
 )
 
@@ -39,8 +44,8 @@ var opts struct {
 }
 
 // IMPORTANT: all the code in main() until bootstrap is finished may be run
-// with elevated privileges when invoking snap-update-ns from the setuid
-// snap-confine.
+// with elevated privileges when invoking snap-update-ns from snap-confine
+// which grants additional capabilities.
 
 func main() {
 	logger.SimpleSetup(nil)
@@ -80,6 +85,8 @@ func run() error {
 		return err
 	}
 
+	setupOptInLogging(opts.Positionals.SnapName, opts.UserMounts)
+
 	// Explicitly set the umask to 0 to prevent permission bits
 	// being masked out when creating files and directories.
 	//
@@ -98,4 +105,28 @@ func run() error {
 		upCtx = NewSystemProfileUpdateContext(opts.Positionals.SnapName, opts.FromSnapConfine)
 	}
 	return executeMountProfileUpdate(upCtx)
+}
+
+func setupOptInLogging(snapName string, userMounts bool) {
+	var path string
+	if userMounts {
+		path = filepath.Join(dirs.SnapRunNsDir, fmt.Sprintf("snap.%s.user.%d.log", snapName, os.Getuid()))
+	} else {
+		path = filepath.Join(dirs.SnapRunNsDir, fmt.Sprintf("snap.%s.log", snapName))
+	}
+
+	// NOTE: This file is never closed.
+	f, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			logger.Debugf("Cannot open snap-update-ns log file: %v", err)
+		}
+		return
+	}
+
+	// Write logs to both os.Stderr and f. Due to how we use LoggerOptions, and
+	// the limited nature of the logger, os.Stderr will see all debug logs even
+	// if that setting is not enabled.  This could be addressed with slog-based
+	// logger that uses a tee-like handler with distinct levels.
+	logger.SetLogger(logger.New(io.MultiWriter(os.Stderr, f), 0, &logger.LoggerOptions{ForceDebug: true}))
 }

--- a/cmd/snap-update-ns/trespassing.go
+++ b/cmd/snap-update-ns/trespassing.go
@@ -61,11 +61,13 @@ type ModeHint struct {
 // such as /tmp, $SNAP_DATA and $SNAP.
 func (as *Assumptions) AddUnrestrictedPaths(paths ...string) {
 	as.unrestrictedPaths = append(as.unrestrictedPaths, paths...)
+	logger.Debugf("Assumptions.AddUnrestrictedPaths: paths:%s", strings.Join(paths, ","))
 }
 
 // AddModeHint adds a path glob and mode used when creating path elements.
 func (as *Assumptions) AddModeHint(pathGlob string, mode os.FileMode) {
 	as.modeHints = append(as.modeHints, ModeHint{PathGlob: pathGlob, Mode: mode})
+	logger.Debugf("Assumptions.AddModeHint: glob:%s mode:%v", pathGlob, mode)
 }
 
 // ModeForPath returns the mode for creating a directory at a given path.
@@ -90,6 +92,7 @@ func (as *Assumptions) ModeForPath(path string) os.FileMode {
 			}
 		}
 	}
+	logger.Debugf("Assumptions.ModeForPath path:%s => %v", path, mode)
 	return mode
 }
 

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -1049,6 +1049,10 @@ profile snap-update-ns.###SNAP_INSTANCE_NAME### (attach_disconnected) {
   # mount profile at a given moment.
   /run/snapd/ns/snap.###SNAP_INSTANCE_NAME###.fstab{,.*} rw,
 
+  # Allow writing to a log file for both per-snap and per-snap-and-user log files.
+  /run/snapd/ns/snap.###SNAP_INSTANCE_NAME###.log w,
+  /run/snapd/ns/snap.###SNAP_INSTANCE_NAME###.user.*.log w,
+
   # NOTE: at this stage the /snap directory is stable as we have called
   # pivot_root already.
 


### PR DESCRIPTION
When /run/snapd/ns/snap.$SNAP_NAME.log, for per-snap operations, or /run/snapd/ns/snap.$SNAP_NAME.user.$UID.log, for per-snap-and-user operations, file exists and can be written to, then configure it as a write-only (that is, without truncate) log.

This log captures all the operations performed by snap-confine and snap-update-ns, in relation to constructing and updating a persisted mount namespace of a given snap.

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-35498

