### PR TITLE
osutil/vfs: trade memory for safety

### DIFF
--- a/osutil/vfs/lists/export_test.go
+++ b/osutil/vfs/lists/export_test.go
@@ -23,7 +23,7 @@ package lists
 //
 // Positive indices iterate first-to-last, with 0 being the first visited element.
 // Negative indices iterate last-to-first, with -1 being the first visited element.
-func (l *List[T, O]) At(n int) (e *T) {
+func (l *List[T]) At(n int) (e *T) {
 	var idx int
 	if n >= 0 {
 		l.FirstToLast()(func(el *T) bool {
@@ -45,4 +45,9 @@ func (l *List[T, O]) At(n int) (e *T) {
 		})
 	}
 	return e
+}
+
+// HeadContainer returns the container of the head element of the list.
+func (l *List[T]) HeadContainer() *T {
+	return l.head.container
 }

--- a/osutil/vfs/lists/lists.go
+++ b/osutil/vfs/lists/lists.go
@@ -22,16 +22,20 @@
 // nodes, and thus participate in identical number of lists.
 package lists
 
-import "unsafe"
-
 // Node is a pair of pointers to nodes of the same type.
 //
 // Node is embedded within another type T, so that a list of values of T may be
 // created, without the necessity of separate allocation of Node structures.
 //
 // The zero value of a node is lazy-initialized to point to itself.
+//
+// The container field is never initialized by any of the node functions.
+// Since the container is only known by higher-level constructs, such as [List],
+// the higher-level functions [List.Append] and [List.Prepend] set the
+// container field appropriately.
 type Node[T any] struct {
 	prev, next *Node[T]
+	container  *T
 }
 
 // lazyInit initializes the node to point to itself.
@@ -88,21 +92,54 @@ func (n *Node[T]) linkBefore(other *Node[T]) {
 	prev.next = other
 }
 
+// NodePointerer is an interface that types must implement to provide access
+// to their embedded Node[T].
+//
+// This is used by [containedNode] to create a NodeContainer[T] from a T.
+type NodePointerer[T any] interface {
+	NodePointer(*T) *Node[T]
+}
+
+// containedNode is a private type that wraps a pointer to a node embedded in a structure
+// of type T. It is used to provide type safety for list operations, by ensuring
+// that the node container pointer was set correctly.
+type containedNode[T any] struct {
+	n *Node[T]
+}
+
+// ContainedNode returns a private type that ensures node container pointer is initialized.
+//
+// The returned value is suitable for use with List.Append and List.Prepend.
+func ContainedNode[NP NodePointerer[T], T any](c *T) containedNode[T] {
+	if c == nil {
+		panic("cannot initialize containedNode: container is nil")
+	}
+
+	var helper NP
+	n := helper.NodePointer(c)
+	if n == nil {
+		panic("cannot initialize containedNode: node pointer is nil (computed by NodePointer)")
+	}
+
+	n.container = c
+	return containedNode[T]{n: n}
+}
+
 // List is a head of circular, doubly-linked list of elements of the same type T.
-// The support type O provides an offset of Node[T] within T.
+// The type T must have a related type that implements the NodePointerer[T] interface.
 //
 // The zero value has length zero and is empty.
-type List[T any, O Offsetter[T]] struct {
+type List[T any] struct {
 	head Node[T]
 }
 
 // Empty returns true if the list has no elements.
-func (l *List[T, O]) Empty() bool {
+func (l *List[T]) Empty() bool {
 	return l.head.Unlinked()
 }
 
 // Len counts and returns the number of elements of the list.
-func (l *List[T, O]) Len() int {
+func (l *List[T]) Len() int {
 	var c int
 	for n := l.head.next; n != nil && n != &l.head; n = n.next {
 		c++
@@ -113,29 +150,25 @@ func (l *List[T, O]) Len() int {
 // Append appends an element to the end of the list.
 //
 // The element e needs a Node[T] field for each list it is a member of.
-func (l *List[T, O]) Append(e *T) {
-	var o O
-	l.head.linkBefore(nodePtr(e, o.Offset(nil)))
+func (l *List[T]) Append(cn containedNode[T]) {
+	l.head.linkBefore(cn.n)
 }
 
 // Prepend prepends an element to the start of the list.
-func (l *List[T, O]) Prepend(v *T) {
-	var o O
-	l.head.linkAfter(nodePtr(v, o.Offset(nil)))
+func (l *List[T]) Prepend(cn containedNode[T]) {
+	l.head.linkAfter(cn.n)
 }
 
 // FirstToLast returns an iterator over elements of the list from first to last.
 //
 // It is safe to call [Node.Unlink] on the node that participates in the list.
 // Iteration always advances through the original chain of nodes.
-func (l *List[T, O]) FirstToLast() Seq[*T] {
-	var o O
-	off := o.Offset(nil)
+func (l *List[T]) FirstToLast() Seq[*T] {
 	return func(yield func(*T) bool) {
 		var next *Node[T]
 		for n := l.head.next; n != nil && n != &l.head; n = next {
 			next = n.next
-			if !yield(containerPtr(n, off)) {
+			if !yield(n.container) {
 				return
 			}
 		}
@@ -146,37 +179,14 @@ func (l *List[T, O]) FirstToLast() Seq[*T] {
 //
 // It is safe to call [Node.Unlink] on the node that participates in the list.
 // Iteration always advances through the original chain of nodes.
-func (l *List[T, O]) LastToFirst() Seq[*T] {
-	var o O
-	off := o.Offset(nil)
+func (l *List[T]) LastToFirst() Seq[*T] {
 	return func(yield func(*T) bool) {
 		var prev *Node[T]
 		for n := l.head.prev; n != nil && n != &l.head; n = prev {
 			prev = n.prev
-			if !yield(containerPtr(n, off)) {
+			if !yield(n.container) {
 				return
 			}
 		}
 	}
-}
-
-// Offsetter provides an offset of a particular [Node[T]] within [T].
-type Offsetter[T any] interface {
-	Offset(*T) uintptr
-}
-
-// nodePtr returns a pointer to node within a container.
-func nodePtr[T any](c *T, off uintptr) *Node[T] {
-	// This relies on valid use of unsafe.Pointer number (3) since we can
-	// guarantee that returned pointer points to the same object.
-	p := unsafe.Pointer(uintptr(unsafe.Pointer(c)) + off)
-	return (*Node[T])(p)
-}
-
-// containerPtr returns a pointer to a container of a given node.
-func containerPtr[T any](n *Node[T], off uintptr) *T {
-	// This relies on valid use of unsafe.Pointer number (3) since we can
-	// guarantee that returned pointer points to the same object.
-	p := unsafe.Pointer(uintptr(unsafe.Pointer(n)) - off)
-	return (*T)(p)
 }


### PR DESCRIPTION
At the cost of storing the pointer to `*T` within `Node[T]`, we can stop relying on
the unsafe package. The overall shape of `Node[T]` and `List[T]` is still very
close to the Linux kernel, but the chance of getting something catastrophically
wrong is smaller.

The signature of `List[T, O]` was changed to just `List[T]`, at the cost of making
`List.Append` and `List.Prepend` take an argument that ensures `Node.container` is
initialized. With the help of a new public function `ContainedNode` that
calls the `NodePointer` method on the helper associated type constrained by the
interface `NodePointerer`.

All the test and non-test code is adjusted to the new design.

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>