### PR TITLE
image-garden: set fedora to selinux permissive mode

### DIFF
--- a/.image-garden.mk
+++ b/.image-garden.mk
@@ -23,6 +23,11 @@ endef
 
 define FEDORA_CLOUD_INIT_USER_DATA_TEMPLATE
 $(CLOUD_INIT_USER_DATA_TEMPLATE)
+# set selinux to permissive mode
+- sed -i 's/SELINUX=.*/SELINUX=permissive/g' /etc/selinux/config
+# pre-install wget so that prepare with snapd built from master works
+packages:
+- wget
 endef
 
 define OPENSUSE_tumbleweed_CLOUD_INIT_USER_DATA_TEMPLATE


### PR DESCRIPTION
Selinux is interfering with tests.session so set it in permissive mode. 