### PR TITLE
tests: fix qemu-runner.sh on xenial

### DIFF
--- a/tests/lib/qemu-runner.sh
+++ b/tests/lib/qemu-runner.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-set -eu
+# TODO: add set -u once xenial is not supported anymore
+set -e
 shopt -s nullglob
 
 CREDS="${1}"


### PR DESCRIPTION
Remove the -u which is not working properly on xenial, and add a TODO to revert that once xenial is not supported anymore.
