### PR TITLE
tests/main/sru-validation-check, spread: fix test, add TODOs

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -299,6 +299,7 @@ backends:
                   workers: 6
                   storage: 30G
 
+    # TODO add garden-sru backend
     google-sru:
         type: google
         key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'

--- a/tests/main/sru-validation-check/task.yaml
+++ b/tests/main/sru-validation-check/task.yaml
@@ -4,7 +4,7 @@ details: |
     When sru validation is being executed, it is needed to check the correct
     snapd deb is being used and no-reexec policy is applied. 
 
-backends: [google-sru]
+backends: [google-sru, garden]
 
 environment: 
     SRU_VALIDATION_VERSION: '$(HOST: echo "${SPREAD_SRU_VALIDATION_VERSION:-}")'
@@ -41,8 +41,8 @@ execute: |
     # shellcheck disable=SC2034
     SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
     # shellcheck disable=SC2153
-    /usr/bin/env SNAPD_DEBUG=1 SNAP_REEXEC=1 snap list 2>&1 | MATCH "DEBUG: restarting into \"$SNAPD_MOUNT_DIR/snapd/current/usr/bin/snap\""
+    /usr/bin/env SNAPD_DEBUG=1 SNAP_REEXEC=1 snap list 2>&1 | MATCH "DEBUG: restarting into \"$SNAP_MOUNT_DIR/snapd/current/usr/bin/snap\""
 
     # Check the snap version has the proper value expected when the snapd snap is not being used
     . /etc/os-release
-    snap version | MATCH "snap .+${SRU_VALIDATION_VERSION}\+${VERSION_ID}$"
+    snap version | MATCH "snap .+${SRU_VALIDATION_VERSION}\+${ID}${VERSION_ID}$"


### PR DESCRIPTION
Fix the test which fails with:
```
+ /usr/bin/env SNAPD_DEBUG=1 SNAP_REEXEC=1 snap list
/bin/bash: line 126: SNAPD_MOUNT_DIR: unbound variable
-----
```
and then with:
```
+ snap version
+ MATCH 'snap .+2.71\+24.04$'
grep error: pattern not found, got:
snap    2.71+ubuntu24.04
snapd   2.71+ubuntu24.04
series  16
ubuntu  24.04
kernel  6.8.0-57-generic
```
