### PR TITLE
tests: tweaks to image-garden

### DIFF
--- a/.image-garden.mk
+++ b/.image-garden.mk
@@ -56,6 +56,8 @@ $(CLOUD_INIT_USER_DATA_TEMPLATE)
 # proxy that image-garden snap is providing for faster testing. The ESM archive
 # is not used so this is not a problem.
 - rm -f /etc/apt/sources.list.d/ubuntu-esm-infra.list
+# Some systems do not have persistent journal, let's fix that.
+- mkdir -p /var/log/journal
 endef
 
 # In the snapd project Ubuntu Core images are built from classic Ubuntu images

--- a/.image-garden.mk
+++ b/.image-garden.mk
@@ -52,6 +52,10 @@ endef
 
 define UBUNTU_CLOUD_INIT_USER_DATA_TEMPLATE
 $(CLOUD_INIT_USER_DATA_TEMPLATE)
+# ESM archive doesn't work over plain http and this is not compatible with the
+# proxy that image-garden snap is providing for faster testing. The ESM archive
+# is not used so this is not a problem.
+- rm -f /etc/apt/sources.list.d/ubuntu-esm-infra.list
 endef
 
 # In the snapd project Ubuntu Core images are built from classic Ubuntu images

--- a/.image-garden.mk
+++ b/.image-garden.mk
@@ -2,6 +2,15 @@ define AMAZONLINUX_CLOUD_INIT_USER_DATA_TEMPLATE
 $(CLOUD_INIT_USER_DATA_TEMPLATE)
 endef
 
+define AMAZONLINUX_2_CLOUD_INIT_USER_DATA_TEMPLATE
+$(CLOUD_INIT_USER_DATA_TEMPLATE)
+# Amazon 2 does not implement the power_state cloud-init plugin.
+- shutdown --poweroff now
+# Pre-install Python3 that is used by our scripts.
+packages:
+- python3
+endef
+
 define ARCHLINUX_CLOUD_INIT_USER_DATA_TEMPLATE
 $(CLOUD_INIT_USER_DATA_TEMPLATE)
 # enable AppArmor

--- a/spread.yaml
+++ b/spread.yaml
@@ -1423,7 +1423,7 @@ suites:
         restore-each: |
             "$TESTSLIB"/prepare-restore.sh --restore-suite-each-minimal-no-snaps
     tests/utils/cross-build/suite/:
-        summary: Test building snapd in different architectures        
+        summary: Test building snapd in different architectures
         manual: true
         prepare-each: |
             "$TESTSLIB"/prepare-restore.sh --prepare-suite-each-minimal-no-snaps

--- a/spread.yaml
+++ b/spread.yaml
@@ -795,6 +795,9 @@ backends:
             - arch-linux-64:
                   username: root
                   password: root
+            - amazon-linux-2-64:
+                  username: root
+                  password: root
             - amazon-linux-2023-64:
                   username: root
                   password: root


### PR DESCRIPTION
Left-overs from recent development sessions:

- Support for Amazon Linux 2
- Persistent journal on all Ubuntu releases
- Removal of ESM entry from /etc/apt/sources.list.d
- Some stray white-space in spread.yaml