### PR TITLE
many: add snapctl enable/disable services

### DIFF
--- a/overlord/hookstate/ctlcmd/disable.go
+++ b/overlord/hookstate/ctlcmd/disable.go
@@ -1,0 +1,59 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016-2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ctlcmd
+
+import (
+	"github.com/snapcore/snapd/client/clientutil"
+	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/overlord/servicestate"
+)
+
+type disableCommand struct {
+	baseCommand
+	clientutil.ServiceScopeOptions
+	Positional struct {
+		ServiceNames []string `positional-arg-name:"<service>" required:"yes"`
+	} `positional-args:"yes" required:"yes"`
+}
+
+var (
+	shortDisableHelp = i18n.G("Disable services")
+	longDisableHelp  = i18n.G(`
+The disable command disables the given services of the snap. If executed from the
+"configure" hook, the services will be disabled after the hook finishes.`)
+)
+
+func init() {
+	addCommand("disable", shortDisableHelp, longDisableHelp, func() command { return &disableCommand{} })
+}
+
+func (c *disableCommand) Execute(args []string) error {
+	if err := c.Validate(); err != nil {
+		return err
+	}
+
+	inst := servicestate.Instruction{
+		Action: "disable",
+		Names:  c.Positional.ServiceNames,
+		Scope:  c.Scope(),
+		Users:  c.Users(),
+	}
+	return runServiceCommand(c.context(), &inst)
+}

--- a/overlord/hookstate/ctlcmd/enable.go
+++ b/overlord/hookstate/ctlcmd/enable.go
@@ -1,0 +1,59 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2016-2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ctlcmd
+
+import (
+	"github.com/snapcore/snapd/client/clientutil"
+	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/overlord/servicestate"
+)
+
+type enableCommand struct {
+	baseCommand
+	clientutil.ServiceScopeOptions
+	Positional struct {
+		ServiceNames []string `positional-arg-name:"<service>" required:"yes"`
+	} `positional-args:"yes" required:"yes"`
+}
+
+var (
+	shortEnableHelp = i18n.G("Enable services")
+	longEnableHelp  = i18n.G(`
+The enable command enables the given services of the snap. If executed from the
+"configure" hook or "default-configure" hook, the services will be enabled after the hook finishes.`)
+)
+
+func init() {
+	addCommand("enable", shortEnableHelp, longEnableHelp, func() command { return &enableCommand{} })
+}
+
+func (c *enableCommand) Execute(args []string) error {
+	if err := c.Validate(); err != nil {
+		return err
+	}
+
+	inst := servicestate.Instruction{
+		Action: "enable",
+		Names:  c.Positional.ServiceNames,
+		Scope:  c.Scope(),
+		Users:  c.Users(),
+	}
+	return runServiceCommand(c.context(), &inst)
+}

--- a/overlord/hookstate/ctlcmd/services_test.go
+++ b/overlord/hookstate/ctlcmd/services_test.go
@@ -320,6 +320,52 @@ func (s *servicectlSuite) TestStartCommand(c *C) {
 	c.Assert(serviceChangeFuncCalled, Equals, true)
 }
 
