### PR TITLE
many: add better error kinds for some /v2/system-volumes actions

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -185,6 +185,9 @@ const (
 
 	// ErrorKindSystemKeyVersionUnsupported: snapd does not support the system key version sent by the client.
 	ErrorKindSystemKeyVersionUnsupported ErrorKind = "unsupported-system-key-version"
+
+	// ErrorKindKeyslotNotFound: keyslots cannot be found.
+	ErrorKindKeyslotsNotFound ErrorKind = "keyslots-not-found"
 )
 
 // Maintenance error kinds.

--- a/client/errors.go
+++ b/client/errors.go
@@ -188,6 +188,9 @@ const (
 
 	// ErrorKindKeyslotNotFound: keyslots cannot be found.
 	ErrorKindKeyslotsNotFound ErrorKind = "keyslots-not-found"
+
+	// ErrorKindInvalidRecoveryKey: recovery key itself or its ID is invalid.
+	ErrorKindInvalidRecoveryKey ErrorKind = "invalid-recovery-key"
 )
 
 // Maintenance error kinds.

--- a/daemon/api_system_volumes_test.go
+++ b/daemon/api_system_volumes_test.go
@@ -354,6 +354,21 @@ func (s *systemVolumesSuite) TestSystemVolumesActionReplaceRecoveryKeyError(c *C
 	c.Assert(rsp.Status, Equals, 409)
 	c.Check(rsp.Kind, Equals, client.ErrorKindSnapChangeConflict)
 	c.Check(rsp.Message, Equals, "conflict error: boom!")
+
+	// typed keyslots not found error kind
+	mockErr = &fdestate.KeyslotRefsNotFoundError{
+		KeyslotRefs: []fdestate.KeyslotRef{{ContainerRole: "some-container-role", Name: "some-name"}},
+	}
+	body = strings.NewReader(`{"action": "replace-recovery-key", "key-id": "some-key-id"}`)
+	req, err = http.NewRequest("POST", "/v2/system-volumes", body)
+	req.Header.Add("Content-Type", "application/json")
+
+	c.Assert(err, IsNil)
+	rsp = s.errorReq(c, req, nil, actionIsExpected)
+	c.Assert(rsp.Status, Equals, 400)
+	c.Check(rsp.Kind, Equals, client.ErrorKindKeyslotsNotFound)
+	c.Check(rsp.Message, Equals, `key slot reference (container-role: "some-container-role", name: "some-name") not found`)
+	c.Check(rsp.Value, DeepEquals, []fdestate.KeyslotRef{{ContainerRole: "some-container-role", Name: "some-name"}})
 }
 
 func (s *systemVolumesSuite) TestSystemVolumesActionReplaceRecoveryKeyMissingKeyID(c *C) {
@@ -523,6 +538,21 @@ func (s *systemVolumesSuite) TestSystemVolumesActionReplacePlatformKeyError(c *C
 	c.Assert(rsp.Status, Equals, 409)
 	c.Check(rsp.Kind, Equals, client.ErrorKindSnapChangeConflict)
 	c.Check(rsp.Message, Equals, "conflict error: boom!")
+
+	// typed keyslots not found error kind
+	mockErr = &fdestate.KeyslotRefsNotFoundError{
+		KeyslotRefs: []fdestate.KeyslotRef{{ContainerRole: "some-container-role", Name: "some-name"}},
+	}
+	body = strings.NewReader(`{"action": "replace-platform-key", "auth-mode": "none"}`)
+	req, err = http.NewRequest("POST", "/v2/system-volumes", body)
+	req.Header.Add("Content-Type", "application/json")
+
+	c.Assert(err, IsNil)
+	rsp = s.errorReq(c, req, nil, actionIsExpected)
+	c.Assert(rsp.Status, Equals, 400)
+	c.Check(rsp.Kind, Equals, client.ErrorKindKeyslotsNotFound)
+	c.Check(rsp.Message, Equals, `key slot reference (container-role: "some-container-role", name: "some-name") not found`)
+	c.Check(rsp.Value, DeepEquals, []fdestate.KeyslotRef{{ContainerRole: "some-container-role", Name: "some-name"}})
 }
 
 func (s *systemVolumesSuite) TestSystemVolumesActionReplacePlatformKeyMissingAuthMode(c *C) {
@@ -663,6 +693,21 @@ func (s *systemVolumesSuite) TestSystemVolumesActionChangePassphraseChangeAuthEr
 	c.Assert(rsp.Status, Equals, 409)
 	c.Check(rsp.Kind, Equals, client.ErrorKindSnapChangeConflict)
 	c.Check(rsp.Message, Equals, "conflict error: boom!")
+
+	// typed keyslots not found error kind
+	mockErr = &fdestate.KeyslotRefsNotFoundError{
+		KeyslotRefs: []fdestate.KeyslotRef{{ContainerRole: "some-container-role", Name: "some-name"}},
+	}
+	body = strings.NewReader(`{"action": "change-passphrase", "old-passphrase": "old", "new-passphrase": "new"}`)
+	req, err = http.NewRequest("POST", "/v2/system-volumes", body)
+	req.Header.Add("Content-Type", "application/json")
+
+	c.Assert(err, IsNil)
+	rsp = s.errorReq(c, req, nil, actionIsExpected)
+	c.Assert(rsp.Status, Equals, 400)
+	c.Check(rsp.Kind, Equals, client.ErrorKindKeyslotsNotFound)
+	c.Check(rsp.Message, Equals, `key slot reference (container-role: "some-container-role", name: "some-name") not found`)
+	c.Check(rsp.Value, DeepEquals, []fdestate.KeyslotRef{{ContainerRole: "some-container-role", Name: "some-name"}})
 }
 
 type mockKeyData struct {

--- a/daemon/api_system_volumes_test.go
+++ b/daemon/api_system_volumes_test.go
@@ -242,7 +242,9 @@ func (s *systemVolumesSuite) TestSystemVolumesActionCheckRecoveryKeyBadRecoveryK
 	rsp := s.errorReq(c, req, nil, actionIsExpected)
 	c.Assert(rsp.Status, Equals, 400)
 	// rest of error is coming from secboot
+	c.Assert(rsp.Kind, Equals, client.ErrorKindInvalidRecoveryKey)
 	c.Assert(rsp.Message, Equals, "cannot parse recovery key: incorrectly formatted: insufficient characters")
+	c.Assert(rsp.Value, DeepEquals, map[string]any{"reason": fdestate.InvalidRecoveryKeyReasonInvalidFormat})
 
 	c.Check(called, Equals, 0)
 }
@@ -255,12 +257,12 @@ func (s *systemVolumesSuite) TestSystemVolumesActionCheckRecoveryKeyError(c *C) 
 	s.daemon(c)
 	s.mockHybridSystem()
 
-	called := 0
+	var mockErr error
 	s.AddCleanup(daemon.MockFdeMgrCheckRecoveryKey(func(fdemgr *fdestate.FDEManager, rkey keys.RecoveryKey, containerRoles []string) (err error) {
-		called++
-		return errors.New("boom!")
+		return mockErr
 	}))
 
+	mockErr = errors.New("boom!")
 	body := strings.NewReader(`{"action": "check-recovery-key", "recovery-key": "25970-28515-25974-31090-12593-12593-12593-12593"}`)
 	req, err := http.NewRequest("POST", "/v2/system-volumes", body)
 	c.Assert(err, IsNil)
@@ -269,9 +271,22 @@ func (s *systemVolumesSuite) TestSystemVolumesActionCheckRecoveryKeyError(c *C) 
 	rsp := s.errorReq(c, req, nil, actionIsExpected)
 	c.Assert(rsp.Status, Equals, 400)
 	// rest of error is coming from secboot
-	c.Assert(rsp.Message, Equals, "cannot find matching recovery key: boom!")
+	c.Assert(rsp.Message, Equals, "boom!")
 
-	c.Check(called, Equals, 1)
+	// typed no matching recovery key error kind
+	mockErr = &fdestate.InvalidRecoveryKeyError{
+		Reason: fdestate.InvalidRecoveryKeyReasonNoMatchFound,
+	}
+	body = strings.NewReader(`{"action": "check-recovery-key", "recovery-key": "25970-28515-25974-31090-12593-12593-12593-12593"}`)
+	req, err = http.NewRequest("POST", "/v2/system-volumes", body)
+	req.Header.Add("Content-Type", "application/json")
+
+	c.Assert(err, IsNil)
+	rsp = s.errorReq(c, req, nil, actionIsExpected)
+	c.Assert(rsp.Status, Equals, 400)
+	c.Check(rsp.Kind, Equals, client.ErrorKindInvalidRecoveryKey)
+	c.Check(rsp.Message, Equals, "invalid recovery key: no match found")
+	c.Assert(rsp.Value, DeepEquals, map[string]any{"reason": fdestate.InvalidRecoveryKeyReasonNoMatchFound})
 }
 
 func (s *systemVolumesSuite) TestSystemVolumesActionReplaceRecoveryKey(c *C) {
@@ -369,6 +384,21 @@ func (s *systemVolumesSuite) TestSystemVolumesActionReplaceRecoveryKeyError(c *C
 	c.Check(rsp.Kind, Equals, client.ErrorKindKeyslotsNotFound)
 	c.Check(rsp.Message, Equals, `key slot reference (container-role: "some-container-role", name: "some-name") not found`)
 	c.Check(rsp.Value, DeepEquals, []fdestate.KeyslotRef{{ContainerRole: "some-container-role", Name: "some-name"}})
+
+	// typed invalid recovery key error kind
+	mockErr = &fdestate.InvalidRecoveryKeyError{
+		Reason: fdestate.InvalidRecoveryKeyReasonExpired,
+	}
+	body = strings.NewReader(`{"action": "replace-recovery-key", "key-id": "some-key-id"}`)
+	req, err = http.NewRequest("POST", "/v2/system-volumes", body)
+	req.Header.Add("Content-Type", "application/json")
+
+	c.Assert(err, IsNil)
+	rsp = s.errorReq(c, req, nil, actionIsExpected)
+	c.Assert(rsp.Status, Equals, 400)
+	c.Check(rsp.Kind, Equals, client.ErrorKindInvalidRecoveryKey)
+	c.Check(rsp.Message, Equals, `invalid recovery key: expired`)
+	c.Check(rsp.Value, DeepEquals, map[string]any{"reason": fdestate.InvalidRecoveryKeyReasonExpired})
 }
 
 func (s *systemVolumesSuite) TestSystemVolumesActionReplaceRecoveryKeyMissingKeyID(c *C) {

--- a/daemon/errors.go
+++ b/daemon/errors.go
@@ -277,6 +277,17 @@ func KeyslotsNotFound(err *fdestate.KeyslotRefsNotFoundError) *apiError {
 	}
 }
 
+func InvalidRecoveryKey(err *fdestate.InvalidRecoveryKeyError) *apiError {
+	return &apiError{
+		Status:  400,
+		Message: err.Error(),
+		Kind:    client.ErrorKindInvalidRecoveryKey,
+		Value: map[string]any{
+			"reason": err.Reason,
+		},
+	}
+}
+
 // AppNotFound is an error responder used when an operation is
 // requested on a app that doesn't exist.
 func AppNotFound(format string, v ...any) *apiError {
@@ -367,6 +378,8 @@ func errToResponse(err error, snaps []string, fallback errorResponder, format st
 			return InsufficientSpace(err)
 		case *fdestate.KeyslotRefsNotFoundError:
 			return KeyslotsNotFound(err)
+		case *fdestate.InvalidRecoveryKeyError:
+			return InvalidRecoveryKey(err)
 		case net.Error:
 			if err.Timeout() {
 				kind = client.ErrorKindNetworkTimeout

--- a/daemon/errors.go
+++ b/daemon/errors.go
@@ -28,6 +28,7 @@ import (
 	"github.com/snapcore/snapd/arch"
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/overlord/fdestate"
 	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/snap"
@@ -267,6 +268,15 @@ func InsufficientSpace(dserr *snapstate.InsufficientSpaceError) *apiError {
 	}
 }
 
+func KeyslotsNotFound(err *fdestate.KeyslotRefsNotFoundError) *apiError {
+	return &apiError{
+		Status:  400,
+		Message: err.Error(),
+		Kind:    client.ErrorKindKeyslotsNotFound,
+		Value:   err.KeyslotRefs,
+	}
+}
+
 // AppNotFound is an error responder used when an operation is
 // requested on a app that doesn't exist.
 func AppNotFound(format string, v ...any) *apiError {
@@ -355,6 +365,8 @@ func errToResponse(err error, snaps []string, fallback errorResponder, format st
 			snapName = err.Snap
 		case *snapstate.InsufficientSpaceError:
 			return InsufficientSpace(err)
+		case *fdestate.KeyslotRefsNotFoundError:
+			return KeyslotsNotFound(err)
 		case net.Error:
 			if err.Timeout() {
 				kind = client.ErrorKindNetworkTimeout

--- a/overlord/fdestate/errors.go
+++ b/overlord/fdestate/errors.go
@@ -62,3 +62,37 @@ func (e *keyslotsAlreadyExistsError) Error() string {
 		return fmt.Sprintf("key slots [%s] already exist", concatRefs.String())
 	}
 }
+
+type InvalidRecoveryKeyReason string
+
+const (
+	InvalidRecoveryKeyReasonExpired       InvalidRecoveryKeyReason = "expired"
+	InvalidRecoveryKeyReasonNotFound      InvalidRecoveryKeyReason = "not-found"
+	InvalidRecoveryKeyReasonInvalidFormat InvalidRecoveryKeyReason = "invalid-format"
+	InvalidRecoveryKeyReasonNoMatchFound  InvalidRecoveryKeyReason = "no-match-found"
+)
+
+type InvalidRecoveryKeyError struct {
+	Reason InvalidRecoveryKeyReason
+
+	Message string
+}
+
+func (e *InvalidRecoveryKeyError) Error() string {
+	if e.Message != "" {
+		return e.Message
+	}
+
+	switch e.Reason {
+	case InvalidRecoveryKeyReasonExpired:
+		return "invalid recovery key: expired"
+	case InvalidRecoveryKeyReasonNotFound:
+		return "invalid recovery key: not found"
+	case InvalidRecoveryKeyReasonInvalidFormat:
+		return "invalid recovery key: bad format"
+	case InvalidRecoveryKeyReasonNoMatchFound:
+		return "invalid recovery key: no match found"
+	default:
+		return "internal error: unexpected recovery key error"
+	}
+}

--- a/overlord/fdestate/fdemgr.go
+++ b/overlord/fdestate/fdemgr.go
@@ -646,7 +646,11 @@ func (m *FDEManager) CheckRecoveryKey(rkey keys.RecoveryKey, containerRoles []st
 	for _, container := range containers {
 		if allContainers || strutil.ListContains(containerRoles, container.ContainerRole()) {
 			if err := secbootCheckRecoveryKey(container.DevPath(), rkey); err != nil {
-				return fmt.Errorf("recovery key failed for %q: %v", container.ContainerRole(), err)
+				logger.Noticef("invalid recovery key: no match found for %q: %v", container.ContainerRole(), err)
+				return &InvalidRecoveryKeyError{
+					Reason:  InvalidRecoveryKeyReasonNoMatchFound,
+					Message: fmt.Sprintf("invalid recovery key: no match found for %q", container.ContainerRole()),
+				}
 			}
 			found[container.ContainerRole()] = true
 		}

--- a/overlord/fdestate/fdemgr_test.go
+++ b/overlord/fdestate/fdemgr_test.go
@@ -1031,7 +1031,11 @@ func (s *fdeMgrSuite) TestCheckRecoveryKeyError(c *C) {
 	})()
 
 	err = mgr.CheckRecoveryKey(keys.RecoveryKey{}, []string{"system-data"})
-	c.Assert(err, ErrorMatches, `recovery key failed for "system-data": boom!`)
+	c.Assert(err, ErrorMatches, `invalid recovery key: no match found for "system-data"`)
+	var rkeyErr *fdestate.InvalidRecoveryKeyError
+	c.Assert(errors.As(err, &rkeyErr), Equals, true)
+	c.Assert(rkeyErr.Reason, Equals, fdestate.InvalidRecoveryKeyReasonNoMatchFound)
+	c.Assert(rkeyErr.Message, Equals, `invalid recovery key: no match found for "system-data"`)
 }
 
 type mockKeyData struct {

--- a/overlord/fdestate/fdestate_test.go
+++ b/overlord/fdestate/fdestate_test.go
@@ -422,6 +422,9 @@ func (s *fdeMgrSuite) TestChangeAuthErrors(c *C) {
 	badKeyslot = fdestate.KeyslotRef{ContainerRole: "system-save", Name: "default-fallback"}
 	_, err = fdestate.ChangeAuth(s.st, device.AuthModePassphrase, "old", "new", []fdestate.KeyslotRef{badKeyslot})
 	c.Assert(err, ErrorMatches, `key slot reference \(container-role: "system-save", name: "default-fallback"\) not found`)
+	var notFoundErr *fdestate.KeyslotRefsNotFoundError
+	c.Assert(errors.As(err, &notFoundErr), Equals, true)
+	c.Check(notFoundErr.KeyslotRefs, DeepEquals, []fdestate.KeyslotRef{badKeyslot})
 
 	// bad keyslot auth mode
 	badKeyslot = fdestate.KeyslotRef{ContainerRole: "system-data", Name: "default"}
@@ -666,6 +669,9 @@ func (s *fdeMgrSuite) TestReplacePlatformKeyErrors(c *C) {
 	badKeyslot = fdestate.KeyslotRef{ContainerRole: "system-save", Name: "default-fallback"}
 	_, err = fdestate.ReplacePlatformKey(s.st, nil, []fdestate.KeyslotRef{badKeyslot})
 	c.Assert(err, ErrorMatches, `key slot reference \(container-role: "system-save", name: "default-fallback"\) not found`)
+	var notFoundErr *fdestate.KeyslotRefsNotFoundError
+	c.Assert(errors.As(err, &notFoundErr), Equals, true)
+	c.Check(notFoundErr.KeyslotRefs, DeepEquals, []fdestate.KeyslotRef{badKeyslot})
 
 	// keyslot key data loading error
 	badKeyslot = fdestate.KeyslotRef{ContainerRole: "system-data", Name: "default-fallback"}

--- a/overlord/fdestate/fdestate_test.go
+++ b/overlord/fdestate/fdestate_test.go
@@ -233,11 +233,16 @@ func (s *fdeMgrSuite) TestReplaceRecoveryKeyErrors(c *C) {
 
 	// invalid recovery key id
 	_, err := fdestate.ReplaceRecoveryKey(s.st, "bad-key-id", keyslots)
-	c.Assert(err, ErrorMatches, "invalid recovery key ID: no recovery key entry for key-id")
+	c.Assert(err, ErrorMatches, "invalid recovery key: not found")
+	var rkeyErr *fdestate.InvalidRecoveryKeyError
+	c.Assert(errors.As(err, &rkeyErr), Equals, true)
+	c.Assert(rkeyErr.Reason, Equals, fdestate.InvalidRecoveryKeyReasonNotFound)
 
 	// expired recovery key id
 	_, err = fdestate.ReplaceRecoveryKey(s.st, "expired-key-id", keyslots)
-	c.Assert(err, ErrorMatches, "invalid recovery key ID: recovery key has expired")
+	c.Assert(err, ErrorMatches, "invalid recovery key: expired")
+	c.Assert(errors.As(err, &rkeyErr), Equals, true)
+	c.Assert(rkeyErr.Reason, Equals, fdestate.InvalidRecoveryKeyReasonExpired)
 
 	// invalid keyslot
 	badKeyslot := fdestate.KeyslotRef{ContainerRole: "", Name: "some-name"}


### PR DESCRIPTION
This PR adds two new error kinds:
- kind: `keyslots-not-found`, value: list of keyslot references that were not found
- kind: `invalid-recovery-key`, value: `{"reason": fdestate.InvalidRecoveryKeyReason}`

Those machine readable error kinds allow API consumers (i.e. security-center snap) to provide a better user experience like providing translations.

JIRA: SNAPDENG-35202
