### PR TITLE
tests: fix missing go vendor to build fakestore

### DIFF
--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -551,7 +551,7 @@ prepare_project() {
     esac
 
     # Retry go mod vendor to minimize the number of connection errors during the sync
-    # It is required in any case because the tesing tools like the fakestore are always compiled
+    # It is required in any case because the testing tools like the fakestore are always compiled
     retry -n 10 go mod vendor
 
     # We are testing snapd snap on top of snapd from the archive

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -550,6 +550,10 @@ prepare_project() {
             ;;
     esac
 
+    # Retry go mod vendor to minimize the number of connection errors during the sync
+    # It is required in any case because the tesing tools like the fakestore are always compiled
+    retry -n 10 go mod vendor
+
     # We are testing snapd snap on top of snapd from the archive
     # of the tested distribution. Download snapd and snap-confine
     # as they exist in the archive for further use.
@@ -574,8 +578,6 @@ prepare_project() {
                 ;;
         esac
     else
-        # Retry go mod vendor to minimize the number of connection errors during the sync
-        retry -n 10 go mod vendor
         # Update C dependencies
         ( cd c-vendor && retry -n 10 ./vendor.sh )
 


### PR DESCRIPTION
Error when runing locally using snapd snap from master
```
++ go install ./tests/lib/fakestore/cmd/fakestore
go: inconsistent vendoring in
/home/gopath/src/github.com/snapcore/snapd:
	github.com/canonical/go-efilib@v1.6.0: is explicitly required in
go.mod, but not marked as explicit in vendor/modules.txt
	github.com/canonical/go-tpm2@v1.13.0: is explicitly required in
go.mod, but not marked as explicit in vendor/modules.txt
	github.com/godbus/dbus/v5@v5.1.0: is explicitly required in
go.mod, but not marked as explicit in vendor/modules.txt
	github.com/mattn/go-runewidth@v0.0.15: is explicitly required in
go.mod, but not marked as explicit in vendor/modules.txt
	github.com/snapcore/secboot@v0.0.0-20250925122121-f8400226f49a:
is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	golang.org/x/time@v0.10.0: is explicitly required in go.mod, but
not marked as explicit in vendor/modules.txt

github.com/canonical/go-password-validator@v0.0.0-20250617132709-1b205303ca54: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
	github.com/rivo/uniseg@v0.2.0: is explicitly required in go.mod,
but not marked as explicit in vendor/modules.txt
	github.com/canonical/go-efilib@v1.4.1: is marked as explicit in
vendor/modules.txt, but not explicitly required in go.mod
	github.com/canonical/go-tpm2@v1.12.2: is marked as explicit in
vendor/modules.txt, but not explicitly required in go.mod
	github.com/godbus/dbus@v0.0.0-20190726142602-4481cbc300e2: is
marked as explicit in vendor/modules.txt, but not explicitly required in go.mod
	github.com/snapcore/secboot@v0.0.0-20250326125418-bf2f40ea35c4:
is marked as explicit in vendor/modules.txt, but not explicitly required in go.mod

	To ignore the vendor directory, use -mod=readonly or -mod=mod.
	To sync the vendor directory, run:
		go mod vendor
-----
.
```