### PR TITLE
tests: removing images from google bucket

### DIFF
--- a/tests/lib/image.sh
+++ b/tests/lib/image.sh
@@ -52,40 +52,6 @@ get_ubuntu_image() {
 }
 
 # shellcheck disable=SC2120
-get_google_image_url_for_vm() {
-    case "${1:-$SPREAD_SYSTEM}" in
-        ubuntu-16.04-64*)
-            echo "https://storage.googleapis.com/snapd-spread-tests/images/cloudimg/xenial-server-cloudimg-amd64-disk1.img"
-            ;;
-        ubuntu-18.04-64*)
-            echo "https://storage.googleapis.com/snapd-spread-tests/images/cloudimg/bionic-server-cloudimg-amd64.img"
-            ;;
-        ubuntu-20.04-64*)
-            echo "https://storage.googleapis.com/snapd-spread-tests/images/cloudimg/focal-server-cloudimg-amd64.img"
-            ;;
-        ubuntu-20.04-arm-64*)
-            echo "https://storage.googleapis.com/snapd-spread-tests/images/cloudimg/focal-server-cloudimg-arm64.img"
-            ;;
-        ubuntu-22.04-64*)
-            echo "https://storage.googleapis.com/snapd-spread-tests/images/cloudimg/jammy-server-cloudimg-amd64.img"
-            ;;
-        ubuntu-22.04-arm-64*)
-            echo "https://storage.googleapis.com/snapd-spread-tests/images/cloudimg/jammy-server-cloudimg-arm64.img"
-            ;;
-        ubuntu-23.10-64*)
-            echo "https://storage.googleapis.com/snapd-spread-tests/images/cloudimg/mantic-server-cloudimg-amd64.img"
-            ;;
-        ubuntu-24.04-64*)
-            echo "https://storage.googleapis.com/snapd-spread-tests/images/cloudimg/noble-server-cloudimg-amd64.img"
-            ;;
-        *)
-            echo "unsupported system"
-            exit 1
-            ;;
-    esac
-}
-
-# shellcheck disable=SC2120
 get_ubuntu_image_url_for_vm() {
     case "${1:-$SPREAD_SYSTEM}" in
         ubuntu-16.04-64*)
@@ -106,11 +72,11 @@ get_ubuntu_image_url_for_vm() {
         ubuntu-22.04-arm-64*)
             echo "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-arm64.img"
             ;;
-        ubuntu-23.10-64*)
-            echo "https://cloud-images.ubuntu.com/mantic/current/mantic-server-cloudimg-amd64.img"
-            ;;
         ubuntu-24.04-64*)
             echo "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img"
+            ;;
+        ubuntu-24.04-arm-64*)
+            echo "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-arm64.img"
             ;;
         *)
             echo "unsupported system"
@@ -121,9 +87,5 @@ get_ubuntu_image_url_for_vm() {
 
 # shellcheck disable=SC2120
 get_image_url_for_vm() {
-    if [[ "$SPREAD_BACKEND" =~ google ]]; then
-        get_google_image_url_for_vm "$@"
-    else
-        get_ubuntu_image_url_for_vm "$@"
-    fi
+    get_ubuntu_image_url_for_vm "$@"
 }


### PR DESCRIPTION
As the spread-cron job to daily updaload new images is being  disabled, the images in the bucket are being removed as well. The impact is minimal as the images are already being downloaded form cloud-images.ubuntu.com
