### PR TITLE
i/p/requestrules,o/i/apparmorprompting: batch adding rule notices

### DIFF
--- a/interfaces/prompting/constraints.go
+++ b/interfaces/prompting/constraints.go
@@ -346,7 +346,7 @@ type PermExpirationStatus int
 
 const (
 	NoPermsExpired PermExpirationStatus = iota
-	AnyPermsExpired
+	SomePermsExpired
 	AllPermsExpired
 )
 
@@ -614,7 +614,7 @@ func unmarshalRulePermissionMap(iface string, permissionsJSON json.RawMessage) (
 // pruneExpired prunes any permissions from the permission map which have
 // expired at the given point in time. If all permissions have expired, then
 // returns AllPermsExpired. If any permissions have expired, then returns
-// AnyPermsExpired. Otherwise, returns NoPermsExpired.
+// SomePermsExpired. Otherwise, returns NoPermsExpired.
 func (pm RulePermissionMap) pruneExpired(at At) PermExpirationStatus {
 	var expiredPerms []string
 	for perm, entry := range pm {
@@ -632,7 +632,7 @@ func (pm RulePermissionMap) pruneExpired(at At) PermExpirationStatus {
 	}
 
 	if len(pm) < originalLength {
-		return AnyPermsExpired
+		return SomePermsExpired
 	}
 	return NoPermsExpired
 }

--- a/interfaces/prompting/constraints_test.go
+++ b/interfaces/prompting/constraints_test.go
@@ -895,7 +895,7 @@ func (s *constraintsSuite) TestRuleConstraintsPruneExpired(c *C) {
 					Expiration: at.Time,
 				},
 			},
-			prompting.AnyPermsExpired,
+			prompting.SomePermsExpired,
 			prompting.RulePermissionMap{
 				"write": &prompting.RulePermissionEntry{
 					Outcome:    prompting.OutcomeDeny,
@@ -971,7 +971,7 @@ func (s *constraintsSuite) TestRuleConstraintsPruneExpired(c *C) {
 					SessionID: at.SessionID,
 				},
 			},
-			prompting.AnyPermsExpired,
+			prompting.SomePermsExpired,
 			prompting.RulePermissionMap{
 				"write": &prompting.RulePermissionEntry{
 					Outcome:    prompting.OutcomeAllow,

--- a/interfaces/prompting/requestrules/requestrules.go
+++ b/interfaces/prompting/requestrules/requestrules.go
@@ -299,7 +299,7 @@ func (rdb *RuleDB) load() (retErr error) {
 
 		// Being merged is more important than being partially expired, so only
 		// check this after first adding the rule to the DB.
-		if status == prompting.AnyPermsExpired {
+		if status == prompting.SomePermsExpired {
 			partiallyExpiredRules = append(partiallyExpiredRules, rule)
 		}
 	}

--- a/interfaces/prompting/requestrules/requestrules.go
+++ b/interfaces/prompting/requestrules/requestrules.go
@@ -319,17 +319,17 @@ func (rdb *RuleDB) load() (retErr error) {
 	}
 
 	rdb.notifyRules(partiallyExpiredRules, nil)
-	expiredData := map[string]string{"removed": "expired"}
-	if l := len(expiredRules); l > 0 {
-		logger.Debugf("calling notifyRules() for %d rules which were expired during load", l)
+	if len(expiredRules) > 0 {
+		data := map[string]string{"removed": "expired"}
+		logger.Debugf("removed %d rules which were expired during load", len(expiredRules))
+		rdb.notifyRules(expiredRules, data)
 	}
-	rdb.notifyRules(expiredRules, expiredData)
 	for rule, newID := range mergedRules {
 		data := map[string]string{
 			"removed":     "merged",
 			"merged-into": newID.String(),
 		}
-		logger.Debugf("calling notifyRules() for merged rule with ID %s", rule.ID)
+		logger.Debugf("merged rule with ID %q into rule with ID %q", rule.ID, newID)
 		rdb.notifyRules([]*Rule{rule}, data)
 	}
 
@@ -736,7 +736,7 @@ func (rdb *RuleDB) addRulePermissionToTree(rule *Rule, permission string, permis
 		return conflicts
 	}
 
-	expiredData := map[string]string{"removed": "expired"}
+	expiredRules := make([]*Rule, 0, len(partiallyExpiredRules))
 	for ruleID := range partiallyExpiredRules {
 		maybeExpired, err := rdb.lookupRuleByIDForUser(rule.User, ruleID)
 		if err != nil {
@@ -761,10 +761,14 @@ func (rdb *RuleDB) addRulePermissionToTree(rule *Rule, permission string, permis
 		// Error shouldn't occur. If it does, the rule was already removed.
 		if err == nil {
 			logger.Debugf("rule was expired when new rule %q was added: %q", ruleID, maybeExpired.ID)
-			rdb.notifyRules([]*Rule{maybeExpired}, expiredData)
+			expiredRules = append(expiredRules, maybeExpired)
 		} else {
 			logger.Debugf("WARNING: error occurred when trying to remove expired rule %q: %v", maybeExpired.ID, err)
 		}
+	}
+	if len(expiredRules) > 0 {
+		data := map[string]string{"removed": "expired"}
+		rdb.notifyRules(expiredRules, data)
 	}
 
 	for variantStr, variantEntry := range newVariantEntries {

--- a/interfaces/prompting/requestrules/requestrules.go
+++ b/interfaces/prompting/requestrules/requestrules.go
@@ -175,9 +175,9 @@ type RuleDB struct {
 	perUser map[uint32]*userDB
 
 	dbPath string
-	// notifyRule is a closure which will be called to record a notice when a
-	// rule is added, patched, or removed.
-	notifyRule func(userID uint32, ruleID prompting.IDType, data map[string]string) error
+	// notifyRules is a closure which will be called to record notices when
+	// rules are added, patched, or removed.
+	notifyRules func(rules []*Rule, data map[string]string) error
 
 	// userSessionIDMu ensures that two threads cannot race to write a new user
 	// session ID.
@@ -187,14 +187,14 @@ type RuleDB struct {
 // New creates a new rule database, loads existing rules from the database file,
 // and returns the populated database.
 //
-// The given notifyRule closure may be called before `New()` returns, if a
+// The given notifyRules closure may be called before `New()` returns, if a
 // previously-saved rule has expired or if there are conflicts between rules.
 //
-// The given notifyRule closure will be called when a rule is added, modified,
-// expired, or removed. In order to guarantee the order of notices, notifyRule
+// The given notifyRules closure will be called when a rule is added, modified,
+// expired, or removed. In order to guarantee the order of notices, notifyRules
 // is called with the prompt DB lock held, so it should not block for a
 // substantial amount of time (such as to lock and modify snapd state).
-func New(notifyRule func(userID uint32, ruleID prompting.IDType, data map[string]string) error) (*RuleDB, error) {
+func New(notifyRules func(rules []*Rule, data map[string]string) error) (*RuleDB, error) {
 	maxIDFilepath := filepath.Join(dirs.SnapInterfacesRequestsStateDir, "request-rule-max-id")
 	rulesFilepath := filepath.Join(dirs.SnapInterfacesRequestsStateDir, "request-rules.json")
 
@@ -208,9 +208,9 @@ func New(notifyRule func(userID uint32, ruleID prompting.IDType, data map[string
 	}
 
 	rdb := &RuleDB{
-		maxIDMmap:  maxIDMmap,
-		notifyRule: notifyRule,
-		dbPath:     rulesFilepath,
+		maxIDMmap:   maxIDMmap,
+		notifyRules: notifyRules,
+		dbPath:      rulesFilepath,
 	}
 	if err = rdb.load(); err != nil {
 		logger.Noticef("cannot load rule database: %v; using new empty rule database", err)
@@ -241,11 +241,11 @@ func (rdb *RuleDB) load() (retErr error) {
 	rdb.rules = make([]*Rule, 0)
 	rdb.perUser = make(map[uint32]*userDB)
 
-	expiredRules := make(map[prompting.IDType]bool)
-	partiallyExpiredRules := make(map[prompting.IDType]bool)
-	// Store map of merged rules, where the original merged (removed) rule ID
+	var expiredRules []*Rule
+	var partiallyExpiredRules []*Rule
+	// Store map of merged rules, where the original merged (removed) rule
 	// maps to the ID of the rule into which it was merged.
-	mergedRules := make(map[prompting.IDType]prompting.IDType)
+	mergedRules := make(map[*Rule]prompting.IDType)
 
 	f, err := os.Open(rdb.dbPath)
 	if err != nil {
@@ -281,7 +281,7 @@ func (rdb *RuleDB) load() (retErr error) {
 		}
 		status := rule.pruneExpired(at)
 		if status == prompting.AllPermsExpired {
-			expiredRules[rule.ID] = true
+			expiredRules = append(expiredRules, rule)
 			continue
 		}
 
@@ -293,14 +293,14 @@ func (rdb *RuleDB) load() (retErr error) {
 			break
 		}
 		if merged {
-			mergedRules[rule.ID] = mergedRule.ID
+			mergedRules[rule] = mergedRule.ID
 			continue
 		}
 
 		// Being merged is more important than being partially expired, so only
 		// check this after first adding the rule to the DB.
 		if status == prompting.AnyPermsExpired {
-			partiallyExpiredRules[rule.ID] = true
+			partiallyExpiredRules = append(partiallyExpiredRules, rule)
 		}
 	}
 
@@ -308,9 +308,7 @@ func (rdb *RuleDB) load() (retErr error) {
 		// The DB on disk was invalid, so drop every rule and start over
 		logger.Debug("WARNING: rule DB invalid, so dropping every rule")
 		data := map[string]string{"removed": "dropped"}
-		for _, rule := range wrapped.Rules {
-			rdb.notifyRule(rule.User, rule.ID, data)
-		}
+		rdb.notifyRules(wrapped.Rules, data)
 		rdb.indexByID = make(map[prompting.IDType]int)
 		rdb.rules = make([]*Rule, 0)
 		rdb.perUser = make(map[uint32]*userDB)
@@ -320,23 +318,19 @@ func (rdb *RuleDB) load() (retErr error) {
 		return strutil.JoinErrors(errInvalid, rdb.save())
 	}
 
+	rdb.notifyRules(partiallyExpiredRules, nil)
 	expiredData := map[string]string{"removed": "expired"}
-	for _, rule := range wrapped.Rules {
-		var data map[string]string
-		if expiredRules[rule.ID] {
-			data = expiredData
-		} else if newID, exists := mergedRules[rule.ID]; exists {
-			data = map[string]string{
-				"removed":     "merged",
-				"merged-into": newID.String(),
-			}
-		} else if partiallyExpiredRules[rule.ID] {
-			// no-op, want to record notice with empty data
-		} else {
-			// not expired or merged, so don't record notice
-			continue
+	if l := len(expiredRules); l > 0 {
+		logger.Debugf("calling notifyRules() for %d rules which were expired during load", l)
+	}
+	rdb.notifyRules(expiredRules, expiredData)
+	for rule, newID := range mergedRules {
+		data := map[string]string{
+			"removed":     "merged",
+			"merged-into": newID.String(),
 		}
-		rdb.notifyRule(rule.User, rule.ID, data)
+		logger.Debugf("calling notifyRules() for merged rule with ID %s", rule.ID)
+		rdb.notifyRules([]*Rule{rule}, data)
 	}
 
 	if len(expiredRules) > 0 || len(partiallyExpiredRules) > 0 || len(mergedRules) > 0 {
@@ -760,14 +754,14 @@ func (rdb *RuleDB) addRulePermissionToTree(rule *Rule, permission string, permis
 			delete(maybeExpired.Constraints.Permissions, permission)
 
 			logger.Debugf("expired permission %q was pruned from partially-expired rule because it conflicted with new rule %q: %q", permission, ruleID, maybeExpired.ID)
-			rdb.notifyRule(maybeExpired.User, maybeExpired.ID, nil)
+			rdb.notifyRules([]*Rule{maybeExpired}, nil)
 			continue
 		}
 		_, err = rdb.removeRuleByID(ruleID)
 		// Error shouldn't occur. If it does, the rule was already removed.
 		if err == nil {
 			logger.Debugf("rule was expired when new rule %q was added: %q", ruleID, maybeExpired.ID)
-			rdb.notifyRule(maybeExpired.User, maybeExpired.ID, expiredData)
+			rdb.notifyRules([]*Rule{maybeExpired}, expiredData)
 		} else {
 			logger.Debugf("WARNING: error occurred when trying to remove expired rule %q: %v", maybeExpired.ID, err)
 		}
@@ -1053,7 +1047,7 @@ func (rdb *RuleDB) AddRule(user uint32, snap string, iface string, constraints *
 	}
 
 	logger.Debugf("new rule added: %q", newRule.ID)
-	rdb.notifyRule(user, newRule.ID, nil)
+	rdb.notifyRules([]*Rule{newRule}, nil)
 	return newRule, nil
 }
 
@@ -1299,7 +1293,7 @@ func (rdb *RuleDB) RemoveRule(user uint32, id prompting.IDType) (*Rule, error) {
 
 	data := map[string]string{"removed": "removed"}
 	logger.Debugf("rule was removed: %q", id)
-	rdb.notifyRule(user, id, data)
+	rdb.notifyRules([]*Rule{rule}, data)
 	return rule, nil
 }
 
@@ -1351,14 +1345,14 @@ func (rdb *RuleDB) removeRulesInternal(user uint32, rules []*Rule) error {
 	}
 
 	// Save successful, now remove rules' variants from tree
-	logger.Debugf("removed rules: %q", removedRuleIDs)
-	data := map[string]string{"removed": "removed"}
 	for _, rule := range rules {
 		rdb.removeRuleFromTree(rule)
 		// If error occurs, rule was still fully removed from tree, and no other
 		// rule was affected. We want the rule fully removed, so this is fine.
-		rdb.notifyRule(user, rule.ID, data)
 	}
+	logger.Debugf("removed rules: %q", removedRuleIDs)
+	data := map[string]string{"removed": "removed"}
+	rdb.notifyRules(rules, data)
 	return nil
 }
 
@@ -1486,7 +1480,7 @@ func (rdb *RuleDB) PatchRule(user uint32, id prompting.IDType, constraintsPatch 
 	}
 
 	logger.Debugf("rule was patched: %q", newRule.ID)
-	rdb.notifyRule(newRule.User, newRule.ID, nil)
+	rdb.notifyRules([]*Rule{newRule}, nil)
 	return newRule, nil
 }
 

--- a/interfaces/prompting/requestrules/requestrules_test.go
+++ b/interfaces/prompting/requestrules/requestrules_test.go
@@ -62,23 +62,25 @@ func (ni *noticeInfo) String() string {
 type requestrulesSuite struct {
 	testutil.BaseTest
 
-	defaultNotifyRule func(userID uint32, ruleID prompting.IDType, data map[string]string) error
-	defaultUser       uint32
-	ruleNotices       []*noticeInfo
-	currSession       prompting.IDType
+	defaultNotifyRules func(rules []*requestrules.Rule, data map[string]string) error
+	defaultUser        uint32
+	ruleNotices        []*noticeInfo
+	currSession        prompting.IDType
 }
 
 var _ = Suite(&requestrulesSuite{})
 
 func (s *requestrulesSuite) SetUpTest(c *C) {
 	s.defaultUser = 1000
-	s.defaultNotifyRule = func(userID uint32, ruleID prompting.IDType, data map[string]string) error {
-		info := &noticeInfo{
-			userID: userID,
-			ruleID: ruleID,
-			data:   data,
+	s.defaultNotifyRules = func(rules []*requestrules.Rule, data map[string]string) error {
+		for _, rule := range rules {
+			info := &noticeInfo{
+				userID: rule.User,
+				ruleID: rule.ID,
+				data:   data,
+			}
+			s.ruleNotices = append(s.ruleNotices, info)
 		}
-		s.ruleNotices = append(s.ruleNotices, info)
 		return nil
 	}
 	s.ruleNotices = make([]*noticeInfo, 0)
@@ -199,7 +201,7 @@ func (s *requestrulesSuite) TestRuleMarshalUnmarshalJSON(c *C) {
 }
 
 func (s *requestrulesSuite) TestNew(c *C) {
-	rdb, err := requestrules.New(s.defaultNotifyRule)
+	rdb, err := requestrules.New(s.defaultNotifyRules)
 	c.Assert(err, IsNil)
 	c.Assert(rdb, NotNil)
 }
@@ -211,7 +213,7 @@ func (s *requestrulesSuite) TestNewErrors(c *C) {
 	c.Assert(err, IsNil)
 	f.Close() // No need to keep the file open
 
-	rdb, err := requestrules.New(s.defaultNotifyRule)
+	rdb, err := requestrules.New(s.defaultNotifyRules)
 	c.Assert(err, ErrorMatches, "cannot create interfaces requests state directory.*") // Error from os.MkdirAll
 	c.Assert(rdb, IsNil)
 
@@ -222,7 +224,7 @@ func (s *requestrulesSuite) TestNewErrors(c *C) {
 	maxIDFilepath := filepath.Join(dirs.SnapInterfacesRequestsStateDir, "request-rule-max-id")
 	c.Assert(os.MkdirAll(maxIDFilepath, 0o700), IsNil)
 
-	rdb, err = requestrules.New(s.defaultNotifyRule)
+	rdb, err = requestrules.New(s.defaultNotifyRules)
 	c.Assert(err, ErrorMatches, "cannot open max ID file:.*")
 	c.Assert(rdb, IsNil)
 
@@ -242,7 +244,7 @@ func (s *requestrulesSuite) prepDBPath(c *C) string {
 func (s *requestrulesSuite) testLoadError(c *C, expectedErr string, rules []*requestrules.Rule, checkWritten bool) {
 	logbuf, restore := logger.MockLogger()
 	defer restore()
-	rdb, err := requestrules.New(s.defaultNotifyRule)
+	rdb, err := requestrules.New(s.defaultNotifyRules)
 	c.Check(err, IsNil)
 	c.Check(rdb, NotNil)
 	filtered := filterOutDebugLogs(logbuf)
@@ -476,7 +478,7 @@ func (s *requestrulesSuite) TestLoadExpiredRules(c *C) {
 
 	logbuf, restore := logger.MockLogger()
 	defer restore()
-	rdb, err := requestrules.New(s.defaultNotifyRule)
+	rdb, err := requestrules.New(s.defaultNotifyRules)
 	c.Check(err, IsNil)
 	c.Check(rdb, NotNil)
 	// Check that no error was logged
@@ -502,7 +504,7 @@ func (s *requestrulesSuite) TestLoadExpiredRules(c *C) {
 	c.Assert(rdb.Close(), IsNil)
 
 	// Restart, reloading the rule db should not emit new notices
-	rdb, err = requestrules.New(s.defaultNotifyRule)
+	rdb, err = requestrules.New(s.defaultNotifyRules)
 	c.Check(err, IsNil)
 	c.Check(rdb, NotNil)
 
@@ -522,7 +524,7 @@ func (s *requestrulesSuite) TestLoadPartiallyExpiredRules(c *C) {
 
 	s.writeRules(c, dbPath, []*requestrules.Rule{partialRule})
 
-	rdb, err := requestrules.New(s.defaultNotifyRule)
+	rdb, err := requestrules.New(s.defaultNotifyRules)
 	c.Check(err, IsNil)
 	c.Check(rdb, NotNil)
 
@@ -538,7 +540,7 @@ func (s *requestrulesSuite) TestLoadPartiallyExpiredRules(c *C) {
 	c.Assert(rdb.Close(), IsNil)
 
 	// Restart, reloading the rule db should not emit new notices
-	rdb, err = requestrules.New(s.defaultNotifyRule)
+	rdb, err = requestrules.New(s.defaultNotifyRules)
 	c.Check(err, IsNil)
 	c.Check(rdb, NotNil)
 
@@ -685,7 +687,7 @@ func (s *requestrulesSuite) TestLoadMergedRules(c *C) {
 
 	logbuf, restore := logger.MockLogger()
 	defer restore()
-	rdb, err := requestrules.New(s.defaultNotifyRule)
+	rdb, err := requestrules.New(s.defaultNotifyRules)
 	c.Check(err, IsNil)
 	c.Check(rdb, NotNil)
 	// Check that no error was logged
@@ -733,12 +735,12 @@ func (s *requestrulesSuite) TestLoadMergedRules(c *C) {
 			},
 		},
 	}
-	s.checkNewNotices(c, expectedNoticeInfo)
+	s.checkNewNoticesUnordered(c, expectedNoticeInfo)
 
 	c.Assert(rdb.Close(), IsNil)
 
 	// Restart, reloading the rule db should not emit new notices
-	rdb, err = requestrules.New(s.defaultNotifyRule)
+	rdb, err = requestrules.New(s.defaultNotifyRules)
 	c.Check(err, IsNil)
 	c.Check(rdb, NotNil)
 
@@ -766,7 +768,7 @@ func (s *requestrulesSuite) TestLoadHappy(c *C) {
 
 	logbuf, restore := logger.MockLogger()
 	defer restore()
-	rdb, err := requestrules.New(s.defaultNotifyRule)
+	rdb, err := requestrules.New(s.defaultNotifyRules)
 	c.Check(err, IsNil)
 	c.Check(rdb, NotNil)
 	// Check that no error was logged
@@ -812,14 +814,14 @@ func (s *requestrulesSuite) TestJoinInternalErrors(c *C) {
 }
 
 func (s *requestrulesSuite) TestClose(c *C) {
-	rdb, err := requestrules.New(s.defaultNotifyRule)
+	rdb, err := requestrules.New(s.defaultNotifyRules)
 	c.Assert(err, IsNil)
 
 	c.Check(rdb.Close(), IsNil)
 }
 
 func (s *requestrulesSuite) TestCloseSaves(c *C) {
-	rdb, err := requestrules.New(s.defaultNotifyRule)
+	rdb, err := requestrules.New(s.defaultNotifyRules)
 	c.Assert(err, IsNil)
 
 	// Add a rule, then mutate it in memory, then check that it is saved to
@@ -852,7 +854,7 @@ func (s *requestrulesSuite) TestCloseSaves(c *C) {
 }
 
 func (s *requestrulesSuite) TestCloseRepeatedly(c *C) {
-	rdb, err := requestrules.New(s.defaultNotifyRule)
+	rdb, err := requestrules.New(s.defaultNotifyRules)
 	c.Assert(err, IsNil)
 
 	c.Check(rdb.Close(), IsNil)
@@ -864,7 +866,7 @@ func (s *requestrulesSuite) TestCloseRepeatedly(c *C) {
 }
 
 func (s *requestrulesSuite) TestCloseErrors(c *C) {
-	rdb, err := requestrules.New(s.defaultNotifyRule)
+	rdb, err := requestrules.New(s.defaultNotifyRules)
 	c.Assert(err, IsNil)
 
 	// Mark state dir as non-writeable so save fails
@@ -895,7 +897,7 @@ func (s *requestrulesSuite) TestReadOrAssignUserSessionID(c *C) {
 	userSessionIDXattr, restore := requestrules.MockUserSessionIDXattr()
 	defer restore()
 
-	rdb, err := requestrules.New(s.defaultNotifyRule)
+	rdb, err := requestrules.New(s.defaultNotifyRules)
 	c.Assert(err, IsNil)
 
 	// If there is no user session dir, expect errNoUserSession
@@ -979,7 +981,7 @@ func (s *requestrulesSuite) TestReadOrAssignUserSessionIDConcurrent(c *C) {
 	_, restore := requestrules.MockUserSessionIDXattr()
 	defer restore()
 
-	rdb, err := requestrules.New(s.defaultNotifyRule)
+	rdb, err := requestrules.New(s.defaultNotifyRules)
 	c.Assert(err, IsNil)
 
 	// Multiple threads acting at once all return the same ID
@@ -1048,7 +1050,7 @@ type addRuleContents struct {
 }
 
 func (s *requestrulesSuite) TestAddRuleHappy(c *C) {
-	rdb, err := requestrules.New(s.defaultNotifyRule)
+	rdb, err := requestrules.New(s.defaultNotifyRules)
 	c.Assert(err, IsNil)
 
 	template := &addRuleContents{
@@ -1155,7 +1157,7 @@ func addRuleFromTemplate(c *C, rdb *requestrules.RuleDB, template *addRuleConten
 }
 
 func (s *requestrulesSuite) TestAddRuleRemoveRuleDuplicateVariants(c *C) {
-	rdb, err := requestrules.New(s.defaultNotifyRule)
+	rdb, err := requestrules.New(s.defaultNotifyRules)
 	c.Assert(err, IsNil)
 
 	ruleContents := &addRuleContents{
@@ -1202,7 +1204,7 @@ func (s *requestrulesSuite) TestAddRuleRemoveRuleDuplicateVariants(c *C) {
 }
 
 func (s *requestrulesSuite) TestAddRuleErrors(c *C) {
-	rdb, err := requestrules.New(s.defaultNotifyRule)
+	rdb, err := requestrules.New(s.defaultNotifyRules)
 	c.Assert(err, IsNil)
 
 	template := &addRuleContents{
@@ -1302,7 +1304,7 @@ func (s *requestrulesSuite) TestAddRuleErrors(c *C) {
 }
 
 func (s *requestrulesSuite) TestAddRuleOverlapping(c *C) {
-	rdb, err := requestrules.New(s.defaultNotifyRule)
+	rdb, err := requestrules.New(s.defaultNotifyRules)
 	c.Assert(err, IsNil)
 
 	template := &addRuleContents{
@@ -1596,7 +1598,7 @@ func (s *requestrulesSuite) TestAddRuleMerges(c *C) {
 		s.AddCleanup(func() { dirs.SetRootDir("") })
 		c.Assert(os.MkdirAll(dirs.SnapdStateDir(dirs.GlobalRootDir), 0o755), IsNil)
 
-		rdb, err := requestrules.New(s.defaultNotifyRule)
+		rdb, err := requestrules.New(s.defaultNotifyRules)
 		c.Assert(err, IsNil)
 
 		user := s.defaultUser
@@ -1665,7 +1667,7 @@ func (s *requestrulesSuite) TestAddRuleMerges(c *C) {
 }
 
 func (s *requestrulesSuite) TestAddRuleExpired(c *C) {
-	rdb, err := requestrules.New(s.defaultNotifyRule)
+	rdb, err := requestrules.New(s.defaultNotifyRules)
 	c.Assert(err, IsNil)
 
 	template := &addRuleContents{
@@ -1808,7 +1810,7 @@ func (s *requestrulesSuite) TestAddRuleExpired(c *C) {
 }
 
 func (s *requestrulesSuite) TestAddRulePartiallyExpired(c *C) {
-	rdb, err := requestrules.New(s.defaultNotifyRule)
+	rdb, err := requestrules.New(s.defaultNotifyRules)
 	c.Assert(err, IsNil)
 
 	user := s.defaultUser
@@ -2106,7 +2108,7 @@ func (s *requestrulesSuite) TestIsPathPermAllowedSimple(c *C) {
 			err:          prompting_errors.ErrNoMatchingRule,
 		},
 	} {
-		rdb, err := requestrules.New(s.defaultNotifyRule)
+		rdb, err := requestrules.New(s.defaultNotifyRules)
 		c.Assert(err, IsNil)
 		c.Assert(rdb, NotNil)
 
@@ -2156,7 +2158,7 @@ func (s *requestrulesSuite) TestIsPathPermAllowedPrecedence(c *C) {
 		Lifespan:    prompting.LifespanForever,
 	}
 
-	rdb, err := requestrules.New(s.defaultNotifyRule)
+	rdb, err := requestrules.New(s.defaultNotifyRules)
 	c.Assert(err, IsNil)
 	c.Assert(rdb, NotNil)
 
@@ -2226,7 +2228,7 @@ func (s *requestrulesSuite) TestIsPathPermAllowedExpiration(c *C) {
 		Duration:    "1h",
 	}
 
-	rdb, err := requestrules.New(s.defaultNotifyRule)
+	rdb, err := requestrules.New(s.defaultNotifyRules)
 	c.Assert(err, IsNil)
 	c.Assert(rdb, NotNil)
 
@@ -2311,7 +2313,7 @@ func (s *requestrulesSuite) TestIsPathPermAllowedSession(c *C) {
 		Duration:    "1h",
 	}
 
-	rdb, err := requestrules.New(s.defaultNotifyRule)
+	rdb, err := requestrules.New(s.defaultNotifyRules)
 	c.Assert(err, IsNil)
 	c.Assert(rdb, NotNil)
 
@@ -2395,7 +2397,7 @@ func (s *requestrulesSuite) TestIsPathPermAllowedSession(c *C) {
 }
 
 func (s *requestrulesSuite) TestRuleWithID(c *C) {
-	rdb, _ := requestrules.New(s.defaultNotifyRule)
+	rdb, _ := requestrules.New(s.defaultNotifyRules)
 
 	template := &addRuleContents{
 		User:        s.defaultUser,
@@ -2434,7 +2436,7 @@ func (s *requestrulesSuite) TestRuleWithID(c *C) {
 }
 
 func (s *requestrulesSuite) TestRules(c *C) {
-	rdb, err := requestrules.New(s.defaultNotifyRule)
+	rdb, err := requestrules.New(s.defaultNotifyRules)
 	c.Assert(err, IsNil)
 	c.Assert(rdb, NotNil)
 
@@ -2485,7 +2487,7 @@ func (s *requestrulesSuite) prepRuleDBForRulesForSnapInterface(c *C, rdb *reques
 }
 
 func (s *requestrulesSuite) TestRulesExpired(c *C) {
-	rdb, err := requestrules.New(s.defaultNotifyRule)
+	rdb, err := requestrules.New(s.defaultNotifyRules)
 	c.Assert(err, IsNil)
 	c.Assert(rdb, NotNil)
 
@@ -2517,7 +2519,7 @@ func (s *requestrulesSuite) TestRulesExpired(c *C) {
 }
 
 func (s *requestrulesSuite) TestRulesForSnap(c *C) {
-	rdb, err := requestrules.New(s.defaultNotifyRule)
+	rdb, err := requestrules.New(s.defaultNotifyRules)
 	c.Assert(err, IsNil)
 	c.Assert(rdb, NotNil)
 
@@ -2532,7 +2534,7 @@ func (s *requestrulesSuite) TestRulesForSnap(c *C) {
 }
 
 func (s *requestrulesSuite) TestRulesForInterface(c *C) {
-	rdb, err := requestrules.New(s.defaultNotifyRule)
+	rdb, err := requestrules.New(s.defaultNotifyRules)
 	c.Assert(err, IsNil)
 	c.Assert(rdb, NotNil)
 
@@ -2547,7 +2549,7 @@ func (s *requestrulesSuite) TestRulesForInterface(c *C) {
 }
 
 func (s *requestrulesSuite) TestRulesForSnapInterface(c *C) {
-	rdb, err := requestrules.New(s.defaultNotifyRule)
+	rdb, err := requestrules.New(s.defaultNotifyRules)
 	c.Assert(err, IsNil)
 	c.Assert(rdb, NotNil)
 
@@ -2562,7 +2564,7 @@ func (s *requestrulesSuite) TestRulesForSnapInterface(c *C) {
 }
 
 func (s *requestrulesSuite) TestRemoveRuleForward(c *C) {
-	rdb, err := requestrules.New(s.defaultNotifyRule)
+	rdb, err := requestrules.New(s.defaultNotifyRules)
 	c.Assert(err, IsNil)
 
 	addedRules := s.prepRuleDBForRulesForSnapInterface(c, rdb)
@@ -2573,7 +2575,7 @@ func (s *requestrulesSuite) TestRemoveRuleForward(c *C) {
 }
 
 func (s *requestrulesSuite) TestRemoveRuleBackward(c *C) {
-	rdb, err := requestrules.New(s.defaultNotifyRule)
+	rdb, err := requestrules.New(s.defaultNotifyRules)
 	c.Assert(err, IsNil)
 
 	addedRules := s.prepRuleDBForRulesForSnapInterface(c, rdb)
@@ -2605,7 +2607,7 @@ func (s *requestrulesSuite) testRemoveRule(c *C, rdb *requestrules.RuleDB, rule 
 }
 
 func (s *requestrulesSuite) TestRemoveRuleErrors(c *C) {
-	rdb, err := requestrules.New(s.defaultNotifyRule)
+	rdb, err := requestrules.New(s.defaultNotifyRules)
 	c.Assert(err, IsNil)
 
 	addedRules := s.prepRuleDBForRulesForSnapInterface(c, rdb)
@@ -2676,7 +2678,7 @@ func (s *requestrulesSuite) TestRemoveRuleErrors(c *C) {
 }
 
 func (s *requestrulesSuite) TestRemoveRulesForSnap(c *C) {
-	rdb, err := requestrules.New(s.defaultNotifyRule)
+	rdb, err := requestrules.New(s.defaultNotifyRules)
 	c.Assert(err, IsNil)
 	c.Assert(rdb, NotNil)
 
@@ -2692,7 +2694,7 @@ func (s *requestrulesSuite) TestRemoveRulesForSnap(c *C) {
 }
 
 func (s *requestrulesSuite) TestRemoveRulesForInterface(c *C) {
-	rdb, err := requestrules.New(s.defaultNotifyRule)
+	rdb, err := requestrules.New(s.defaultNotifyRules)
 	c.Assert(err, IsNil)
 	c.Assert(rdb, NotNil)
 
@@ -2708,7 +2710,7 @@ func (s *requestrulesSuite) TestRemoveRulesForInterface(c *C) {
 }
 
 func (s *requestrulesSuite) TestRemoveRulesForSnapInterface(c *C) {
-	rdb, err := requestrules.New(s.defaultNotifyRule)
+	rdb, err := requestrules.New(s.defaultNotifyRules)
 	c.Assert(err, IsNil)
 	c.Assert(rdb, NotNil)
 
@@ -2726,7 +2728,7 @@ func (s *requestrulesSuite) TestRemoveRulesForSnapInterface(c *C) {
 func (s *requestrulesSuite) TestRemoveRulesForSnapInterfaceErrors(c *C) {
 	dbPath := filepath.Join(dirs.SnapInterfacesRequestsStateDir, "request-rules.json")
 
-	rdb, err := requestrules.New(s.defaultNotifyRule)
+	rdb, err := requestrules.New(s.defaultNotifyRules)
 	c.Assert(err, IsNil)
 	c.Assert(rdb, NotNil)
 
@@ -2854,13 +2856,13 @@ func (s *requestrulesSuite) TestLoadEmptyPermissionMap(c *C) {
 	}
 	s.writeRules(c, dbPath, rules)
 
-	requestrules.New(s.defaultNotifyRule)
+	requestrules.New(s.defaultNotifyRules)
 	logErr := fmt.Errorf("%s", strings.TrimSpace(logbuf.String()))
 	c.Check(logErr, ErrorMatches, ".*cannot load rule database: invalid permissions for home interface: permissions empty; using new empty rule database")
 }
 
 func (s *requestrulesSuite) TestPatchRule(c *C) {
-	rdb, err := requestrules.New(s.defaultNotifyRule)
+	rdb, err := requestrules.New(s.defaultNotifyRules)
 	c.Assert(err, IsNil)
 
 	template := &addRuleContents{
@@ -3059,7 +3061,7 @@ func (s *requestrulesSuite) TestPatchRule(c *C) {
 }
 
 func (s *requestrulesSuite) TestPatchRuleErrors(c *C) {
-	rdb, err := requestrules.New(s.defaultNotifyRule)
+	rdb, err := requestrules.New(s.defaultNotifyRules)
 	c.Assert(err, IsNil)
 
 	template := &addRuleContents{
@@ -3151,7 +3153,7 @@ func (s *requestrulesSuite) TestPatchRuleErrors(c *C) {
 }
 
 func (s *requestrulesSuite) TestPatchRuleExpired(c *C) {
-	rdb, err := requestrules.New(s.defaultNotifyRule)
+	rdb, err := requestrules.New(s.defaultNotifyRules)
 	c.Assert(err, IsNil)
 
 	template := &addRuleContents{
@@ -3276,7 +3278,7 @@ func (s *requestrulesSuite) TestPatchRuleExpired(c *C) {
 }
 
 func (s *requestrulesSuite) TestUserSessionIDCache(c *C) {
-	rdb, err := requestrules.New(s.defaultNotifyRule)
+	rdb, err := requestrules.New(s.defaultNotifyRules)
 	c.Assert(err, IsNil)
 
 	checkedDiskForUser := make(map[uint32]int)

--- a/overlord/ifacestate/apparmorprompting/export_test.go
+++ b/overlord/ifacestate/apparmorprompting/export_test.go
@@ -135,6 +135,12 @@ func (nb *noticeBackends) RuleBackend() *noticeTypeBackend {
 	return nb.ruleBackend
 }
 
+type AddNoticesInfo = addNoticesInfo
+
+func (ntb *noticeTypeBackend) AddNotices(infos []AddNoticesInfo) error {
+	return ntb.addNotices(infos)
+}
+
 func (ntb *noticeTypeBackend) AddNotice(userID uint32, id prompting.IDType, data map[string]string) error {
 	return ntb.addNotice(userID, id, data)
 }

--- a/overlord/ifacestate/apparmorprompting/noticebackend.go
+++ b/overlord/ifacestate/apparmorprompting/noticebackend.go
@@ -37,6 +37,7 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/notices"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/strutil"
 )
 
 const (
@@ -196,18 +197,99 @@ func (ntb *noticeTypeBackend) noticeKeyToID(key string) string {
 	return fmt.Sprintf("%s-%s", ntb.namespace, key)
 }
 
+// addNoticesInfo holds the information required to record one notice.
+type addNoticesInfo struct {
+	UserID uint32
+	ID     prompting.IDType
+	Data   map[string]string
+}
+
+// addNotices records an occurrence of a notice for each given notice info.
+// The notice key equals the info's prompt/rule ID, and the notice ID and type
+// are derived from the receiver.
+func (ntb *noticeTypeBackend) addNotices(infos []addNoticesInfo) error {
+	logger.Debugf("called addNotices() with %d notice infos", len(infos))
+	ntb.rwmu.Lock()
+	defer ntb.rwmu.Unlock()
+
+	// XXX: because each rollback function holds a pointer to the notice slice
+	// prior to its relevant change, and the change produces a copy, there will
+	// be a N copies of all the non-expired notices until this function returns.
+	rollbackStack := make([]func(), 0, len(infos))
+
+	// Even if an error occurs, try to continue with the rest of the notices,
+	// so we don't miss notices which should otherwise be recorded successfully.
+	var errs []error
+	for _, info := range infos {
+		rollback, err := ntb.doAddNotice(info.UserID, info.ID, info.Data)
+		if err != nil {
+			errs = append(errs, err)
+		} else {
+			rollbackStack = append(rollbackStack, rollback)
+		}
+	}
+
+	if err := ntb.save(); err != nil {
+		for i := len(rollbackStack) - 1; i >= 0; i-- {
+			rollbackStack[i]()
+		}
+		logger.Debugf("error when saving prompting %s notice backend: %v", ntb.noticeType, err)
+		return fmt.Errorf("cannot add notices to prompting %s backend: %w", ntb.noticeType, err)
+	}
+
+	ntb.cond.Broadcast()
+
+	if len(errs) > 0 {
+		// TODO:GOVERSION: replace with errors.Join() once we're on golang v1.20+
+		joinedErrors := strutil.JoinErrors(errs...)
+		logger.Debugf("error(s) when adding %d notices to prompting %s notice backend: %v", len(infos), ntb.noticeType, joinedErrors)
+		return joinedErrors
+	}
+
+	logger.Debugf("successfully added %d notices to prompting %s notice backend", len(infos), ntb.noticeType)
+
+	return nil
+}
+
 // addNotice records an occurrence of a notice with the specified user ID, a
 // key equal to the given prompt/rule ID, and the given data, with notice ID
 // and type derived from the receiver.
 func (ntb *noticeTypeBackend) addNotice(userID uint32, id prompting.IDType, data map[string]string) error {
 	ntb.rwmu.Lock()
 	defer ntb.rwmu.Unlock()
+
+	rollback, err := ntb.doAddNotice(userID, id, data)
+	if err != nil {
+		return err
+	}
+
+	if err := ntb.save(); err != nil {
+		rollback()
+		logger.Debugf("error when saving prompting %s notice backend: %v", ntb.noticeType, err)
+		return fmt.Errorf("cannot add notice to prompting %s backend: %w", ntb.noticeType, err)
+	}
+
+	ntb.cond.Broadcast()
+
+	noticeID := fmt.Sprintf("%s-%s", ntb.namespace, id.String())
+	logger.Debugf("successfully added notice with ID %s", noticeID)
+
+	return nil
+}
+
+// doAddNotice is an internal helper function which adds a notice with the
+// given ID, key, and data for the given user. Returns a rollback function to
+// revert the ntb state in case this needs to be rolled back in the future.
+//
+// The caller must hold the backend lock and is responsible for saving the
+// backend state to disk and calling ntb.cond.Broadcast().
+func (ntb *noticeTypeBackend) doAddNotice(userID uint32, id prompting.IDType, data map[string]string) (rollback func(), err error) {
 	key := id.String()
 	noticeID := ntb.noticeKeyToID(key)
 
 	userNotices, existingNotice, existingIndex, err := ntb.searchExistingNotices(userID, noticeID)
 	if err != nil {
-		return err
+		return func() {}, err
 	}
 
 	// Now that errors can't occur (other than save error), get a new unique
@@ -239,24 +321,26 @@ func (ntb *noticeTypeBackend) addNotice(userID uint32, id prompting.IDType, data
 	ntb.userNotices[userID] = newUserNotices
 	ntb.idToNotice[noticeID] = newNotice
 
-	if err := ntb.save(); err != nil {
+	expiredNotices := userNotices[:expiredCount]
+	for _, expiredNotice := range expiredNotices {
+		delete(ntb.idToNotice, expiredNotice.ID())
+	}
+
+	rollback = func() {
 		ntb.userNotices[userID] = userNotices
 		if existingNotice != nil {
 			ntb.idToNotice[noticeID] = existingNotice
 		} else {
 			delete(ntb.idToNotice, noticeID)
 		}
-		return fmt.Errorf("cannot add notice to prompting %s backend: %w", ntb.noticeType, err)
+		// Re-add expired notices to map after potentially deleting the new
+		// noticeID, in case an expired notice with that ID did exist.
+		for _, expiredNotice := range expiredNotices {
+			ntb.idToNotice[expiredNotice.ID()] = expiredNotice
+		}
 	}
 
-	// Now that we've successfully saved, delete the expired notices
-	for _, expiredNotice := range userNotices[:expiredCount] {
-		delete(ntb.idToNotice, expiredNotice.ID())
-	}
-
-	ntb.cond.Broadcast()
-
-	return nil
+	return rollback, nil
 }
 
 // searchExistingNotices looks up the list of existing notices for the given

--- a/overlord/ifacestate/apparmorprompting/noticebackend.go
+++ b/overlord/ifacestate/apparmorprompting/noticebackend.go
@@ -208,7 +208,9 @@ type addNoticesInfo struct {
 // The notice key equals the info's prompt/rule ID, and the notice ID and type
 // are derived from the receiver.
 func (ntb *noticeTypeBackend) addNotices(infos []addNoticesInfo) error {
-	logger.Debugf("called addNotices() with %d notice infos", len(infos))
+	if len(infos) == 0 {
+		return nil
+	}
 	ntb.rwmu.Lock()
 	defer ntb.rwmu.Unlock()
 
@@ -319,12 +321,16 @@ func (ntb *noticeTypeBackend) doAddNotice(userID uint32, id prompting.IDType, da
 	newUserNotices := appendNotice(userNotices, newNotice, existingIndex, expiredCount)
 
 	ntb.userNotices[userID] = newUserNotices
-	ntb.idToNotice[noticeID] = newNotice
 
+	// Delete expired notices from the ID map before setting the new notice,
+	// in case an expired notice shares the same ID as the new notice (i.e.
+	// when re-recording an expired notice).
 	expiredNotices := userNotices[:expiredCount]
 	for _, expiredNotice := range expiredNotices {
 		delete(ntb.idToNotice, expiredNotice.ID())
 	}
+
+	ntb.idToNotice[noticeID] = newNotice
 
 	rollback = func() {
 		ntb.userNotices[userID] = userNotices

--- a/overlord/ifacestate/apparmorprompting/noticebackend_test.go
+++ b/overlord/ifacestate/apparmorprompting/noticebackend_test.go
@@ -409,6 +409,12 @@ func (s *noticebackendSuite) TestAddNoticeAllExpired(c *C) {
 		// Check that the nesly (re-)recorded notice is the only one
 		c.Check(notices, HasLen, 1, Commentf("trying to add notice %s", id))
 		c.Check(notices[0].Key(), Equals, id.String())
+
+		// Check that the re-recorded notice is retrievable via BackendNotice,
+		// which uses the ID map. This catches a bug where re-recording an
+		// expired notice could leave it absent from the ID map.
+		noticeID := "prompt-" + id.String()
+		c.Check(promptBackend.BackendNotice(noticeID), NotNil, Commentf("could not find re-recorded notice with ID %s via BackendNotice", id))
 	}
 }
 
@@ -539,6 +545,15 @@ func (s *noticebackendSuite) TestAddNotices(c *C) {
 		default:
 			c.Check(afterNotices[i].LastData(), HasLen, 0)
 		}
+	}
+
+	// Check that all notices, including re-recorded expired ones, are
+	// retrievable via BackendNotice (which uses the ID map). This catches
+	// a bug where re-recording an expired notice could leave it absent from
+	// the ID map if expired notice cleanup ran after setting the new notice.
+	for _, id := range []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11} {
+		noticeID := fmt.Sprintf("rule-%016X", id)
+		c.Check(ruleBackend.BackendNotice(noticeID), NotNil, Commentf("could not find notice with ID %d via BackendNotice", id))
 	}
 }
 

--- a/overlord/ifacestate/apparmorprompting/noticebackend_test.go
+++ b/overlord/ifacestate/apparmorprompting/noticebackend_test.go
@@ -21,8 +21,10 @@ package apparmorprompting_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -468,6 +470,223 @@ func (s *noticebackendSuite) TestAddNoticeSaveFailureRollback(c *C) {
 		c.Check(promptBackend.BackendNotice("prompt-0000000000000001"), NotNil, Commentf("could not find expired notice with ID 1 after adding notice with ID %s", id))
 		c.Check(promptBackend.BackendNotice("prompt-0000000000000002"), NotNil, Commentf("could not find expired notice with ID 2 after adding notice with ID %s", id))
 	}
+}
+
+func (s *noticebackendSuite) TestAddNotices(c *C) {
+	noticeBackend, err := apparmorprompting.NewNoticeBackends(s.noticeMgr)
+	c.Assert(err, IsNil)
+	ruleBackend := noticeBackend.RuleBackend()
+
+	// Add 10 notices, alternating between user 0 and 1
+	infos := make([]apparmorprompting.AddNoticesInfo, 0, 10)
+	for i := uint32(1); i <= 10; i++ {
+		infos = append(infos, apparmorprompting.AddNoticesInfo{
+			UserID: i % 2,
+			ID:     prompting.IDType(i),
+			Data:   map[string]string{"foo": fmt.Sprintf("%d", i)},
+		})
+	}
+	c.Check(ruleBackend.AddNotices(infos), IsNil)
+	origNotices := ruleBackend.BackendNotices(nil)
+	c.Assert(origNotices, HasLen, 10)
+	// Expire the first two notices by re-recording them in the past
+	for _, notice := range origNotices[:2] {
+		notice.Reoccur(notice.LastRepeated().Add(-1000*time.Hour), nil, 0)
+	}
+
+	beforeNotices := ruleBackend.BackendNotices(nil)
+	c.Assert(beforeNotices, HasLen, 8)
+	for i := 0; i < 8; i++ {
+		c.Check(beforeNotices[i].Key(), Equals, prompting.IDType(i+3).String())
+		c.Check(beforeNotices[i].LastData()["foo"], Equals, fmt.Sprintf("%d", i+3))
+	}
+	// Check that one of the users has 4 of the notices
+	userID := uint32(1)
+	c.Assert(ruleBackend.BackendNotices(&state.NoticeFilter{UserID: &userID}), HasLen, 4)
+
+	// Add notices:
+	// - ID 1, user 1, which is expired
+	// - ID 4, user 0, which is the first non-expired notice for that user
+	// - ID 5, user 1, which is from the middle
+	// - ID 11, user 1, which is new
+	// - ID 8, user 0, which is from the middle
+	// - ID 4, user 0, which is from the middle now
+	// - ID 4, user 0, which is from the end now
+	// - ID 2, user 0, which previously existed long ago but was discarded
+	// - ID 3, user 1, which is the first non-expired notice for that user
+	infos = make([]apparmorprompting.AddNoticesInfo, 0, 9)
+	for _, id := range []uint32{1, 4, 5, 11, 8, 4, 4, 2, 3} {
+		infos = append(infos, apparmorprompting.AddNoticesInfo{
+			UserID: id % 2,
+			ID:     prompting.IDType(id),
+			Data:   nil,
+		})
+	}
+	c.Check(ruleBackend.AddNotices(infos), IsNil)
+
+	// Check that the new notices were added
+	afterNotices := ruleBackend.BackendNotices(nil)
+	c.Check(afterNotices, HasLen, 11, Commentf("after adding notices, afterNotices: %+v", afterNotices))
+	for i, id := range []uint32{6, 7, 9, 10, 1, 5, 11, 8, 4, 2, 3} {
+		c.Check(afterNotices[i].Key(), Equals, prompting.IDType(id).String())
+		userID, isSet := afterNotices[i].UserID()
+		c.Check(userID, Equals, id%2)
+		c.Check(isSet, Equals, true)
+		switch id {
+		case 6, 7, 9, 10:
+			// Original notices which were not re-recorded should still have data set
+			c.Check(afterNotices[i].LastData()["foo"], Equals, fmt.Sprintf("%d", id))
+		default:
+			c.Check(afterNotices[i].LastData(), HasLen, 0)
+		}
+	}
+}
+
+func (s *noticebackendSuite) TestAddNoticesErrors(c *C) {
+	noticeBackend, err := apparmorprompting.NewNoticeBackends(s.noticeMgr)
+	c.Assert(err, IsNil)
+	ruleBackend := noticeBackend.RuleBackend()
+
+	// Add 6 notices, alternating between user 0 and 1
+	infos := make([]apparmorprompting.AddNoticesInfo, 0, 6)
+	for i := uint32(1); i <= 6; i++ {
+		infos = append(infos, apparmorprompting.AddNoticesInfo{
+			UserID: i % 2,
+			ID:     prompting.IDType(i),
+			Data:   map[string]string{"foo": fmt.Sprintf("%d", i)},
+		})
+	}
+	c.Check(ruleBackend.AddNotices(infos), IsNil)
+	origNotices := ruleBackend.BackendNotices(nil)
+	c.Assert(origNotices, HasLen, 6)
+	// Expire the first two notices by re-recording them in the past
+	for _, notice := range origNotices[:2] {
+		notice.Reoccur(notice.LastRepeated().Add(-1000*time.Hour), nil, 0)
+	}
+
+	beforeNotices := ruleBackend.BackendNotices(nil)
+	c.Assert(beforeNotices, HasLen, 4)
+	for i := 0; i < 4; i++ {
+		c.Check(beforeNotices[i].Key(), Equals, prompting.IDType(i+3).String())
+		c.Check(beforeNotices[i].LastData()["foo"], Equals, fmt.Sprintf("%d", i+3))
+	}
+
+	// Add notices:
+	// - ID 1, user 0, which conflicts with existing notice
+	// - ID 7, user 1, which is a new notice
+	// - ID 4, user 1, which conflicts with existing notice
+	// - ID 4, user 0, which re-records original notice
+	// - ID 3, user 0, which conflicts with existing notice
+	infos = []apparmorprompting.AddNoticesInfo{
+		{UserID: 0, ID: prompting.IDType(1)},
+		{UserID: 1, ID: prompting.IDType(7)},
+		{UserID: 1, ID: prompting.IDType(4)},
+		{UserID: 0, ID: prompting.IDType(4)},
+		{UserID: 0, ID: prompting.IDType(3)},
+	}
+	result := ruleBackend.AddNotices(infos)
+	c.Check(result, NotNil)
+	onelined := strings.ReplaceAll(result.Error(), "\n", "; ")
+	c.Check(onelined, Matches, ".*cannot add rule notice with ID rule-0000000000000001 for user 0:.*")
+	c.Check(onelined, Not(Matches), ".*cannot add rule notice with ID rule-0000000000000007.*")
+	c.Check(onelined, Matches, ".*cannot add rule notice with ID rule-0000000000000004 for user 1:.*")
+	c.Check(onelined, Not(Matches), ".*cannot add rule notice with ID rule-0000000000000004 for user 0:.*")
+	c.Check(onelined, Matches, ".*cannot add rule notice with ID rule-0000000000000003 for user 0:.*")
+
+	// Check that the new notices which did not result in error were added
+	afterNotices := ruleBackend.BackendNotices(nil)
+	c.Assert(afterNotices, HasLen, 5, Commentf("after adding notices, afterNotices: %+v", afterNotices))
+	for i, id := range []uint32{3, 5, 6, 7, 4} {
+		c.Check(afterNotices[i].Key(), Equals, prompting.IDType(id).String())
+		userID, isSet := afterNotices[i].UserID()
+		c.Check(userID, Equals, id%2)
+		c.Check(isSet, Equals, true)
+		switch id {
+		case 3, 5, 6:
+			// Original notices which were not re-recorded should still have data set
+			c.Check(afterNotices[i].LastData()["foo"], Equals, fmt.Sprintf("%d", id))
+		default:
+			c.Check(afterNotices[i].LastData(), HasLen, 0)
+		}
+	}
+}
+
+func (s *noticebackendSuite) TestAddNoticesSaveFailureRollback(c *C) {
+	noticeBackend, err := apparmorprompting.NewNoticeBackends(s.noticeMgr)
+	c.Assert(err, IsNil)
+	ruleBackend := noticeBackend.RuleBackend()
+
+	// Add 10 notices, alternating between user 0 and 1, so we can test that
+	// re-recorded and new notices are rolled back/deleted when save fails.
+	infos := make([]apparmorprompting.AddNoticesInfo, 0, 10)
+	for i := uint32(1); i <= 10; i++ {
+		infos = append(infos, apparmorprompting.AddNoticesInfo{
+			UserID: i % 2,
+			ID:     prompting.IDType(i),
+			Data:   map[string]string{"foo": fmt.Sprintf("%d", i)},
+		})
+	}
+	c.Check(ruleBackend.AddNotices(infos), IsNil)
+	origNotices := ruleBackend.BackendNotices(nil)
+	c.Assert(origNotices, HasLen, 10)
+	// Expire the first two notices by re-recording them in the past
+	for _, notice := range origNotices[:2] {
+		notice.Reoccur(notice.LastRepeated().Add(-1000*time.Hour), nil, 0)
+	}
+
+	beforeNotices := ruleBackend.BackendNotices(nil)
+	c.Assert(beforeNotices, HasLen, 8)
+	for i := 0; i < 8; i++ {
+		c.Check(beforeNotices[i].Key(), Equals, prompting.IDType(i+3).String())
+		c.Check(beforeNotices[i].LastData()["foo"], Equals, fmt.Sprintf("%d", i+3))
+	}
+	// Check that one of the users has 4 of the notices
+	userID := uint32(1)
+	c.Assert(ruleBackend.BackendNotices(&state.NoticeFilter{UserID: &userID}), HasLen, 4)
+
+	// Check that the expired notices are still in the ID map.
+	// Technically, this check relies on internal implementation details
+	// which are not required to remain true.
+	c.Assert(ruleBackend.BackendNotice("rule-0000000000000001"), NotNil)
+	c.Assert(ruleBackend.BackendNotice("rule-0000000000000002"), NotNil)
+
+	// Cause a save error by writing a directory in place of the notices state file
+	path := filepath.Join(dirs.SnapInterfacesRequestsStateDir, "rule-notices.json")
+	c.Assert(os.Remove(path), IsNil)
+	c.Assert(os.Mkdir(path, 0o700), IsNil)
+
+	// Add notices:
+	// - ID 1, user 1, which is expired
+	// - ID 4, user 0, which is the first non-expired notice for that user
+	// - ID 5, user 1, which is from the middle
+	// - ID 11, user 1, which is new
+	// - ID 8, user 0, which is from the middle
+	// - ID 4, user 0, which is from the middle now
+	// - ID 4, user 0, which is from the end now
+	// - ID 2, user 0, which previously existed long ago but was discarded
+	// - ID 3, user 1, which is the first non-expired notice for that user
+	infos = make([]apparmorprompting.AddNoticesInfo, 0, 9)
+	for _, id := range []uint32{1, 4, 5, 11, 8, 4, 4, 2, 3} {
+		infos = append(infos, apparmorprompting.AddNoticesInfo{
+			UserID: id % 2,
+			ID:     prompting.IDType(id),
+			Data:   nil,
+		})
+	}
+	result := ruleBackend.AddNotices(infos)
+	c.Check(result, ErrorMatches, "cannot add notices to prompting interfaces-requests-rule-update backend.*")
+
+	// Check that the new notices were not added
+	afterNotices := ruleBackend.BackendNotices(nil)
+	c.Check(afterNotices, HasLen, 8, Commentf("after adding notices, afterNotices: %+v", afterNotices))
+	for i := 0; i < 8; i++ {
+		c.Check(afterNotices[i].Key(), Equals, prompting.IDType(i+3).String())
+		c.Check(afterNotices[i].LastData()["foo"], Equals, fmt.Sprintf("%d", i+3))
+	}
+
+	// Check that the expired notices are still in the ID map.
+	c.Check(ruleBackend.BackendNotice("rule-0000000000000001"), NotNil, Commentf("could not find expired notice with ID 1 after adding notices"))
+	c.Check(ruleBackend.BackendNotice("rule-0000000000000002"), NotNil, Commentf("could not find expired notice with ID 2 after adding notices"))
 }
 
 func (s *noticebackendSuite) TestLoad(c *C) {

--- a/overlord/ifacestate/apparmorprompting/prompting.go
+++ b/overlord/ifacestate/apparmorprompting/prompting.go
@@ -101,16 +101,15 @@ func New(noticeMgr *notices.NoticeManager) (m *InterfacesRequestsManager, retErr
 	notifyPrompt := noticeBackends.promptBackend.addNotice
 
 	notifyRules := func(rules []*requestrules.Rule, data map[string]string) error {
-		// XXX: currently this is pointless since each notice is added and
-		// written to disk individually.
-		var errs []error
+		infos := make([]addNoticesInfo, 0, len(rules))
 		for _, rule := range rules {
-			if err := noticeBackends.ruleBackend.addNotice(rule.User, rule.ID, data); err != nil {
-				errs = append(errs, err)
-			}
+			infos = append(infos, addNoticesInfo{
+				UserID: rule.User,
+				ID:     rule.ID,
+				Data:   data,
+			})
 		}
-		// TODO:GOVERSION: replace with errors.Join() once we're on golang v1.20+
-		return strutil.JoinErrors(errs...)
+		return noticeBackends.ruleBackend.addNotices(infos)
 	}
 
 	listenerBackend, err := listenerRegister()

--- a/overlord/ifacestate/apparmorprompting/prompting.go
+++ b/overlord/ifacestate/apparmorprompting/prompting.go
@@ -98,6 +98,21 @@ func New(noticeMgr *notices.NoticeManager) (m *InterfacesRequestsManager, retErr
 		return nil, fmt.Errorf("cannot initialize prompting notice backend: %w", err)
 	}
 
+	notifyPrompt := noticeBackends.promptBackend.addNotice
+
+	notifyRules := func(rules []*requestrules.Rule, data map[string]string) error {
+		// XXX: currently this is pointless since each notice is added and
+		// written to disk individually.
+		var errs []error
+		for _, rule := range rules {
+			if err := noticeBackends.ruleBackend.addNotice(rule.User, rule.ID, data); err != nil {
+				errs = append(errs, err)
+			}
+		}
+		// TODO:GOVERSION: replace with errors.Join() once we're on golang v1.20+
+		return strutil.JoinErrors(errs...)
+	}
+
 	listenerBackend, err := listenerRegister()
 	if err != nil {
 		return nil, fmt.Errorf("cannot register prompting listener: %w", err)
@@ -108,7 +123,7 @@ func New(noticeMgr *notices.NoticeManager) (m *InterfacesRequestsManager, retErr
 		}
 	}()
 
-	promptsBackend, err := requestprompts.New(noticeBackends.promptBackend.addNotice)
+	promptsBackend, err := requestprompts.New(notifyPrompt)
 	if err != nil {
 		return nil, fmt.Errorf("cannot open request prompts backend: %w", err)
 	}
@@ -118,7 +133,7 @@ func New(noticeMgr *notices.NoticeManager) (m *InterfacesRequestsManager, retErr
 		}
 	}()
 
-	rulesBackend, err := requestrules.New(noticeBackends.ruleBackend.addNotice)
+	rulesBackend, err := requestrules.New(notifyRules)
 	if err != nil {
 		return nil, fmt.Errorf("cannot open request rules backend: %w", err)
 	}


### PR DESCRIPTION
This PR is based on #16127

Instead of separately calling `notifyRule` for each rule when many rules require notices (such as on snapd startup), make `notifyRule` into `notifyRules` which takes a list of rules and records notices for all of them at once, only writing notices to disk once after all have been added.

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-35903