### PR TITLE
snadbox/cgroup/tracking: Use a dot to split cgroup scope uuid

### DIFF
--- a/sandbox/cgroup/freezer_test.go
+++ b/sandbox/cgroup/freezer_test.go
@@ -357,7 +357,7 @@ func (s *freezerV2Suite) TestFreezeThawSnapProcessesV2ErrWalking(c *C) {
 	err := cgroup.FreezeSnapProcesses(context.TODO(), "foo")
 	// go 1.10+ slightly changed the order of calls in filepath.Walk(), make
 	// sure the error check matches both
-	c.Check(err, ErrorMatches, `cannot finish freezing processes of snap "foo":( cannot freeze processes of snap "foo",)? open .*/sys/fs/cgroup/system.slice/snap.foo.app.1234.1234.1234.scope(/cgroup.freeze)?: permission denied`)
+	c.Check(err, ErrorMatches, `cannot finish freezing processes of snap "foo":( cannot freeze processes of snap "foo",)? open .*/sys/fs/cgroup/system.slice/snap.foo.app.1234-1234.1234.scope(/cgroup.freeze)?: permission denied`)
 	// other group was unfrozen
 	c.Check(gUnfreeze, testutil.FileEquals, "0")
 
@@ -367,13 +367,13 @@ func (s *freezerV2Suite) TestFreezeThawSnapProcessesV2ErrWalking(c *C) {
 	c.Assert(os.Chmod(g, 0000), IsNil)
 	// other group was unfrozen
 	err = cgroup.FreezeSnapProcesses(context.TODO(), "foo")
-	c.Check(err, ErrorMatches, `cannot finish freezing processes of snap "foo": cannot freeze processes in group "snap.foo.app.1234-1234-1234.scope": open .*/sys/fs/cgroup/system.slice/snap.foo.app.1234.1234.1234.scope/cgroup.freeze: permission denied`)
+	c.Check(err, ErrorMatches, `cannot finish freezing processes of snap "foo": cannot freeze processes in group "snap.foo.app.1234-1234-1234.scope": open .*/sys/fs/cgroup/system.slice/snap.foo.app.1234-1234.1234.scope/cgroup.freeze: permission denied`)
 	// other group was unfrozen
 	c.Check(gUnfreeze, testutil.FileEquals, "0")
 
 	// thawing fails likewise
 	err = cgroup.ThawSnapProcesses("foo")
-	c.Check(err, ErrorMatches, `cannot thaw processes of snap "foo", open .*/sys/fs/cgroup/system.slice/snap.foo.app.1234.1234.1234.scope/cgroup.freeze: permission denied`)
+	c.Check(err, ErrorMatches, `cannot thaw processes of snap "foo", open .*/sys/fs/cgroup/system.slice/snap.foo.app.1234-1234.1234.scope/cgroup.freeze: permission denied`)
 	// other group was unfrozen
 	c.Check(gUnfreeze, testutil.FileEquals, "0")
 
@@ -384,7 +384,7 @@ func (s *freezerV2Suite) TestFreezeThawSnapProcessesV2ErrWalking(c *C) {
 
 	err = cgroup.FreezeSnapProcesses(context.TODO(), "foo")
 	// but the unfreeze errors are ignored anyuway
-	c.Check(err, ErrorMatches, `cannot finish freezing processes of snap "foo": cannot freeze processes in group "snap.foo.app.1234-1234-1234.scope": open .*/sys/fs/cgroup/system.slice/snap.foo.app.1234.1234.1234.scope/cgroup.freeze: permission denied`)
+	c.Check(err, ErrorMatches, `cannot finish freezing processes of snap "foo": cannot freeze processes in group "snap.foo.app.1234-1234-1234.scope": open .*/sys/fs/cgroup/system.slice/snap.foo.app.1234-1234.1234.scope/cgroup.freeze: permission denied`)
 	// the other group is unmodified
 	os.Chmod(filepath.Dir(gUnfreeze), 0755)
 	c.Check(gUnfreeze, testutil.FileEquals, "1")

--- a/sandbox/cgroup/tracking.go
+++ b/sandbox/cgroup/tracking.go
@@ -93,7 +93,7 @@ func CreateTransientScopeForTracking(securityTag string, opts *TrackingOptions) 
 	// - the originally started scope must be marked as a delegate, with all
 	//   consequences.
 	// - the method AttachProcessesToUnit is unavailable on Ubuntu 16.04
-	unitName := fmt.Sprintf("%s-%s.scope", securityTagUnitName, uuid)
+	unitName := fmt.Sprintf("%s.%s.scope", securityTagUnitName, uuid)
 
 	pid := osGetpid()
 	start := time.Now()


### PR DESCRIPTION
Using a dash may break applications using libnotify that were using this information to figure out their current snap names, so use a dot instead, as it allows to keep supporting them without breaking desktop expectations

See: https://gitlab.gnome.org/GNOME/libnotify/-/blob/0.8.6/libnotify/notify.c?ref_type=tags#L223-306

[LP: #2125222](https://bugs.launchpad.net/ubuntu/+source/snapd/+bug/2125222)
