### PR TITLE
daemon: wrap confdb write values under "values" key

### DIFF
--- a/client/confdb.go
+++ b/client/confdb.go
@@ -36,7 +36,12 @@ func (c *Client) ConfdbGetViaView(viewID string, requests []string) (changeID st
 }
 
 func (c *Client) ConfdbSetViaView(viewID string, requestValues map[string]any) (changeID string, err error) {
-	body, err := json.Marshal(requestValues)
+	type setBody struct {
+		Values map[string]any `json:"values"`
+	}
+
+	body := setBody{Values: requestValues}
+	bodyRaw, err := json.Marshal(body)
 	if err != nil {
 		return "", err
 	}
@@ -45,5 +50,5 @@ func (c *Client) ConfdbSetViaView(viewID string, requestValues map[string]any) (
 	headers["Content-Type"] = "application/json"
 
 	endpoint := fmt.Sprintf("/v2/confdb/%s", viewID)
-	return c.doAsync("PUT", endpoint, nil, headers, bytes.NewReader(body))
+	return c.doAsync("PUT", endpoint, nil, headers, bytes.NewReader(bodyRaw))
 }

--- a/client/confdb_test.go
+++ b/client/confdb_test.go
@@ -61,5 +61,5 @@ func (cs *clientSuite) TestConfdbSet(c *C) {
 	res := make(map[string]any)
 	err = json.Unmarshal(data, &res)
 	c.Assert(err, IsNil)
-	c.Check(res, DeepEquals, map[string]any{"foo": "bar", "baz": float64(1)})
+	c.Check(res, DeepEquals, map[string]any{"values": map[string]any{"foo": "bar", "baz": float64(1)}})
 }

--- a/cmd/snap/cmd_set_test.go
+++ b/cmd/snap/cmd_set_test.go
@@ -237,7 +237,7 @@ func (s *confdbSuite) TestConfdbSet(c *check.C) {
 	restore := s.mockConfdbFlag(c)
 	defer restore()
 
-	s.mockConfdbServer(c, `{"abc":"cba"}`, false)
+	s.mockConfdbServer(c, `{"values":{"abc":"cba"}}`, false)
 
 	rest, err := snapset.Parser(snapset.Client()).ParseArgs([]string{"set", "foo/bar/baz", `abc="cba"`})
 	c.Assert(err, check.IsNil)
@@ -251,7 +251,7 @@ func (s *confdbSuite) TestConfdbSetMany(c *check.C) {
 	restore := s.mockConfdbFlag(c)
 	defer restore()
 
-	s.mockConfdbServer(c, `{"abc":{"foo":1},"xyz":true}`, false)
+	s.mockConfdbServer(c, `{"values":{"abc":{"foo":1},"xyz":true}}`, false)
 
 	rest, err := snapset.Parser(snapset.Client()).ParseArgs([]string{"set", "foo/bar/baz", `abc={"foo":1}`, "xyz=true"})
 	c.Assert(err, check.IsNil)
@@ -274,7 +274,7 @@ func (s *confdbSuite) TestConfdbSetNoWait(c *check.C) {
 	restore := s.mockConfdbFlag(c)
 	defer restore()
 
-	s.mockConfdbServer(c, `{"abc":1}`, true)
+	s.mockConfdbServer(c, `{"values":{"abc":1}}`, true)
 
 	rest, err := snapset.Parser(snapset.Client()).ParseArgs([]string{"set", "--no-wait", "foo/bar/baz", "abc=1"})
 	c.Assert(err, check.IsNil)
@@ -306,7 +306,7 @@ func (s *confdbSuite) TestConfdbSetExclamationMark(c *check.C) {
 	restore := s.mockConfdbFlag(c)
 	defer restore()
 
-	s.mockConfdbServer(c, `{"abc":null}`, false)
+	s.mockConfdbServer(c, `{"values":{"abc":null}}`, false)
 
 	_, err := snapset.Parser(snapset.Client()).ParseArgs([]string{"set", "foo/bar/baz", "abc!"})
 	c.Assert(err, check.IsNil)

--- a/cmd/snap/cmd_unset_test.go
+++ b/cmd/snap/cmd_unset_test.go
@@ -53,7 +53,7 @@ func (s *confdbSuite) TestConfdbUnset(c *check.C) {
 	restore := s.mockConfdbFlag(c)
 	defer restore()
 
-	s.mockConfdbServer(c, `{"abc":null}`, false)
+	s.mockConfdbServer(c, `{"values":{"abc":null}}`, false)
 
 	_, err := snapunset.Parser(snapunset.Client()).ParseArgs([]string{"unset", "foo/bar/baz", "abc"})
 	c.Assert(err, check.IsNil)
@@ -63,7 +63,7 @@ func (s *confdbSuite) TestConfdbUnsetNoWait(c *check.C) {
 	restore := s.mockConfdbFlag(c)
 	defer restore()
 
-	s.mockConfdbServer(c, `{"abc":null}`, true)
+	s.mockConfdbServer(c, `{"values":{"abc":null}}`, true)
 
 	rest, err := snapunset.Parser(snapunset.Client()).ParseArgs([]string{"unset", "--no-wait", "foo/bar/baz", "abc"})
 	c.Assert(err, check.IsNil)

--- a/daemon/api_confdb.go
+++ b/daemon/api_confdb.go
@@ -97,10 +97,18 @@ func setView(c *Command, r *http.Request, _ *auth.UserState) Response {
 	vars := muxVars(r)
 	account, schemaName, viewName := vars["account"], vars["confdb-schema"], vars["view"]
 
+	type setAction struct {
+		Values map[string]any `json:"values"`
+	}
+
+	var action setAction
 	decoder := json.NewDecoder(r.Body)
-	var values map[string]any
-	if err := decoder.Decode(&values); err != nil {
+	if err := decoder.Decode(&action); err != nil {
 		return BadRequest("cannot decode confdb request body: %v", err)
+	}
+
+	if len(action.Values) == 0 {
+		return BadRequest("cannot set confdb: request body contains no values")
 	}
 
 	view, err := confdbstateGetView(st, account, schemaName, viewName)
@@ -113,7 +121,7 @@ func setView(c *Command, r *http.Request, _ *auth.UserState) Response {
 		return toAPIError(err)
 	}
 
-	err = confdbstateSetViaView(tx, view, values)
+	err = confdbstateSetViaView(tx, view, action.Values)
 	if err != nil {
 		return toAPIError(err)
 	}


### PR DESCRIPTION
Put the map of values to be written to confdb nested under "values". This helps with backwards compatibility if we need to add new fields to the PUT body. It's also more consistent with other parts of the API, namely on read and other related endpoints currently in spec stage.