### PR TITLE
cmd/snap-mgmt: support for migrating snap mount directory

### DIFF
--- a/cmd/Makefile.am
+++ b/cmd/Makefile.am
@@ -433,7 +433,8 @@ snap-mgmt/$(am__dirstamp):
 EXTRA_DIST += snap-mgmt/snap-mgmt.sh.in
 
 snap-mgmt/snap-mgmt: snap-mgmt/snap-mgmt.sh.in Makefile snap-mgmt/$(am__dirstamp)
-	sed -e 's,[@]STATIC_SNAP_MOUNT_DIR[@],$(STATIC_SNAP_MOUNT_DIR),' <$< >$@
+	sed -e 's,[@]STATIC_SNAP_MOUNT_DIR[@],$(STATIC_SNAP_MOUNT_DIR),' \
+	    -e 's,[@]STATIC_SNAP_TOOLING_DIR[@],$(STATIC_SNAP_TOOLING_DIR),' <$< >$@
 
 if SELINUX
 ##

--- a/cmd/configure.ac
+++ b/cmd/configure.ac
@@ -160,6 +160,10 @@ AC_ARG_WITH([snap-mount-dir],
 AC_SUBST(STATIC_SNAP_MOUNT_DIR)
 AC_DEFINE_UNQUOTED([STATIC_SNAP_MOUNT_DIR], "${STATIC_SNAP_MOUNT_DIR}", [Static location of the snap mount points])
 
+STATIC_SNAP_TOOLING_DIR="${libexecdir%/snapd}/snapd"
+AC_SUBST(STATIC_SNAP_TOOLING_DIR)
+AC_DEFINE_UNQUOTED([STATIC_SNAP_TOOLING_DIR], "${STATIC_SNAP_TOOLING_DIR}", [Static location of the snapd tooling directory])
+
 SNAP_MOUNT_DIR_SYSTEMD_UNIT="$(systemd-escape -p "$STATIC_SNAP_MOUNT_DIR")"
 AC_SUBST([SNAP_MOUNT_DIR_SYSTEMD_UNIT])
 AC_DEFINE_UNQUOTED([SNAP_MOUNT_DIR_SYSTEMD_UNIT], "${SNAP_MOUNT_DIR_SYSTEMD_UNIT}", [Systemd unit name for snap mount points location])

--- a/cmd/snap-mgmt/snap-mgmt.sh.in
+++ b/cmd/snap-mgmt/snap-mgmt.sh.in
@@ -9,6 +9,7 @@ set -e
 set +x
 
 STATIC_SNAP_MOUNT_DIR="@STATIC_SNAP_MOUNT_DIR@"
+STATIC_SNAP_TOOLING_DIR="@STATIC_SNAP_TOOLING_DIR@"
 
 show_help() {
     exec cat <<'EOF'
@@ -19,7 +20,9 @@ A simple script to cleanup snap installations.
 optional arguments:
   --help                           Show this help message and exit
   --snap-mount-dir=<path>          Provide a path to be used as $STATIC_SNAP_MOUNT_DIR
+  --snap-tooling-dir=<path>        Override default path to snapd tooling dir
   --purge                          Purge all data from $STATIC_SNAP_MOUNT_DIR
+  --migrate-mount-dir              Migrate mount directory from /snap to /var//lib/snapd/snap
 EOF
 }
 
@@ -239,6 +242,188 @@ purge() {
     fi
 }
 
+ensure_snap_apps_stopped() {
+    apps_or_services="$(find /sys/fs/cgroup/ -name 'snap.*.*.scope' -o -name 'snap.*.*.service')"
+    if [ -n "$apps_or_services" ]; then
+        echo "Found active snap services or applications applications in the following cgroups:"
+        for n in $apps_or_services; do
+            echo "- $n: PIDs: $(cat "$n/cgroup.procs" | paste -s -d' ')"
+        done
+        return 1
+    fi
+    return 0
+}
+
+discard_mount_namespaces() {
+    if [ ! -d /run/snapd/ns ]; then
+        return
+    fi
+
+    tooldir="$1"
+    if [ -z "$tooldir" ]; then
+        tooldir="$STATIC_SNAP_TOOLING_DIR"
+    fi
+
+    echo "Discarding snap mount namespaces"
+    find /run/snapd/ns/ -name '*.mnt' | while read -r mntns; do
+        snname="$(basename "${mntns%.mnt}")"
+        echo "  ..discarding mount namespace of snap $snname"
+        "$tooldir"/snap-discard-ns "$snname"
+    done
+}
+
+_mount_dir_migrate() {
+    mount_from="$1"
+    mount_from_nopref="${mount_from#/}"
+    mount_to="$2"
+    mount_to_nopref="${mount_to#/}"
+
+    # TODO error when $mount_from is a prefix of $mount_to
+
+    set -x
+    mount_from_escaped="$(systemd-escape -p "${mount_from_nopref}")"
+    mount_to_escaped="$(systemd-escape -p "${mount_to_nopref}")"
+
+    # TODO banner to stop all snap applications
+
+    echo "Attempting migration of snap mount location:"
+    echo "  $mount_from -> $mount_to"
+
+    if ! ensure_snap_apps_stopped; then
+        echo "Please ensure all snap services or applications are stopped before attempting migration."
+        exit 1
+    fi
+
+    service_units=$(systemctl list-unit-files --no-legend --full 'snap.*' | cut -f1 -d' '|| true)
+    mount_units=$(systemctl list-unit-files --no-legend --full "${mount_from_escaped}-*.mount" | cut -f1 -d' ' || true)
+
+    echo "-- services"
+    echo "$service_units"
+    echo "-- mounts"
+    echo "$mount_units"
+
+    if [ -z "$mount_units" ]; then
+        echo "All mount units already migrated or no snap mounts"
+        return
+    fi
+
+    tmpdir="$(mktemp -d -t snap-mgmt-migrate.XXXXX)"
+    mkdir -p "$tmpdir/backup"
+    echo "Backup saved to $tmpdir"
+
+    # TODO expect the user to stop all services
+    
+    # stop service units first, the services could theoretically reach out to
+    # snapd while stopping
+    echo "Stopping snap services..."
+    for unit in $service_units; do
+        echo "Stopping service $unit"
+        systemctl stop "$unit"
+    done
+
+    echo "Stopping snapd..."
+    systemctl stop snapd.socket snapd.service
+
+    echo "Checking for snap applications or services that are still alive"
+    if ! ensure_snap_apps_stopped; then
+        echo "Found running snap services or applications."
+        exit 1
+    fi
+
+    discard_mount_namespaces "$STATIC_SNAP_TOOLING_DIR"
+
+    echo "Stopping mount units..."
+    for unit in $mount_units; do
+        echo "Stopping mount unit $unit"
+        systemctl stop "$unit"
+    done
+
+    # make a backup copy of the whole snap mount dir, all units should be
+    # stopped now, so this should be a tree of empty directories and current
+    # symlinks
+    cp -av "/$mount_from_nopref" "$tmpdir/backup/"
+
+    echo "Updating mount units"
+    new_units=()
+    # note, we're only iterating over mount units which still have the old name
+    for unit in $mount_units; do
+        # e.g. /snap/foo/123
+        where_mount="$(systemctl show -p Where "$unit" | cut -f2 -d=)"
+        # e.g. /snap/foo
+        snap_where_mount="$(dirname "$where_mount")"
+
+        # some units may have been patched already
+        echo "Updating mount unit $unit"
+        # new unit name
+        nn="${mount_to_escaped}-${unit#"$mount_from_escaped"-}"
+        new_units+=("$nn")
+        echo "  ..new unit name $nn"
+        # new mount point location
+        n_where_mount="$mount_to/${where_mount#"$mount_from"}"
+        # new snap mount location
+        n_snap_where_mount="$(dirname "$n_where_mount")"
+        echo "  ..new mount path $n_where_mount"
+
+        # make a backup copy
+        mkdir -p "$tmpdir/backup/etc/systemd/system"
+        cp -v "/etc/systemd/system/$unit" "$tmpdir/backup/etc/systemd/system/"
+
+        echo "  ..patching $unit"
+        # Where=/snap/foo/123 -> Where=/var/lib/snapd/snap/foo/123
+        sed -e "s#Where=/${mount_from_nopref}/#Where=/${mount_to_nopref}/#" \
+            "/etc/systemd/system/$unit" > "/etc/systemd/system/$unit.swp"
+        echo "  ..renaming to $nn"
+        mv -v "/etc/systemd/system/$unit.swp" "/etc/systemd/system/$nn"
+        rm -v "/etc/systemd/system/$unit"
+
+        if [ -L "/etc/systemd/system/multi-user.target.wants/$unit" ]; then
+            # enabled units appear as symlinks
+            rm -v "/etc/systemd/system/multi-user.target.wants/$unit"
+            ln -sv "/etc/systemd/system/$nn" "/etc/systemd/system/multi-user.target.wants/$nn"
+        fi
+
+        # ensure mount point exists
+        mkdir -p "$n_where_mount"
+
+        # recreate current symlink
+        if [ -s  "$snap_where_mount/current" ] && [ ! -s "$n_snap_where_mount/current" ]; then
+            cp -av "$snap_where_mount/current" "$n_snap_where_mount/current"
+        fi
+    done
+
+    if [ -d "$mount_from/bin" ]; then
+        cp -av "$mount_from/bin" "$mount_to/bin"
+    fi
+    if [ -f "$mount_from/README" ]; then
+        cp -av "$mount_from/README" "$mount_to/README"
+    fi
+
+    echo "Reloading systemd"
+    systemctl daemon-reload
+
+    echo "Starting new mount units"
+    for new_unit in "${new_units[@]}"; do
+        systemctl start "$new_unit"
+    done
+
+    echo "Removing old snap mount directory $mount_from"
+    rm -rfv "$mount_from"
+
+    if [ "$mount_from" = "/snap" ]; then
+        echo "Restoring ability to run classic snaps"
+        ln -sv "$mount_to" "$mount_from"
+    fi
+
+    systemctl start snapd.socket snapd.service
+}
+
+mount_dir_migrate() {
+    # TODO snapd version check
+
+    _mount_dir_migrate "/snap" "/var/lib/snapd/snap"
+}
+
+action=""
 while [ -n "$1" ]; do
     case "$1" in
         --help)
