### PR TITLE
core-initrd: Add missing order dependency for setting default system files

### DIFF
--- a/core-initrd/latest/factory/usr/lib/systemd/system/initrd-core-tmpfiles-setup.service
+++ b/core-initrd/latest/factory/usr/lib/systemd/system/initrd-core-tmpfiles-setup.service
@@ -4,6 +4,7 @@ ConditionPathExists=!/sysroot/etc/system-image/writable-paths
 DefaultDependencies=no
 Conflicts=shutdown.target
 Before=initrd-root-fs.target shutdown.target
+Before=initrd-core-system-defaults.service
 RefuseManualStop=yes
 RequiresMountsFor=/sysroot/writable
 


### PR DESCRIPTION
Because tmpfiles only copy directories if the target is empty, we need to make sure that `initrd-core-system-defaults.service` runs after tmpfiles. Otherwise it creates directories like `/etc/systemd`, and files do not get copied.
