### PR TITLE
tests: support running beta validation tests in openstack

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -1465,9 +1465,7 @@ nested_start_core_vm_unit() {
 }
 
 nested_setup_vm(){
-    if nested_is_core_ge 20; then
-        remote.exec "sudo snap set system journal.persistent=true"
-    fi
+
     if [ "${SNAPD_USE_PROXY:-}" = true ]; then
         nested_no_proxy="${NO_PROXY},10.0.2.2"
 

--- a/tests/nested/manual/run-spread/task.yaml
+++ b/tests/nested/manual/run-spread/task.yaml
@@ -4,7 +4,7 @@ details: |
     Verify that it is possible to run the full test suite in ubuntu core system
     using a nested vm. The test can be used to validate specific pre-built images.
 
-backends: [google-nested-dev]
+backends: [google-nested-dev, openstack-ext-ps7]
 
 systems: [ubuntu-*]
 
@@ -36,6 +36,11 @@ execute: |
 
     set +x
     export SPREAD_EXTERNAL_ADDRESS=localhost:8022
+    export SPREAD_HTTP_PROXY="$HTTP_PROXY"
+    export SPREAD_HTTPS_PROXY="$HTTPS_PROXY"
+    export SPREAD_NO_PROXY="$NO_PROXY"
+    export SPREAD_SNAPD_USE_PROXY="$SNAPD_USE_PROXY"
+
     RUN_TESTS="external:$NESTED_SPREAD_SYSTEM:$TESTS"
     if [ "$SPREAD_VARIANT" = "custom" ]; then
         RUN_TESTS="$NESTED_SPREAD_TESTS"


### PR DESCRIPTION
This change will allow future executions in openstack. It is remaining the migration itself.

It is also removed the journal.persistent=true for nested vms as it is causing issues in beta validation executions. This is removing the /var/log/journal dir and making some tests fail on the nested vm.
