### PR TITLE
many: make constraints types interfaces to support other snap interfaces

### DIFF
--- a/interfaces/prompting/constraints_home.go
+++ b/interfaces/prompting/constraints_home.go
@@ -1,0 +1,257 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package prompting
+
+import (
+	"errors"
+
+	prompting_errors "github.com/snapcore/snapd/interfaces/prompting/errors"
+	"github.com/snapcore/snapd/interfaces/prompting/patterns"
+)
+
+type PromptConstraintsHome struct {
+	// Path is the path to which the application is requesting access.
+	Path string `json:"path"`
+	// Embed PromptPermissions to inherit their marshalling
+	PromptPermissions
+}
+
+func (pc *PromptConstraintsHome) Permissions() *PromptPermissions {
+	return &pc.PromptPermissions
+}
+
+func (pc *PromptConstraintsHome) Equal(other PromptConstraints) bool {
+	otherConstraints, ok := other.(*PromptConstraintsHome)
+	if !ok {
+		return false
+	}
+	if pc.Path != otherConstraints.Path {
+		return false
+	}
+	return pc.Permissions().OriginalPermissionsEqual(other.Permissions())
+}
+
+// ReplyConstraintsHome hold information about the applicability of a reply to
+// particular paths and permissions. Upon receiving the reply, snapd converts
+// ReplyConstraints to Constraints.
+type ReplyConstraintsHome struct {
+	PathPattern    *patterns.PathPattern `json:"path-pattern"`
+	PermissionList []string              `json:"permissions"`
+}
+
+func (rc *ReplyConstraintsHome) Permissions() []string {
+	return rc.PermissionList
+}
+
+// ToConstraints validates the given reply constraints, outcome, lifespan, and
+// duration, and uses them to construct constraints.
+func (rc *ReplyConstraintsHome) ToConstraints(outcome OutcomeType, lifespan LifespanType, duration string) (Constraints, error) {
+	if rc.PathPattern == nil {
+		return nil, prompting_errors.NewInvalidPathPatternError("", "no path pattern")
+	}
+	const iface = "home"
+	permissionMap, err := NewPermissionMap(iface, rc.PermissionList, outcome, lifespan, duration)
+	if err != nil {
+		return nil, err
+	}
+	constraints := &ConstraintsHome{
+		PathPattern:   rc.PathPattern,
+		PermissionMap: permissionMap,
+	}
+	return constraints, nil
+}
+
+// ConstraintsHome hold information about the applicability of a new rule to
+// particular paths and permissions. When creating a new rule, snapd converts
+// Constraints to RuleConstraints.
+type ConstraintsHome struct {
+	PathPattern   *patterns.PathPattern `json:"path-pattern"`
+	PermissionMap PermissionMap         `json:"permissions"`
+}
+
+func (c *ConstraintsHome) Permissions() PermissionMap {
+	return c.PermissionMap
+}
+
+// MatchPromptConstraints returns an error if the constraints do not match the
+// given prompt constraints.
+//
+// This method is only intended to be called on constraints which have just
+// been created from a reply, to check that the reply covers the request.
+func (c *ConstraintsHome) MatchPromptConstraints(promptConstraints PromptConstraints) error {
+	if c.PathPattern == nil {
+		return prompting_errors.NewInvalidPathPatternError("", "no path pattern")
+	}
+	promptConstraintsHome, ok := promptConstraints.(*PromptConstraintsHome)
+	if !ok {
+		// Error should not occur, since we create the constraints for the
+		// corresponding interface internally
+		return errors.New(`internal error: cannot match "home" constraints against prompt constraints for another interface`)
+	}
+	match, err := c.PathPattern.Match(promptConstraintsHome.Path)
+	if err != nil {
+		// Error should not occur, since it was parsed internally
+		return prompting_errors.NewInvalidPathPatternError(c.PathPattern.String(), err.Error())
+	}
+	if !match {
+		return &prompting_errors.RequestedPathNotMatchedError{
+			Requested: promptConstraintsHome.Path,
+			Replied:   c.PathPattern.String(),
+		}
+	}
+	return nil
+}
+
+// ToRuleConstraints validates the receiving Constraints and converts it to
+// RuleConstraints. If the constraints are not valid with respect to the given
+// interface, returns an error.
+func (c *ConstraintsHome) ToRuleConstraints(at At) (RuleConstraints, error) {
+	if c.PathPattern == nil {
+		return nil, prompting_errors.NewInvalidPathPatternError("", "no path pattern")
+	}
+	const iface = "home"
+	rulePermissions, err := c.PermissionMap.toRulePermissionMap(iface, at)
+	if err != nil {
+		return nil, err
+	}
+	ruleConstraints := &RuleConstraintsHome{
+		Pattern:       c.PathPattern,
+		PermissionMap: rulePermissions,
+	}
+	return ruleConstraints, nil
+}
+
+// RuleConstraintsHome hold information about the applicability of an existing rule
+// to particular paths and permissions. A request will be matched by the rule
+// constraints if the requested path is matched by the path pattern (according
+// to bash's globstar matching) and one or more requested permissions are denied
+// in the permission map, or all of the requested permissions are allowed in the
+// map.
+type RuleConstraintsHome struct {
+	Pattern       *patterns.PathPattern `json:"path-pattern"`
+	PermissionMap RulePermissionMap     `json:"permissions"`
+}
+
+// Validate checks that the rule constraints are valid, and prunes any
+// permissions which are expired at the given point in time. If all permissions
+// have expired, then returns true. If the rule is invalid, returns an error.
+func (c *RuleConstraintsHome) Validate(at At) (expired bool, err error) {
+	if c.Pattern == nil {
+		return false, prompting_errors.NewInvalidPathPatternError("", "no path pattern")
+	}
+	return c.PermissionMap.validateForInterface("home", at)
+}
+
+// Permissions returns the permission map embedded in the rule constraints.
+func (c *RuleConstraintsHome) Permissions() RulePermissionMap {
+	return c.PermissionMap
+}
+
+// MatchPromptConstraints returns true if the rule constraints match the given
+// prompt constraints.
+//
+// If the constraints are invalid, returns an error.
+func (c *RuleConstraintsHome) MatchPromptConstraints(promptConstraints PromptConstraints) (bool, error) {
+	if c.Pattern == nil {
+		return false, prompting_errors.NewInvalidPathPatternError("", "no path pattern")
+	}
+	promptConstraintsHome, ok := promptConstraints.(*PromptConstraintsHome)
+	if !ok {
+		return false, nil
+	}
+	match, err := c.Pattern.Match(promptConstraintsHome.Path)
+	if err != nil {
+		// Error should not occur, since it was parsed internally
+		return false, prompting_errors.NewInvalidPathPatternError(c.Pattern.String(), err.Error())
+	}
+	return match, nil
+}
+
+// CloneWithPermissions returns a copy of the constraints with the given
+// permission map set as its permissions.
+func (c *RuleConstraintsHome) CloneWithPermissions(permissions RulePermissionMap) RuleConstraints {
+	return &RuleConstraintsHome{
+		Pattern:       c.Pattern,
+		PermissionMap: permissions,
+	}
+}
+
+// PathPattern returns the path pattern which should be used to match incoming
+// requests.
+func (c *RuleConstraintsHome) PathPattern() *patterns.PathPattern {
+	return c.Pattern
+}
+
+// RuleConstraintsPatchHome holds partial rule contents which will be used to modify
+// an existing rule. When snapd modifies the rule using RuleConstraintsPatch,
+// it converts the RuleConstraintsPatch to RuleConstraints, using the rule's
+// existing constraints wherever a field is omitted from the
+// RuleConstraintsPatch.
+//
+// Any permissions which are omitted from the new permission map are left
+// unchanged from the existing rule. To remove an existing permission from the
+// rule, the permission should map to null.
+type RuleConstraintsPatchHome struct {
+	Pattern       *patterns.PathPattern `json:"path-pattern,omitempty"`
+	PermissionMap PermissionMap         `json:"permissions,omitempty"`
+}
+
+// PatchRuleConstraints validates the receiving RuleConstraintsPatchHome and
+// uses the given existing rule constraints to construct new rule constraints.
+//
+// If the path pattern or permissions fields are omitted, they are left
+// unchanged from the existing rule. If the permissions field is present in
+// the patch, then any permissions which are omitted from the patch's
+// permission map are left unchanged from the existing rule. To remove an
+// existing permission from the rule, the permission should map to null in the
+// permission map of the patch.
+//
+// The given at information is used to prune any existing expired permissions
+// and compute any expirations for new permissions.
+//
+// The existing rule constraints are not mutated.
+func (c *RuleConstraintsPatchHome) PatchRuleConstraints(existing RuleConstraints, at At) (RuleConstraints, error) {
+	if c == nil {
+		c = &RuleConstraintsPatchHome{}
+	}
+	existingConstraints, ok := existing.(*RuleConstraintsHome)
+	if !ok {
+		// Error should never occur, caller should ensure interfaces match
+		return nil, errors.New(`internal error: cannot use a constraints patch for the "home" interface to patch constraints for another interface`)
+	}
+	ruleConstraints := &RuleConstraintsHome{
+		Pattern: c.Pattern,
+	}
+	if c.Pattern == nil {
+		ruleConstraints.Pattern = existingConstraints.Pattern
+	}
+	if c.PermissionMap == nil {
+		ruleConstraints.PermissionMap = existingConstraints.PermissionMap
+		return ruleConstraints, nil
+	}
+	// Permissions are specified in the patch, need to merge them
+	const iface = "home"
+	newPermissions, err := c.PermissionMap.patchRulePermissions(existingConstraints.PermissionMap, iface, at)
+	if err != nil {
+		return nil, err
+	}
+	ruleConstraints.PermissionMap = newPermissions
+	return ruleConstraints, nil
+}

