### PR TITLE
tests: fix interfaces-posix-mq for snapd deb testing

### DIFF
--- a/tests/main/interfaces-posix-mq/task.yaml
+++ b/tests/main/interfaces-posix-mq/task.yaml
@@ -35,8 +35,13 @@ prepare: |
 execute: |
     # We cannot create a queue before connecting the can-create slot.
     not test-snapd-posix-mq.mqctl create /test read-only 600 max-size=16,max-count=10
-    # We cannot probe /dev/mqueue
-    not snap run --shell test-snapd-posix-mq.mqctl -c 'stat /dev/mqueue'
+
+    # TODO: remove this check once distro apparmor fixes the issue
+    # When re-exec is not used, the distro apparmor allows to stat /dev/mqueue
+    if tests.info is-reexec-in-use; then
+        # We cannot probe /dev/mqueue
+        not snap run --shell test-snapd-posix-mq.mqctl -c 'stat /dev/mqueue'
+    fi
 
     snap connect test-snapd-posix-mq:posix-mq test-snapd-posix-mq:can-create
     # Technically the read permission is required because there's no way to


### PR DESCRIPTION
This changes skips the failing check when using apparmor from the distro. This test fails when using snapd deb with not re-exec.

To check the fix run:
`spread
openstack-sru-ps7:ubuntu-25.10-64:tests/main/interfaces-posix-mq`
