### PR TITLE
github/workflows/data-non-fundamental-systems: temporarily disable 24.04 FIPS

### DIFF
--- a/.github/workflows/data-non-fundamental-systems.json
+++ b/.github/workflows/data-non-fundamental-systems.json
@@ -108,7 +108,7 @@
         "group": "ubuntu-fips-snap",
         "backend": "google-pro",
         "alternative-backend": "google-pro",
-        "systems": "ubuntu-fips-22.04-64 ubuntu-fips-24.04-64",
+        "systems": "ubuntu-fips-22.04-64",
         "tasks": "tests/fips-snap/...",
         "rules": "fips"
       },
@@ -116,7 +116,7 @@
         "group": "ubuntu-fips-deb",
         "backend": "google-pro",
         "alternative-backend": "google-pro",
-        "systems": "ubuntu-fips-22.04-64 ubuntu-fips-24.04-64",
+        "systems": "ubuntu-fips-22.04-64",
         "tasks": "tests/fips-deb/...",
         "rules": "fips"
       },


### PR DESCRIPTION
24.04 FIPS will keep failing until upstream fixes land. Let's disable it for now.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
