### PR TITLE
interfaces/builtin/ssh_agent: Add ssh-agent interface

### DIFF
--- a/interfaces/builtin/ssh_agent.go
+++ b/interfaces/builtin/ssh_agent.go
@@ -30,9 +30,9 @@ const sshAgentBaseDeclarationSlots = `
 
 const sshAgentConnectedPlugAppArmor = `
 # allow access to socket owned by user in default locatin for openssh ssh-agent
-owner /tmp/ssh-[a-zA-Z0-9]+/agent.[0-9]+ rw,
+owner /tmp/ssh-*/agent.* rw,
 # allow access to default location for gnome keyring ssh-agent for standard users (uid 1000+)
-owner /run/user/[0-9]{4,}/keyring/ssh rw,
+owner /run/user/*/keyring/ssh rw,
 `
 
 func init() {

--- a/interfaces/builtin/ssh_agent.go
+++ b/interfaces/builtin/ssh_agent.go
@@ -1,0 +1,30 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+package builtin
+
+const sshAgentSummary = `allows access to users ssh-agent`
+const sshAgentBaseDeclarationSlots = `
+  ssh-agent:
+    allow-installation:
+      slot-snap-type:
+        - app
+    deny-auto-connection: true
+`
+
+const sshAgentConnectedPlugAppArmor = `
+# allow access to socket owned by user in default locatin for openssh ssh-agent
+owner /tmp/ssh-[a-zA-Z0-9]+/agent.[0-9]+ rw,
+# allow access to default location for gnome keyring ssh-agent for standard users (uid 1000+)
+owner /run/user/[0-9]{4,}/keyring/ssh rw,
+`
+
+func init() {
+	registerIface(&commonInterface{
+		name:                  "ssh-agent",
+		summary:               sshAgentSummary,
+		implicitOnCore:        true,
+		implicitOnClassic:     true,
+		baseDeclarationSlots:  sshAgentBaseDeclarationSlots,
+		connectedPlugAppArmor: sshAgentConnectedPlugAppArmor,
+	})
+}

--- a/interfaces/builtin/ssh_agent.go
+++ b/interfaces/builtin/ssh_agent.go
@@ -24,7 +24,7 @@ const sshAgentBaseDeclarationSlots = `
   ssh-agent:
     allow-installation:
       slot-snap-type:
-        - app
+        - core
     deny-auto-connection: true
 `
 

--- a/interfaces/builtin/ssh_agent.go
+++ b/interfaces/builtin/ssh_agent.go
@@ -29,9 +29,9 @@ const sshAgentBaseDeclarationSlots = `
 `
 
 const sshAgentConnectedPlugAppArmor = `
-# allow access to socket owned by user in default locatin for openssh ssh-agent
+# allow access to socket owned by user in default location for openssh ssh-agent
 owner /tmp/ssh-*/agent.* rw,
-# allow access to default location for gnome keyring ssh-agent for standard users (uid 1000+)
+# allow access to default location for gnome keyring ssh-agent
 owner /run/user/*/keyring/ssh rw,
 `
 

--- a/interfaces/builtin/ssh_agent.go
+++ b/interfaces/builtin/ssh_agent.go
@@ -33,6 +33,8 @@ const sshAgentConnectedPlugAppArmor = `
 owner /tmp/ssh-*/agent.* rw,
 # allow access to default location for gnome keyring ssh-agent
 owner /run/user/*/keyring/ssh rw,
+# allow access to default location for gcr ssh-agent socket
+owner /run/user/*/gcr/ssh rw,
 `
 
 func init() {

--- a/interfaces/builtin/ssh_agent.go
+++ b/interfaces/builtin/ssh_agent.go
@@ -1,5 +1,22 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 package builtin
 
 const sshAgentSummary = `allows access to users ssh-agent`

--- a/interfaces/builtin/ssh_agent.go
+++ b/interfaces/builtin/ssh_agent.go
@@ -32,7 +32,7 @@ const sshAgentConnectedPlugAppArmor = `
 # allow access to socket owned by user in default location for openssh ssh-agent
 owner /tmp/ssh-*/agent.* rw,
 # allow access to default location for gnome keyring ssh-agent
