### PR TITLE
tests/nested/manual: extend preinstall check test to cover actions api

### DIFF
--- a/tests/nested/manual/hybrid-tpm-fde-preinstall-check/task.yaml
+++ b/tests/nested/manual/hybrid-tpm-fde-preinstall-check/task.yaml
@@ -2,8 +2,9 @@ summary: Test secboot efi preinstall check used for TPM backed FDE on hybrid Ubu
 
 details: |
   This test prepares an encrypted hybrid Ubuntu system seed and test that the
-  snapd API endpoint /v2/systems/{system-label} can be used to determine
-  encryption availability.
+  snapd API endpoint /v2/systems/{system-label} (1) can be used to determine
+  encryption availability as well as (2) request actions to recover from errors
+  preventing the use of encryption.
 
 systems: [-ubuntu-1*, -ubuntu-20*, -ubuntu-22*]
 
@@ -108,6 +109,7 @@ execute: |
   remote.exec "sudo snap debug api /v2/systems/classic 2>/dev/null" | gojq '.result["storage-encryption"]."encryption-type"' | MATCH "cryptsetup"
 
   # Cause an error by configuring bogus shim
+  remote.exec "sudo cp /cdrom/EFI/boot/bootx64.efi /cdrom/EFI/boot/bootx64.efi.orig"
   remote.exec "sudo cp /boot/efi/EFI/ubuntu/grubx64.efi /cdrom/EFI/boot/bootx64.efi"
 
   # Check that encryption is not available for the targeted system and provides reason with error-kind
@@ -134,3 +136,49 @@ execute: |
   # Check that the basic availability check that do not consider shim, grub and kernel still works
   remote.exec "sudo sed -i 's/^VERSION_ID=.*/VERSION_ID=25.04/' /etc/os-release"
   remote.exec "sudo snap debug api /v2/systems/classic 2>/dev/null" | gojq '.result["storage-encryption"].support' | MATCH "available"
+
+  # Revert back to working preinstall check
+  remote.exec "sudo cp /cdrom/EFI/boot/bootx64.efi.orig /cdrom/EFI/boot/bootx64.efi" # restore correct shim
+  remote.exec "sudo sed -i 's/^VERSION_ID=.*/VERSION_ID=25.10/' /etc/os-release"     # enable secboot preinstall check
+
+  # Check that encryption is again available for the targeted system
+  remote.exec "sudo snap debug api /v2/systems/classic 2>/dev/null" | gojq '.result["storage-encryption"].support' | MATCH "available"
+  remote.exec "sudo snap debug api /v2/systems/classic 2>/dev/null" | gojq '.result["storage-encryption"]."encryption-type"' | MATCH "cryptsetup"
+
+  # Restart snapd to clear preinstall context from cache
+  remote.exec "sudo systemctl restart snapd.service"
+
+  # Requesting a fix action when there is no preinstall context available should result in error
+  remote.exec "echo '{ \"action\": \"fix-encryption-support\", \"fix-action\": \"\"}' | sudo snap debug api -X POST -H 'Content-Type: application/json' /v2/systems/classic 2>/dev/null" > result
+
+  cat <<EOF > result.reference
+  {
+    "result": {
+      "message": "cannot use check action without cached encryption information"
+    },
+    "status": "Internal Server Error",
+    "status-code": 500,
+    "type": "error"
+  }
+  EOF
+
+  diff result result.reference
+
+  # Run preinstall check to provide cached context
+  remote.exec "sudo snap debug api /v2/systems/classic 2>/dev/null" | gojq '.result["storage-encryption"].support' | MATCH "available"
+  remote.exec "sudo snap debug api /v2/systems/classic 2>/dev/null" | gojq '.result["storage-encryption"]."encryption-type"' | MATCH "cryptsetup"
+
+  # Requesting a fix action with preinstall context available should succeed
+  remote.exec "echo '{ \"action\": \"fix-encryption-support\", \"fix-action\": \"\"}' | sudo snap debug api -X POST -H 'Content-Type: application/json' /v2/systems/classic 2>/dev/null" | gojq '.result["storage-encryption"].support' | MATCH "available"
+
+  remote.exec "echo '{ \"action\": \"fix-encryption-support\", \"fix-action\": \"\"}' | sudo snap debug api -X POST -H 'Content-Type: application/json' /v2/systems/classic 2>/dev/null" | gojq '.result["storage-encryption"].support' | MATCH "cryptsetup"
+
+  # Cause an error by configuring bogus shim
+  remote.exec "sudo cp /boot/efi/EFI/ubuntu/grubx64.efi /cdrom/EFI/boot/bootx64.efi"
+
+  # Check that when requesting and action encryption is not available for the targeted system and provides reason with error-kind
+  remote.exec "echo '{ \"action\": \"fix-encryption-support\", \"fix-action\": \"\"}' | sudo snap debug api -X POST -H 'Content-Type: application/json' /v2/systems/classic 2>/dev/null" | gojq '.result["storage-encryption"].support' | MATCH "unavailable"
+
+  remote.exec "echo '{ \"action\": \"fix-encryption-support\", \"fix-action\": \"\"}' | sudo snap debug api -X POST -H 'Content-Type: application/json' /v2/systems/classic 2>/dev/null" | gojq '.result["storage-encryption"].support' > availability-check-errors
+
+  diff availability-check-errors availability-check-errors.reference


### PR DESCRIPTION
Add spread coverage for error actions

Error actions api was added [here](https://github.com/canonical/snapd/pull/15871)
Jira: https://warthogs.atlassian.net/browse/SNAPDENG-35035

Checking for the /run/mnt/.../preinstall file with the runchecks information for optimum PCR configuration will be added to a different general hybrid test running on 25.10 (in the works).