### PR TITLE
tests: use prebuilt snapd snap for testing times workflow

### DIFF
--- a/.github/workflows/ci-spread-times.yaml
+++ b/.github/workflows/ci-spread-times.yaml
@@ -27,6 +27,9 @@ jobs:
           echo -e "summary: test\nexecute: true\n" > tests/smoke/empty/task.yaml
       
       - name: run empty test with spread
+        env:
+          SPREAD_USE_SNAPD_SNAP_URL: https://storage.googleapis.com/snapd-spread-tests/snapd-tests/snaps/snapd_master_amd64.snap
+          SPREAD_USE_PREBUILT_SNAPD_SNAP: true
         run: |
           # Run spread in all the systems defined for openstack-ps7 environment
           spread -no-debug-output -json report.json openstack-ps7:tests/smoke/empty


### PR DESCRIPTION
SPREAD_USE_SNAPD_SNAP_URL and SPREAD_USE_PREBUILT_SNAPD_SNAP vars are set to be used by spread.
