### PR TITLE
interfaces/builtin/fwupd: Allow access to /sys/devices/**/power/control for intel-gsc

### DIFF
--- a/interfaces/builtin/fwupd.go
+++ b/interfaces/builtin/fwupd.go
@@ -172,6 +172,9 @@ const fwupdPermanentSlotAppArmor = `
   /sys/devices/**/cvs_ctrl_data_fwupd r,
   /sys/devices/**/cvs_ctrl_data_pre rw,
 
+  # Required by plugin intel-gsc
+  /sys/devices/**/power/control rw,
+
   # DBus accesses
   #include <abstractions/dbus-strict>
   dbus (send)


### PR DESCRIPTION
**Context:** 
fwupd [release 2.0.9](https://github.com/fwupd/fwupd/releases/tag/2.0.9) added support for Arc Battlemage products; however, this version is not natively available on ubuntu 24.04.

The fwupd readme discourages compiling the project from scratch, and instead suggests to install newer versions alternative packaging/deployment services when necessary.

**What this PR is meant to  solve:**
When the latest fwupd version is installed via snap on Ubuntu 24.04, features to read device and firmware information are working, but attempting to actually update firmware shows:
`failed to open /sys/devices/**/power/control: permission denied`

If fwupd is installed via snap with `--devmode` flag, this does not happen.