@@ -250,8 +435,24 @@ while [ -n "$1" ]; do
             SNAP_UNIT_PREFIX=$(systemd-escape -p "$STATIC_SNAP_MOUNT_DIR")
             shift
             ;;
+        --snap-tooling-dir=*)
+            STATIC_SNAP_TOOLING_DIR=${1#*=}
+            shift
+            ;;
         --purge)
-            purge
+            if [ -n "$action" ]; then
+                echo "Cannot request purge when already doing '$action'"
+                exit 1
+            fi
+            action=purge
+            shift
+            ;;
+        --migrate-mount-dir)
+            if [ -n "$action" ]; then
+                echo "Cannot request mount directory migration when already doing '$action'"
+                exit 1
+            fi
+            action=migrate-mount-dir
             shift
             ;;
         *)
@@ -260,3 +461,16 @@ while [ -n "$1" ]; do
             ;;
     esac
 done
+
+case "$action" in
+    purge)
+        purge
+        ;;
+    migrate-mount-dir)
+        mount_dir_migrate
+        ;;
+    *)
+        echo "Unknown action '$action'"
+        exit 1
+        ;;
+esac

--- a/syscheck/dirs.go
+++ b/syscheck/dirs.go
@@ -53,6 +53,11 @@ var (
 		"manjaro",
 		"manjaro-arm",
 	}
