### PR TITLE
tests: allow runing test using kernel pattern

### DIFF
--- a/.github/workflows/nightly-spread.yaml
+++ b/.github/workflows/nightly-spread.yaml
@@ -238,7 +238,7 @@ jobs:
         tests/main/user-mounts
       rules: ''
       use-snapd-snap-from-master: true
-      spread-env: "SPREAD_UPDATE_UBUNTU_KERNEL_VERSION=${{ matrix.kernel }}"
+      spread-env: "SPREAD_UPDATE_UBUNTU_KERNEL_PATTERN=${{ matrix.kernel }}"
     strategy:
       fail-fast: false
       matrix:
@@ -247,42 +247,42 @@ jobs:
           - group: bionic-4.15
             backend: openstack-ps7
             systems: 'ubuntu-18.04-64'
-            kernel: 4.15.0-213-generic
+            kernel: '4\.15.*-generic'
             support: '2030-04-30'
           - group: bionic-5.4
             backend: openstack-ps7
             systems: 'ubuntu-18.04-64'
-            kernel: 5.4.0-150-generic
+            kernel: '5\.4.*-generic'
             support: '2030-04-30'
           - group: focal-5.4
             backend: openstack-ps7
             systems: 'ubuntu-20.04-64'
-            kernel: 5.4.0-216-generic
+            kernel: '5\.4.*-generic'
             support: '2032-04-30'
           - group: focal-5.15
             backend: openstack-ps7
             systems: 'ubuntu-20.04-64'
-            kernel: 5.15.0-139-generic
+            kernel: '5\.15.*-generic'
             support: '2032-04-30'
           - group: jammy-5.15
             backend: openstack-ps7
             systems: 'ubuntu-20.04-64'
-            kernel: 5.15.0-156-generic
+            kernel: '5\.15.*-generic'
             support: '2034-04-30'
           - group: jammy-6.8
             backend: openstack-ps7
             systems: 'ubuntu-20.04-64'
-            kernel: 6.8.0-84-generic
+            kernel: '6\.8.*-generic'
             support: '2034-04-30'
           - group: noble-6.8
             backend: openstack-ps7
             systems: 'ubuntu-20.04-64'
-            kernel: 6.8.0-84-generic
+            kernel: '6\.8.*-generic'
             support: '2036-04-30'
           - group: noble-6.14
             backend: openstack-ps7
             systems: 'ubuntu-20.04-64'
-            kernel: 6.14.0-29-generic
+            kernel: '6\.14.*-generic'
             support: '2036-04-30'
 
   re-run:

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -175,12 +175,13 @@ jobs:
             # The tests are just filtered when the change is a PR
             # When 'Run Nested' label is added in a PR, all the nested tests have to be executed
             TASKS_TO_RUN=""
+            INPUT_TASKS="$(echo ${{ inputs.tasks }} | tr '\n' ' ')"
             if [ -z "${{ github.event.number }}" ] || [ "$RUN_NESTED" = 'true' ] || [ -z "${{ inputs.rules }}" ] || [ -z "$changes_param" ]; then
-                for TASKS in ${{ inputs.tasks }}; do
+                for TASKS in $INPUT_TASKS; do
                     TASKS_TO_RUN="$TASKS_TO_RUN $prefix:$TASKS"
                 done
             else
-                NEW_TASKS="$(./tests/lib/external/snapd-testing-tools/utils/spread-filter -r ./tests/lib/spread/rules/${{ inputs.rules }}.yaml -p "$prefix" $changes_param -t "${{ inputs.tasks }}")"
+                NEW_TASKS="$(./tests/lib/external/snapd-testing-tools/utils/spread-filter -r ./tests/lib/spread/rules/${{ inputs.rules }}.yaml -p "$prefix" $changes_param -t "$INPUT_TASKS")"
                 TASKS_TO_RUN="$NEW_TASKS"
             fi
             echo "$TASKS_TO_RUN"

--- a/spread.yaml
+++ b/spread.yaml
@@ -93,6 +93,8 @@ environment:
     SNAPD_ALLOW_SNAPD_KERNEL_MISMATCH: '$(HOST: echo "${SNAPD_ALLOW_SNAPD_KERNEL_MISMATCH:-true}")'
     # The version of the ubuntu kernel used in tests
     UPDATE_UBUNTU_KERNEL_VERSION: '$(HOST: echo "${SPREAD_UPDATE_UBUNTU_KERNEL_VERSION:-}")'
+    # The pattern used by apt-cache search to determine the ubuntu kernel used in tests
+    UPDATE_UBUNTU_KERNEL_PATTERN: '$(HOST: echo "${SPREAD_UPDATE_UBUNTU_KERNEL_PATTERN:-}")'
 
     # Directory where the nested images and test assets are stored
     NESTED_WORK_DIR: '$(HOST: echo "${NESTED_WORK_DIR:-/var/tmp/work-dir}")'


### PR DESCRIPTION
This change allows to run the tests using the last kernel which matches with a pattern. Also it fixes the error in the kernels workflow execution by removing the \n at the end of the list (in case it finishes with \n)

Now the kernels workflow contains a pattern used to determine the kernel to be used instead of a fixed version.
