### PR TITLE
release: 2.71.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# New in snapd 2.71.1
+* LP: #2125439 FDE: update secboot to revision f8400226f49a to fix possible preinstall secboot panic when secure boot is disabled
+
 # New in snapd 2.71
 * FDE: auto-repair when recovery key is used
 * FDE: revoke keys on shim update

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/mvo5/libseccomp-golang v0.9.1-0.20180308152521-f4de83b52afb // old trusty builds only
 	github.com/seccomp/libseccomp-golang v0.9.2-0.20220502024300-f57e1d55ea18
 	github.com/snapcore/go-gettext v0.0.0-20191107141714-82bbea49e785
-	github.com/snapcore/secboot v0.0.0-20250723142039-3e181c8edf0f
+	github.com/snapcore/secboot v0.0.0-20250925122121-f8400226f49a
 	golang.org/x/crypto v0.23.0
 	golang.org/x/net v0.21.0 // indirect
 	golang.org/x/sys v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -55,10 +55,8 @@ github.com/snapcore/go-gettext v0.0.0-20191107141714-82bbea49e785 h1:PaunR+BhraK
 github.com/snapcore/go-gettext v0.0.0-20191107141714-82bbea49e785/go.mod h1:D3SsWAXK7wCCBZu+Vk5hc1EuKj/L3XN1puEMXTU4LrQ=
 github.com/snapcore/maze.io-x-crypto v0.0.0-20190131090603-9b94c9afe066 h1:InG0EmriMOiI4YgtQNOo+6fNxzLCYioo3Q3BCVLdMCE=
 github.com/snapcore/maze.io-x-crypto v0.0.0-20190131090603-9b94c9afe066/go.mod h1:VuAdaITF1MrGzxPU+8GxagM1HW2vg7QhEFEeGHbmEMU=
-github.com/snapcore/secboot v0.0.0-20250716090113-a44df50f5352 h1:2r8fFh1ItbDAZp31tck02YJ81gjmqnOVsQjsMf2Iwq0=
-github.com/snapcore/secboot v0.0.0-20250716090113-a44df50f5352/go.mod h1:YOJQnKKG5YXotxAebtzIJrnDiDAMirAbVTRj7IkGa7U=
-github.com/snapcore/secboot v0.0.0-20250723142039-3e181c8edf0f h1:9fDxDbmLSfDTk3T9pAdHqmP/cm5s8brua3OnIbG8d9Y=
-github.com/snapcore/secboot v0.0.0-20250723142039-3e181c8edf0f/go.mod h1:YOJQnKKG5YXotxAebtzIJrnDiDAMirAbVTRj7IkGa7U=
+github.com/snapcore/secboot v0.0.0-20250925122121-f8400226f49a h1:13Ig7wII7bCXwL4ic+QWxULMixfJ19ILeEdxJWMPZMQ=
+github.com/snapcore/secboot v0.0.0-20250925122121-f8400226f49a/go.mod h1:YOJQnKKG5YXotxAebtzIJrnDiDAMirAbVTRj7IkGa7U=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 go.etcd.io/bbolt v1.3.9 h1:8x7aARPEXiXbHmtUwAIv7eV2fQFHrLLavdiJ3uzJXoI=
 go.etcd.io/bbolt v1.3.9/go.mod h1:zaO32+Ti0PK1ivdPtgMESzuzL2VPoIG1PCQNvOdo/dE=

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -11,7 +11,7 @@ pkgdesc="Service and tools for management of snap packages."
 depends=('squashfs-tools' 'libseccomp' 'libsystemd' 'libcap' 'apparmor')
 optdepends=('bash-completion: bash completion support'
             'xdg-desktop-portal: desktop integration')
-pkgver=2.71
+pkgver=2.71.1
 pkgrel=1
 arch=('x86_64' 'i686' 'armv7h' 'aarch64')
 url="https://github.com/snapcore/snapd"