+
+	// distributions which support migration from /snap to /var/lib/snapd/snap
+	migratedAltDirDistros = []string{
+		"opensuse", // openSUSE Tumbleweed, Slowroll, Leap, but not SLE
+	}
 )
 
 func checkSnapMountDir() error {
@@ -62,6 +67,8 @@ func checkSnapMountDir() error {
 
 	smd := dirs.StripRootDir(dirs.SnapMountDir)
 	switch {
+	case release.DistroLike(migratedAltDirDistros...) && smd == dirs.AltSnapMountDir:
+		// some distributions support migration from /snap -> /var/lib/snapd/snap/
 	case release.DistroLike(defaultDirDistros...) && smd != dirs.DefaultSnapMountDir:
 		fallthrough
 	case release.DistroLike(altDirDistros...) && smd != dirs.AltSnapMountDir:

--- a/syscheck/dirs_test.go
+++ b/syscheck/dirs_test.go
@@ -72,20 +72,24 @@ func (s *dirsSuite) TestUndetermined(c *C) {
 
 var (
 	known = []struct {
-		ID           string
-		IDLike       []string
-		canonicalDir bool
+		ID                string
+		IDLike            []string
+		canonicalDir      bool
+		supportsMigration bool
 	}{
-		{"fedora", nil, false},
-		{"rhel", []string{"fedora"}, false},
-		{"centos", []string{"fedora"}, false},
-		{"ubuntu", []string{"debian"}, true},
-		{"debian", nil, true},
-		{"suse", nil, true},
-		{"yocto", nil, true},
-		{"arch", []string{"archlinux"}, false},
-		{"archlinux", nil, false},
-		{"altlinux", nil, false},
+		{"fedora", nil, false, false},
+		{"rhel", []string{"fedora"}, false, false},
+		{"centos", []string{"fedora"}, false, false},
+		{"ubuntu", []string{"debian"}, true, false},
+		{"debian", nil, true, false},
+		{"suse", nil, true, false}, // SLE?
+		{"opensuse-leap", []string{"opensuse"}, true, true},
+		{"opensuse-tumbleweed", []string{"opensuse"}, true, true},
+		{"opensuse-slowroll", []string{"opensuse"}, true, true},
+		{"yocto", nil, true, false},
+		{"arch", []string{"archlinux"}, false, false},
+		{"archlinux", nil, false, false},
+		{"altlinux", nil, false, false},
 	}
 
 	knownSpecial = []struct {
@@ -101,10 +105,10 @@ func (s *dirsSuite) TestMountDirKnownDistroHappy(c *C) {
 
 	for _, tc := range known {
 		c.Logf("happy case %+v", tc)
-		func() {
+		tf := func(canonicalDir bool) {
 			defer release.MockReleaseInfo(&release.OS{ID: tc.ID, IDLike: tc.IDLike})()
 			d := c.MkDir()
-			if tc.canonicalDir {
+			if canonicalDir {
 				dirstest.MustMockCanonicalSnapMountDir(d)
 			} else {
 				dirstest.MustMockAltSnapMountDir(d)
@@ -112,7 +116,11 @@ func (s *dirsSuite) TestMountDirKnownDistroHappy(c *C) {
 			dirs.SetRootDir(d)
 
 			c.Check(syscheck.CheckSnapMountDir(), IsNil)
-		}()
+		}
+		tf(tc.canonicalDir)
+		if tc.supportsMigration {
+			tf(!tc.canonicalDir)
+		}
 	}
 }
 
@@ -122,6 +130,10 @@ func (s *dirsSuite) TestMountDirKnownDistroMismatch(c *C) {
 	for _, tc := range known {
 		c.Logf("mismatch case %+v", tc)
 		func() {
+			if tc.supportsMigration {
+				c.Logf("distro supports migration skipping test case: %+v", tc)
+				return
+			}
 			defer release.MockReleaseInfo(&release.OS{ID: tc.ID, IDLike: tc.IDLike})()
 			d := c.MkDir()
 			// do the complete opposite so that the mount directory does not

--- a/tests/main/migrate-snap-mount-dir/task.yaml
+++ b/tests/main/migrate-snap-mount-dir/task.yaml
@@ -1,0 +1,118 @@
+summary: Execute snap mount directory migration
+details: |
+    Execute migration of snap mount directory. Ensure that snaps continue to
+    work after.
+
+systems:
+    - opensuse-*
+
+prepare: |
+    snap set system experimental.user-daemons=true
+
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh-core24
+    # install twice
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh-core24
+    
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-service
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-user-service
+
+    #  TODO variant with parallel installs?
+
+restore: |
+    snap remove --purge test-snapd-user-service
+
+    # although state reset should clean that up
+    snap unset system experimental.user-daemons
+
+execute: |
+    if [ "$SPREAD_REBOOT" = 0 ]; then
+        test-snapd-sh-core24.sh -c true
+        systemctl is-active snap.test-snapd-service.test-snapd-service.service
+        not snapd.tool exec snap-mgmt --migrate-mount-dir |& tee migrate.log
+        
+        MATCH "Please ensure all snap services or applications are stopped" < migrate.log
+        
+        # stop the services
+        snap stop test-snapd-service
+        # but start the application
+        test-snapd-sh-core24.sh -c 'exec sleep infinity' &
+        
+        not snapd.tool exec snap-mgmt --migrate-mount-dir |& tee migrate.log
+        MATCH "test-snapd-sh-core24.sh" < migrate.log
+
+        # kill whole process group
+        kill -9 $!
+        wait $! || true
+
+        # still blocked by user services
+        not snapd.tool exec snap-mgmt --migrate-mount-dir |& tee migrate.log
+        MATCH "test-snapd-user-service" < migrate.log
+        NOMATCH "test-snapd-sh-core24" < migrate.log
+
+        snap stop test-snapd-user-service
+        
+        # now we're good
+        snapd.tool exec snap-mgmt --migrate-mount-dir |& tee migrate.log
+        
+        snap list | NOMATCH broken
+        
+        test-snapd-sh-core24.sh -c true
+        
+        # XXX should this be done automatically?
+        snap start test-snapd-service
+        
+        snap services test-snapd-service | MATCH ' active'
+        
+        # both revisions are present
+        test -f /var/lib/snapd/snap/test-snapd-sh-core24/x1/meta/snap.yaml
+        test -f /var/lib/snapd/snap/test-snapd-sh-core24/x2/meta/snap.yaml
+        # curent is correct
+        test "$(readlink /var/lib/snapd/snap/test-snapd-sh-core24/current)" = "x2"
+        # mount units are active
+        systemctl is-active "$(systemd-escape -p var/lib/snapd/snap/test-snapd-sh-core24/x1).mount"
+        systemctl is-active "$(systemd-escape -p var/lib/snapd/snap/test-snapd-sh-core24/x2).mount"
+        
+        # same for the service snap
+        test -f /var/lib/snapd/snap/test-snapd-service/x1/meta/snap.yaml
+        test "$(readlink /var/lib/snapd/snap/test-snapd-service/current)" = "x1"
+        # mount unit is active
+        systemctl is-active "$(systemd-escape -p var/lib/snapd/snap/test-snapd-service/x1).mount"
+        
+        # /snap is preserved as symlink
+        test -L /snap
+        test "$(readlink /snap)" = "/var/lib/snapd/snap"
+        
+        # we can install another revision of a snap
+        "$TESTSTOOLS"/snaps-state install-local test-snapd-sh-core24
+        
+        test -f /var/lib/snapd/snap/test-snapd-sh-core24/x3/meta/snap.yaml
+        # and remove the old old
+        snap remove test-snapd-sh-core24 --revision=x2
+        
+        not test -f /var/lib/snapd/snap/test-snapd-sh-core24/x2/meta/snap.yaml
+        
+        # path is correctly reported by the snapd tooling
+        snap debug paths | MATCH 'SNAPD_MOUNT=/var/lib/snapd/snap$'
+
+        # stop all services
+        snap stop test-snapd-service
+        echo "Attempting another migration should be a noop"
+        snapd.tool exec snap-mgmt --migrate-mount-dir |& tee migrate-already-done.log
+        MATCH "All mount units already migrated or no snap mounts" < migrate-already-done.log
+
+        echo "Reboot to assert post reboot state"
+        REBOOT
+        
+    elif [ "$SPREAD_REBOOT" = 1 ]; then
+        echo "After reboot..."
+        echo "No snaps are broken"
+        snap list | NOMATCH broken
+        echo "Mount units are active"
+        systemctl is-active "$(systemd-escape -p var/lib/snapd/snap/test-snapd-sh-core24/x3).mount"
+        systemctl is-active "$(systemd-escape -p var/lib/snapd/snap/test-snapd-service/x1).mount"
+
+        echo "Snaps continue to work"
+        snap services test-snapd-service | MATCH ' active'
+
+        test-snapd-sh-core24.sh -c true
+    fi

--- a/tests/main/mount-dir-detect-check/task.yaml
+++ b/tests/main/mount-dir-detect-check/task.yaml
@@ -61,13 +61,30 @@ execute: |
   SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
   baddir="$(cat mock-mount-dir)"
 
-  echo "No snaps can be installed if detection found unexpected snap mount directory"
-  "$TESTSTOOLS"/snaps-state install-local test-snapd-sh-core24 2>&1 | MATCH "unexpected snap mount directory"
+  if ! os.query is-opensuse; then
+      echo "No snaps can be installed if detection found unexpected snap mount directory"
+      "$TESTSTOOLS"/snaps-state install-local test-snapd-sh-core24 2>&1 | MATCH "unexpected snap mount directory"
+  else
+      # on openSUSE, we support mount dir migration so either location works
+      "$TESTSTOOLS"/snaps-state install-local test-snapd-sh-core24
+
+      tests.systemd stop-unit snapd.service
+      # purge all snaps so that the alt mount directory can be purged
+      snapd.tool exec snap-mgmt --purge --snap-mount-dir="$baddir"
+  fi
 
   echo "After restoring the correct snap mount directory"
   rm -rf "$baddir"
   mkdir -p "$SNAP_MOUNT_DIR"
   systemctl restart snapd.service
+  # previous steps may have purged the state
+  snap wait system seed.loaded
 
   echo "Snaps can be installed again"
   "$TESTSTOOLS"/snaps-state install-local test-snapd-sh-core24
+
+  test -d "$SNAP_MOUNT_DIR"
+  test ! -d "$baddir"
+
+  echo "And still work"
+  test-snapd-sh-core24.sh -c true


### PR DESCRIPTION
Extend snap-mgmt to with support for doing snap mount dir migration.

Related: [SNAPDENG-35406](https://warthogs.atlassian.net/browse/SNAPDENG-35406)

[SNAPDENG-35406]: https://warthogs.atlassian.net/browse/SNAPDENG-35406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