### PR TITLE
many: add TODO:GOVERSION to comments related to updating the go version

### DIFF
--- a/bootloader/lkenv/lkenv.go
+++ b/bootloader/lkenv/lkenv.go
@@ -261,7 +261,7 @@ func (e compatErrNotExist) Unwrap() error {
 func (l *Env) LoadEnv(path string) error {
 	f, err := os.Open(path)
 	if err != nil {
-		// TODO: when we drop support for Go 1.9, this code can go away, in Go
+		// TODO:GOVERSION: when we drop support for Go 1.9, this code can go away, in Go
 		//       1.9 *os.PathError does not implement Unwrap(), and so callers
 		//       that try to call xerrors.Is(err,os.ErrNotExist) will fail, so
 		//       instead we do our own wrapping first such that when Unwrap() is

--- a/cluster/assemblestate/assemblestate.go
+++ b/cluster/assemblestate/assemblestate.go
@@ -580,7 +580,7 @@ func (as *AssembleState) Run(
 	var wg sync.WaitGroup
 
 	// channel to receive server errors that should cause the process to fail
-	// TODO: replace with [context.Cause] when we're on go >= 1.20
+	// TODO:GOVERSION: replace with [context.Cause] when we're on go >= 1.20
 	serverError := make(chan error, 1)
 
 	// start the server that handles incoming requests

--- a/cluster/assemblestate/intset/intset.go
+++ b/cluster/assemblestate/intset/intset.go
@@ -114,7 +114,7 @@ func (is *IntSet[T]) Diff(other *IntSet[T]) *IntSet[T] {
 // Range calls fn for every value present in the set. If fn returns false,
 // iteration stops early.
 //
-// TODO: consider using the new range functionality from go 1.23 once possible
+// TODO:GOVERSION: consider using the new range functionality from go 1.23 once possible
 func (is *IntSet[T]) Range(fn func(value T) bool) {
 	for wi, word := range is.words {
 		for word != 0 {
@@ -175,7 +175,7 @@ func (is *IntSet[T]) Equal(other *IntSet[T]) bool {
 
 // max returns the larger of the two given values.
 //
-// TOD0: remove once we are on go>=1.21
+// TODO:GOVERSION: remove once we are on go>=1.21
 func max(x, y int) int {
 	if x > y {
 		return x

--- a/cluster/assemblestate/selector.go
+++ b/cluster/assemblestate/selector.go
@@ -484,7 +484,7 @@ func (p *PrioritySelector) edgesToRoutes(edges []edgeID) Routes {
 
 // min returns the smaller of the two given values.
 //
-// TODO: remove once we are on go>=1.21
+// TODO:GOVERSION: remove once we are on go>=1.21
 func min(x int, y int) int {
 	if x < y {
 		return x

--- a/gadget/gadget_test.go
+++ b/gadget/gadget_test.go
@@ -4316,8 +4316,7 @@ func (s *gadgetYamlTestSuite) TestAllDiskVolumeDeviceTraitsWithDeviceSetHappy(c 
 }
 
 func (s *gadgetYamlTestSuite) TestGadgetInfoHasSameYamlAndJsonTags(c *C) {
-	// TODO: once we move to go 1.17 just use
-	//       reflect.StructField.IsExported() directly
+	// TODO:GOVERSION: once we move to go 1.17 just use reflect.StructField.IsExported() directly
 	var isExported = func(s reflect.StructField) bool {
 		// see https://pkg.go.dev/reflect#StructField
 		return s.PkgPath == ""

--- a/interfaces/prompting/requestprompts/requestprompts.go
+++ b/interfaces/prompting/requestprompts/requestprompts.go
@@ -138,7 +138,7 @@ func (p *Prompt) containsListenerRequestID(requestID uint64) bool {
 	})
 }
 
-// TODO: replace this with slices.ContainsFunc once on go 1.21+
+// TODO:GOVERSION: replace this with slices.ContainsFunc once on go 1.21+
 func slicesContainsFunc(s []*listener.Request, f func(r *listener.Request) bool) bool {
 	for _, element := range s {
 		if f(element) {
@@ -419,7 +419,7 @@ func (udb *userPromptDB) timeoutCallback(pdb *PromptDB, user uint32) {
 	expiredPrompts := udb.prompts
 	// Clear all outstanding prompts for the user
 	udb.prompts = nil
-	udb.ids = make(map[prompting.IDType]int) // TODO: clear() once we're on Go 1.21+
+	udb.ids = make(map[prompting.IDType]int) // TODO:GOVERSION: clear() once we're on Go 1.21+
 
 	// Remove the request ID mappings now before unlocking the prompt DB
 	for _, p := range expiredPrompts {

--- a/interfaces/prompting/requestrules/requestrules.go
+++ b/interfaces/prompting/requestrules/requestrules.go
@@ -818,7 +818,7 @@ func joinInternalErrors(errs []error) error {
 	if joinedErr == nil {
 		return nil
 	}
-	// TODO: wrap joinedErr as well once we're on golang v1.20+
+	// TODO:GOVERSION: wrap joinedErr as well once we're on golang v1.20+
 	return fmt.Errorf("%w\n%v", prompting_errors.ErrRuleDBInconsistent, joinedErr)
 }
 

--- a/interfaces/prompting/requestrules/requestrules_test.go
+++ b/interfaces/prompting/requestrules/requestrules_test.go
@@ -653,7 +653,7 @@ func (s *requestrulesSuite) TestJoinInternalErrors(c *C) {
 	errs := []error{nil, errFoo, nil}
 	err := requestrules.JoinInternalErrors(errs)
 	c.Check(errors.Is(err, prompting_errors.ErrRuleDBInconsistent), Equals, true)
-	// XXX: check the following when we're on golang v1.20+
+	// TODO:GOVERSION: XXX: check the following when we're on golang v1.20+
 	// c.Check(errors.Is(err, errFoo), Equals, true)
 	c.Check(errors.Is(err, errBar), Equals, false)
 	c.Check(err.Error(), Equals, fmt.Sprintf("%v\n%v", prompting_errors.ErrRuleDBInconsistent, errFoo))
@@ -661,7 +661,7 @@ func (s *requestrulesSuite) TestJoinInternalErrors(c *C) {
 	errs = append(errs, errBar, errBaz)
 	err = requestrules.JoinInternalErrors(errs)
 	c.Check(errors.Is(err, prompting_errors.ErrRuleDBInconsistent), Equals, true)
-	// XXX: check the following when we're on golang v1.20+
+	// TODO:GOVERSION: XXX: check the following when we're on golang v1.20+
 	// c.Check(errors.Is(err, errFoo), Equals, true)
 	// c.Check(errors.Is(err, errBar), Equals, true)
 	// c.Check(errors.Is(err, errBaz), Equals, true)
@@ -1541,7 +1541,7 @@ func (s *requestrulesSuite) TestAddRuleMerges(c *C) {
 				// that the difference is less than 100ms. We'll always have
 				// deltas of 1s for time differences we care about.
 				difference := entry.Expiration.Sub(expectedEntry.Expiration)
-				// TODO: call Abs() once we're on Go 1.19+
+				// TODO:GOVERSION: call Abs() once we're on Go 1.19+
 				if difference < 0 {
 					difference *= -1
 				}

--- a/osutil/exitcode.go
+++ b/osutil/exitcode.go
@@ -27,7 +27,7 @@ import (
 // ExitCode extract the exit code from the error of a failed cmd.Run() or the
 // original error if its not a exec.ExitError
 func ExitCode(runErr error) (e int, err error) {
-	// TODO: with golang-1.12 this becomes a bit nicer:
+	// TODO:GOVERSION: with golang-1.12 this becomes a bit nicer:
 	//       https://github.com/golang/go/issues/26539
 	// golang, you are kidding me, right?
 	if exitErr, ok := runErr.(*exec.ExitError); ok {

--- a/osutil/mount/libmount/libmount_linux.go
+++ b/osutil/mount/libmount/libmount_linux.go
@@ -181,6 +181,6 @@ func ValidateMountOptions(opts ...string) error {
 		priorClearMask |= opt.clearMask
 	}
 
-	// TODO: use errors.Join when we update to go 1.20.
+	// TODO:GOVERSION: use errors.Join when we update to go 1.20.
 	return nil
 }

--- a/osutil/udev/netlink/rawsockstop.go
+++ b/osutil/udev/netlink/rawsockstop.go
@@ -11,7 +11,7 @@ import (
 // reading from a raw socket, readableOrStop blocks until
 // fd is readable or stop was called. To work properly it sets fd
 // to non-blocking mode.
-// TODO: with go 1.11+ it should be possible to just switch to setting
+// TODO:GOVERSION: with go 1.11+ it should be possible to just switch to setting
 // fd to non-blocking and then wrapping the socket via os.NewFile and
 // use Close to force a read to stop.
 // c.f. https://github.com/golang/go/commit/ea5825b0b64e1a017a76eac0ad734e11ff557c8e

--- a/osutil/udev/netlink/rawsockstop_other.go
+++ b/osutil/udev/netlink/rawsockstop_other.go
@@ -7,7 +7,7 @@ package netlink
 
 import "syscall"
 
-// once we use something other than go1.10 we can move this back into
+// TODO:GOVERSION: once we use something other than go1.10 we can move this back into
 // rawsocketstop.go and remove rawsocketstop_arm64.go, see
 // rawsocketstop_arm64.go for details
 var stopperSelectTimeout = func() *syscall.Timeval {

--- a/osutil/vfs/lists/iter.go
+++ b/osutil/vfs/lists/iter.go
@@ -18,7 +18,7 @@
  */
 package lists
 
-// TODO: replace with iter.Seq after go 1.23 update.
+// TODO:GOVERSION: replace with iter.Seq after go 1.23 update.
 
 // Seq is an iterator over sequences of individual values. When called as
 // seq(yield), seq calls yield(v) for each value v in the sequence, stopping

--- a/osutil/vfs/vfs.go
+++ b/osutil/vfs/vfs.go
@@ -198,7 +198,7 @@ func (v *VFS) detachMount(m *mount, idx int) {
 	m.parentID = 0
 	m.mountID = 0
 
-	// TODO: use slices from future go to avoid this hand-crafted surgery.
+	// TODO:GOVERSION: use slices from future go to avoid this hand-crafted surgery.
 	v.mounts = append(v.mounts[:idx], v.mounts[idx+1:]...)
 }
 

--- a/overlord/ifacestate/apparmorprompting/noticebackend.go
+++ b/overlord/ifacestate/apparmorprompting/noticebackend.go
@@ -262,7 +262,7 @@ func (ntb *noticeTypeBackend) searchExistingNotices(userID uint32, noticeID stri
 	// Since the user notices are sorted by LastRepeated timestamp, and
 	// each notice has a unique LastRepeated timestamp, we can use binary
 	// search by LastRepeated timestamp.
-	// XXX: maybe use slices.BinarySearchFunc instead once on go 1.21+
+	// TODO:GOVERSION: XXX: maybe use slices.BinarySearchFunc instead once on go 1.21+
 	existingIndex = sort.Search(len(userNotices), func(i int) bool {
 		// Find first index which has a LastRepeated timestamp >= the
 		// existing notice, since we're binary searching for that notice.
@@ -406,7 +406,7 @@ func (f ntbFilter) filterNotices(notices []*state.Notice, now time.Time) []*stat
 	return keyNotices
 }
 
-// TODO: remove in favor of slices.Contains once we're on Go 1.21+
+// TODO:GOVERSION: remove in favor of slices.Contains once we're on Go 1.21+
 func slicesContains[T comparable](haystack []T, needle T) bool {
 	for _, v := range haystack {
 		if v == needle {
@@ -494,7 +494,7 @@ func (ntb *noticeTypeBackend) BackendWaitNotices(ctx context.Context, filter *st
 	// When the context is done/cancelled, wake up the waiters so that they can
 	// check their ctx.Err() and return if they're cancelled.
 	//
-	// TODO: replace this with context.AfterFunc once we're on Go 1.21.
+	// TODO:GOVERSION: replace this with context.AfterFunc once we're on Go 1.21.
 	stop := contextAfterFunc(ctx, func() {
 		// We need to acquire a lock mutually exclusive with the cond lock here
 		// to be sure that the Broadcast below won't occur before the call to
@@ -535,7 +535,7 @@ func (ntb *noticeTypeBackend) BackendWaitNotices(ctx context.Context, filter *st
 	}
 }
 
-// Remove this and just use context.AfterFunc once we're on Go 1.21.
+// TODO:GOVERSION: Remove this and just use context.AfterFunc once we're on Go 1.21.
 func contextAfterFunc(ctx context.Context, f func()) func() {
 	stopCh := make(chan struct{})
 	go func() {

--- a/overlord/notices/notices.go
+++ b/overlord/notices/notices.go
@@ -197,7 +197,7 @@ func (nm *NoticeManager) RegisterBackend(bknd NoticeBackend, typ state.NoticeTyp
 	return validateNotice, drainedNotices, nil
 }
 
-// TODO: replace this with slices.Contains() once we're on go 1.21+.
+// TODO:GOVERSION: replace this with slices.Contains() once we're on go 1.21+.
 func backendsContain(backends []NoticeBackend, backend NoticeBackend) bool {
 	for _, bknd := range backends {
 		if bknd == backend {

--- a/overlord/restart/restart.go
+++ b/overlord/restart/restart.go
@@ -124,7 +124,7 @@ type restartManagerKey struct{}
 // RestartManager takes care of restart-related state.
 type RestartManager struct {
 	state            *state.State
-	restarting       int32 // really of type RestartType -- TODO: use atomic.Int32 once on go 1.19+
+	restarting       int32 // really of type RestartType -- TODO:GOVERSION: use atomic.Int32 once on go 1.19+
 	h                Handler
 	bootID           string
 	changeCallbackID int

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -9228,7 +9228,8 @@ func (s *snapmgrTestSuite) TestResolveValidationSetsEnforcementErrorComponents(c
 		}})
 		for _, comp := range comps {
 			// since we take a pointer to comp here, we've gotta copy it out of
-			// the loop variable. can be removed once we're on go 1.22
+			// the loop variable.
+			// TODO:GOVERSION: can be removed once we're on go 1.22
 			comp := comp
 			err := seq.AddComponentForRevision(rev, sequence.NewComponentState(&comp, snap.TestComponent))
 			c.Assert(err, IsNil)
@@ -9383,7 +9384,8 @@ func (s *snapmgrTestSuite) TestResolveValidationSetsEnforcementErrorBaseOrdering
 		}})
 		for _, comp := range comps {
 			// since we take a pointer to comp here, we've gotta copy it out of
-			// the loop variable. can be removed once we're on go 1.22
+			// the loop variable.
+			// TODO:GOVERSION: can be removed once we're on go 1.22
 			comp := comp
 			err := seq.AddComponentForRevision(rev, sequence.NewComponentState(&comp, snap.TestComponent))
 			c.Assert(err, IsNil)

--- a/overlord/state/notices.go
+++ b/overlord/state/notices.go
@@ -670,7 +670,7 @@ func (s *State) WaitNotices(ctx context.Context, filter *NoticeFilter) ([]*Notic
 	// When the context is done/cancelled, wake up the waiters so that they
 	// can check their ctx.Err() and return if they're cancelled.
 	//
-	// TODO: replace this with context.AfterFunc once we're on Go 1.21.
+	// TODO:GOVERSION: replace this with context.AfterFunc once we're on Go 1.21.
 	stop := contextAfterFunc(ctx, func() {
 		// We need to acquire a lock mutually exclusive with the cond lock here
 		// to be sure that the Broadcast below won't occur before the call to
@@ -716,7 +716,7 @@ func (s *State) WaitNotices(ctx context.Context, filter *NoticeFilter) ([]*Notic
 	}
 }
 
-// Remove this and just use context.AfterFunc once we're on Go 1.21.
+// TODO:GOVERSION: Remove this and just use context.AfterFunc once we're on Go 1.21.
 func contextAfterFunc(ctx context.Context, f func()) func() {
 	stopCh := make(chan struct{})
 	go func() {

--- a/run-checks
+++ b/run-checks
@@ -507,7 +507,7 @@ if [ "$STATIC" = 1 ]; then
 
     echo ">> [Go] checking the go.sum is up to date and tidy"
     go mod tidy
-    # TODO:go: replace with go mod tidy -diff when we're running with Go 1.23+
+    # TODO:GOVERSION: replace with go mod tidy -diff when we're running with Go 1.23+
     # everywhere
     if git status | grep -q go.sum ; then
         echo "go.sum is not tidy, please run 'go mod tidy'"

--- a/sandbox/apparmor/notify/notify.go
+++ b/sandbox/apparmor/notify/notify.go
@@ -19,7 +19,7 @@ import (
 var (
 	doIoctl = Ioctl
 
-	// TODO: replace with binary.NativeEndian once we're at go 1.21+
+	// TODO:GOVERSION: replace with binary.NativeEndian once we're at go 1.21+
 	nativeByteOrder = arch.Endian() // ioctl messages are native byte order
 )
 

--- a/sandbox/apparmor/notify/strings.go
+++ b/sandbox/apparmor/notify/strings.go
@@ -76,7 +76,7 @@ func (sp *stringPacker) packTagsets(ts TagsetMap) uint32 {
 	for perm := range ts {
 		perms = append(perms, perm)
 	}
-	// TODO: use slices.Sort() once we're on go 1.21+
+	// TODO:GOVERSION: use slices.Sort() once we're on go 1.21+
 	sort.Slice(perms, func(i, j int) bool {
 		return perms[i].AsAppArmorOpMask() < perms[j].AsAppArmorOpMask()
 	})

--- a/sandbox/cgroup/freezer.go
+++ b/sandbox/cgroup/freezer.go
@@ -98,8 +98,9 @@ var freezeSnapProcessesImplV1 = func(ctx context.Context, snapName string) error
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, maxFreezeTimeout)
 	defer cancel()
 	ticker := time.NewTicker(freezePulseDelay)
-	// The ticker.Stop() can be removed starting 1.23 where the garbage collector can recover
-	// unreferenced tickers, even if they haven't been stopped.
+	// TODO:GOVERSION: The ticker.Stop() can be removed starting 1.23 where the
+	// garbage collector can recover unreferenced tickers, even if they haven't
+	// been stopped.
 	defer ticker.Stop()
 	for {
 		data, err := osReadFile(fname)
@@ -205,8 +206,9 @@ func freezeOneV2(ctx context.Context, dir string) error {
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, maxFreezeTimeout)
 	defer cancel()
 	ticker := time.NewTicker(freezePulseDelay)
-	// ticker.Stop() can be removed starting 1.23 where the garbage collector can recover
-	// unreferenced tickers, even if they haven't been stopped.
+	// TODO:GOVERSION: ticker.Stop() can be removed starting 1.23 where the
+	// garbage collector can recover unreferenced tickers, even if they haven't
+	// been stopped.
 	defer ticker.Stop()
 	for {
 		data, err := os.ReadFile(fname)

--- a/snap/container.go
+++ b/snap/container.go
@@ -420,7 +420,7 @@ func validateContainer(c Container, needsrx, needsx, needsr, needsf, noskipd map
 	}
 
 	if firstBadModeErr != nil {
-		// TODO: fmt.Errorf("%w: %w", ErrBadModes, firstBadModeErr) when using go 1.20+
+		// TODO:GOVERSION: fmt.Errorf("%w: %w", ErrBadModes, firstBadModeErr) when using go 1.20+
 		// TODO: aggregate bad mode errors not just the first one
 		return fmt.Errorf("%w: %v", ErrBadModes, firstBadModeErr)
 	}

--- a/store/tooling/tooling_test.go
+++ b/store/tooling/tooling_test.go
@@ -622,7 +622,7 @@ func (s *toolingSuite) SnapAction(_ context.Context, curSnaps []*store.CurrentSn
 		})
 	}
 
-	// TODO: we can remove this source once we move to go >=1.20
+	// TODO:GOVERSION: we can remove this source once we move to go >=1.20
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	// caller of SnapAction shouldn't depend on the order of the results

--- a/strutil/joinerrors.go
+++ b/strutil/joinerrors.go
@@ -27,7 +27,7 @@ import (
 // Any nil error values are discarded.
 // Join returns nil if every value in errs is nil.
 //
-// TODO: replace with errors.Join() once we're on golang v1.20+
+// TODO:GOVERSION: replace with errors.Join() once we're on golang v1.20+
 //
 // This is a lossy implementation of errors.Join, where only the first non-nil
 // error is preserved in a state which can be unwrapped.


### PR DESCRIPTION
Unsure if we want this, but it might make it easier to find these when we do update go. This is probably not comprehensive, just tried to grep around for things.

Some of these are actually fixable now, but I figured not good to mix in with this PR.