--- a/packaging/debian-sid/changelog
+++ b/packaging/debian-sid/changelog
@@ -1,3 +1,11 @@
+snapd (2.71.1-1) unstable; urgency=medium
+
+  * New upstream release, LP: #2118396
+    - LP: #2125439 FDE: update secboot to revision f8400226f49a to fix
+      possible preinstall secboot panic when secure boot is disabled
+
+ -- Ernest Lotter <ernest.lotter@canonical.com>  Fri, 26 Sep 2025 07:39:49 +0200
+
 snapd (2.71-1) unstable; urgency=medium
 
   * New upstream release, LP: #2118396

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -104,7 +104,7 @@
 %endif
 
 Name:           snapd
-Version:        2.71
+Version:        2.71.1
 Release:        0%{?dist}
 Summary:        A transactional software package manager
 License:        GPL-3.0-only
@@ -991,6 +991,11 @@ fi
 %endif
 
 %changelog
+* Fri Sep 26 2025 Ernest Lotter <ernest.lotter@canonical.com>
+- New upstream release 2.71.1
+ - LP: #2125439 FDE: update secboot to revision f8400226f49a to fix
+   possible preinstall secboot panic when secure boot is disabled
+
 * Fri Jul 25 2025 Ernest Lotter <ernest.lotter@canonical.com>
 - New upstream release 2.71
  - FDE: auto-repair when recovery key is used

--- a/packaging/opensuse/snapd.changes
+++ b/packaging/opensuse/snapd.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Sep 26 05:39:49 UTC 2025 - ernest.lotter@canonical.com
+
+- Update to upstream release 2.71.1
+
+-------------------------------------------------------------------
 Fri Jul 25 11:18:47 UTC 2025 - ernest.lotter@canonical.com
 
 - Update to upstream release 2.71

--- a/packaging/opensuse/snapd.spec
+++ b/packaging/opensuse/snapd.spec
@@ -100,7 +100,7 @@
 
 
 Name:           snapd
-Version:        2.71
+Version:        2.71.1
 Release:        0
 Summary:        Tools enabling systems to work with .snap files
 License:        GPL-3.0

--- a/packaging/ubuntu-14.04/changelog
+++ b/packaging/ubuntu-14.04/changelog
@@ -1,3 +1,11 @@
+snapd (2.71.1~14.04) trusty; urgency=medium
+
+  * New upstream release, LP: #2118396
+    - LP: #2125439 FDE: update secboot to revision f8400226f49a to fix
+      possible preinstall secboot panic when secure boot is disabled
+
+ -- Ernest Lotter <ernest.lotter@canonical.com>  Fri, 26 Sep 2025 07:39:49 +0200
+
 snapd (2.71~14.04) trusty; urgency=medium
 
   * New upstream release, LP: #2118396

--- a/packaging/ubuntu-16.04/changelog
+++ b/packaging/ubuntu-16.04/changelog
@@ -1,3 +1,11 @@
+snapd (2.71.1) xenial; urgency=medium
+
+  * New upstream release, LP: #2118396
+    - LP: #2125439 FDE: update secboot to revision f8400226f49a to fix
+      possible preinstall secboot panic when secure boot is disabled
+
+ -- Ernest Lotter <ernest.lotter@canonical.com>  Fri, 26 Sep 2025 07:39:49 +0200
+
 snapd (2.71) xenial; urgency=medium
 
   * New upstream release, LP: #2118396

--- a/tests/lib/muinstaller/mk-classic-rootfs.sh
+++ b/tests/lib/muinstaller/mk-classic-rootfs.sh
@@ -110,7 +110,7 @@ else
             pointrel=.4
             ;;
         24.04)
-            pointrel=.2
+            pointrel=.3
             ;;
         *)
             pointrel=


### PR DESCRIPTION
Follow-up of https://github.com/canonical/snapd/pull/15733 to update secboot revision f8400226f49a which with fix for possible panic when  secure boot is disabled: https://github.com/canonical/secboot/pull/461

DEBEMAIL="Ernest Lotter <[ernest.lotter@canonical.com](mailto:ernest.lotter@canonical.com)>" release-tools/changelog.py 2.71.1 2118396 NEWS.md

**Cherry-picks:**
- https://github.com/canonical/snapd/pull/16047
- https://github.com/canonical/snapd/pull/15794

This release is intended only to supersede deb release 2.71 only on Questing to fix this issue classic hybrid preinstall issue that was reported in  [LP: #2125439](https://bugs.launchpad.net/ubuntu-desktop-provision/+bug/2125439)

**Requires Rebase Merge** 
