### PR TITLE
tests: define an ubuntu kernel version to use with spread tests

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -91,6 +91,8 @@ environment:
     SNAPD_STATE_LOCK_TRACE_THRESHOLD_MS: '$(HOST: echo "${SPREAD_SNAPD_STATE_LOCK_TRACE_THRESHOLD_MS:-0}")'
     # Allow mismatch in snapd/kernel versions
     SNAPD_ALLOW_SNAPD_KERNEL_MISMATCH: '$(HOST: echo "${SNAPD_ALLOW_SNAPD_KERNEL_MISMATCH:-true}")'
+    # The version of the ubuntu kernel used in tests
+    UPDATE_UBUNTU_KERNEL_VERSION: '$(HOST: echo "${SPREAD_UPDATE_UBUNTU_KERNEL_VERSION:-}")'
 
     # Directory where the nested images and test assets are stored
     NESTED_WORK_DIR: '$(HOST: echo "${NESTED_WORK_DIR:-/var/tmp/work-dir}")'

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -223,7 +223,7 @@ prepare_project() {
         apt-get autoremove --purge -y
         "$TESTSTOOLS"/lxd-state undo-mount-changes
 
-        if [ -n "$UPDATE_UBUNTU_KERNEL_VERSION" ] && [ "$SPREAD_REBOOT" == 0 ]; then
+        if [ -n "$UPDATE_UBUNTU_KERNEL_VERSION" ] && [ "$SPREAD_REBOOT" = 0 ]; then
             apt-get update
             apt-get install -y linux-image-"$UPDATE_UBUNTU_KERNEL_VERSION" linux-headers-"$UPDATE_UBUNTU_KERNEL_VERSION"
 

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -222,6 +222,18 @@ prepare_project() {
         apt-get remove --purge -y lxd lxcfs || true
         apt-get autoremove --purge -y
         "$TESTSTOOLS"/lxd-state undo-mount-changes
+
+        if [ -n "$UPDATE_UBUNTU_KERNEL_VERSION" ] && [ "$SPREAD_REBOOT" == 0 ]; then
+            apt-get update
+            apt-get install -y linux-image-"$UPDATE_UBUNTU_KERNEL_VERSION" linux-headers-"$UPDATE_UBUNTU_KERNEL_VERSION"
+
+            # Update grub to set this kernel as default
+            echo "[*] Updating GRUB to set $UPDATE_UBUNTU_KERNEL_VERSION as default..."
+            grub-set-default "Advanced options for Ubuntu>Ubuntu, with Linux $UPDATE_UBUNTU_KERNEL_VERSION"
+            update-grub
+
+            REBOOT
+        fi
     fi
 
     # Check if running inside a container.


### PR DESCRIPTION
This change allows to specify the ubuntu kernel version to be used for tests. This is an example to use this change.

Then this will be integrated with a new workflow which will be used to test snapd using the different supported kernels.

SPREAD_UPDATE_UBUNTU_^CRNEL_VERSION=6.2.0-32-generic spread -shell openstack-ps7:ubuntu-22.04-64:tests/main/abort
