### PR TITLE
gsettings: Do not provide direct access to the dconf database

### DIFF
--- a/interfaces/builtin/gsettings.go
+++ b/interfaces/builtin/gsettings.go
@@ -38,8 +38,6 @@ const gsettingsConnectedPlugAppArmor = `
 #include <abstractions/dbus-session-strict>
 
 #include <abstractions/dconf>
-owner /{,var/}run/user/*/dconf/user w,
-owner @{HOME}/.config/dconf/user w,
 dbus (receive, send)
     bus=session
     interface="ca.desrt.dconf.Writer"


### PR DESCRIPTION
The gsettings interface is misleading: it promises access to the user settings via GSettings (that is a [Gio API](https://docs.gtk.org/gio/class.Settings.html)), but it rather provides access to the [dconf API](https://manpages.ubuntu.com/manpages/resolute/en/man7/dconf.7.html) and also its database.

Now, while this interface should have likely be renamed "dconf" (since gsettings per se can work with multiple settings databases) I guess we're too late for that.

At the same time, given that this API meant to provide *gsettings* access to the user settings, it should *not* provide access to the database itself.

As per this, block the direct access to the user settings database files, while still keep providing access to the dbus API.

That implies that if a snap is connected to this interface:
 - It will still be able to use `gsettings` tool, the `g_settings_*` Gio or DBus API to access to user settings
 - It will be not allowed to directly use the `dconf` tool or its C-API counterparts.
   - For local database it will still work, of course, but not for user level ones

I think this is fine since the interface never promised low-level access but it rather allowed to potentially use the settings through a DBus API (gsettings).

This is a first step to improve the gsettings situation, as it would potentially allow us to:
 - Drop the gsettings auto-connection (and make apps to rely on local snap databases instead)
 - Add check to the `dconf-daemon` to only allow applications to access to the gsettings namespace they claimed to have access to

---

Note that we don't really need access to the runtime dir either, this is something that the desktop launcher [tries to do](https://github.com/canonical/snapcraft-desktop-integration/blob/5e44f1f44e5179da32c7aca36213a8105c5d67d9/common/desktop-exports#L424-L428), but we can safely remove that too
