### PR TITLE
cmd/snap-seccomp: fix unit test for armhf

### DIFF
--- a/cmd/snap-seccomp/main_test.go
+++ b/cmd/snap-seccomp/main_test.go
@@ -278,6 +278,7 @@ exit
 set_thread_area
 # armhf
 set_tls
+ugetrlimit
 # arm64
 readlinkat
 faccessat


### PR DESCRIPTION
Add allowing armhf early syscall.

**Verification on LP:**
https://launchpad.net/~ernestl/+archive/ubuntu/snapd2/+sourcepub/17613877/+listing-archive-extra


**Fault identification:**

Instrumented the unit test with a strace command right after compiled c based test binary, enabled verbose test output , and added strace as dependency for the snapd package.

Ran strace on LP build, the diff is outlined below:

armhf:
----------
```
START: main_test.go:197: snapSeccompSuite.SetUpSuite
execve("/tmp/check-158800464/1/seccomp_syscall_runner", ["/tmp/check-158800464/1/seccomp_s"...], 0xffce2f70 /* 102 vars */) = 0
brk(NULL)                               = 0x1c6e000
brk(0x1c6e880)                          = 0x1c6e880
set_tls(0x1c6e500)                      = 0                                
set_tid_address(0x1c6e088)              = 92162                        
set_robust_list(0x1c6e08c, 12)          = 0
rseq(0x1c6e540, 0x20, 0, 0xe7f5def3)    = 0
ugetrlimit(RLIMIT_STACK, {rlim_cur=8192*1024, rlim_max=RLIM_INFINITY}) = 0                           <---------- diff
getrandom("\xd6\xa4\x94\xec", 4, GRND_NONBLOCK) = 4
readlinkat(AT_FDCWD, "/proc/self/exe", "/tmp/check-158800464/1/seccomp_s"..., 4096) = 45
brk(NULL)                               = 0x1c6e880
brk(0x1c8f880)                          = 0x1c8f880
brk(0x1c90000)                          = 0x1c90000
mprotect(0x7d000, 12288, PROT_READ)     = 0
restart_syscall(<... resuming interrupted mprotect ...>) = -1 EINTR (Interrupted system call)
exit(0) 
```

amd64
----------
```
START: main_test.go:197: snapSeccompSuite.SetUpSuite
execve("/tmp/check-2409860134/1/seccomp_syscall_runner", ["/tmp/check-2409860134/1/seccomp_"...], 0x7ffed8751690 /* 101 vars */) = 0
brk(NULL)                               = 0x38364000
brk(0x38364d40)                         = 0x38364d40
arch_prctl(ARCH_SET_FS, 0x383643c0)     = 0
set_tid_address(0x38364690)             = 71590
set_robust_list(0x383646a0, 24)         = 0
rseq(0x38364340, 0x20, 0, 0x53053053)   = 0
prlimit64(0, RLIMIT_STACK, NULL, {rlim_cur=8192*1024, rlim_max=RLIM64_INFINITY}) = 0
getrandom("\x6a\x62\x52\xf2\x54\x21\xcb\x00", 8, GRND_NONBLOCK) = 8
readlinkat(AT_FDCWD, "/proc/self/exe", "/tmp/check-2409860134/1/seccomp_"..., 4096) = 46
brk(NULL)                               = 0x38364d40
brk(0x38385d40)                         = 0x38385d40
brk(0x38386000)                         = 0x38386000
mprotect(0x4b9000, 20480, PROT_READ)    = 0
syscall_0x401180(0, 0, 0, 0xb290da90, 0x7ffd, 0x481468) = -1 ENOSYS (Function not implemented)
exit(0)                  
```