### PR TITLE
tests/main/interfaces-libvirt: specify libvirt connect URI

### DIFF
--- a/tests/main/interfaces-libvirt/task.yaml
+++ b/tests/main/interfaces-libvirt/task.yaml
@@ -43,6 +43,9 @@ prepare: |
     ip addr add 10.0.0.1/24 dev tap100
     ip link set dev tap100 up
 
+    # start the user session only after adding supplemental groups
+    tests.session -u test prepare
+
 restore: |
     if not os.query is-pc-amd64; then
         echo "The snap test-snapd-libvirt-consumer is just available for amd64"
@@ -53,6 +56,8 @@ restore: |
 
     # remove test user from the libvirt group
     deluser test libvirt
+
+    tests.session -u test restore
 
 execute: |
     if not os.query is-pc-amd64; then
@@ -67,21 +72,21 @@ execute: |
     snap connect test-snapd-libvirt-consumer:libvirt
 
     echo "Then the snap is able to create the unikernel domain"
-    su -l -c "test-snapd-libvirt-consumer.machine-up" test
+    tests.session -u test exec sh -c 'VIRSH_DEFAULT_CONNECT_URI=qemu:///system test-snapd-libvirt-consumer.machine-up'
     virsh list | MATCH ping-unikernel
 
     echo "And the unikernel is accesible"
     ping -c 1 -q -W 1 10.0.0.2
 
     echo "And the snap is able to destroy the unikernel domain"
-    su -l -c "test-snapd-libvirt-consumer.machine-down" test
+    tests.session -u test exec sh -c 'VIRSH_DEFAULT_CONNECT_URI=qemu:///system test-snapd-libvirt-consumer.machine-down'
     virsh list | NOMATCH ping-unikernel
 
     echo "When the plug is disconnected"
     snap disconnect test-snapd-libvirt-consumer:libvirt
 
     echo "Then the snap is not able to create a domain"
-    if su -l -c "test-snapd-libvirt-consumer.machine-up" test 2> creation.error; then
+    if tests.session -u test exec sh -c 'VIRSH_DEFAULT_CONNECT_URI=qemu:///system test-snapd-libvirt-consumer.machine-up' 2> creation.error; then
         echo "Expected permission error accessing libvirtd socket with disconnected plug"
         exit 1
     fi


### PR DESCRIPTION
Explicitly specify libvirt connect URI. This seems to be required as driver auto detection ends up trying the session socket instead of the system one, even though the test theoretically keeps running as the test user.

Related: SNAPDENG-35497

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
