### PR TITLE
Grant read/write permission to /run/nvidia-persistenced/socket

### DIFF
--- a/interfaces/builtin/opengl.go
+++ b/interfaces/builtin/opengl.go
@@ -207,6 +207,9 @@ unix (send, receive) type=dgram peer=(addr="@var/run/nvidia-xdriver-*"),
 /sys/devices/virtual/kfd/kfd/uevent r,
 /sys/devices/virtual/kfd/kfd/topology/{,generation_id,system_properties} r,
 /sys/devices/virtual/kfd/kfd/topology/nodes/[0-9]*/{,gpu_id,properties,io_links/[0-9]*/properties,caches/[0-9]*/properties,mem_banks/[0-9]*/properties} r,
+
+# DCGM keeps GPU driver initialized and handles client communication for persistence mode
+/run/nvidia-persistenced/socket rw,
 `
 
 type openglInterface struct {


### PR DESCRIPTION
With this, DCGM can communicate with the NVIDIA persistence daemon. This ensures proper GPU initialization and monitoring when persistence mode is enabled.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
