### PR TITLE
tests, github: clean up packaging in tests

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -140,10 +140,13 @@ jobs:
       fail-fast: false
       matrix:
         build-config:
+          - { system: "ubuntu-25.10-64",     runs-on: '["ubuntu-latest"]',     os: ubuntu, os-version: '25.10' }
+          - { system: "ubuntu-25.04-64",     runs-on: '["ubuntu-latest"]',     os: ubuntu, os-version: '25.04' }
           - { system: "ubuntu-24.04-64",     runs-on: '["ubuntu-latest"]',     os: ubuntu, os-version: '24.04' }
           - { system: "ubuntu-22.04-64",     runs-on: '["ubuntu-latest"]',     os: ubuntu, os-version: '22.04' }
           - { system: "ubuntu-20.04-64",     runs-on: '["ubuntu-latest"]',     os: ubuntu, os-version: '20.04' }
           - { system: "ubuntu-18.04-64",     runs-on: '["ubuntu-latest"]',     os: ubuntu, os-version: '18.04' }
+          - { system: "debian-sid-64",       runs-on: '["ubuntu-latest"]',     os: debian, os-version: 'sid'   }
           - { system: "ubuntu-24.04-arm-64", runs-on: '["ubuntu-24.04-arm"]',  os: ubuntu, os-version: '24.04' }
           - { system: "ubuntu-22.04-arm-64", runs-on: '["ubuntu-24.04-arm"]',  os: ubuntu, os-version: '22.04' }
 

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -140,15 +140,10 @@ jobs:
       fail-fast: false
       matrix:
         build-config:
-          - { system: "ubuntu-25.10-64",     runs-on: '["ubuntu-latest"]',     os: ubuntu, os-version: '25.10' }
-          - { system: "ubuntu-25.04-64",     runs-on: '["ubuntu-latest"]',     os: ubuntu, os-version: '25.04' }
           - { system: "ubuntu-24.04-64",     runs-on: '["ubuntu-latest"]',     os: ubuntu, os-version: '24.04' }
           - { system: "ubuntu-22.04-64",     runs-on: '["ubuntu-latest"]',     os: ubuntu, os-version: '22.04' }
           - { system: "ubuntu-20.04-64",     runs-on: '["ubuntu-latest"]',     os: ubuntu, os-version: '20.04' }
           - { system: "ubuntu-18.04-64",     runs-on: '["ubuntu-latest"]',     os: ubuntu, os-version: '18.04' }
-          - { system: "ubuntu-16.04-64",     runs-on: '["ubuntu-latest"]',     os: ubuntu, os-version: '16.04' }
-          - { system: "debian-12-64",        runs-on: '["ubuntu-latest"]',     os: debian, os-version: '12'    }
-          - { system: "debian-sid-64",       runs-on: '["ubuntu-latest"]',     os: debian, os-version: 'sid'   }
           - { system: "ubuntu-24.04-arm-64", runs-on: '["ubuntu-24.04-arm"]',  os: ubuntu, os-version: '24.04' }
           - { system: "ubuntu-22.04-arm-64", runs-on: '["ubuntu-24.04-arm"]',  os: ubuntu, os-version: '22.04' }
 

--- a/tests/cross/go-build/task.yaml
+++ b/tests/cross/go-build/task.yaml
@@ -69,7 +69,7 @@ restore: |
 execute: |
     cd /tmp/cross-build/src/github.com/snapcore/snapd
     # grab only packages whose name is 'main'
