### PR TITLE
github: add prebuilt snapd snap to perf metrics workflow

### DIFF
--- a/.github/workflows/ci-spread-times.yaml
+++ b/.github/workflows/ci-spread-times.yaml
@@ -28,6 +28,8 @@ jobs:
       
       - name: run empty test with spread
         run: |
+          export SPREAD_USE_PREBUILT_SNAPD_SNAP=true
+          export SPREAD_USE_SNAPD_SNAP_URL=https://storage.googleapis.com/snapd-spread-tests/snapd-tests/snaps/snapd_master_amd64.snap
           # Run spread in all the systems defined for openstack-ps7 environment
           spread -no-debug-output -json report.json openstack-ps7:tests/smoke/empty
 


### PR DESCRIPTION
We use a prebuilt snapd snap in the CI both in nightly runs as well as in PRs. This uses a prebuilt snapd snap also for recording perf metrics