### PR TITLE
tests: run ubuntu-core-18 tests in openstack

### DIFF
--- a/.github/workflows/data-fundamental-systems.json
+++ b/.github/workflows/data-fundamental-systems.json
@@ -34,7 +34,7 @@
       },
       {
         "group": "ubuntu-core-18 (fundamental)",
-        "backend": "google-core",
+        "backend": "openstack-ps7",
         "alternative-backend": "google-core",
         "systems": "ubuntu-core-18-64",
         "tasks": "tests/...",

--- a/spread.yaml
+++ b/spread.yaml
@@ -441,6 +441,9 @@ backends:
                 image: snapd-spread/ubuntu-25.10-64
                 workers: 8
 
+            - ubuntu-core-18-64:
+                image: snapd-spread/ubuntu-18.04-64
+                workers: 8
             - ubuntu-core-20-64:
                 image: snapd-spread/ubuntu-20.04-64-uefi
                 workers: 8


### PR DESCRIPTION
When running in openstack backend and uc18 it is required to use an specific kernel snap which is using the 5.4.0 instead of the 4.15 because this version has a fix for https://bugs.launchpad.net/qemu/+bug/1844053