-    #su -c "GOPATH=/tmp/cross-build go mod vendor" test
+    su -c "GOPATH=/tmp/cross-build go mod vendor" test
     for cmd in $( GOPATH=/tmp/cross-build go list -f '{{if eq .Name "main"}}{{.ImportPath}}{{end}}' ./cmd/...); do
       su -c "GOPATH=/tmp/cross-build CGO_ENABLED=1 GOARCH=$X_GOARCH CC=$X_CC go build -mod vendor -v -o /dev/null $cmd" test
     done

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -70,6 +70,26 @@ create_test_user(){
 }
 
 build_deb(){
+    # debian-sid packaging is special
+    if os.query is-debian sid; then
+        if [ ! -d packaging/debian-sid ]; then
+            echo "no packaging/debian-sid/ directory "
+            echo "broken test setup"
+            exit 1
+        fi
+
+        # remove etckeeper
+        apt purge -y etckeeper
+
+        # debian has its own packaging
+        rm -f debian
+        # the debian dir must be a real dir, a symlink will make
+        # dpkg-buildpackage choke later.
+        mv packaging/debian-sid debian
+
+        # ensure we really build without vendored packages
+        mv ./vendor /tmp
+    fi
     newver="$(dpkg-parsechangelog --show-field Version)"
 
     case "$SPREAD_SYSTEM" in
@@ -80,11 +100,6 @@ build_deb(){
     esac
     # Use fake version to ensure we are always bigger than anything else
     dch --newversion "1337.$newver" "testing build"
-
-    if os.query is-debian sid; then
-        # ensure we really build without vendored packages
-        mv ./vendor /tmp
-    fi
 
     unshare -n -- \
             su -l -c "cd $PWD && DEB_BUILD_OPTIONS='nocheck testkeys ${FIPS_BUILD_OPTION}' dpkg-buildpackage -tc -b -Zgzip -uc -us" test
@@ -336,36 +351,6 @@ prepare_project() {
         fi
     fi
 
-    # debian-sid packaging is special
-    if os.query is-debian sid; then
-        if [ ! -d packaging/debian-sid ]; then
-            echo "no packaging/debian-sid/ directory "
-            echo "broken test setup"
-            exit 1
-        fi
-
-        # remove etckeeper
-        apt purge -y etckeeper
-
-        # debian has its own packaging
-        rm -f debian
-        # the debian dir must be a real dir, a symlink will make
-        # dpkg-buildpackage choke later.
-        mv packaging/debian-sid debian
-
-        # get the build-deps
-        apt build-dep -y ./
-
-        # and ensure we don't take any of the vendor deps
-        rm -rf vendor/*/
-
-        # and create a fake upstream tarball
-        tar -c -z -f ../snapd_"$(dpkg-parsechangelog --show-field Version|cut -d- -f1)".orig.tar.gz --exclude=./debian --exclude=./.git --exclude='*.pyc' .
-
-        # and build a source package - this will be used during the sbuild test
-        dpkg-buildpackage -S -uc -us
-    fi
-
     # so is ubuntu-14.04
     if os.query is-trusty; then
         if [ ! -d packaging/ubuntu-14.04 ]; then
@@ -546,14 +531,6 @@ prepare_project() {
             ;;
     esac
 
-    # Retry go mod vendor to minimize the number of connection errors during the sync
-    retry -n 10 go mod vendor
-    # Update C dependencies
-    ( cd c-vendor && retry -n 10 ./vendor.sh )
-
-    # go mod runs as root and will leave strange permissions
-    chown test:test -R "$SPREAD_PATH"
-
     # We are testing snapd snap on top of snapd from the archive
     # of the tested distribution. Download snapd and snap-confine
     # as they exist in the archive for further use.
@@ -578,8 +555,19 @@ prepare_project() {
                 ;;
         esac
     else
+        # Retry go mod vendor to minimize the number of connection errors during the sync
+        retry -n 10 go mod vendor
+        # Update C dependencies
+        ( cd c-vendor && retry -n 10 ./vendor.sh )
+
+        # go mod runs as root and will leave strange permissions
+        chown test:test -R "$SPREAD_PATH"
         case "$SPREAD_SYSTEM" in
             ubuntu-*|debian-*)
+                # in 16.04: "apt build-dep -y ./" would also work but not on 14.04
+                gdebi --quiet --apt-line ./debian/control >deps.txt
+                quiet xargs -r eatmydata apt-get install -y < deps.txt
+                
                 build_deb
                 ;;
             fedora-*|opensuse-*|amazon-*|centos-*)

--- a/tests/main/user-libnss/task.yaml
+++ b/tests/main/user-libnss/task.yaml
@@ -34,6 +34,8 @@ restore: |
     rm -rf /var/lib/extrausers
 
 execute: |
+    go mod vendor
+
     echo "Ensure tests run with both CGO and without"
     su test -c 'CGO_ENABLED=1 go test -mod vendor github.com/snapcore/snapd/osutil'
     su test -c 'CGO_ENABLED=0 go test -mod vendor github.com/snapcore/snapd/osutil'

--- a/tests/unit/go/task.yaml
+++ b/tests/unit/go/task.yaml
@@ -40,7 +40,7 @@ execute: |
     chown -R test:12345 /tmp/static-unit-tests
 
     # remove leftovers
-    rm -r /tmp/static-unit-tests/src/github.com/snapcore/snapd/vendor/*/
+    rm -rf /tmp/static-unit-tests/src/github.com/snapcore/snapd/vendor/*/
     rm -rf /tmp/static-unit-tests/src/github.com/snapcore/snapd/cmd/{autom4te.cache,configure,test-driver,config.status,config.guess,config.sub,config.h.in,compile,install-sh,depcomp,build,missing,aclocal.m4,Makefile,Makefile.in}
 
     # The format of code produced by "gofmt" drifts over time. Perform checks


### PR DESCRIPTION
This removes the unnecessary pre-building packages for debian and non-core and non-nested ubuntu. In the ci-tests.yaml workflow, those systems use the deb from the archive and do not build snapd. Additionally, this moves around packaging steps to inside the packaging else branch.