### PR TITLE
cmd/snap-seccomp: extend list of allowed syscalls in unit tests

### DIFF
--- a/cmd/snap-seccomp/main_test.go
+++ b/cmd/snap-seccomp/main_test.go
@@ -287,6 +287,8 @@ restart_syscall
 mprotect
 # libc6 2.42
 getrandom
+clock_gettime
+clock_gettime64
 `
 	bpfPath := filepath.Join(c.MkDir(), "bpf")
 	err := main.Compile([]byte(common+seccompAllowlist), bpfPath)


### PR DESCRIPTION
In 9c72382c1a51b46690a55214034da03961ac807d we introduced getrandom(), but running unit tests on armhf shows that the execution is stalling on calls to clock_gettime64(). Extend the list of allowed syscalls so that unit tests may execute.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
