### PR TITLE
o/hookstate, o/snapstate: use in-flight validation sets when calling "snapctl install" from hook

### DIFF
--- a/overlord/hookstate/context.go
+++ b/overlord/hookstate/context.go
@@ -178,8 +178,6 @@ func (c *Context) PendingValidationSets() (*snapasserts.ValidationSets, error) {
 
 	encoded := make(map[string][]byte)
 	if err := enforce.Get("validation-sets", &encoded); err != nil {
-		// TODO: this could happen when we're enforcing validation sets during first
-		// boot. we might need to handle that case as well?
 		if errors.Is(err, &state.NoStateError{}) {
 			return nil, nil
 		}

--- a/overlord/hookstate/ctlcmd/helpers.go
+++ b/overlord/hookstate/ctlcmd/helpers.go
@@ -318,11 +318,18 @@ func createSnapctlInstallTasks(hctx *hookstate.Context, cmd managementCommand) (
 	st.Lock()
 	defer st.Unlock()
 
+	// note, vsets might be nil if no validation sets are going to be enforced
+	// by the current change
+	vsets, err := hctx.PendingValidationSets()
+	if err != nil {
+		return nil, err
+	}
+
 	info, err := currentSnapInfo(st, hctx.InstanceName())
 	if err != nil {
 		return nil, err
 	}
-	return snapstateInstallComponents(context.TODO(), st, cmd.components, info, nil,
+	return snapstateInstallComponents(context.TODO(), st, cmd.components, info, vsets,
 		snapstate.Options{ExpectOneSnap: true, FromChange: changeIDIfNotEphemeral(hctx)})
 }
 


### PR DESCRIPTION
This makes it so that we use the validation sets that are currently being enforced to create the tasks to install the components, rather than using the validation sets that are currently enforced (which would be out of date).