-owner /run/user/*/keyring/ssh rw,
+owner /run/user/[0-9]*/keyring/ssh rw,
 # allow access to default location for gcr ssh-agent socket
 owner /run/user/*/gcr/ssh rw,
 `

--- a/interfaces/builtin/ssh_agent.go
+++ b/interfaces/builtin/ssh_agent.go
@@ -34,7 +34,7 @@ owner /tmp/ssh-*/agent.* rw,
 # allow access to default location for gnome keyring ssh-agent
 owner /run/user/[0-9]*/keyring/ssh rw,
 # allow access to default location for gcr ssh-agent socket
-owner /run/user/*/gcr/ssh rw,
+owner /run/user/[0-9]*/gcr/ssh rw,
 `
 
 func init() {

--- a/interfaces/builtin/ssh_agent.go
+++ b/interfaces/builtin/ssh_agent.go
@@ -19,7 +19,7 @@
 
 package builtin
 
-const sshAgentSummary = `allows access to users ssh-agent`
+const sshAgentSummary = `allows access to the user's gnome keyring or gcr based ssh-agent`
 const sshAgentBaseDeclarationSlots = `
   ssh-agent:
     allow-installation:
@@ -29,8 +29,6 @@ const sshAgentBaseDeclarationSlots = `
 `
 
 const sshAgentConnectedPlugAppArmor = `
-# allow access to socket owned by user in default location for openssh ssh-agent
-owner /tmp/ssh-*/agent.* rw,
 # allow access to default location for gnome keyring ssh-agent
 owner /run/user/[0-9]*/keyring/ssh rw,
 # allow access to default location for gcr ssh-agent socket
@@ -41,7 +39,7 @@ func init() {
 	registerIface(&commonInterface{
 		name:                  "ssh-agent",
 		summary:               sshAgentSummary,
-		implicitOnCore:        true,
+		implicitOnCore:        false,
 		implicitOnClassic:     true,
 		baseDeclarationSlots:  sshAgentBaseDeclarationSlots,
 		connectedPlugAppArmor: sshAgentConnectedPlugAppArmor,

--- a/interfaces/builtin/ssh_agent_test.go
+++ b/interfaces/builtin/ssh_agent_test.go
@@ -78,8 +78,8 @@ func (s *SshAgentInterfaceSuite) TestAppArmorSpec(c *C) {
 	spec := apparmor.NewSpecification(appSet)
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `owner /tmp/ssh-[a-zA-Z0-9]+/agent.[0-9]+ rw,`)
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `owner /run/user/[0-9]{4,}/keyring/ssh rw,`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `owner /tmp/ssh-*/agent.* rw,`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `owner /run/user/*/keyring/ssh rw,`)
 }
 
 func (s *SshAgentInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/ssh_agent_test.go
+++ b/interfaces/builtin/ssh_agent_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2017 Canonical Ltd
+ * Copyright (C) 2026 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as

--- a/interfaces/builtin/ssh_agent_test.go
+++ b/interfaces/builtin/ssh_agent_test.go
@@ -80,6 +80,7 @@ func (s *SshAgentInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `owner /tmp/ssh-*/agent.* rw,`)
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `owner /run/user/*/keyring/ssh rw,`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `owner /run/user/*/gcr/ssh rw,`)
 }
 
 func (s *SshAgentInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/ssh_agent_test.go
+++ b/interfaces/builtin/ssh_agent_test.go
@@ -1,0 +1,99 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2017 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type SshAgentInterfaceSuite struct {
+	iface    interfaces.Interface
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+}
+
+var _ = Suite(&SshAgentInterfaceSuite{
+	iface: builtin.MustInterface("ssh-agent"),
+})
+
+const sshAgentConsumerYaml = `name: consumer
+version: 0
+apps:
+ app:
+   plugs: [ssh-agent]
+   `
+
+const sshAgentCoreYaml = `name: core
+version: 0
+type: os
+slots:
+  ssh-agent:
+`
+
+func (s *SshAgentInterfaceSuite) SetUpTest(c *C) {
+	s.plug, s.plugInfo = MockConnectedPlug(c, sshAgentConsumerYaml, nil, "ssh-agent")
+	s.slot, s.slotInfo = MockConnectedSlot(c, sshAgentCoreYaml, nil, "ssh-agent")
+}
+
+func (s *SshAgentInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "ssh-agent")
+}
+
+func (s *SshAgentInterfaceSuite) TestSanitizeSlot(c *C) {
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
+}
+
+func (s *SshAgentInterfaceSuite) TestSanitizePlug(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+}
+
+func (s *SshAgentInterfaceSuite) TestAppArmorSpec(c *C) {
+	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
+	c.Assert(err, IsNil)
+	spec := apparmor.NewSpecification(appSet)
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `owner /tmp/ssh-[a-zA-Z0-9]+/agent.[0-9]+ rw,`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `owner /run/user/[0-9]{4,}/keyring/ssh rw,`)
+}
+
+func (s *SshAgentInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Assert(si.ImplicitOnCore, Equals, true)
+	c.Assert(si.ImplicitOnClassic, Equals, true)
+	c.Assert(si.Summary, Equals, `allows access to users ssh-agent`)
+	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "ssh-agent")
+}
+
+func (s *SshAgentInterfaceSuite) TestAutoConnect(c *C) {
+	c.Assert(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
+}
+
+func (s *SshAgentInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/interfaces/builtin/ssh_agent_test.go
+++ b/interfaces/builtin/ssh_agent_test.go
@@ -78,16 +78,15 @@ func (s *SshAgentInterfaceSuite) TestAppArmorSpec(c *C) {
 	spec := apparmor.NewSpecification(appSet)
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `owner /tmp/ssh-*/agent.* rw,`)
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `owner /run/user/*/keyring/ssh rw,`)
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `owner /run/user/*/gcr/ssh rw,`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `owner /run/user/[0-9]*/keyring/ssh rw,`)
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `owner /run/user/[0-9]*/gcr/ssh rw,`)
 }
 
 func (s *SshAgentInterfaceSuite) TestStaticInfo(c *C) {
 	si := interfaces.StaticInfoOf(s.iface)
-	c.Assert(si.ImplicitOnCore, Equals, true)
+	c.Assert(si.ImplicitOnCore, Equals, false)
 	c.Assert(si.ImplicitOnClassic, Equals, true)
-	c.Assert(si.Summary, Equals, `allows access to users ssh-agent`)
+	c.Assert(si.Summary, Equals, `allows access to the user's gnome keyring or gcr based ssh-agent`)
 	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "ssh-agent")
 }
 