--- a/interfaces/prompting/constraints_home_test.go
+++ b/interfaces/prompting/constraints_home_test.go
@@ -1,0 +1,214 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2025 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package prompting_test
+
+import (
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces/prompting"
+)
+
+func (s *constraintsSuite) TestPromptConstraintsHomeEqual(c *C) {
+	type fakePromptConstraints struct {
+		prompting.PromptConstraintsHome
+	}
+
+	for _, testCase := range []struct {
+		left  *prompting.PromptConstraintsHome
+		right prompting.PromptConstraints // test against non-home constraints
+		equal bool
+	}{
+		{
+			left: &prompting.PromptConstraintsHome{
+				Path: "/path/to/foo",
+				PromptPermissions: prompting.PromptPermissions{
+					OriginalPermissions: []string{"read", "write"},
+				},
+			},
+			right: &prompting.PromptConstraintsHome{
+				Path: "/path/to/foo",
+				PromptPermissions: prompting.PromptPermissions{
+					OriginalPermissions: []string{"read", "write"},
+				},
+			},
+			equal: true,
+		},
+		{
+			left: &prompting.PromptConstraintsHome{
+				Path: "/path/to/foo",
+				PromptPermissions: prompting.PromptPermissions{
+					OriginalPermissions: []string{"read", "write"},
+				},
+			},
+			right: &fakePromptConstraints{
+				prompting.PromptConstraintsHome{
+					Path: "/path/to/foo",
+					PromptPermissions: prompting.PromptPermissions{
+						OriginalPermissions: []string{"read", "write"},
+					},
+				},
+			},
+			equal: false,
+		},
+		{
+			left: &prompting.PromptConstraintsHome{
+				Path: "/path/to/foo",
+				PromptPermissions: prompting.PromptPermissions{
+					OriginalPermissions:    []string{"read", "write"},
+					OutstandingPermissions: []string{"read"},
+				},
+			},
+			right: &prompting.PromptConstraintsHome{
+				Path: "/path/to/foo",
+				PromptPermissions: prompting.PromptPermissions{
+					OriginalPermissions:    []string{"read", "write"},
+					OutstandingPermissions: []string{"read", "write"},
+					AvailablePermissions:   []string{"read", "write", "execute"},
+				},
+			},
+			equal: true,
+		},
+		{
+			left: &prompting.PromptConstraintsHome{
+				Path: "/path/to/foo",
+				PromptPermissions: prompting.PromptPermissions{
+					OriginalPermissions:    []string{"read", "write"},
+					OutstandingPermissions: []string{"read"},
+				},
+			},
+			right: &prompting.PromptConstraintsHome{
+				Path: "/path/to/foo",
+				PromptPermissions: prompting.PromptPermissions{
+					OriginalPermissions:    []string{"read"},
+					OutstandingPermissions: []string{"read"},
+				},
+			},
+			equal: false,
+		},
+		{
+			left: &prompting.PromptConstraintsHome{
+				Path: "/path/to/foo",
+				PromptPermissions: prompting.PromptPermissions{
+					OriginalPermissions: []string{"read", "write"},
+				},
+			},
+			right: &prompting.PromptConstraintsHome{
+				Path: "/path/to/bar",
+				PromptPermissions: prompting.PromptPermissions{
+					OriginalPermissions: []string{"read", "write"},
+				},
+			},
+			equal: false,
+		},
+	} {
+		c.Check(testCase.left.Equal(testCase.right), Equals, testCase.equal, Commentf("testCase: %+v", testCase))
+	}
+}
+
+func (s *constraintsSuite) TestReplyConstraintsHomeToConstraints(c *C) {
+	c.Fatalf("TODO")
+}
+
+func (s *constraintsSuite) TestConstraintsHomeMatchPromptConstraints(c *C) {
+	c.Fatalf("TODO")
+}
+
+func (s *constraintsSuite) TestConstraintsHomeToRuleConstraintsHappy(c *C) {
+	at := prompting.At{
+		Time:      time.Now(),
+		SessionID: prompting.IDType(0x12345),
+	}
+	pathPattern := mustParsePathPattern(c, "/path/to/{foo,*or*,bar}{,/}**")
+	constraints := &prompting.ConstraintsHome{
+		PathPattern: pathPattern,
+		PermissionMap: prompting.PermissionMap{
+			"read": &prompting.PermissionEntry{
+				Outcome:  prompting.OutcomeAllow,
+				Lifespan: prompting.LifespanForever,
+			},
+			"write": &prompting.PermissionEntry{
+				Outcome:  prompting.OutcomeDeny,
+				Lifespan: prompting.LifespanTimespan,
+				Duration: "10s",
+			},
+			"execute": &prompting.PermissionEntry{
+				Outcome:  prompting.OutcomeAllow,
+				Lifespan: prompting.LifespanSession,
+			},
+		},
+	}
+	expectedRuleConstraints := &prompting.RuleConstraintsHome{
+		Pattern: pathPattern,
+		PermissionMap: prompting.RulePermissionMap{
+			"read": &prompting.RulePermissionEntry{
+				Outcome:  prompting.OutcomeAllow,
+				Lifespan: prompting.LifespanForever,
+			},
+			"write": &prompting.RulePermissionEntry{
+				Outcome:    prompting.OutcomeDeny,
+				Lifespan:   prompting.LifespanTimespan,
+				Expiration: at.Time.Add(10 * time.Second),
+			},
+			"execute": &prompting.RulePermissionEntry{
+				Outcome:   prompting.OutcomeAllow,
+				Lifespan:  prompting.LifespanSession,
+				SessionID: at.SessionID,
+			},
+		},
+	}
+	result, err := constraints.ToRuleConstraints(at)
+	c.Assert(err, IsNil)
+	c.Assert(result, DeepEquals, expectedRuleConstraints)
+}
+
+func (s *constraintsSuite) TestConstraintsHomeToRuleConstraintsUnhappy(c *C) {
+	at := prompting.At{
+		Time:      time.Now(),
+		SessionID: prompting.IDType(0),
+	}
+
+	badConstraints := &prompting.ConstraintsHome{}
+	result, err := badConstraints.ToRuleConstraints(at)
+	c.Check(result, IsNil)
+	c.Check(err, ErrorMatches, `invalid path pattern: no path pattern.*`)
+
+	badConstraints.PathPattern = mustParsePathPattern(c, "/path/to/foo")
+	result, err = badConstraints.ToRuleConstraints(at)
+	c.Check(result, IsNil)
+	c.Check(err, ErrorMatches, `invalid permissions for home interface: permissions empty`)
+}
+
+func (s *constraintsSuite) TestRuleConstraintsHomeValidate(c *C) {
+	c.Fatalf("TODO")
+}
+
+func (s *constraintsSuite) TestRuleConstraintsHomeMatchPromptConstraints(c *C) {
+	c.Fatalf("TODO")
+}
+
+func (s *constraintsSuite) TestRuleConstraintsHomeCloneWithPermissions(c *C) {
+	c.Fatalf("TODO")
+}
+
+func (s *constraintsSuite) TestRuleConstraintsPatchHomePatchRuleConstraints(c *C) {
+	c.Fatalf("TODO")
+}

--- a/interfaces/prompting/constraints_test.go
+++ b/interfaces/prompting/constraints_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/prompting/patterns"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/sandbox/apparmor/notify"
+	"github.com/snapcore/snapd/sandbox/apparmor/notify/listener"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -45,65 +46,406 @@ func mustParsePathPattern(c *C, patternStr string) *patterns.PathPattern {
 	return pattern
 }
 
