### PR TITLE
cmd/snap-seccomp: fix unit tests running on questing with glibc 2.42

### DIFF
--- a/cmd/snap-seccomp/main_test.go
+++ b/cmd/snap-seccomp/main_test.go
@@ -285,6 +285,8 @@ faccessat
 restart_syscall
 # libc6 2.31/gcc-9.3
 mprotect
+# libc6 2.42
+getrandom
 `
 	bpfPath := filepath.Join(c.MkDir(), "bpf")
 	err := main.Compile([]byte(common+seccompAllowlist), bpfPath)


### PR DESCRIPTION
Apparently glibc attempts use some randomized values when setting up ptmalloc allocator. When the initial call to getrandom() fails, it will then proceed to call clock_gettime() in a loop, probably initializing the random seed from current time. When both system calls are blocked, the seccomp_syscall_runner appears to be stuck thus blocking the unit tests.

Fix that by allowing `getrandom()`.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
