### PR TITLE
tests: account for omitzero in go 1.24+ for apparmor-prompting-snapd-startup

### DIFF
--- a/tests/main/apparmor-prompting-snapd-startup/task.yaml
+++ b/tests/main/apparmor-prompting-snapd-startup/task.yaml
@@ -227,15 +227,9 @@ execute: |
     if ! tests.info is-reexec-in-use && os.query is-ubuntu-ge 25.04; then
         echo "Expect snapd to be built with go 1.24+, which supports omitzero,"
         echo "so remove the zero-valued fields from the rules."
-        # We need to remove the comma from the preceding line, and preserve the
-        # comma on the current line (if it exists), so we make everything appear
-        # on the same line so sed works. We'll re-jq it later to re-add newlines.
-        tr -d '\n' < expected.json > expected-modified.json
-        sed -E \
-            -e 's/, *"expiration": ?"0001-01-01T00:00:00Z"//g' \
-            -e 's/, *"session-id": ?"0000000000000000"//g' \
-            expected-modified.json | gojq | tee expected.json
-        rm -f expected-modified.json
+        gojq 'del(.rules.[].constraints.permissions.[]."expiration" | select(. == "0001-01-01T00:00:00Z"))' < expected.json | \
+        gojq 'del(.rules.[].constraints.permissions.[]."session-id" | select(. == "0000000000000000"))' | tee expected-modified.json
+        mv expected-modified.json expected.json
     fi
 
     echo "Check that rules on disk match what is expected"

--- a/tests/main/apparmor-prompting-snapd-startup/task.yaml
+++ b/tests/main/apparmor-prompting-snapd-startup/task.yaml
@@ -224,6 +224,20 @@ execute: |
     }' | gojq | tee expected.json
     # Parse existing rules through (go)jq so they can be compared
 
+    if ! tests.info is-reexec-in-use && os.query is-ubuntu-ge 25.04; then
+        echo "Expect snapd to be built with go 1.24+, which supports omitzero,"
+        echo "so remove the zero-valued fields from the rules."
+        # We need to remove the comma from the preceding line, and preserve the
+        # comma on the current line (if it exists), so we make everything appear
+        # on the same line so sed works. We'll re-jq it later to re-add newlines.
+        tr -d '\n' < expected.json > expected-modified.json
+        sed -E \
+            -e 's/, *"expiration": ?"0001-01-01T00:00:00Z"//g' \
+            -e 's/, *"session-id": ?"0000000000000000"//g' \
+            expected-modified.json | gojq | tee expected.json
+        rm -f expected-modified.json
+    fi
+
     echo "Check that rules on disk match what is expected"
     gojq < "$RULES_PATH" > current.json
     diff expected.json current.json


### PR DESCRIPTION
When running without reexecution, snapd built on systems which ship go 1.24+ (plucky and questing) obeys omitzero, and thus omits fields which were previously zero values. The snapd snap is built with go 1.23, for now. When this is bumped to 1.24+, this test will need to be updated again, making the lack of fields the default, and adding special cases for old systems when not reexecuting.