### PR TITLE
tests: fix cgroup tests in ubuntu questing

### DIFF
--- a/tests/lib/systems.sh
+++ b/tests/lib/systems.sh
@@ -37,5 +37,7 @@ get_core_for_system(){
 }
 
 is_cgroupv2() {
-    test "$(stat -f -c '%T' /sys/fs/cgroup)" = "cgroup2fs"
+    cgroups_val="$(stat -f -c '%T' /sys/fs/cgroup)"
+    # The hexadecimal number 0x63677270 corresponds to the magic constant CGROUP2_SUPER_MAGIC
+    test "$cgroups_val" = "cgroup2fs" || [[ "$cgroups_val" == *0x63677270* ]]
 }

--- a/tests/main/cgroup-tracking/task.yaml
+++ b/tests/main/cgroup-tracking/task.yaml
@@ -36,13 +36,16 @@ debug: |
     cat /proc/cmdline
 
 execute: |
+    #shellcheck source=tests/lib/systems.sh
+    . "$TESTSLIB/systems.sh"
+
     # This test varies between Ubuntu 16.04, Ubuntu 18.04 and Fedora 31.
     # This combination exercises each of the three cases below, namely:
     # - pure cgroup v2 system, like Fedora 31
     # - hybrid cgroup system, like Ubuntu 18.04
     # - pure cgroup v1 system, like Ubuntu 16.04
     echo "Find the path and id of the cgroup snapd uses for tracking."
-    if [ "$(stat -f --print=%T /sys/fs/cgroup)" = "cgroup2fs" ]; then
+    if is_cgroupv2; then
         base_cg_path=/sys/fs/cgroup
         base_cg_id=0
     elif [ "$(stat -f --print=%T /sys/fs/cgroup/unified)" = "cgroup2fs" ]; then


### PR DESCRIPTION
In ubuntu questing the label of /sys/fs/cgroup is not cgroup2fs, see the output

stat -fc %T /sys/fs/cgroup
UNKNOWN (0x63677270)

So now we check the constant 0x63677270 to validate if it is cgroups v2