-func (s *constraintsSuite) TestConstraintsMatch(c *C) {
-	cases := []struct {
-		pattern string
-		path    string
-		matches bool
+// Test NewPromptConstraints and the simple methods associated with each prompt
+// constraints, including MarshalJSON and Permissions.
+func (s *constraintsSuite) TestNewPromptConstraintsMarshalJSONPermissions(c *C) {
+	for _, testCase := range []struct {
+		iface                  string
+		originalPermissions    []string
+		outstandingPermissions []string
+		req                    *listener.Request
+		expectedType           string
+		expectedJSON           string
+		expectedAvailablePerms []string
 	}{
 		{
-			"/home/test/Documents/foo.txt",
-			"/home/test/Documents/foo.txt",
-			true,
+			iface:                  "home",
+			originalPermissions:    []string{"read", "write"},
+			outstandingPermissions: []string{"read"},
+			req: &listener.Request{
+				Path: "/path/to/foo",
+			},
+			expectedType:           "*prompting.PromptConstraintsHome",
+			expectedJSON:           `{"path":"/path/to/foo","requested-permissions":["read"],"available-permissions":["read","write","execute"]}`,
+			expectedAvailablePerms: []string{"read", "write", "execute"},
+		},
+	} {
+		promptConstraints, err := prompting.NewPromptConstraints(testCase.iface, testCase.originalPermissions, testCase.outstandingPermissions, testCase.req)
+		c.Assert(err, IsNil)
+		c.Check(fmt.Sprintf("%T", promptConstraints), Equals, testCase.expectedType)
+		marshalled, err := json.Marshal(promptConstraints)
+		c.Check(err, IsNil)
+		c.Check(string(marshalled), Equals, testCase.expectedJSON)
+		promptPerms := promptConstraints.Permissions()
+		c.Assert(promptPerms, NotNil)
+		c.Check(promptPerms.OriginalPermissions, DeepEquals, testCase.originalPermissions)
+		c.Check(promptPerms.OutstandingPermissions, DeepEquals, testCase.outstandingPermissions)
+		c.Check(promptPerms.AvailablePermissions, DeepEquals, testCase.expectedAvailablePerms)
+	}
+
+	// Check that bad interface results in error
+	result, err := prompting.NewPromptConstraints("foo", nil, nil, nil)
+	c.Check(err, ErrorMatches, "cannot get available permissions: unsupported interface: foo")
+	c.Check(result, IsNil)
+}
+
+func (s *constraintsSuite) TestUnmarshalReplyConstraints(c *C) {
+	for _, testCase := range []struct {
+		iface               string
+		rawJSON             string
+		expectedType        string
+		expectedPermissions []string
+	}{
+		{
+			iface:               "home",
+			rawJSON:             `{"path-pattern":"/path/to/foo","permissions":["read","write"]}`,
+			expectedType:        "*prompting.ReplyConstraintsHome",
+			expectedPermissions: []string{"read", "write"},
+		},
+	} {
+		rawJSON := json.RawMessage([]byte(testCase.rawJSON))
+		replyConstraints, err := prompting.UnmarshalReplyConstraints(testCase.iface, rawJSON)
+		c.Assert(err, IsNil)
+		c.Check(fmt.Sprintf("%T", replyConstraints), Equals, testCase.expectedType)
+		c.Check(replyConstraints.Permissions(), DeepEquals, testCase.expectedPermissions)
+	}
+
+	// Check that bad interface results in error
+	result, err := prompting.UnmarshalReplyConstraints("foo", nil)
+	c.Check(err, ErrorMatches, `invalid interface: "foo"`)
+	c.Check(result, IsNil)
+
+	// Check that bad json results in error
+	result, err = prompting.UnmarshalReplyConstraints("home", json.RawMessage([]byte(`{"permissions":"not a list"}`)))
+	c.Check(err, ErrorMatches, `json: cannot unmarshal string .*`)
+	c.Check(result, IsNil)
+}
+
+func (s *constraintsSuite) TestUnmarshalConstraints(c *C) {
+	for _, testCase := range []struct {
+		iface               string
+		rawJSON             string
+		expectedType        string
+		expectedPermissions prompting.PermissionMap
+	}{
+		{
+			iface:        "home",
+			rawJSON:      `{"path-pattern":"/path/to/foo","permissions":{"read":{"outcome":"allow","lifespan":"forever"},"write":{"outcome":"deny","lifespan":"session"},"execute":{"outcome":"allow","lifespan":"timespan","duration":"10s"}}}`,
+			expectedType: "*prompting.ConstraintsHome",
+			expectedPermissions: prompting.PermissionMap{
+				"read": &prompting.PermissionEntry{
+					Outcome:  prompting.OutcomeAllow,
+					Lifespan: prompting.LifespanForever,
+				},
+				"write": &prompting.PermissionEntry{
+					Outcome:  prompting.OutcomeDeny,
+					Lifespan: prompting.LifespanSession,
+				},
+				"execute": &prompting.PermissionEntry{
+					Outcome:  prompting.OutcomeAllow,
+					Lifespan: prompting.LifespanTimespan,
+					Duration: "10s",
+				},
+			},
+		},
+	} {
+		rawJSON := json.RawMessage([]byte(testCase.rawJSON))
+		constraints, err := prompting.UnmarshalConstraints(testCase.iface, rawJSON)
+		c.Assert(err, IsNil)
+		c.Check(fmt.Sprintf("%T", constraints), Equals, testCase.expectedType)
+		c.Check(constraints.Permissions(), DeepEquals, testCase.expectedPermissions)
+	}
+
+	// Check that bad interface results in error
+	result, err := prompting.UnmarshalConstraints("foo", nil)
+	c.Check(err, ErrorMatches, `invalid interface: "foo"`)
+	c.Check(result, IsNil)
+
+	// Check that bad json results in error
+	result, err = prompting.UnmarshalConstraints("home", json.RawMessage([]byte(`{"permissions":{"bad":{"outcome":"terrible"}}}`)))
+	c.Check(err, ErrorMatches, `invalid outcome: "terrible"`)
+	c.Check(result, IsNil)
+}
+
+func (s *constraintsSuite) TestUnmarshalRuleConstraints(c *C) {
+	for _, testCase := range []struct {
+		iface               string
+		rawJSON             string
+		expectedType        string
+		expectedPermissions prompting.RulePermissionMap
+		expectedPathPattern *patterns.PathPattern
+	}{
+		{
+			iface:        "home",
+			rawJSON:      `{"path-pattern":"/path/to/foo","permissions":{"read":{"outcome":"allow","lifespan":"forever"},"write":{"outcome":"deny","lifespan":"session","session-id":"0123456789ABCDEF"},"execute":{"outcome":"allow","lifespan":"session","session-id":"1234123412341234"}}}`,
+			expectedType: "*prompting.RuleConstraintsHome",
+			expectedPermissions: prompting.RulePermissionMap{
+				"read": &prompting.RulePermissionEntry{
+					Outcome:  prompting.OutcomeAllow,
+					Lifespan: prompting.LifespanForever,
+				},
+				"write": &prompting.RulePermissionEntry{
+					Outcome:   prompting.OutcomeDeny,
+					Lifespan:  prompting.LifespanSession,
+					SessionID: prompting.IDType(0x0123456789ABCDEF),
+				},
+				"execute": &prompting.RulePermissionEntry{
+					Outcome:   prompting.OutcomeAllow,
+					Lifespan:  prompting.LifespanSession,
+					SessionID: prompting.IDType(0x1234123412341234),
+				},
+			},
+			expectedPathPattern: mustParsePathPattern(c, "/path/to/foo"),
+		},
+	} {
+		rawJSON := json.RawMessage([]byte(testCase.rawJSON))
+		ruleConstraints, err := prompting.UnmarshalRuleConstraints(testCase.iface, rawJSON)
+		c.Assert(err, IsNil)
+		c.Check(fmt.Sprintf("%T", ruleConstraints), Equals, testCase.expectedType)
+		c.Check(ruleConstraints.Permissions(), DeepEquals, testCase.expectedPermissions)
+		c.Check(ruleConstraints.PathPattern(), DeepEquals, testCase.expectedPathPattern)
+	}
+
+	// Check that bad interface results in error
+	result, err := prompting.UnmarshalRuleConstraints("foo", nil)
+	c.Check(err, ErrorMatches, `invalid interface: "foo"`)
+	c.Check(result, IsNil)
+
+	// Check that bad json results in error
+	result, err = prompting.UnmarshalRuleConstraints("home", json.RawMessage([]byte(`{"permissions":{"bad":{"outcome":"terrible"}}}`)))
+	c.Check(err, ErrorMatches, `invalid outcome: "terrible"`)
+	c.Check(result, IsNil)
+}
+
+func (s *constraintsSuite) TestUnmarshalRuleConstraintsPatch(c *C) {
+	for _, testCase := range []struct {
+		iface        string
+		rawJSON      string
+		expectedType string
+	}{
+		{
+			iface:        "home",
+			rawJSON:      `{"path-pattern":"/path/to/foo","permissions":{"read":{"outcome":"allow","lifespan":"forever"},"write":{"outcome":"deny","lifespan":"session"},"execute":{"outcome":"allow","lifespan":"timespan","duration":"10s"}}}`,
+			expectedType: "*prompting.RuleConstraintsPatchHome",
+		},
+	} {
+		rawJSON := json.RawMessage([]byte(testCase.rawJSON))
+		constraintsPatch, err := prompting.UnmarshalRuleConstraintsPatch(testCase.iface, rawJSON)
+		c.Assert(err, IsNil)
+		c.Check(fmt.Sprintf("%T", constraintsPatch), Equals, testCase.expectedType)
+	}
+
+	// Check that bad interface results in error
+	result, err := prompting.UnmarshalRuleConstraintsPatch("foo", nil)
+	c.Check(err, ErrorMatches, `internal error: cannot decode constraints patch: unsupported interface: foo`)
+	c.Check(result, IsNil)
+
+	// Check that bad json results in error
+	result, err = prompting.UnmarshalRuleConstraintsPatch("home", json.RawMessage([]byte(`{"permissions":{"bad":{"outcome":"terrible"}}}`)))
+	c.Check(err, ErrorMatches, `invalid outcome: "terrible"`)
+	c.Check(result, IsNil)
+}
+
+func (s *constraintsSuite) TestPromptPermissionsOriginalPermissionsEqual(c *C) {
+	for _, testCase := range []struct {
+		left  *prompting.PromptPermissions
+		right *prompting.PromptPermissions
+		equal bool
+	}{
+		{
+			left: &prompting.PromptPermissions{
+				OriginalPermissions: []string{"foo", "bar"},
+			},
+			right: &prompting.PromptPermissions{
+				OriginalPermissions: []string{"foo", "bar"},
+			},
+			equal: true,
 		},
 		{
-			"/home/test/Documents/foo",
-			"/home/test/Documents/foo.txt",
-			false,
+			left: &prompting.PromptPermissions{
+				OriginalPermissions:    []string{"foo", "bar"},
+				OutstandingPermissions: []string{"foo", "bar"},
+			},
+			right: &prompting.PromptPermissions{
+				OriginalPermissions:    []string{"foo", "bar"},
+				OutstandingPermissions: []string{"foo"},
+				AvailablePermissions:   []string{"foo", "bar", "baz"},
+			},
+			equal: true,
 		},
-	}
-	for _, testCase := range cases {
-		pattern := mustParsePathPattern(c, testCase.pattern)
-
-		constraints := &prompting.Constraints{
-			PathPattern: pattern,
-		}
-		result, err := constraints.Match(testCase.path)
-		c.Check(err, IsNil, Commentf("test case: %+v", testCase))
-		c.Check(result, Equals, testCase.matches, Commentf("test case: %+v", testCase))
-
-		ruleConstraints := &prompting.RuleConstraints{
-			PathPattern: pattern,
-		}
-		result, err = ruleConstraints.Match(testCase.path)
-		c.Check(err, IsNil, Commentf("test case: %+v", testCase))
-		c.Check(result, Equals, testCase.matches, Commentf("test case: %+v", testCase))
+		{
+			left: &prompting.PromptPermissions{
+				OriginalPermissions:    []string{"foo"},
+				OutstandingPermissions: []string{"foo"},
+				AvailablePermissions:   []string{"foo", "bar", "baz"},
+			},
+			right: &prompting.PromptPermissions{
+				OriginalPermissions:    []string{"foo", "bar"},
+				OutstandingPermissions: []string{"foo"},
+				AvailablePermissions:   []string{"foo", "bar", "baz"},
+			},
+			equal: false,
+		},
+		{
+			left: &prompting.PromptPermissions{
+				OriginalPermissions: []string{"foo", "bar"},
+			},
+			right: &prompting.PromptPermissions{
+				OriginalPermissions: []string{"foo", "bar", "baz"},
+			},
+			equal: false,
+		},
+	} {
+		c.Check(testCase.left.OriginalPermissionsEqual(testCase.right), Equals, testCase.equal, Commentf("testCase: %+v", testCase))
 	}
 }
 
-func (s *constraintsSuite) TestConstraintsMatchUnhappy(c *C) {
-	badPath := `bad\path\`
-
-	badConstraints := &prompting.Constraints{
-		PathPattern: nil,
-	}
-	matches, err := badConstraints.Match(badPath)
-	c.Check(err, ErrorMatches, `invalid path pattern: no path pattern: ""`)
-	c.Check(matches, Equals, false)
-
-	badRuleConstraints := &prompting.RuleConstraints{
-		PathPattern: nil,
-	}
-	matches, err = badRuleConstraints.Match(badPath)
-	c.Check(err, ErrorMatches, `invalid path pattern: no path pattern: ""`)
-	c.Check(matches, Equals, false)
+func (s *constraintsSuite) TestPromptPermissionsApplyRulePermissions(c *C) {
+	c.Fatalf("TODO")
 }
 
-func (s *constraintsSuite) TestConstraintsContainPermissions(c *C) {
+func (s *constraintsSuite) TestPromptPermissionsBuildResponsePermissions(c *C) {
+	c.Fatalf("TODO")
+}
+
+func (s *constraintsSuite) TestNewPermissionMapHappy(c *C) {
+	for _, testCase := range []struct {
+		iface       string
+		permissions []string
+		outcome     prompting.OutcomeType
+		lifespan    prompting.LifespanType
+		duration    string
+		expected    prompting.PermissionMap
+	}{
+		{
+			iface:       "home",
+			permissions: []string{"read", "write", "execute"},
+			outcome:     prompting.OutcomeAllow,
+			lifespan:    prompting.LifespanForever,
+			expected: prompting.PermissionMap{
+				"read": &prompting.PermissionEntry{
+					Outcome:  prompting.OutcomeAllow,
+					Lifespan: prompting.LifespanForever,
+				},
+				"write": &prompting.PermissionEntry{
+					Outcome:  prompting.OutcomeAllow,
+					Lifespan: prompting.LifespanForever,
+				},
+				"execute": &prompting.PermissionEntry{
+					Outcome:  prompting.OutcomeAllow,
+					Lifespan: prompting.LifespanForever,
+				},
+			},
+		},
+		{
+			iface:       "home",
+			permissions: []string{"write", "read"},
+			outcome:     prompting.OutcomeDeny,
+			lifespan:    prompting.LifespanTimespan,
+			duration:    "10m",
+			expected: prompting.PermissionMap{
+				"read": &prompting.PermissionEntry{
+					Outcome:  prompting.OutcomeDeny,
+					Lifespan: prompting.LifespanTimespan,
+					Duration: "10m",
+				},
+				"write": &prompting.PermissionEntry{
+					Outcome:  prompting.OutcomeDeny,
+					Lifespan: prompting.LifespanTimespan,
+					Duration: "10m",
+				},
+			},
+		},
+		{
+			iface:       "camera",
+			permissions: []string{"access"},
+			outcome:     prompting.OutcomeAllow,
+			lifespan:    prompting.LifespanSession,
+			expected: prompting.PermissionMap{
+				"access": &prompting.PermissionEntry{
+					Outcome:  prompting.OutcomeAllow,
+					Lifespan: prompting.LifespanSession,
+				},
+			},
+		},
+	} {
+		result, err := prompting.NewPermissionMap(testCase.iface, testCase.permissions, testCase.outcome, testCase.lifespan, testCase.duration)
+		c.Check(err, IsNil)
+		c.Check(result, DeepEquals, testCase.expected)
+	}
+}
+
+func (s *constraintsSuite) TestNewPermissionMapUnhappy(c *C) {
+	for _, testCase := range []struct {
+		iface       string
+		permissions []string
+		outcome     prompting.OutcomeType
+		lifespan    prompting.LifespanType
+		duration    string
+		errStr      string
+	}{
+		{
+			outcome: prompting.OutcomeType("foo"),
+			errStr:  `invalid outcome: "foo"`,
+		},
+		{
+			outcome:  prompting.OutcomeAllow,
+			lifespan: prompting.LifespanTimespan,
+			duration: "",
+			errStr:   `invalid duration: cannot have unspecified duration when lifespan is "timespan":.*`,
+		},
+		{
+			outcome:  prompting.OutcomeAllow,
+			lifespan: prompting.LifespanForever,
+			duration: "10s",
+			errStr:   `invalid duration: cannot have specified duration when lifespan is "forever":.*`,
+		},
+		{
+			outcome:  prompting.OutcomeAllow,
+			lifespan: prompting.LifespanForever,
+			iface:    "foo",
+			errStr:   `invalid interface: "foo"`,
+		},
+		{
+			outcome:     prompting.OutcomeAllow,
+			lifespan:    prompting.LifespanForever,
+			iface:       "home",
+			permissions: make([]string, 0),
+			errStr:      `invalid permissions for home interface: permissions empty`,
+		},
+		{
+			outcome:     prompting.OutcomeAllow,
+			lifespan:    prompting.LifespanForever,
+			iface:       "camera",
+			permissions: make([]string, 0),
+			errStr:      `invalid permissions for camera interface: permissions empty`,
+		},
+		{
+			outcome:     prompting.OutcomeAllow,
+			lifespan:    prompting.LifespanForever,
+			iface:       "home",
+			permissions: []string{"read", "append", "write", "access", "create", "execute"},
+			errStr:      `invalid permissions for home interface: "append", "access", "create"`,
+		},
+		{
+			outcome:     prompting.OutcomeAllow,
+			lifespan:    prompting.LifespanForever,
+			iface:       "camera",
+			permissions: []string{"read", "append", "write", "access", "create", "execute"},
+			errStr:      `invalid permissions for camera interface: "read", "append", "write", "create", "execute"`,
+		},
+	} {
+		result, err := prompting.NewPermissionMap(testCase.iface, testCase.permissions, testCase.outcome, testCase.lifespan, testCase.duration)
+		c.Check(result, IsNil, Commentf("testCase: %+v", testCase))
+		c.Check(err, ErrorMatches, testCase.errStr, Commentf("testCase: %+v", testCase))
+	}
+}
+
+func (s *constraintsSuite) TestPermissionMapContainsOutstandingPermissions(c *C) {
 	cases := []struct {
-		constPerms []string
-		queryPerms []string
-		contained  bool
+		permMapPerms []string
+		queryPerms   []string
+		contained    bool
 	}{
 		{
 			[]string{"read", "write", "execute"},
@@ -147,189 +489,174 @@ func (s *constraintsSuite) TestConstraintsContainPermissions(c *C) {
 		},
 	}
 	for _, testCase := range cases {
-		pathPattern := mustParsePathPattern(c, "/arbitrary")
-		constraints := &prompting.Constraints{
-			PathPattern: pathPattern,
-			Permissions: make(prompting.PermissionMap),
-		}
+		permMap := make(prompting.PermissionMap)
 		fakeEntry := &prompting.PermissionEntry{}
-		for _, perm := range testCase.constPerms {
-			constraints.Permissions[perm] = fakeEntry
+		for _, perm := range testCase.permMapPerms {
+			permMap[perm] = fakeEntry
 		}
-		contained := constraints.ContainPermissions(testCase.queryPerms)
+		promptPerms := &prompting.PromptPermissions{
+			OutstandingPermissions: testCase.queryPerms,
+		}
+		contained := permMap.ContainsOutstandingPermissions(promptPerms)
 		c.Check(contained, Equals, testCase.contained, Commentf("testCase: %+v", testCase))
 	}
 }
 
-func (s *constraintsSuite) TestConstraintsToRuleConstraintsHappy(c *C) {
+func (s *constraintsSuite) TestPermissionMapToRulePermissionMapHappy(c *C) {
 	at := prompting.At{
 		Time:      time.Now(),
 		SessionID: prompting.IDType(0x12345),
 	}
-
-	iface := "home"
-	pathPattern := mustParsePathPattern(c, "/path/to/{foo,*or*,bar}{,/}**")
-	constraints := &prompting.Constraints{
-		PathPattern: pathPattern,
-		Permissions: prompting.PermissionMap{
-			"read": &prompting.PermissionEntry{
-				Outcome:  prompting.OutcomeAllow,
-				Lifespan: prompting.LifespanForever,
-			},
-			"write": &prompting.PermissionEntry{
-				Outcome:  prompting.OutcomeDeny,
-				Lifespan: prompting.LifespanTimespan,
-				Duration: "10s",
-			},
-			"execute": &prompting.PermissionEntry{
-				Outcome:  prompting.OutcomeAllow,
-				Lifespan: prompting.LifespanSession,
-			},
-		},
-	}
-	expectedRuleConstraints := &prompting.RuleConstraints{
-		PathPattern: pathPattern,
-		Permissions: prompting.RulePermissionMap{
-			"read": &prompting.RulePermissionEntry{
-				Outcome:  prompting.OutcomeAllow,
-				Lifespan: prompting.LifespanForever,
-			},
-			"write": &prompting.RulePermissionEntry{
-				Outcome:    prompting.OutcomeDeny,
-				Lifespan:   prompting.LifespanTimespan,
-				Expiration: at.Time.Add(10 * time.Second),
-			},
-			"execute": &prompting.RulePermissionEntry{
-				Outcome:   prompting.OutcomeAllow,
-				Lifespan:  prompting.LifespanSession,
-				SessionID: at.SessionID,
-			},
-		},
-	}
-	result, err := constraints.ToRuleConstraints(iface, at)
-	c.Assert(err, IsNil)
-	c.Assert(result, DeepEquals, expectedRuleConstraints)
-
-	iface = "camera"
-	constraints = &prompting.Constraints{
-		PathPattern: pathPattern,
-		Permissions: prompting.PermissionMap{
-			"access": &prompting.PermissionEntry{
-				Outcome:  prompting.OutcomeAllow,
-				Lifespan: prompting.LifespanSession,
-			},
-		},
-	}
-	expectedRuleConstraints = &prompting.RuleConstraints{
-		PathPattern: pathPattern,
-		Permissions: prompting.RulePermissionMap{
-			"access": &prompting.RulePermissionEntry{
-				Outcome:   prompting.OutcomeAllow,
-				Lifespan:  prompting.LifespanSession,
-				SessionID: at.SessionID,
-			},
-		},
-	}
-	result, err = constraints.ToRuleConstraints(iface, at)
-	c.Assert(err, IsNil)
-	c.Assert(result, DeepEquals, expectedRuleConstraints)
-}
-
-func (s *constraintsSuite) TestConstraintsToRuleConstraintsUnhappy(c *C) {
-	at := prompting.At{
-		Time:      time.Now(),
-		SessionID: prompting.IDType(0),
-	}
-	badConstraints := &prompting.Constraints{}
-	result, err := badConstraints.ToRuleConstraints("home", at)
-	c.Check(result, IsNil)
-	c.Check(err, ErrorMatches, `invalid path pattern: no path pattern.*`)
-
-	constraints := &prompting.Constraints{
-		PathPattern: mustParsePathPattern(c, "/path/to/foo"),
-		Permissions: prompting.PermissionMap{
-			"read": &prompting.PermissionEntry{
-				Outcome:  prompting.OutcomeAllow,
-				Lifespan: prompting.LifespanForever,
-			},
-		},
-	}
-	result, err = constraints.ToRuleConstraints("foo", at)
-	c.Check(result, IsNil)
-	c.Check(err, ErrorMatches, `invalid interface: "foo"`)
-
 	for _, testCase := range []struct {
-		perms  prompting.PermissionMap
-		errStr string
+		permissionMap prompting.PermissionMap
+		iface         string
+		expected      prompting.RulePermissionMap
 	}{
 		{
-			perms:  nil,
-			errStr: `invalid permissions for home interface: permissions empty`,
-		},
-		{
-			perms: prompting.PermissionMap{
-				"create": &prompting.PermissionEntry{
+			permissionMap: prompting.PermissionMap{
+				"read": &prompting.PermissionEntry{
 					Outcome:  prompting.OutcomeAllow,
 					Lifespan: prompting.LifespanForever,
 				},
-			},
-			errStr: `invalid permissions for home interface: "create"`,
-		},
-		{
-			perms: prompting.PermissionMap{
-				"read": &prompting.PermissionEntry{
-					Outcome:  prompting.OutcomeAllow,
+				"write": &prompting.PermissionEntry{
+					Outcome:  prompting.OutcomeDeny,
 					Lifespan: prompting.LifespanTimespan,
+					Duration: "10s",
 				},
-			},
-			errStr: `invalid duration: cannot have unspecified duration when lifespan is "timespan".*`,
-		},
-		{
-			perms: prompting.PermissionMap{
-				"write": &prompting.PermissionEntry{
-					Outcome:  prompting.OutcomeDeny,
-					Lifespan: prompting.LifespanSession,
-					Duration: "5s",
-				},
-			},
-			errStr: `invalid duration: cannot have specified duration when lifespan is "session":.*`,
-		},
-		{
-			perms: prompting.PermissionMap{
-				"write": &prompting.PermissionEntry{
-					Outcome:  prompting.OutcomeDeny,
-					Lifespan: prompting.LifespanSession,
-				},
-			},
-			// Error will occur because current session is 0 (not found) below
-			errStr: prompting_errors.ErrNewSessionRuleNoSession.Error(),
-		},
-		{
-			perms: prompting.PermissionMap{
-				"read": &prompting.PermissionEntry{
+				"execute": &prompting.PermissionEntry{
 					Outcome:  prompting.OutcomeAllow,
-					Lifespan: prompting.LifespanTimespan,
-				},
-				"write": &prompting.PermissionEntry{
-					Outcome:  prompting.OutcomeDeny,
 					Lifespan: prompting.LifespanSession,
-					Duration: "5s",
 				},
-				"create": &prompting.PermissionEntry{
+			},
+			iface: "home",
+			expected: prompting.RulePermissionMap{
+				"read": &prompting.RulePermissionEntry{
 					Outcome:  prompting.OutcomeAllow,
 					Lifespan: prompting.LifespanForever,
 				},
+				"write": &prompting.RulePermissionEntry{
+					Outcome:    prompting.OutcomeDeny,
+					Lifespan:   prompting.LifespanTimespan,
+					Expiration: at.Time.Add(10 * time.Second),
+				},
+				"execute": &prompting.RulePermissionEntry{
+					Outcome:   prompting.OutcomeAllow,
+					Lifespan:  prompting.LifespanSession,
+					SessionID: at.SessionID,
+				},
 			},
-			errStr: joinErrorsUnordered(joinErrorsUnordered(`invalid duration: cannot have unspecified duration when lifespan is "timespan": ""`, `invalid duration: cannot have specified duration when lifespan is "session":.*`), `invalid permissions for home interface: "create"`),
 		},
 	} {
-		constraints := &prompting.Constraints{
-			PathPattern: mustParsePathPattern(c, "/path/to/foo"),
-			Permissions: testCase.perms,
-		}
-		result, err = constraints.ToRuleConstraints("home", at)
-		c.Check(result, IsNil, Commentf("testCase: %+v", testCase))
-		c.Check(err, ErrorMatches, testCase.errStr, Commentf("testCase: %+v", testCase))
+		result, err := testCase.permissionMap.ToRulePermissionMap(testCase.iface, at)
+		c.Check(err, IsNil)
+		c.Check(result, DeepEquals, testCase.expected)
+	}
+}
+
+func (s *constraintsSuite) TestPermissionMapToRulePermissionMapUnhappy(c *C) {
+	at := prompting.At{
+		Time:      time.Now(),
+		SessionID: prompting.IDType(0), // will result in session not found error
+	}
+	for _, testCase := range []struct {
+		permissionMap prompting.PermissionMap
+		iface         string
+		expectedErr   string
+	}{
+		{
+			permissionMap: prompting.PermissionMap{
+				"read": &prompting.PermissionEntry{
+					Outcome:  prompting.OutcomeAllow,
+					Lifespan: prompting.LifespanForever,
+				},
+				"write": &prompting.PermissionEntry{
+					Outcome:  prompting.OutcomeDeny,
+					Lifespan: prompting.LifespanTimespan,
+					Duration: "10s",
+				},
+				"execute": &prompting.PermissionEntry{
+					Outcome:  prompting.OutcomeAllow,
+					Lifespan: prompting.LifespanSession,
+				},
+			},
+			iface:       "foo",
+			expectedErr: `invalid interface: "foo"`,
+		},
+		{
+			permissionMap: nil,
+			iface:         "home",
+			expectedErr:   `invalid permissions for home interface: permissions empty`,
+		},
+		{
+			permissionMap: prompting.PermissionMap{},
+			iface:         "home",
+			expectedErr:   `invalid permissions for home interface: permissions empty`,
+		},
+		{
+			permissionMap: prompting.PermissionMap{
+				"create": &prompting.PermissionEntry{
+					Outcome:  prompting.OutcomeAllow,
+					Lifespan: prompting.LifespanForever,
+				},
+			},
+			iface:       "home",
+			expectedErr: `invalid permissions for home interface: "create"`,
+		},
+		{
+			permissionMap: prompting.PermissionMap{
+				"read": &prompting.PermissionEntry{
+					Outcome:  prompting.OutcomeAllow,
+					Lifespan: prompting.LifespanTimespan,
+				},
+			},
+			iface:       "home",
+			expectedErr: `invalid duration: cannot have unspecified duration when lifespan is "timespan".*`,
+		},
+		{
+			permissionMap: prompting.PermissionMap{
+				"write": &prompting.PermissionEntry{
+					Outcome:  prompting.OutcomeDeny,
+					Lifespan: prompting.LifespanSession,
+					Duration: "5s",
+				},
+			},
+			iface:       "home",
+			expectedErr: `invalid duration: cannot have specified duration when lifespan is "session":.*`,
+		},
+		{
+			permissionMap: prompting.PermissionMap{
+				"write": &prompting.PermissionEntry{
+					Outcome:  prompting.OutcomeDeny,
+					Lifespan: prompting.LifespanSession,
+				},
+			},
+			iface: "home",
+			// Error will occur because current session is 0 (not found) below
+			expectedErr: prompting_errors.ErrNewSessionRuleNoSession.Error(),
+		},
+		{
+			permissionMap: prompting.PermissionMap{
+				"read": &prompting.PermissionEntry{
+					Outcome:  prompting.OutcomeAllow,
+					Lifespan: prompting.LifespanTimespan,
+				},
+				"write": &prompting.PermissionEntry{
+					Outcome:  prompting.OutcomeDeny,
+					Lifespan: prompting.LifespanSession,
+					Duration: "5s",
+				},
+				"create": &prompting.PermissionEntry{
+					Outcome:  prompting.OutcomeAllow,
+					Lifespan: prompting.LifespanForever,
+				},
+			},
+			iface:       "home",
+			expectedErr: joinErrorsUnordered(joinErrorsUnordered(`invalid duration: cannot have unspecified duration when lifespan is "timespan": ""`, `invalid duration: cannot have specified duration when lifespan is "session":.*`), `invalid permissions for home interface: "create"`),
+		},
+	} {
+		result, err := testCase.permissionMap.ToRulePermissionMap(testCase.iface, at)
+		c.Check(err, ErrorMatches, testCase.expectedErr, Commentf("testCase: %+v", testCase))
+		c.Check(result, IsNil)
 	}
 }
 
@@ -337,57 +664,358 @@ func joinErrorsUnordered(err1, err2 string) string {
 	return fmt.Sprintf("(%s\n%s|%s\n%s)", err1, err2, err2, err1)
 }
 
-func (s *constraintsSuite) TestRuleConstraintsValidateForInterface(c *C) {
-	validPathPattern := mustParsePathPattern(c, "/path/to/foo")
+func (s *constraintsSuite) TestPermissionMapPatchRulePermissionsHappy(c *C) {
+	origTime := time.Now()
+	origSession := prompting.IDType(0x12345)
+	patchTime := origTime.Add(time.Second)
+	patchSession := prompting.IDType(0xf00ba4)
+	patchAt := prompting.At{
+		Time:      patchTime,
+		SessionID: patchSession,
+	}
+
+	for i, testCase := range []struct {
+		iface   string
+		initial prompting.RulePermissionMap
+		patch   prompting.PermissionMap
+		final   prompting.RulePermissionMap
+	}{
+		{
+			iface: "home",
+			initial: prompting.RulePermissionMap{
+				"write": &prompting.RulePermissionEntry{
+					Outcome:    prompting.OutcomeDeny,
+					Lifespan:   prompting.LifespanTimespan,
+					Expiration: patchTime.Add(time.Second),
+				},
+			},
+			patch: nil,
+			final: prompting.RulePermissionMap{
+				"write": &prompting.RulePermissionEntry{
+					Outcome:    prompting.OutcomeDeny,
+					Lifespan:   prompting.LifespanTimespan,
+					Expiration: patchTime.Add(time.Second),
+				},
+			},
+		},
+		{
+			iface: "home",
+			initial: prompting.RulePermissionMap{
+				"read": &prompting.RulePermissionEntry{
+					Outcome:    prompting.OutcomeAllow,
+					Lifespan:   prompting.LifespanTimespan,
+					Expiration: patchTime.Add(time.Second),
+				},
+				"write": &prompting.RulePermissionEntry{
+					Outcome:    prompting.OutcomeDeny,
+					Lifespan:   prompting.LifespanTimespan,
+					Expiration: origTime,
+				},
+			},
+			patch: prompting.PermissionMap{
+				// Remove read permissions, let write permission expire,
+				// and add new execute permission
+				"read": nil,
+				"execute": &prompting.PermissionEntry{
+					Outcome:  prompting.OutcomeDeny,
+					Lifespan: prompting.LifespanTimespan,
+					Duration: "1m",
+				},
+			},
+			final: prompting.RulePermissionMap{
+				"execute": &prompting.RulePermissionEntry{
+					Outcome:    prompting.OutcomeDeny,
+					Lifespan:   prompting.LifespanTimespan,
+					Expiration: patchTime.Add(time.Minute),
+				},
+			},
+		},
+		{
+			iface: "home",
+			initial: prompting.RulePermissionMap{
+				"read": &prompting.RulePermissionEntry{
+					Outcome:   prompting.OutcomeAllow,
+					Lifespan:  prompting.LifespanSession,
+					SessionID: patchSession,
+				},
+				"write": &prompting.RulePermissionEntry{
+					Outcome:   prompting.OutcomeDeny,
+					Lifespan:  prompting.LifespanSession,
+					SessionID: origSession,
+				},
+			},
+			patch: prompting.PermissionMap{
+				"execute": &prompting.PermissionEntry{
+					Outcome:  prompting.OutcomeDeny,
+					Lifespan: prompting.LifespanSession,
+				},
+			},
+			final: prompting.RulePermissionMap{
+				"read": &prompting.RulePermissionEntry{
+					Outcome:   prompting.OutcomeAllow,
+					Lifespan:  prompting.LifespanSession,
+					SessionID: patchSession,
+				},
+				"execute": &prompting.RulePermissionEntry{
+					Outcome:   prompting.OutcomeDeny,
+					Lifespan:  prompting.LifespanSession,
+					SessionID: patchSession,
+				},
+			},
+		},
+		{
+			iface: "home",
+			initial: prompting.RulePermissionMap{
+				"read": &prompting.RulePermissionEntry{
+					Outcome:  prompting.OutcomeAllow,
+					Lifespan: prompting.LifespanForever,
+				},
+				"write": &prompting.RulePermissionEntry{
+					Outcome:    prompting.OutcomeDeny,
+					Lifespan:   prompting.LifespanTimespan,
+					Expiration: origTime,
+				},
+				"execute": &prompting.RulePermissionEntry{
+					Outcome:  prompting.OutcomeAllow,
+					Lifespan: prompting.LifespanForever,
+				},
+			},
+			patch: prompting.PermissionMap{
+				"read": nil,
+				"execute": &prompting.PermissionEntry{
+					Outcome:  prompting.OutcomeAllow,
+					Lifespan: prompting.LifespanSession,
+				},
+			},
+			final: prompting.RulePermissionMap{
+				"execute": &prompting.RulePermissionEntry{
+					Outcome:   prompting.OutcomeAllow,
+					Lifespan:  prompting.LifespanSession,
+					SessionID: patchSession,
+				},
+			},
+		},
+		{
+			iface: "camera",
+			initial: prompting.RulePermissionMap{
+				"access": &prompting.RulePermissionEntry{
+					Outcome:  prompting.OutcomeAllow,
+					Lifespan: prompting.LifespanForever,
+				},
+			},
+			patch: prompting.PermissionMap{
+				"access": &prompting.PermissionEntry{
+					Outcome:  prompting.OutcomeAllow,
+					Lifespan: prompting.LifespanSession,
+				},
+			},
+			final: prompting.RulePermissionMap{
+				"access": &prompting.RulePermissionEntry{
+					Outcome:   prompting.OutcomeAllow,
+					Lifespan:  prompting.LifespanSession,
+					SessionID: patchSession,
+				},
+			},
+		},
+		{
+			iface: "camera",
+			initial: prompting.RulePermissionMap{
+				"access": &prompting.RulePermissionEntry{
+					Outcome:   prompting.OutcomeAllow,
+					Lifespan:  prompting.LifespanSession,
+					SessionID: patchSession,
+				},
+			},
+			patch: nil,
+			final: prompting.RulePermissionMap{
+				"access": &prompting.RulePermissionEntry{
+					Outcome:   prompting.OutcomeAllow,
+					Lifespan:  prompting.LifespanSession,
+					SessionID: patchSession,
+				},
+			},
+		},
+	} {
+		result, err := testCase.patch.PatchRulePermissions(testCase.initial, testCase.iface, patchAt)
+		c.Check(err, IsNil, Commentf("testCase %d: %+v", i, testCase))
+		c.Check(result, DeepEquals, testCase.final, Commentf("testCase %d: %+v", i, testCase))
+	}
+}
+
+func (s *constraintsSuite) TestPermissionMapPatchRulePermissionsUnhappy(c *C) {
+	origTime := time.Now()
+	patchTime := origTime.Add(time.Second)
+	patchSession := prompting.IDType(0x12345)
+	patchAt := prompting.At{
+		Time:      patchTime,
+		SessionID: patchSession,
+	}
+
+	goodInitial := prompting.RulePermissionMap{
+		"read": &prompting.RulePermissionEntry{
+			Outcome:    prompting.OutcomeAllow,
+			Lifespan:   prompting.LifespanTimespan,
+			Expiration: patchTime.Add(time.Second),
+		},
+		"write": &prompting.RulePermissionEntry{
+			Outcome:    prompting.OutcomeDeny,
+			Lifespan:   prompting.LifespanTimespan,
+			Expiration: origTime,
+		},
+	}
+	goodPatch := prompting.PermissionMap{
+		"write": nil,
+		"execute": &prompting.PermissionEntry{
+			Outcome:  prompting.OutcomeDeny,
+			Lifespan: prompting.LifespanSession,
+		},
+	}
+
+	const goodIface = "home"
+	const badIface = "foo"
+
+	result, err := goodPatch.PatchRulePermissions(goodInitial, badIface, patchAt)
+	c.Check(err, ErrorMatches, `invalid interface: "foo"`)
+	c.Check(result, IsNil)
+
+	badPatch := prompting.PermissionMap{
+		"read": &prompting.PermissionEntry{
+			Outcome:  prompting.OutcomeAllow,
+			Lifespan: prompting.LifespanSingle,
+		},
+		"create": &prompting.PermissionEntry{
+			Outcome:  prompting.OutcomeAllow,
+			Lifespan: prompting.LifespanForever,
+		},
+		"lock": nil, // even if invalid permission is meant to be removed, include it
+		"execute": &prompting.PermissionEntry{
+			Outcome:  prompting.OutcomeAllow,
+			Lifespan: prompting.LifespanTimespan,
+		},
+	}
+	expected := joinErrorsUnordered(`cannot create rule with lifespan "single"`, `invalid duration: cannot have unspecified duration when lifespan is "timespan": ""`) + "\n" + `invalid permissions for home interface: ("create", "lock"|"lock", "create")`
+	result, err = badPatch.PatchRulePermissions(goodInitial, goodIface, patchAt)
+	c.Check(err, ErrorMatches, expected)
+	c.Check(result, IsNil)
+
+	badPatch = prompting.PermissionMap{
+		// Remove all permissions
+		"read": nil,
+	}
+	result, err = badPatch.PatchRulePermissions(goodInitial, goodIface, patchAt)
+	c.Check(err, Equals, prompting_errors.ErrPatchedRuleHasNoPerms)
+	c.Check(result, IsNil)
+}
+
+func (s *constraintsSuite) TestRulePermissionMapValidateForInterfaceHappy(c *C) {
 	at := prompting.At{
 		Time:      time.Now(),
 		SessionID: prompting.IDType(0x12345),
 	}
-
-	// Happy
-	// "home"
-	constraints := &prompting.RuleConstraints{
-		PathPattern: validPathPattern,
-		Permissions: prompting.RulePermissionMap{
-			"read": &prompting.RulePermissionEntry{
-				Outcome:  prompting.OutcomeAllow,
-				Lifespan: prompting.LifespanForever,
+	for _, testCase := range []struct {
+		iface       string
+		permissions prompting.RulePermissionMap
+		expired     bool
+	}{
+		{
+			iface: "home",
+			permissions: prompting.RulePermissionMap{
+				"read": &prompting.RulePermissionEntry{
+					Outcome:  prompting.OutcomeAllow,
+					Lifespan: prompting.LifespanForever,
+				},
+				"write": &prompting.RulePermissionEntry{
+					Outcome:    prompting.OutcomeDeny,
+					Lifespan:   prompting.LifespanTimespan,
+					Expiration: at.Time.Add(time.Second),
+				},
+				"execute": &prompting.RulePermissionEntry{
+					Outcome:   prompting.OutcomeAllow,
+					Lifespan:  prompting.LifespanSession,
+					SessionID: at.SessionID,
+				},
 			},
-			"write": &prompting.RulePermissionEntry{
-				Outcome:    prompting.OutcomeDeny,
-				Lifespan:   prompting.LifespanTimespan,
-				Expiration: at.Time.Add(time.Second),
-			},
-			"execute": &prompting.RulePermissionEntry{
-				Outcome:   prompting.OutcomeAllow,
-				Lifespan:  prompting.LifespanSession,
-				SessionID: at.SessionID,
-			},
+			expired: false,
 		},
-	}
-	expired, err := constraints.ValidateForInterface("home", at)
-	c.Check(err, IsNil)
-	c.Check(expired, Equals, false)
-	// "camera"
-	constraints = &prompting.RuleConstraints{
-		PathPattern: validPathPattern,
-		Permissions: prompting.RulePermissionMap{
-			"access": &prompting.RulePermissionEntry{
-				Outcome:   prompting.OutcomeAllow,
-				Lifespan:  prompting.LifespanSession,
-				SessionID: at.SessionID,
+		{
+			iface: "home",
+			permissions: prompting.RulePermissionMap{
+				"read": &prompting.RulePermissionEntry{
+					Outcome:  prompting.OutcomeAllow,
+					Lifespan: prompting.LifespanForever,
+				},
+				"write": &prompting.RulePermissionEntry{
+					Outcome:    prompting.OutcomeDeny,
+					Lifespan:   prompting.LifespanTimespan,
+					Expiration: at.Time,
+				},
+				"execute": &prompting.RulePermissionEntry{
+					Outcome:   prompting.OutcomeAllow,
+					Lifespan:  prompting.LifespanSession,
+					SessionID: at.SessionID + 1,
+				},
 			},
+			expired: false,
 		},
+		{
+			iface: "home",
+			permissions: prompting.RulePermissionMap{
+				"read": &prompting.RulePermissionEntry{
+					Outcome:    prompting.OutcomeAllow,
+					Lifespan:   prompting.LifespanTimespan,
+					Expiration: at.Time.Add(-time.Hour),
+				},
+				"write": &prompting.RulePermissionEntry{
+					Outcome:    prompting.OutcomeDeny,
+					Lifespan:   prompting.LifespanTimespan,
+					Expiration: at.Time,
+				},
+				"execute": &prompting.RulePermissionEntry{
+					Outcome:   prompting.OutcomeAllow,
+					Lifespan:  prompting.LifespanSession,
+					SessionID: at.SessionID + 1,
+				},
+			},
+			expired: true,
+		},
+		{
+			iface: "camera",
+			permissions: prompting.RulePermissionMap{
+				"access": &prompting.RulePermissionEntry{
+					Outcome:   prompting.OutcomeDeny,
+					Lifespan:  prompting.LifespanSession,
+					SessionID: at.SessionID,
+				},
+			},
+			expired: false,
+		},
+		{
+			iface: "camera",
+			permissions: prompting.RulePermissionMap{
+				"access": &prompting.RulePermissionEntry{
+					Outcome:    prompting.OutcomeDeny,
+					Lifespan:   prompting.LifespanTimespan,
+					Expiration: at.Time,
+				},
+			},
+			expired: true,
+		},
+	} {
+		expired, err := testCase.permissions.ValidateForInterface(testCase.iface, at)
+		c.Check(err, IsNil, Commentf("testCase: %+v", testCase))
+		c.Check(expired, Equals, testCase.expired, Commentf("testCase: %+v", testCase))
 	}
-	expired, err = constraints.ValidateForInterface("camera", at)
-	c.Check(err, IsNil)
-	c.Check(expired, Equals, false)
+}
 
-	// Bad interface or permissions
-	cases := []struct {
-		iface  string
-		perms  prompting.RulePermissionMap
-		errStr string
+func (s *constraintsSuite) TestRulePermissionMapValidateForInterfaceUnhappy(c *C) {
+	at := prompting.At{
+		Time:      time.Now(),
+		SessionID: prompting.IDType(0x12345),
+	}
+	for _, testCase := range []struct {
+		iface       string
+		permissions prompting.RulePermissionMap
+		expectedErr string
 	}{
 		{
 			"foo",
@@ -473,676 +1101,15 @@ func (s *constraintsSuite) TestRuleConstraintsValidateForInterface(c *C) {
 			},
 			`invalid outcome: "bar"`,
 		},
-	}
-	at = prompting.At{
-		Time:      time.Now(),
-		SessionID: prompting.IDType(0),
-	}
-	for _, testCase := range cases {
-		constraints := &prompting.RuleConstraints{
-			PathPattern: validPathPattern,
-			Permissions: testCase.perms,
-		}
-		expired, err = constraints.ValidateForInterface(testCase.iface, at)
-		c.Check(err, ErrorMatches, testCase.errStr, Commentf("testCase: %+v", testCase))
+	} {
+		expired, err := testCase.permissions.ValidateForInterface(testCase.iface, at)
+		c.Check(err, ErrorMatches, testCase.expectedErr, Commentf("testCase: %+v", testCase))
 		c.Check(expired, Equals, false)
 	}
-
-	// Check missing path pattern
-	constraints = &prompting.RuleConstraints{
-		Permissions: prompting.RulePermissionMap{
-			"read": &prompting.RulePermissionEntry{
-				Outcome:  prompting.OutcomeAllow,
-				Lifespan: prompting.LifespanForever,
-			},
-		},
-	}
-	_, err = constraints.ValidateForInterface("home", at)
-	c.Check(err, ErrorMatches, `invalid path pattern: no path pattern: ""`)
-}
-
-func (s *constraintsSuite) TestRuleConstraintsValidateForInterfaceExpiration(c *C) {
-	pathPattern := mustParsePathPattern(c, "/path/to/foo")
-	at := prompting.At{
-		Time:      time.Now(),
-		SessionID: prompting.IDType(0x12345),
-	}
-
-	for _, testCase := range []struct {
-		perms    prompting.RulePermissionMap
-		expired  bool
-		expected prompting.RulePermissionMap
-	}{
-		{
-			prompting.RulePermissionMap{
-				"read": &prompting.RulePermissionEntry{
-					Outcome:  prompting.OutcomeAllow,
-					Lifespan: prompting.LifespanForever,
-				},
-			},
-			false,
-			prompting.RulePermissionMap{
-				"read": &prompting.RulePermissionEntry{
-					Outcome:  prompting.OutcomeAllow,
-					Lifespan: prompting.LifespanForever,
-				},
-			},
-		},
-		{
-			prompting.RulePermissionMap{
-				"read": &prompting.RulePermissionEntry{
-					Outcome:    prompting.OutcomeAllow,
-					Lifespan:   prompting.LifespanTimespan,
-					Expiration: at.Time,
-				},
-			},
-			true,
-			prompting.RulePermissionMap{},
-		},
-		{
-			prompting.RulePermissionMap{
-				"read": &prompting.RulePermissionEntry{
-					Outcome:    prompting.OutcomeAllow,
-					Lifespan:   prompting.LifespanTimespan,
-					Expiration: at.Time.Add(-time.Minute),
-				},
-				"write": &prompting.RulePermissionEntry{
-					Outcome:    prompting.OutcomeDeny,
-					Lifespan:   prompting.LifespanTimespan,
-					Expiration: at.Time.Add(time.Minute),
-				},
-				"execute": &prompting.RulePermissionEntry{
-					Outcome:    prompting.OutcomeDeny,
-					Lifespan:   prompting.LifespanTimespan,
-					Expiration: at.Time,
-				},
-			},
-			false,
-			prompting.RulePermissionMap{
-				"write": &prompting.RulePermissionEntry{
-					Outcome:    prompting.OutcomeDeny,
-					Lifespan:   prompting.LifespanTimespan,
-					Expiration: at.Time.Add(time.Minute),
-				},
-			},
-		},
-		{
-			prompting.RulePermissionMap{
-				"read": &prompting.RulePermissionEntry{
-					Outcome:   prompting.OutcomeAllow,
-					Lifespan:  prompting.LifespanSession,
-					SessionID: at.SessionID,
-				},
-			},
-			false,
-			prompting.RulePermissionMap{
-				"read": &prompting.RulePermissionEntry{
-					Outcome:   prompting.OutcomeAllow,
-					Lifespan:  prompting.LifespanSession,
-					SessionID: at.SessionID,
-				},
-			},
-		},
-		{
-			prompting.RulePermissionMap{
-				"read": &prompting.RulePermissionEntry{
-					Outcome:   prompting.OutcomeAllow,
-					Lifespan:  prompting.LifespanSession,
-					SessionID: at.SessionID + 1,
-				},
-			},
-			true,
-			prompting.RulePermissionMap{},
-		},
-		{
-			prompting.RulePermissionMap{
-				"read": &prompting.RulePermissionEntry{
-					Outcome:    prompting.OutcomeAllow,
-					Lifespan:   prompting.LifespanTimespan,
-					Expiration: at.Time.Add(-time.Minute),
-				},
-				"write": &prompting.RulePermissionEntry{
-					Outcome:    prompting.OutcomeDeny,
-					Lifespan:   prompting.LifespanTimespan,
-					Expiration: at.Time,
-				},
-				"execute": &prompting.RulePermissionEntry{
-					Outcome:   prompting.OutcomeAllow,
-					Lifespan:  prompting.LifespanSession,
-					SessionID: at.SessionID + 1,
-				},
-			},
-			true,
-			prompting.RulePermissionMap{},
-		},
-		{
-			prompting.RulePermissionMap{
-				"read": &prompting.RulePermissionEntry{
-					Outcome:    prompting.OutcomeAllow,
-					Lifespan:   prompting.LifespanTimespan,
-					Expiration: at.Time.Add(-time.Minute),
-				},
-				"write": &prompting.RulePermissionEntry{
-					Outcome:    prompting.OutcomeAllow,
-					Lifespan:   prompting.LifespanTimespan,
-					Expiration: at.Time.Add(time.Minute),
-				},
-				"execute": &prompting.RulePermissionEntry{
-					Outcome:   prompting.OutcomeDeny,
-					Lifespan:  prompting.LifespanSession,
-					SessionID: at.SessionID,
-				},
-			},
-			false,
-			prompting.RulePermissionMap{
-				"write": &prompting.RulePermissionEntry{
-					Outcome:    prompting.OutcomeAllow,
-					Lifespan:   prompting.LifespanTimespan,
-					Expiration: at.Time.Add(time.Minute),
-				},
-				"execute": &prompting.RulePermissionEntry{
-					Outcome:   prompting.OutcomeDeny,
-					Lifespan:  prompting.LifespanSession,
-					SessionID: at.SessionID,
-				},
-			},
-		},
-	} {
-		copiedPerms := make(prompting.RulePermissionMap, len(testCase.perms))
-		for perm, entry := range testCase.perms {
-			copiedPerms[perm] = entry
-		}
-		constraints := &prompting.RuleConstraints{
-			PathPattern: pathPattern,
-			Permissions: copiedPerms,
-		}
-		expired, err := constraints.ValidateForInterface("home", at)
-		c.Check(err, IsNil)
-		c.Check(expired, Equals, testCase.expired, Commentf("testCase: %+v\nremaining perms: %+v", testCase, constraints.Permissions))
-		c.Check(constraints.Permissions, DeepEquals, testCase.expected, Commentf("testCase: %+v\nremaining perms: %+v", testCase, constraints.Permissions))
-	}
-}
-
-func (s *constraintsSuite) TestReplyConstraintsToConstraintsHappy(c *C) {
-	pathPattern := mustParsePathPattern(c, "/path/to/dir/{foo*,ba?/**}")
-
-	for _, testCase := range []struct {
-		iface       string
-		pathPattern *patterns.PathPattern
-		permissions []string
-		outcome     prompting.OutcomeType
-		lifespan    prompting.LifespanType
-		duration    string
-		expected    *prompting.Constraints
-	}{
-		{
-			iface:       "home",
-			permissions: []string{"read", "write", "execute"},
-			outcome:     prompting.OutcomeAllow,
-			lifespan:    prompting.LifespanForever,
-			expected: &prompting.Constraints{
-				PathPattern: pathPattern,
-				Permissions: prompting.PermissionMap{
-					"read": &prompting.PermissionEntry{
-						Outcome:  prompting.OutcomeAllow,
-						Lifespan: prompting.LifespanForever,
-					},
-					"write": &prompting.PermissionEntry{
-						Outcome:  prompting.OutcomeAllow,
-						Lifespan: prompting.LifespanForever,
-					},
-					"execute": &prompting.PermissionEntry{
-						Outcome:  prompting.OutcomeAllow,
-						Lifespan: prompting.LifespanForever,
-					},
-				},
-			},
-		},
-		{
-			iface:       "home",
-			permissions: []string{"write", "read"},
-			outcome:     prompting.OutcomeDeny,
-			lifespan:    prompting.LifespanTimespan,
-			duration:    "10m",
-			expected: &prompting.Constraints{
-				PathPattern: pathPattern,
-				Permissions: prompting.PermissionMap{
-					"read": &prompting.PermissionEntry{
-						Outcome:  prompting.OutcomeDeny,
-						Lifespan: prompting.LifespanTimespan,
-						Duration: "10m",
-					},
-					"write": &prompting.PermissionEntry{
-						Outcome:  prompting.OutcomeDeny,
-						Lifespan: prompting.LifespanTimespan,
-						Duration: "10m",
-					},
-				},
-			},
-		},
-		{
-			iface:       "camera",
-			permissions: []string{"access"},
-			outcome:     prompting.OutcomeAllow,
-			lifespan:    prompting.LifespanSession,
-			expected: &prompting.Constraints{
-				PathPattern: pathPattern,
-				Permissions: prompting.PermissionMap{
-					"access": &prompting.PermissionEntry{
-						Outcome:  prompting.OutcomeAllow,
-						Lifespan: prompting.LifespanSession,
-					},
-				},
-			},
-		},
-	} {
-		replyConstraints := &prompting.ReplyConstraints{
-			PathPattern: pathPattern,
-			Permissions: testCase.permissions,
-		}
-		constraints, err := replyConstraints.ToConstraints(testCase.iface, testCase.outcome, testCase.lifespan, testCase.duration)
-		c.Check(err, IsNil)
-		c.Check(constraints, DeepEquals, testCase.expected)
-	}
-}
-
-func (s *constraintsSuite) TestReplyConstraintsToConstraintsUnhappy(c *C) {
-	for _, testCase := range []struct {
-		nilPattern  bool
-		permissions []string
-		iface       string
-		outcome     prompting.OutcomeType
-		lifespan    prompting.LifespanType
-		duration    string
-		errStr      string
-	}{
-		{
-			outcome: prompting.OutcomeType("foo"),
-			errStr:  `invalid outcome: "foo"`,
-		},
-		{
-			lifespan: prompting.LifespanTimespan,
-			duration: "",
-			errStr:   `invalid duration: cannot have unspecified duration when lifespan is "timespan":.*`,
-		},
-		{
-			lifespan: prompting.LifespanForever,
-			duration: "10s",
-			errStr:   `invalid duration: cannot have specified duration when lifespan is "forever":.*`,
-		},
-		{
-			nilPattern: true,
-			errStr:     `invalid path pattern: no path pattern: ""`,
-		},
-		{
-			iface:  "foo",
-			errStr: `invalid interface: "foo"`,
-		},
-		{
-			permissions: make([]string, 0),
-			errStr:      `invalid permissions for home interface: permissions empty`,
-		},
-		{
-			permissions: []string{"read", "append", "write", "create", "execute"},
-			errStr:      `invalid permissions for home interface: "append", "create"`,
-		},
-	} {
-		replyConstraints := &prompting.ReplyConstraints{
-			PathPattern: mustParsePathPattern(c, "/path/to/foo"),
-			Permissions: []string{"read", "write", "execute"},
-		}
-		if testCase.nilPattern {
-			replyConstraints.PathPattern = nil
-		}
-		if testCase.permissions != nil {
-			replyConstraints.Permissions = testCase.permissions
-		}
-		iface := "home"
-		if testCase.iface != "" {
-			iface = testCase.iface
-		}
-		outcome := prompting.OutcomeAllow
-		if testCase.outcome != prompting.OutcomeUnset {
-			outcome = testCase.outcome
-		}
-		lifespan := prompting.LifespanForever
-		if testCase.lifespan != prompting.LifespanUnset {
-			lifespan = testCase.lifespan
-		}
-		duration := ""
-		if testCase.duration != "" {
-			duration = testCase.duration
-		}
-		result, err := replyConstraints.ToConstraints(iface, outcome, lifespan, duration)
-		c.Check(result, IsNil, Commentf("testCase: %+v", testCase))
-		c.Check(err, ErrorMatches, testCase.errStr, Commentf("testCase: %+v", testCase))
-	}
-}
-
-func (s *constraintsSuite) TestPatchRuleConstraintsHappy(c *C) {
-	origTime := time.Now()
-	origSession := prompting.IDType(0x12345)
-	patchTime := origTime.Add(time.Second)
-	patchSession := prompting.IDType(0xf00ba4)
-	patchAt := prompting.At{
-		Time:      patchTime,
-		SessionID: patchSession,
-	}
-
-	pathPattern := mustParsePathPattern(c, "/path/to/foo/ba?/**")
-	otherPattern := mustParsePathPattern(c, "/path/to/*/another*")
-
-	for i, testCase := range []struct {
-		iface   string
-		initial *prompting.RuleConstraints
-		patch   *prompting.RuleConstraintsPatch
-		final   *prompting.RuleConstraints
-	}{
-		{
-			iface: "home",
-			initial: &prompting.RuleConstraints{
-				PathPattern: pathPattern,
-				Permissions: prompting.RulePermissionMap{
-					"read": &prompting.RulePermissionEntry{
-						Outcome:    prompting.OutcomeAllow,
-						Lifespan:   prompting.LifespanTimespan,
-						Expiration: origTime,
-					},
-					"write": &prompting.RulePermissionEntry{
-						Outcome:    prompting.OutcomeDeny,
-						Lifespan:   prompting.LifespanTimespan,
-						Expiration: origTime.Add(-time.Second),
-					},
-					"execute": &prompting.RulePermissionEntry{
-						Outcome:   prompting.OutcomeAllow,
-						Lifespan:  prompting.LifespanSession,
-						SessionID: origSession,
-					},
-				},
-			},
-			patch: &prompting.RuleConstraintsPatch{},
-			final: &prompting.RuleConstraints{
-				PathPattern: pathPattern,
-				Permissions: prompting.RulePermissionMap{
-					"read": &prompting.RulePermissionEntry{
-						Outcome:    prompting.OutcomeAllow,
-						Lifespan:   prompting.LifespanTimespan,
-						Expiration: origTime,
-					},
-					"write": &prompting.RulePermissionEntry{
-						Outcome:    prompting.OutcomeDeny,
-						Lifespan:   prompting.LifespanTimespan,
-						Expiration: origTime.Add(-time.Second), // expired perms are not pruned if patch perms are nil
-					},
-					"execute": &prompting.RulePermissionEntry{
-						Outcome:   prompting.OutcomeAllow,
-						Lifespan:  prompting.LifespanSession,
-						SessionID: origSession, // expired perms are not pruned if patch perms are nil
-					},
-				},
-			},
-		},
-		{
-			iface: "home",
-			initial: &prompting.RuleConstraints{
-				PathPattern: pathPattern,
-				Permissions: prompting.RulePermissionMap{
-					"read": &prompting.RulePermissionEntry{
-						Outcome:    prompting.OutcomeAllow,
-						Lifespan:   prompting.LifespanTimespan,
-						Expiration: patchTime.Add(time.Second),
-					},
-					"write": &prompting.RulePermissionEntry{
-						Outcome:    prompting.OutcomeDeny,
-						Lifespan:   prompting.LifespanTimespan,
-						Expiration: origTime,
-					},
-				},
-			},
-			patch: &prompting.RuleConstraintsPatch{
-				Permissions: prompting.PermissionMap{
-					// Remove read permissions, let write permission expire,
-					// and add new execute permission
-					"read": nil,
-					"execute": &prompting.PermissionEntry{
-						Outcome:  prompting.OutcomeDeny,
-						Lifespan: prompting.LifespanTimespan,
-						Duration: "1m",
-					},
-				},
-			},
-			final: &prompting.RuleConstraints{
-				PathPattern: pathPattern,
-				Permissions: prompting.RulePermissionMap{
-					"execute": &prompting.RulePermissionEntry{
-						Outcome:    prompting.OutcomeDeny,
-						Lifespan:   prompting.LifespanTimespan,
-						Expiration: patchTime.Add(time.Minute),
-					},
-				},
-			},
-		},
-		{
-			iface: "home",
-			initial: &prompting.RuleConstraints{
-				PathPattern: pathPattern,
-				Permissions: prompting.RulePermissionMap{
-					"read": &prompting.RulePermissionEntry{
-						Outcome:   prompting.OutcomeAllow,
-						Lifespan:  prompting.LifespanSession,
-						SessionID: patchSession,
-					},
-					"write": &prompting.RulePermissionEntry{
-						Outcome:   prompting.OutcomeDeny,
-						Lifespan:  prompting.LifespanSession,
-						SessionID: origSession,
-					},
-				},
-			},
-			patch: &prompting.RuleConstraintsPatch{
-				Permissions: prompting.PermissionMap{
-					"execute": &prompting.PermissionEntry{
-						Outcome:  prompting.OutcomeDeny,
-						Lifespan: prompting.LifespanSession,
-					},
-				},
-			},
-			final: &prompting.RuleConstraints{
-				PathPattern: pathPattern,
-				Permissions: prompting.RulePermissionMap{
-					"read": &prompting.RulePermissionEntry{
-						Outcome:   prompting.OutcomeAllow,
-						Lifespan:  prompting.LifespanSession,
-						SessionID: patchSession,
-					},
-					"execute": &prompting.RulePermissionEntry{
-						Outcome:   prompting.OutcomeDeny,
-						Lifespan:  prompting.LifespanSession,
-						SessionID: patchSession,
-					},
-				},
-			},
-		},
-		{
-			iface: "home",
-			initial: &prompting.RuleConstraints{
-				PathPattern: pathPattern,
-				Permissions: prompting.RulePermissionMap{
-					"read": &prompting.RulePermissionEntry{
-						Outcome:  prompting.OutcomeAllow,
-						Lifespan: prompting.LifespanForever,
-					},
-					"write": &prompting.RulePermissionEntry{
-						Outcome:    prompting.OutcomeDeny,
-						Lifespan:   prompting.LifespanTimespan,
-						Expiration: origTime,
-					},
-					"execute": &prompting.RulePermissionEntry{
-						Outcome:  prompting.OutcomeAllow,
-						Lifespan: prompting.LifespanForever,
-					},
-				},
-			},
-			patch: &prompting.RuleConstraintsPatch{
-				Permissions: prompting.PermissionMap{
-					"read": nil,
-					"execute": &prompting.PermissionEntry{
-						Outcome:  prompting.OutcomeAllow,
-						Lifespan: prompting.LifespanSession,
-					},
-				},
-			},
-			final: &prompting.RuleConstraints{
-				PathPattern: pathPattern,
-				Permissions: prompting.RulePermissionMap{
-					"execute": &prompting.RulePermissionEntry{
-						Outcome:   prompting.OutcomeAllow,
-						Lifespan:  prompting.LifespanSession,
-						SessionID: patchSession,
-					},
-				},
-			},
-		},
-		{
-			iface: "camera",
-			initial: &prompting.RuleConstraints{
-				PathPattern: pathPattern,
-				Permissions: prompting.RulePermissionMap{
-					"access": &prompting.RulePermissionEntry{
-						Outcome:  prompting.OutcomeAllow,
-						Lifespan: prompting.LifespanForever,
-					},
-				},
-			},
-			patch: &prompting.RuleConstraintsPatch{
-				Permissions: prompting.PermissionMap{
-					"access": &prompting.PermissionEntry{
-						Outcome:  prompting.OutcomeAllow,
-						Lifespan: prompting.LifespanSession,
-					},
-				},
-			},
-			final: &prompting.RuleConstraints{
-				PathPattern: pathPattern,
-				Permissions: prompting.RulePermissionMap{
-					"access": &prompting.RulePermissionEntry{
-						Outcome:   prompting.OutcomeAllow,
-						Lifespan:  prompting.LifespanSession,
-						SessionID: patchSession,
-					},
-				},
-			},
-		},
-		{
-			iface: "camera",
-			initial: &prompting.RuleConstraints{
-				PathPattern: pathPattern,
-				Permissions: prompting.RulePermissionMap{
-					"access": &prompting.RulePermissionEntry{
-						Outcome:    prompting.OutcomeAllow,
-						Lifespan:   prompting.LifespanTimespan,
-						Expiration: origTime,
-					},
-				},
-			},
-			patch: &prompting.RuleConstraintsPatch{
-				PathPattern: otherPattern,
-			},
-			final: &prompting.RuleConstraints{
-				PathPattern: otherPattern,
-				Permissions: prompting.RulePermissionMap{
-					"access": &prompting.RulePermissionEntry{
-						Outcome:    prompting.OutcomeAllow,
-						Lifespan:   prompting.LifespanTimespan,
-						Expiration: origTime,
-					},
-				},
-			},
-		},
-	} {
-		patched, err := testCase.patch.PatchRuleConstraints(testCase.initial, testCase.iface, patchAt)
-		c.Check(err, IsNil, Commentf("testCase %d", i))
-		c.Check(patched, DeepEquals, testCase.final, Commentf("testCase %d", i))
-	}
-}
-
-func (s *constraintsSuite) TestPatchRuleConstraintsUnhappy(c *C) {
-	origTime := time.Now()
-	patchTime := origTime.Add(time.Second)
-	patchSession := prompting.IDType(0x12345)
-	patchAt := prompting.At{
-		Time:      patchTime,
-		SessionID: patchSession,
-	}
-	iface := "home"
-
-	pathPattern := mustParsePathPattern(c, "/path/to/foo/ba{r,z{,/**/}}")
-
-	goodRule := &prompting.RuleConstraints{
-		PathPattern: pathPattern,
-		Permissions: prompting.RulePermissionMap{
-			"read": &prompting.RulePermissionEntry{
-				Outcome:    prompting.OutcomeAllow,
-				Lifespan:   prompting.LifespanTimespan,
-				Expiration: patchTime.Add(time.Second),
-			},
-			"write": &prompting.RulePermissionEntry{
-				Outcome:    prompting.OutcomeDeny,
-				Lifespan:   prompting.LifespanTimespan,
-				Expiration: origTime,
-			},
-		},
-	}
-	goodPatch := &prompting.RuleConstraintsPatch{
-		Permissions: prompting.PermissionMap{
-			"write": nil,
-			"execute": &prompting.PermissionEntry{
-				Outcome:  prompting.OutcomeDeny,
-				Lifespan: prompting.LifespanSession,
-			},
-		},
-	}
-
-	badIface := "foo"
-	result, err := goodPatch.PatchRuleConstraints(goodRule, badIface, patchAt)
-	c.Check(err, ErrorMatches, `invalid interface: "foo"`)
-	c.Check(result, IsNil)
-
-	badPatch := &prompting.RuleConstraintsPatch{
-		Permissions: prompting.PermissionMap{
-			"read": &prompting.PermissionEntry{
-				Outcome:  prompting.OutcomeAllow,
-				Lifespan: prompting.LifespanSingle,
-			},
-			"create": &prompting.PermissionEntry{
-				Outcome:  prompting.OutcomeAllow,
-				Lifespan: prompting.LifespanForever,
-			},
-			"lock": nil, // even if invalid permission is meant to be removed, include it
-			"execute": &prompting.PermissionEntry{
-				Outcome:  prompting.OutcomeAllow,
-				Lifespan: prompting.LifespanTimespan,
-			},
-		},
-	}
-	expected := joinErrorsUnordered(`cannot create rule with lifespan "single"`, `invalid duration: cannot have unspecified duration when lifespan is "timespan": ""`) + "\n" + `invalid permissions for home interface: ("create", "lock"|"lock", "create")`
-
-	result, err = badPatch.PatchRuleConstraints(goodRule, iface, patchAt)
-	c.Check(err, ErrorMatches, expected)
-	c.Check(result, IsNil)
-
-	badPatch = &prompting.RuleConstraintsPatch{
-		Permissions: prompting.PermissionMap{
-			// Remove all permissions
-			"read": nil,
-		},
-	}
-	result, err = badPatch.PatchRuleConstraints(goodRule, iface, patchAt)
-	c.Check(err, Equals, prompting_errors.ErrPatchedRuleHasNoPerms)
-	c.Check(result, IsNil)
 }
 
 func (s *constraintsSuite) TestRulePermissionMapExpired(c *C) {
+	// XXX: should this be moved to TestRulePermissionEntryExpired instead?
 	at := prompting.At{
 		Time:      time.Now(),
 		SessionID: prompting.IDType(0x12345),
@@ -1150,31 +1117,31 @@ func (s *constraintsSuite) TestRulePermissionMapExpired(c *C) {
 	for _, pm := range []prompting.RulePermissionMap{
 		{},
 		{
-			"read": &prompting.RulePermissionEntry{
+			"foo": &prompting.RulePermissionEntry{
 				Outcome:    prompting.OutcomeAllow,
 				Lifespan:   prompting.LifespanTimespan,
 				Expiration: at.Time,
 			},
 		},
 		{
-			"access": &prompting.RulePermissionEntry{
+			"bar": &prompting.RulePermissionEntry{
 				Outcome:   prompting.OutcomeDeny,
 				Lifespan:  prompting.LifespanSession,
 				SessionID: at.SessionID + 1,
 			},
 		},
 		{
-			"read": &prompting.RulePermissionEntry{
+			"foo": &prompting.RulePermissionEntry{
 				Outcome:    prompting.OutcomeAllow,
 				Lifespan:   prompting.LifespanTimespan,
 				Expiration: at.Time.Add(-time.Second),
 			},
-			"write": &prompting.RulePermissionEntry{
+			"bar": &prompting.RulePermissionEntry{
 				Outcome:    prompting.OutcomeDeny,
 				Lifespan:   prompting.LifespanTimespan,
 				Expiration: at.Time,
 			},
-			"execute": &prompting.RulePermissionEntry{
+			"baz": &prompting.RulePermissionEntry{
 				Outcome:   prompting.OutcomeAllow,
 				Lifespan:  prompting.LifespanSession,
 				SessionID: prompting.IDType(0xf00),
@@ -1186,36 +1153,36 @@ func (s *constraintsSuite) TestRulePermissionMapExpired(c *C) {
 
 	for _, pm := range []prompting.RulePermissionMap{
 		{
-			"read": &prompting.RulePermissionEntry{
+			"foo": &prompting.RulePermissionEntry{
 				Outcome:    prompting.OutcomeAllow,
 				Lifespan:   prompting.LifespanTimespan,
 				Expiration: at.Time.Add(-time.Second),
 			},
-			"write": &prompting.RulePermissionEntry{
+			"bar": &prompting.RulePermissionEntry{
 				Outcome:  prompting.OutcomeDeny,
 				Lifespan: prompting.LifespanForever,
 			},
 		},
 		{
-			"read": &prompting.RulePermissionEntry{
+			"foo": &prompting.RulePermissionEntry{
 				Outcome:   prompting.OutcomeAllow,
 				Lifespan:  prompting.LifespanSession,
 				SessionID: prompting.IDType(0xabcd),
 			},
-			"write": &prompting.RulePermissionEntry{
+			"bar": &prompting.RulePermissionEntry{
 				Outcome:  prompting.OutcomeDeny,
 				Lifespan: prompting.LifespanForever,
 			},
 		},
 		{
-			"read": &prompting.RulePermissionEntry{
+			"foo": &prompting.RulePermissionEntry{
 				Outcome:    prompting.OutcomeAllow,
 				Lifespan:   prompting.LifespanTimespan,
 				Expiration: at.Time.Add(time.Second),
 			},
 		},
 		{
-			"read": &prompting.RulePermissionEntry{
+			"foo": &prompting.RulePermissionEntry{
 				Outcome:   prompting.OutcomeAllow,
 				Lifespan:  prompting.LifespanSession,
 				SessionID: at.SessionID,
@@ -1223,6 +1190,49 @@ func (s *constraintsSuite) TestRulePermissionMapExpired(c *C) {
 		},
 	} {
 		c.Check(pm.Expired(at), Equals, false, Commentf("%+v", pm))
+	}
+}
+
+func (s *constraintsSuite) TestRulePermissionMapMergePermissionMap(c *C) {
+	c.Fatalf("TODO")
+}
+
+func (s *constraintsSuite) TestRulePermissionEntryMarshalJSON(c *C) {
+	if runtime.Version() < "go1.24" {
+		c.Skip("omitzero requires go version 1.24 or higher")
+	}
+	timeNow := time.Date(2025, time.February, 20, 16, 0, 27, 913561089, time.UTC)
+	for _, testCase := range []struct {
+		entry    prompting.RulePermissionEntry
+		expected string
+	}{
+		{
+			entry: prompting.RulePermissionEntry{
+				Outcome:  prompting.OutcomeAllow,
+				Lifespan: prompting.LifespanForever,
+			},
+			expected: `{"outcome":"allow","lifespan":"forever"}`,
+		},
+		{
+			entry: prompting.RulePermissionEntry{
+				Outcome:    prompting.OutcomeDeny,
+				Lifespan:   prompting.LifespanTimespan,
+				Expiration: timeNow,
+			},
+			expected: `{"outcome":"deny","lifespan":"timespan","expiration":"2025-02-20T16:00:27.913561089Z"}`,
+		},
+		{
+			entry: prompting.RulePermissionEntry{
+				Outcome:   prompting.OutcomeAllow,
+				Lifespan:  prompting.LifespanSession,
+				SessionID: prompting.IDType(0x12345678),
+			},
+			expected: `{"outcome":"allow","lifespan":"session","session-id":"0000000012345678"}`,
+		},
+	} {
+		marshalled, err := json.Marshal(testCase.entry)
+		c.Check(err, IsNil, Commentf("testCase: %+v", testCase))
+		c.Check(string(marshalled), Equals, testCase.expected, Commentf("testCase: %+v", testCase))
 	}
 }
 
@@ -1551,45 +1561,6 @@ func constructPermissionsMaps() []map[string]map[string]notify.AppArmorPermissio
 	permissionsMaps = append(permissionsMaps, filePermissionsMaps)
 	// TODO: do the same for other maps of permissions maps in the future
 	return permissionsMaps
-}
-
-func (s *constraintsSuite) TestMarshalRulePermissionEntry(c *C) {
-	if runtime.Version() < "go1.24" {
-		c.Skip("omitzero requires go version 1.24 or higher")
-	}
-	timeNow := time.Date(2025, time.February, 20, 16, 0, 27, 913561089, time.UTC)
-	for _, testCase := range []struct {
-		entry    prompting.RulePermissionEntry
-		expected string
-	}{
-		{
-			entry: prompting.RulePermissionEntry{
-				Outcome:  prompting.OutcomeAllow,
-				Lifespan: prompting.LifespanForever,
-			},
-			expected: `{"outcome":"allow","lifespan":"forever"}`,
-		},
-		{
-			entry: prompting.RulePermissionEntry{
-				Outcome:    prompting.OutcomeDeny,
-				Lifespan:   prompting.LifespanTimespan,
-				Expiration: timeNow,
-			},
-			expected: `{"outcome":"deny","lifespan":"timespan","expiration":"2025-02-20T16:00:27.913561089Z"}`,
-		},
-		{
-			entry: prompting.RulePermissionEntry{
-				Outcome:   prompting.OutcomeAllow,
-				Lifespan:  prompting.LifespanSession,
-				SessionID: prompting.IDType(0x12345678),
-			},
-			expected: `{"outcome":"allow","lifespan":"session","session-id":"0000000012345678"}`,
-		},
-	} {
-		marshalled, err := json.Marshal(testCase.entry)
-		c.Check(err, IsNil, Commentf("testCase: %+v", testCase))
-		c.Check(string(marshalled), Equals, testCase.expected, Commentf("testCase: %+v", testCase))
-	}
 }
 
 func (s *constraintsSuite) TestInterfacesAndPermissionsCompleteness(c *C) {

--- a/interfaces/prompting/export_test.go
+++ b/interfaces/prompting/export_test.go
@@ -31,3 +31,15 @@ var (
 func MockApparmorInterfaceForMetadataTag(f func(tag string) (string, bool)) (restore func()) {
 	return testutil.Mock(&apparmorInterfaceForMetadataTag, f)
 }
+
+func (pm PermissionMap) ToRulePermissionMap(iface string, at At) (RulePermissionMap, error) {
+	return pm.toRulePermissionMap(iface, at)
+}
+
+func (pm PermissionMap) PatchRulePermissions(existing RulePermissionMap, iface string, at At) (RulePermissionMap, error) {
+	return pm.patchRulePermissions(existing, iface, at)
+}
+
+func (pm RulePermissionMap) ValidateForInterface(iface string, at At) (bool, error) {
+	return pm.validateForInterface(iface, at)
+}

--- a/interfaces/prompting/requestprompts/export_test.go
+++ b/interfaces/prompting/requestprompts/export_test.go
@@ -39,23 +39,6 @@ type (
 	IDMapEntry    = idMapEntry
 )
 
-func NewPrompt(id prompting.IDType, timestamp time.Time, snap string, iface string, path string, outstandingPermissions []string, availablePermissions []string, originalPermissions []string) *Prompt {
-	constraints := &promptConstraints{
-		path:                   path,
-		outstandingPermissions: outstandingPermissions,
-		availablePermissions:   availablePermissions,
-		originalPermissions:    originalPermissions,
-	}
-	return &Prompt{
-		ID:           id,
-		Timestamp:    timestamp,
-		Snap:         snap,
-		Interface:    iface,
-		Constraints:  constraints,
-		listenerReqs: nil,
-	}
-}
-
 func (p *Prompt) ListenerReqs() []*listener.Request {
 	return p.listenerReqs
 }


### PR DESCRIPTION
WIP PR to make the constraints types interface-agnostic, so that we can support prompting for interfaces other than "home".

There are a lot of LOC changes here. The highlights are:
- Making `PromptConstraints`, `ReplyConstraints`, `Constraints`, `RuleConstraints`, and `RuleConstraintsPatch` into Go interfaces
- Making the existing constraints types into `...Home`, which implement the new interfaces
- Moving as much shared logic around e.g. permissions and expiration into common methods on embedded types like `PromptPermissions`, `PermissionMap`, and `RulePermissionMap`, which interface-specific constraints types should embed and expose with trivial getter methods, so the common logic can call the methods directly on those types, and avoid duplicated logic in each interface-specific implementation

This PR is WIP at the moment. There are some missing tests for the new pieces, and some (lots) of the existing tests still work directly with home-specific types (especially in `requestrules`), to avoid additional changes. Ideally, these tests could be cleaned up, and should be able to be dramatically simplified and shortened now that more of the logic is pushed into lower layers and better-tested.

At the moment, the `requestrules.RuleDB` implementation still heavily assumes that requests/prompts have paths, and replies/rules have path patterns, and all of the rule storage and matching is built around this. As such, the `RuleConstraints` interface still has a `PathPattern()` method, which makes sense for the "home" interface but will not make sense for future interfaces. Ideally, in my view, we could replace the `interfaceDB` struct with an interface which has methods for adding rules, removing rules, and matching rules against both requests and prompts. Then for the "home" interface, this could continue to all be built on `PathPattern` and `PatternVariant`s, while other interfaces which are not concerned with paths can have much simpler implementations. This would require pushing much more of the logic down into the `interfaceDB`, rather than the top-level `RuleDB` where it is now, and would require a major refactor to allow rollback after errors, notices for expired rules found when acting within the `interfaceDB`, etc. I think a refactor would be beneficial in simplifying the code, and the `interfaceDB` interface would enhance clarity and modularity, but this would be a lot of work. For now, the PR makes the minimal changes to continue to work with the "home" interface as well as support the "camera" interface in the future.

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-34732