+func (s *servicectlSuite) TestEnableCommand(c *C) {
+	var serviceChangeFuncCalled bool
+	restore := mockServiceChangeFunc(func(appInfos []*snap.AppInfo, inst *servicestate.Instruction) {
+		serviceChangeFuncCalled = true
+		c.Assert(appInfos, HasLen, 1)
+		c.Assert(appInfos[0].Name, Equals, "test-service")
+		c.Assert(inst, DeepEquals, &servicestate.Instruction{
+			Action: "enable",
+			Names:  []string{"test-snap.test-service"},
+			Users: client.UserSelector{
+				Selector: client.UserSelectionList,
+				Names:    []string{},
+			},
+		},
+		)
+	})
+	defer restore()
+	_, _, err := ctlcmd.Run(s.mockContext, []string{"enable", "test-snap.test-service"}, 0)
+	c.Check(err, NotNil)
+	c.Check(err, ErrorMatches, "forced error")
+	c.Assert(serviceChangeFuncCalled, Equals, true)
+}
+
+func (s *servicectlSuite) TestDisableCommand(c *C) {
+	var serviceChangeFuncCalled bool
+	restore := mockServiceChangeFunc(func(appInfos []*snap.AppInfo, inst *servicestate.Instruction) {
+		serviceChangeFuncCalled = true
+		c.Assert(appInfos, HasLen, 1)
+		c.Assert(appInfos[0].Name, Equals, "test-service")
+		c.Assert(inst, DeepEquals, &servicestate.Instruction{
+			Action: "disable",
+			Names:  []string{"test-snap.test-service"},
+			Users: client.UserSelector{
+				Selector: client.UserSelectionList,
+				Names:    []string{},
+			},
+		},
+		)
+	})
+	defer restore()
+	_, _, err := ctlcmd.Run(s.mockContext, []string{"disable", "test-snap.test-service"}, 0)
+	c.Check(err, NotNil)
+	c.Check(err, ErrorMatches, "forced error")
+	c.Assert(serviceChangeFuncCalled, Equals, true)
+}
+
 func (s *servicectlSuite) TestRestartCommand(c *C) {
 	var serviceChangeFuncCalled bool
 	restore := mockServiceChangeFunc(func(appInfos []*snap.AppInfo, inst *servicestate.Instruction) {

--- a/overlord/servicestate/servicestate.go
+++ b/overlord/servicestate/servicestate.go
@@ -212,6 +212,10 @@ func serviceControlTs(st *state.State, appInfos []*snap.AppInfo, inst *Instructi
 			if inst.Disable {
 				cmd.ActionModifier = "disable"
 			}
+		case inst.Action == "enable":
+			cmd.Action = "enable"
+		case inst.Action == "disable":
+			cmd.Action = "disable"
 		case inst.Action == "restart":
 			cmd.RestartEnabledNonActive = true
 			if inst.Reload {
@@ -283,6 +287,10 @@ func Control(st *state.State, appInfos []*snap.AppInfo, inst *Instruction, cu *u
 				ctlcmds = []string{"disable"}
 			}
 			ctlcmds = append(ctlcmds, "stop")
+		case inst.Action == "enable":
+			ctlcmds = []string{"enable"}
+		case inst.Action == "disable":
+			ctlcmds = []string{"disable"}
 		case inst.Action == "restart":
 			if inst.Reload {
 				ctlcmds = []string{"reload-or-restart"}

--- a/tests/main/services-snapctl/task.yaml
+++ b/tests/main/services-snapctl/task.yaml
@@ -79,6 +79,18 @@ execute: |
     echo "It's stopped"
     _wait_for_service "test-snapd-service.test-snapd-service" " inactive"
 
+    echo "When we disable it via configure hook"
+    snap set test-snapd-service command=disable
+
+    echo "It's disabled but still inactive"
+    snap services test-snapd-service.test-snapd-service | MATCH ' disabled\s+ inactive'
+
+    echo "When we enable it again via configure hook"
+    snap set test-snapd-service command=enable
+
+    echo "It's enabled but still inactive"
+    snap services test-snapd-service.test-snapd-service | MATCH ' enabled\s+ inactive'
+
     echo "And then restart"
     snap set test-snapd-service service-option-source=foo command=restart
 

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -5580,6 +5580,44 @@ func (s *servicesTestSuite) TestStopAndDisableServices(c *C) {
 	})
 }
 
+func (s *servicesTestSuite) TestEnableServices(c *C) {
+	info := snaptest.MockSnap(c, packageHelloNoSrv+`
+ svc1:
+  daemon: simple
+`, &snap.SideInfo{Revision: snap.R(12)})
+	svcFile := "snap.hello-snap.svc1.service"
+
+	err := s.addSnapServices(info, false)
+	c.Assert(err, IsNil)
+
+	s.sysdLog = nil
+	err = wrappers.EnableServices(info.Services(), nil, progress.Null, s.perfTimings)
+	c.Assert(err, IsNil)
+	c.Check(s.sysdLog, DeepEquals, [][]string{
+		{"--no-reload", "enable", svcFile},
+		{"daemon-reload"},
+	})
+}
+
+func (s *servicesTestSuite) TestDisableServices(c *C) {
+	info := snaptest.MockSnap(c, packageHelloNoSrv+`
+ svc1:
+  daemon: simple
+`, &snap.SideInfo{Revision: snap.R(12)})
+	svcFile := "snap.hello-snap.svc1.service"
+
+	err := s.addSnapServices(info, false)
+	c.Assert(err, IsNil)
+
+	s.sysdLog = nil
+	err = wrappers.DisableServices(info.Services(), nil, progress.Null, s.perfTimings)
+	c.Assert(err, IsNil)
+	c.Check(s.sysdLog, DeepEquals, [][]string{
+		{"--no-reload", "disable", svcFile},
+		{"daemon-reload"},
+	})
+}
+
 func (s *servicesTestSuite) TestNewUserServiceClientNames(c *C) {
 	r := osutil.MockUserLookup(func(username string) (*user.User, error) {
 		switch username {


### PR DESCRIPTION
The logic is sequenced after the start/stop snapctl actions. Support for both system and user services is provided.

Fixes: https://bugs.launchpad.net/snapd/+bug/2062578