--- a/tests/main/interfaces-ssh-agent/task.yaml
+++ b/tests/main/interfaces-ssh-agent/task.yaml
@@ -1,0 +1,46 @@
+summary: Ensure that the ssh-agent interface works.
+
+details: |
+    The ssh-agent interface allows to access to the users
+    local ssh-agent socket for managing keys.
+
+environment:
+    KEYRING_SOCKET: "/run/user/1000/keyring/ssh"
+    OPENSSH_SOCKET: "/tmp/ssh-abcdefg123/agent.123456"
+
+prepare: |
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
+
+    # Create files to simulate ssh authentication agent sockets
+    "$TESTSTOOLS"/fs-state mock-file "$KEYRING_SOCKET"
+    "$TESTSTOOLS"/fs-state mock-file "$OPENSSH_SOCKET"
+
+restore: |
+    # Delete the created files
+    "$TESTSTOOLS"/fs-state restore-file "$KEYRING_SOCKET"
+    "$TESTSTOOLS"/fs-state restore-file "$OPENSSH_SOCKET"
+
+execute: |
+    echo "The interface is not connected by default"
+    snap interfaces -i ssh-agent | MATCH -- '^- +test-snapd-sh:ssh-agent'
+
+    echo "When the interface is connected"
+    snap connect test-snapd-sh:ssh-agent
+    
+    echo "Then the snap is able to write to the socket files"
+    test-snapd-sh.with-ssh-agent-plug -c "echo test >> $KEYRING_SOCKET"
+    test-snapd-sh.with-ssh-agent-plug -c "echo test >> $OPENSSH_SOCKET"
+
+    echo "And the snap is able to read the socket files"
+    test-snapd-sh.with-ssh-agent-plug -c "cat $KEYRING_SOCKET"
+    test-snapd-sh.with-ssh-agent-plug -c "cat $OPENSSH_SOCKET"
+
+    echo "When the plug is disconnected"
+    snap disconnect test-snapd-sh:ssh-agent
+    
+    echo "Then the snap is not able to access the ssh-agent socket"
+    if test-snapd-sh.with-ssh-agent -c "cat $KEYRING_SOCKET" 2> call.error; then
+        echo "Expected permission error accessing ssh-agent socket"
+        exit 1
+    fi
+    MATCH "Permission denied" < call.error

--- a/tests/main/interfaces-ssh-agent/task.yaml
+++ b/tests/main/interfaces-ssh-agent/task.yaml
@@ -6,6 +6,7 @@ details: |
 
 environment:
     KEYRING_SOCKET: "/run/user/1000/keyring/ssh"
+    GCR_SOCKET: "/run/user/1000/gcr/ssh"
     OPENSSH_SOCKET: "/tmp/ssh-abcdefg123/agent.123456"
 
 prepare: |
@@ -13,11 +14,13 @@ prepare: |
 
     # Create files to simulate ssh authentication agent sockets
     "$TESTSTOOLS"/fs-state mock-file "$KEYRING_SOCKET"
+    "$TESTSTOOLS"/fs-state mock-file "$GCR_SOCKET"
     "$TESTSTOOLS"/fs-state mock-file "$OPENSSH_SOCKET"
 
 restore: |
     # Delete the created files
     "$TESTSTOOLS"/fs-state restore-file "$KEYRING_SOCKET"
+    "$TESTSTOOLS"/fs-state restore-file "$GCR_SOCKET"
     "$TESTSTOOLS"/fs-state restore-file "$OPENSSH_SOCKET"
 
 execute: |
@@ -29,10 +32,12 @@ execute: |
     
     echo "Then the snap is able to write to the socket files"
     test-snapd-sh.with-ssh-agent-plug -c "echo test >> $KEYRING_SOCKET"
+    test-snapd-sh.with-ssh-agent-plug -c "echo test >> $GCR_SOCKET"
     test-snapd-sh.with-ssh-agent-plug -c "echo test >> $OPENSSH_SOCKET"
 
     echo "And the snap is able to read the socket files"
     test-snapd-sh.with-ssh-agent-plug -c "cat $KEYRING_SOCKET"
+    test-snapd-sh.with-ssh-agent-plug -c "cat $GCR_SOCKET"
     test-snapd-sh.with-ssh-agent-plug -c "cat $OPENSSH_SOCKET"
 
     echo "When the plug is disconnected"

--- a/tests/main/interfaces-ssh-agent/task.yaml
+++ b/tests/main/interfaces-ssh-agent/task.yaml
@@ -40,11 +40,15 @@ execute: |
     test-snapd-sh.with-ssh-agent-plug -c "cat $GCR_SOCKET"
     test-snapd-sh.with-ssh-agent-plug -c "cat $OPENSSH_SOCKET"
 
+    if [ "$(snap debug confinement)" = partial ] ; then
+        exit 0
+    fi
+
     echo "When the plug is disconnected"
     snap disconnect test-snapd-sh:ssh-agent
     
     echo "Then the snap is not able to access the ssh-agent socket"
-    if test-snapd-sh.with-ssh-agent -c "cat $KEYRING_SOCKET" 2> call.error; then
+    if test-snapd-sh.with-ssh-agent-plug -c "cat $KEYRING_SOCKET" 2> call.error; then
         echo "Expected permission error accessing ssh-agent socket"
         exit 1
     fi

--- a/tests/main/interfaces-ssh-agent/test-snapd-sh/bin/sh
+++ b/tests/main/interfaces-ssh-agent/test-snapd-sh/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+PS1='$ '
+exec /bin/sh "$@"

--- a/tests/main/interfaces-ssh-agent/test-snapd-sh/meta/snap.yaml
+++ b/tests/main/interfaces-ssh-agent/test-snapd-sh/meta/snap.yaml
@@ -1,0 +1,8 @@
+name: test-snapd-sh
+summary: A no-strings-attached, no-fuss shell for writing tests
+version: 1.0
+
+apps:
+    with-ssh-agent-plug:
+        command: bin/sh
+        plugs: [ssh-agent]


### PR DESCRIPTION
This PR adds a new interface named `ssh-agent` that allows a snap access to the users local `ssh-agent` socket.

The implementation of this somewhat self-serving as I have an application packaged as a snap that requests SSH certificates from an OIDC IdP to allow "SSO" for SSH via short lived certificates, but as part of the process I need to be able to add the issued certificate to the users local `ssh-agent` so the key and issued certificate can be used by other applications on the system (not just my own snap), and I would like to maintain strict confinement if possible.

The intent of this interface is to only allow access to the following sockets:

- /tmp/ssh-XXXXXXXXXX/agent.PID
- /run/user/UID/keyring/ssh

The above sockets are the default locations for the OpenSSH authentication agent and the Gnome Keyring SSH agent respectively.

This interface would not auto-connect by default so it would need to be explicitly connected by the user/admin.

This is my first attempt at an interface for `snapd` (or any contribution at all) so any recommendations or feedback is welcome.

I have signed the contributor agreement form on the Canonical website as of this morning.
