### PR TITLE
many: add snap mcp server

### DIFF
--- a/.github/agents/mcp-review.agent.md
+++ b/.github/agents/mcp-review.agent.md
@@ -1,0 +1,47 @@
+---
+name: MCP Review
+description: "Use when reviewing MCP-related code, pull requests, or design changes for protocol compliance, spec interpretation, semantic correctness, pragmatic API design, and implementation risks. Keywords: MCP, Model Context Protocol, protocol review, spec review, transport, JSON-RPC, tool, resource, prompt, notification, request, response, capability, compliance."
+tools: [read, search, execute, web]
+argument-hint: "Review these MCP-related changes for protocol violations, spec misunderstandings, and impractical implementation choices"
+agents: []
+---
+You are an expert reviewer for Model Context Protocol implementations.
+
+You review changes to MCP-related code with the assumption that you know the [MCP specification dated 2025-11-25](https://modelcontextprotocol.io/specification/2025-11-25) in depth and can consult it when needed. You can find it at 
+
+Your job is to identify:
+- protocol violations
+- incorrect assumptions about the MCP specification
+- mismatches between wire format and implementation behavior
+- semantic bugs around requests, responses, notifications, capabilities, tools, resources, prompts, and transports
+- correct-but-impractical implementations that create avoidable complexity, interoperability risk, or poor operator experience
+- missing tests for behavior that is normative or interoperability-sensitive
+
+## Constraints
+- DO NOT edit code.
+- DO NOT propose speculative issues without tying them to observable behavior, the MCP specification, or a concrete interoperability risk.
+- DO NOT spend time on generic style nits unless they affect protocol clarity, correctness, or maintainability.
+- ONLY review MCP-related behavior, contracts, tests, and design decisions.
+
+## Approach
+1. Inspect the relevant diff, tests, and touched files first.
+2. Check whether the implementation matches MCP semantics, message flow, and capability negotiation rules.
+3. Verify JSON-RPC envelope handling, request and notification semantics, error mapping, and schema expectations.
+4. Look for cases where the implementation is technically valid but operationally awkward, overly rigid, or likely to break interoperating clients and servers.
+5. Prioritize findings by severity, with concrete file references and reasoning.
+6. Call out missing tests only when they protect important protocol or compatibility behavior.
+
+## Output Format
+Start with findings only.
+
+For each finding, include:
+- severity
+- the impacted file and function
+- the specific protocol, semantic, or interoperability problem
+- why it matters in practice
+
+After findings, include:
+- open questions or assumptions
+- a brief summary of residual risk if no findings were identified
+
+Keep the review concise and evidence-based.

--- a/client/mcp.go
+++ b/client/mcp.go
@@ -1,0 +1,82 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// MCPResult describes the JSON-RPC payload returned by the daemon MCP endpoint.
+// Notifications have no corresponding response and are represented with
+// HasResponse set to false.
+type MCPResult struct {
+	Payload     json.RawMessage
+	HasResponse bool
+}
+
+// MCP sends one MCP JSON-RPC payload to the daemon MCP endpoint and returns
+// the inner MCP response payload from the snapd sync envelope.
+func (client *Client) MCP(ctx context.Context, payload []byte) (MCPResult, error) {
+	// Force interactive authorization on every call. The MCP bridge normally
+	// runs without a controlling TTY (e.g. as a background agent for Copilot
+	// or similar tools), but polkit still needs to be able to pop an auth
+	// dialog when the daemon requires it for the blanket /v2/mcp access.
+	//
+	// In the future individual tools may carry their own authorization
+	// requirements, mirroring the per-endpoint access-control model already
+	// used by the REST API. At that point this flag can become conditional on
+	// the specific tool being invoked rather than being set unconditionally.
+	client.interactive = true
+
+	rsp, err := client.raw(ctx, "POST", "/v2/mcp", nil, nil, bytes.NewReader(payload))
+	if err != nil {
+		return MCPResult{}, err
+	}
+	defer rsp.Body.Close()
+
+	var envelope response
+	if err := decodeInto(rsp.Body, &envelope); err != nil {
+		return MCPResult{}, err
+	}
+	if err := envelope.err(client, rsp.StatusCode); err != nil {
+		return MCPResult{}, err
+	}
+	if envelope.Type != "sync" {
+		return MCPResult{}, fmt.Errorf("expected sync response, got %q", envelope.Type)
+	}
+
+	client.warningCount = envelope.WarningCount
+	client.warningTimestamp = envelope.WarningTimestamp
+
+	if len(envelope.Result) == 0 {
+		return MCPResult{}, fmt.Errorf("missing MCP response payload in sync result")
+	}
+	if string(envelope.Result) == "null" {
+		return MCPResult{}, nil
+	}
+
+	return MCPResult{
+		Payload:     envelope.Result,
+		HasResponse: true,
+	}, nil
+}

--- a/client/mcp_test.go
+++ b/client/mcp_test.go
@@ -1,0 +1,102 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package client_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"time"
+
+	"github.com/snapcore/snapd/client"
+	. "gopkg.in/check.v1"
+)
+
+func (cs *clientSuite) TestClientMCP(c *C) {
+	cs.rsp = `{"type":"sync","result":{"jsonrpc":"2.0","id":1,"result":{}}}`
+
+	result, err := cs.cli.MCP(context.Background(), []byte(`{"jsonrpc":"2.0","id":1,"method":"ping"}`))
+	c.Assert(err, IsNil)
+	c.Check(result, DeepEquals, client.MCPResult{
+		Payload:     json.RawMessage(`{"jsonrpc":"2.0","id":1,"result":{}}`),
+		HasResponse: true,
+	})
+	c.Check(cs.reqs, HasLen, 1)
+	c.Check(cs.reqs[0].Method, Equals, "POST")
+	c.Check(cs.reqs[0].URL.Path, Equals, "/v2/mcp")
+	body, err := io.ReadAll(cs.reqs[0].Body)
+	c.Assert(err, IsNil)
+	c.Check(string(body), Equals, `{"jsonrpc":"2.0","id":1,"method":"ping"}`)
+}
+
+func (cs *clientSuite) TestClientMCPUpdatesWarningsSummary(c *C) {
+	stamp := time.Date(2026, time.January, 2, 3, 4, 5, 0, time.UTC)
+	cs.rsp = `{"type":"sync","result":{"jsonrpc":"2.0","id":1,"result":{}},"warning-count":2,"warning-timestamp":"` + stamp.Format(time.RFC3339) + `"}`
+
+	_, err := cs.cli.MCP(context.Background(), []byte(`{"jsonrpc":"2.0","id":1,"method":"ping"}`))
+	c.Assert(err, IsNil)
+
+	count, gotStamp := cs.cli.WarningsSummary()
+	c.Check(count, Equals, 2)
+	c.Check(gotStamp, Equals, stamp)
+}
+
+func (cs *clientSuite) TestClientMCPReturnsDaemonError(c *C) {
+	cs.status = 400
+	cs.rsp = `{"type":"error","result":{"message":"boom"}}`
+
+	result, err := cs.cli.MCP(context.Background(), []byte(`{"jsonrpc":"2.0","id":1,"method":"ping"}`))
+	c.Check(result, DeepEquals, client.MCPResult{})
+	c.Assert(err, NotNil)
+	c.Check(err.Error(), Equals, "boom")
+}
+
+func (cs *clientSuite) TestClientMCPRejectsInvalidEnvelope(c *C) {
+	cs.rsp = `{`
+
+	result, err := cs.cli.MCP(context.Background(), []byte(`{"jsonrpc":"2.0","id":1,"method":"ping"}`))
+	c.Check(result, DeepEquals, client.MCPResult{})
+	c.Assert(err, NotNil)
+	c.Check(err.Error(), Matches, `cannot decode .*|cannot unmarshal .*|unexpected EOF`)
+}
+
+func (cs *clientSuite) TestClientMCPRejectsNonSyncResponse(c *C) {
+	cs.rsp = `{"type":"async","result":{"jsonrpc":"2.0","id":1,"result":{}}}`
+
+	result, err := cs.cli.MCP(context.Background(), []byte(`{"jsonrpc":"2.0","id":1,"method":"ping"}`))
+	c.Check(result, DeepEquals, client.MCPResult{})
+	c.Assert(err, ErrorMatches, `expected sync response, got "async"`)
+}
+
+func (cs *clientSuite) TestClientMCPReturnsNoResponseForNotification(c *C) {
+	cs.rsp = `{"type":"sync","result":null}`
+
+	result, err := cs.cli.MCP(context.Background(), []byte(`{"jsonrpc":"2.0","method":"notifications/initialized"}`))
+	c.Assert(err, IsNil)
+	c.Check(result, DeepEquals, client.MCPResult{})
+}
+
+func (cs *clientSuite) TestClientMCPRejectsMissingSyncResult(c *C) {
+	cs.rsp = `{"type":"sync"}`
+
+	result, err := cs.cli.MCP(context.Background(), []byte(`{"jsonrpc":"2.0","id":1,"method":"ping"}`))
+	c.Check(result, DeepEquals, client.MCPResult{})
+	c.Assert(err, ErrorMatches, `missing MCP response payload in sync result`)
+}

--- a/cmd/snap/cmd_mcp.go
+++ b/cmd/snap/cmd_mcp.go
@@ -1,0 +1,158 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/jessevdk/go-flags"
+
+	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/i18n"
+)
+
+type mcpBridgeClient interface {
+	MCP(ctx context.Context, payload []byte) (client.MCPResult, error)
+}
+
+type cmdMCP struct {
+	clientMixin
+}
+
+var shortMCPHelp = i18n.G("Bridge to the Model Context Protocol endpoint")
+var longMCPHelp = i18n.G(`
+The mcp command acts as a bridge to the Model Context Protocol (MCP)
+endpoint exposed by snapd. It reads MCP requests from stdin and writes
+responses to stdout.
+
+This command is typically used by MCP clients like Copilot or Lemonade
+to query information about snaps on the local system.
+`)
+
+func init() {
+	cmd := addCommand("mcp",
+		shortMCPHelp,
+		longMCPHelp,
+		func() flags.Commander {
+			return &cmdMCP{}
+		}, map[string]string{},
+		[]argDesc{},
+	)
+	cmd.hidden = true
+}
+
+func (x *cmdMCP) Execute(args []string) error {
+	if len(args) > 0 {
+		return ErrExtraArgs
+	}
+
+	return bridgeToMCPEndpoint(Stdin, Stdout, x.client)
+}
+
+func bridgeToMCPEndpoint(stdin io.Reader, stdout io.Writer, cl mcpBridgeClient) error {
+	reader := bufio.NewReader(stdin)
+	for {
+		// Read frame (skip empty lines)
+		payload, err := readFrame(reader)
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			// Send parse error response
+			errResp := map[string]any{
+				"jsonrpc": "2.0",
+				"error": map[string]any{
+					"code":    -32700,
+					"message": fmt.Sprintf("cannot decode request: %v", err),
+				},
+			}
+			_ = writeFrame(stdout, errResp)
+			continue
+		}
+
+		// Send request to the daemon's MCP endpoint
+		response, err := cl.MCP(context.Background(), payload)
+		if err != nil {
+			// Send error response
+			errResp := map[string]any{
+				"jsonrpc": "2.0",
+				"error": map[string]any{
+					"code":    -32603,
+					"message": fmt.Sprintf("cannot send request to snapd: %v", err),
+				},
+			}
+			_ = writeFrame(stdout, errResp)
+			continue
+		}
+
+		if !response.HasResponse {
+			continue
+		}
+		if len(response.Payload) == 0 {
+			return fmt.Errorf("cannot forward empty response from snapd")
+		}
+
+		// Write the extracted MCP JSON-RPC response frame
+		if _, err := stdout.Write(response.Payload); err != nil {
+			return err
+		}
+		if _, err := stdout.Write([]byte{'\n'}); err != nil {
+			return err
+		}
+	}
+}
+
+// readFrame reads a line-delimited JSON frame from the reader, skipping empty lines.
+func readFrame(r *bufio.Reader) ([]byte, error) {
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			if err == io.EOF && line == "" {
+				return nil, io.EOF
+			}
+			if err == io.EOF && len(line) > 0 {
+				// partial last line with no terminating newline
+				return []byte(strings.TrimRight(line, "\r\n")), nil
+			}
+			return nil, err
+		}
+		trimmed := strings.TrimRight(line, "\r\n")
+		if trimmed == "" {
+			continue // skip empty lines
+		}
+		return []byte(trimmed), nil
+	}
+}
+
+// writeFrame writes a JSON-marshaled object followed by a newline.
+func writeFrame(w io.Writer, payload any) error {
+	buf, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	buf = append(buf, '\n')
+	_, err = w.Write(buf)
+	return err
+}

--- a/cmd/snap/cmd_mcp_test.go
+++ b/cmd/snap/cmd_mcp_test.go
@@ -1,0 +1,198 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	"github.com/snapcore/snapd/client"
+	. "gopkg.in/check.v1"
+)
+
+type mcpSuite struct{}
+
+var _ = Suite(&mcpSuite{})
+
+type fakeMCPBridgeClient struct {
+	response client.MCPResult
+	err      error
+	body     string
+}
+
+type errWriter struct{}
+
+func (errWriter) Write(p []byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+func (f *fakeMCPBridgeClient) MCP(ctx context.Context, payload []byte) (client.MCPResult, error) {
+	_ = ctx
+	f.body = string(payload)
+	if f.err != nil {
+		return client.MCPResult{}, f.err
+	}
+	return f.response, nil
+}
+
+func (s *mcpSuite) TestBridgeToMCPEndpointWritesDaemonResponse(c *C) {
+	stdin := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"ping"}` + "\n")
+	stdout := &bytes.Buffer{}
+	client := &fakeMCPBridgeClient{
+		response: client.MCPResult{Payload: []byte(`{"jsonrpc":"2.0","id":1,"result":{}}`), HasResponse: true},
+	}
+
+	err := bridgeToMCPEndpoint(stdin, stdout, client)
+	c.Assert(err, IsNil)
+	c.Check(client.body, Equals, `{"jsonrpc":"2.0","id":1,"method":"ping"}`)
+	c.Check(stdout.String(), Equals, `{"jsonrpc":"2.0","id":1,"result":{}}`+"\n")
+}
+
+func (s *mcpSuite) TestBridgeSkipsNotificationWithNullResult(c *C) {
+	stdin := strings.NewReader(`{"jsonrpc":"2.0","method":"notifications/initialized"}` + "\n")
+	stdout := &bytes.Buffer{}
+	client := &fakeMCPBridgeClient{
+		response: client.MCPResult{},
+	}
+
+	err := bridgeToMCPEndpoint(stdin, stdout, client)
+	c.Assert(err, IsNil)
+	// Notifications receive no MCP response
+	c.Check(stdout.String(), Equals, "")
+}
+
+func (s *mcpSuite) TestBridgeToMCPEndpointReportsDecodeError(c *C) {
+	// Malformed JSON (single open brace) is forwarded to the daemon as-is.
+	stdin := strings.NewReader("{\n")
+	stdout := &bytes.Buffer{}
+	client := &fakeMCPBridgeClient{
+		response: client.MCPResult{Payload: []byte(`{"jsonrpc":"2.0","error":{"code":-32700,"message":"cannot decode request: unexpected end of JSON input"}}`), HasResponse: true},
+	}
+
+	err := bridgeToMCPEndpoint(stdin, stdout, client)
+	c.Assert(err, IsNil)
+	c.Check(stdout.String(), Matches, `(?s).*"message":"cannot decode request: .*".*`)
+}
+
+func (s *mcpSuite) TestBridgeToMCPEndpointReportsSnapdRequestError(c *C) {
+	stdin := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"ping"}` + "\n")
+	stdout := &bytes.Buffer{}
+	client := &fakeMCPBridgeClient{err: errors.New("boom")}
+
+	err := bridgeToMCPEndpoint(stdin, stdout, client)
+	c.Assert(err, IsNil)
+	c.Check(stdout.String(), Matches, `(?s).*"message":"cannot send request to snapd: boom".*`)
+}
+
+func (s *mcpSuite) TestBridgeToMCPEndpointTranslatesToSnapdHTTPCall(c *C) {
+	var seenMethod, seenPath, seenBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenMethod = r.Method
+		seenPath = r.URL.Path
+		body, err := io.ReadAll(r.Body)
+		c.Assert(err, IsNil)
+		seenBody = string(body)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err = w.Write([]byte(`{"type":"sync","result":{"jsonrpc":"2.0","id":1,"result":{"pong":true}}}`))
+		c.Assert(err, IsNil)
+	}))
+	defer srv.Close()
+
+	stdin := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"ping"}` + "\n")
+	stdout := &bytes.Buffer{}
+	cli := client.New(&client.Config{BaseURL: srv.URL, DisableAuth: true})
+
+	err := bridgeToMCPEndpoint(stdin, stdout, cli)
+	c.Assert(err, IsNil)
+	c.Check(seenMethod, Equals, "POST")
+	c.Check(seenPath, Equals, "/v2/mcp")
+	c.Check(seenBody, Equals, `{"jsonrpc":"2.0","id":1,"method":"ping"}`)
+	c.Check(stdout.String(), Equals, `{"jsonrpc":"2.0","id":1,"result":{"pong":true}}`+"\n")
+}
+
+func (s *mcpSuite) TestReadFrameSkipsEmptyLines(c *C) {
+	frame, err := readFrame(bufio.NewReader(strings.NewReader("\n\r\n{\"jsonrpc\":\"2.0\"}\n")))
+	c.Assert(err, IsNil)
+	c.Check(string(frame), Equals, `{"jsonrpc":"2.0"}`)
+}
+
+func (s *mcpSuite) TestReadFrameReturnsPartialLastLine(c *C) {
+	frame, err := readFrame(bufio.NewReader(strings.NewReader(`{"jsonrpc":"2.0"}`)))
+	c.Assert(err, IsNil)
+	c.Check(string(frame), Equals, `{"jsonrpc":"2.0"}`)
+}
+
+func (s *mcpSuite) TestWriteFrameMarshalError(c *C) {
+	err := writeFrame(&bytes.Buffer{}, map[string]any{"bad": func() {}})
+	c.Assert(err, NotNil)
+}
+
+func (s *mcpSuite) TestBridgeToMCPEndpointReturnsWriteError(c *C) {
+	stdin := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"ping"}` + "\n")
+	client := &fakeMCPBridgeClient{response: client.MCPResult{Payload: []byte(`{"jsonrpc":"2.0","id":1,"result":{}}`), HasResponse: true}}
+
+	err := bridgeToMCPEndpoint(stdin, errWriter{}, client)
+	c.Assert(err, ErrorMatches, `write failed`)
+}
+
+func (s *mcpSuite) TestBridgeRejectsEmptyResponse(c *C) {
+	stdin := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"ping"}` + "\n")
+	stdout := &bytes.Buffer{}
+	client := &fakeMCPBridgeClient{response: client.MCPResult{HasResponse: true}}
+
+	err := bridgeToMCPEndpoint(stdin, stdout, client)
+	c.Assert(err, ErrorMatches, `cannot forward empty response from snapd`)
+	c.Check(stdout.String(), Equals, "")
+}
+
+func (s *mcpSuite) TestReadFrameEOF(c *C) {
+	frame, err := readFrame(bufio.NewReader(strings.NewReader("")))
+	c.Check(frame, IsNil)
+	c.Assert(err, Equals, io.EOF)
+}
+
+func (s *mcpSuite) TestWriteFrameSuccess(c *C) {
+	buf := &bytes.Buffer{}
+	err := writeFrame(buf, map[string]any{"jsonrpc": "2.0"})
+	c.Assert(err, IsNil)
+	c.Check(buf.String(), Equals, "{\"jsonrpc\":\"2.0\"}\n")
+}
+
+func (s *mcpSuite) TestCmdMCPExecute(c *C) {
+	oldStdin, oldStdout := Stdin, Stdout
+	defer func() {
+		Stdin = oldStdin
+		Stdout = oldStdout
+	}()
+
+	Stdin = strings.NewReader("")
+	Stdout = &bytes.Buffer{}
+
+	cmd := &cmdMCP{}
+	c.Check(cmd.Execute([]string{"extra"}), Equals, ErrExtraArgs)
+	c.Check(cmd.Execute(nil), IsNil)
+}

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -95,6 +95,7 @@ var api = []*Command{
 	requestsRuleCmd,
 	systemSecurebootCmd,
 	systemVolumesCmd,
+	mcpCmd,
 }
 
 type featureEndpoint struct {
@@ -136,6 +137,7 @@ const (
 	polkitActionManageInterfaces    = "io.snapcraft.snapd.manage-interfaces"
 	polkitActionManageConfiguration = "io.snapcraft.snapd.manage-configuration"
 	polkitActionManageFDE           = "io.snapcraft.snapd.manage-fde"
+	polkitActionUseMCP              = "io.snapcraft.snapd.mcp"
 )
 
 // userFromRequest extracts user information from request and return the

--- a/daemon/api_confdb.go
+++ b/daemon/api_confdb.go
@@ -212,7 +212,7 @@ func validateFeatureFlag(st *state.State, feature features.SnapdFeature) *apiErr
 	if !enabled {
 		_, confName := feature.ConfigOption()
 		return BadRequest(
-			fmt.Sprintf(`feature flag %q is disabled: set '%s' to true`, feature, confName),
+			fmt.Sprintf(`feature flag %q is disabled, enable with: snap set system %s=true`, feature, confName),
 		)
 	}
 	return nil

--- a/daemon/api_confdb_test.go
+++ b/daemon/api_confdb_test.go
@@ -512,7 +512,7 @@ func (s *confdbSuite) TestSetFailUnsetFeatureFlag(c *C) {
 
 	rspe := s.errorReq(c, req, nil, actionIsExpected)
 	c.Check(rspe.Status, Equals, 400)
-	c.Check(rspe.Message, Equals, `feature flag "confdb" is disabled: set 'experimental.confdb' to true`)
+	c.Check(rspe.Message, Equals, `feature flag "confdb" is disabled, enable with: snap set system experimental.confdb=true`)
 	c.Check(rspe.Kind, Equals, client.ErrorKind(""))
 }
 
@@ -522,7 +522,7 @@ func (s *confdbSuite) TestGetFailUnsetFeatureFlag(c *C) {
 
 	rspe := s.errorReq(c, req, nil, actionIsExpected)
 	c.Check(rspe.Status, Equals, 400)
-	c.Check(rspe.Message, Equals, `feature flag "confdb" is disabled: set 'experimental.confdb' to true`)
+	c.Check(rspe.Message, Equals, `feature flag "confdb" is disabled, enable with: snap set system experimental.confdb=true`)
 	c.Check(rspe.Kind, Equals, client.ErrorKind(""))
 }
 
@@ -733,7 +733,7 @@ func (s *confdbControlSuite) TestConfdbFlagNotEnabled(c *C) {
 
 	rspe := s.errorReq(c, req, nil, actionIsExpected)
 	c.Check(rspe.Status, Equals, 400)
-	c.Check(rspe.Message, Equals, `feature flag "confdb" is disabled: set 'experimental.confdb' to true`)
+	c.Check(rspe.Message, Equals, `feature flag "confdb" is disabled, enable with: snap set system experimental.confdb=true`)
 }
 
 func (s *confdbControlSuite) TestConfdbControlFlagNotEnabled(c *C) {
@@ -742,9 +742,9 @@ func (s *confdbControlSuite) TestConfdbControlFlagNotEnabled(c *C) {
 	req, err := http.NewRequest("POST", "/v2/confdb", nil)
 	c.Assert(err, IsNil)
 
-	rspe := s.errorReq(c, req, nil, actionIsExpected)
-	c.Check(rspe.Status, Equals, 400)
-	c.Check(rspe.Message, Equals, `feature flag "confdb-control" is disabled: set 'experimental.confdb-control' to true`)
+	rsps := s.errorReq(c, req, nil, actionIsExpected)
+	c.Check(rsps.Status, Equals, 400)
+	c.Check(rsps.Message, Equals, `feature flag "confdb-control" is disabled, enable with: snap set system experimental.confdb-control=true`)
 }
 
 func (s *confdbControlSuite) TestConfdbControlActionNoSerial(c *C) {

--- a/daemon/api_mcp.go
+++ b/daemon/api_mcp.go
@@ -1,0 +1,94 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package daemon
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/snapcore/snapd/features"
+	"github.com/snapcore/snapd/overlord/auth"
+)
+
+// maxMCPRequestBodyBytes limits the size of the request body for MCP requests
+// to prevent abuse. The actual limit can be adjusted as needed.
+const maxMCPRequestBodyBytes = 1024 * 1024
+
+var mcpCmd = &Command{
+	Path: "/v2/mcp",
+	POST: postMCP,
+	// This part is tricky as we want to allow both unauthenticated access
+	// (e.g. snap list, snap info equivalents) and authenticated access (e.g.
+	// snap install, snap remove equivalents).  For now everything is
+	// authenticated for simplicity. This makes the first request in an MCP
+	// session pull up the polkit request.
+	//
+	// As an alternative we could have more fine grained access control by
+	// attaching meta-data to individual resources and tools and only require
+	// authentication for those that need it.
+	WriteAccess: authenticatedAccess{Polkit: polkitActionUseMCP},
+}
+
+func postMCP(c *Command, r *http.Request, user *auth.UserState) Response {
+	_ = c
+	_ = user
+
+	st := c.d.state
+	st.Lock()
+	flagErr := validateFeatureFlag(st, features.MCP)
+	st.Unlock()
+	if flagErr != nil {
+		return flagErr
+	}
+
+	// Read the request body up to the limit.
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxMCPRequestBodyBytes+1))
+	if err != nil {
+		return BadRequest("cannot read request body: %v", err)
+	}
+	if len(body) > maxMCPRequestBodyBytes {
+		return BadRequest("request body too large (limit %d bytes)", maxMCPRequestBodyBytes)
+	}
+
+	mcpMgr := c.d.overlord.ModelContextProtocolManager()
+	if mcpMgr == nil {
+		return InternalError("cannot process MCP request: mcp manager is not initialized")
+	}
+
+	// Process the request and get response.
+	response, err := mcpMgr.ProcessRequest(r.Context(), body)
+	if err != nil {
+		return InternalError("cannot process MCP request: %v", err)
+	}
+
+	// Notifications (no id in request) produce no response.
+	if response == nil {
+		return SyncResponse(nil)
+	}
+
+	// Return the response as a raw JSON message wrapped in the standard response
+	var mcpResp any
+	if err := json.Unmarshal(response, &mcpResp); err != nil {
+		return InternalError("cannot parse MCP response: %v", err)
+	}
+
+	return SyncResponse(mcpResp)
+}

--- a/daemon/api_mcp_test.go
+++ b/daemon/api_mcp_test.go
@@ -1,0 +1,193 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package daemon_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http/httptest"
+	"strings"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/daemon"
+	"github.com/snapcore/snapd/features"
+	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+)
+
+type failingReadCloser struct{}
+
+func (failingReadCloser) Read(p []byte) (int, error) {
+	return 0, errors.New("boom")
+}
+
+func (failingReadCloser) Close() error {
+	return nil
+}
+
+type mcpSuite struct {
+	apiBaseSuite
+}
+
+var _ = Suite(&mcpSuite{})
+
+func (s *mcpSuite) setFeatureFlag(c *C, st *state.State) {
+	_, confOption := features.MCP.ConfigOption()
+
+	st.Lock()
+	defer st.Unlock()
+
+	tr := config.NewTransaction(st)
+	err := tr.Set("core", confOption, true)
+	c.Assert(err, IsNil)
+	tr.Commit()
+}
+
+func (s *mcpSuite) TestPostMCPReturnsProcessorResponse(c *C) {
+	d := s.daemon(c)
+	st := d.Overlord().State()
+	s.setFeatureFlag(c, st)
+
+	// Add a snap to the state
+	st.Lock()
+	snapst := &snapstate.SnapState{
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "test-snap", Revision: snap.R(1)},
+		}),
+		Current: snap.R(1),
+		Active:  true,
+	}
+	snapstate.Set(st, "test-snap", snapst)
+	st.Unlock()
+
+	s.expectWriteAccess(daemon.AuthenticatedAccess{Polkit: "io.snapcraft.snapd.mcp"})
+
+	req := httptest.NewRequest("POST", "/v2/mcp", bytes.NewBufferString(`{"jsonrpc":"2.0","id":1,"method":"ping"}`))
+	rec := httptest.NewRecorder()
+
+	s.req(c, req, nil, actionIsExpected).ServeHTTP(rec, nil)
+	c.Check(rec.Code, Equals, 200)
+	c.Check(rec.Body.String(), Matches, `(?s).*"type":"sync".*"result":\{.*\}.*`)
+
+	var rsp daemon.RespJSON
+	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
+	c.Check(rsp.Type, Equals, daemon.ResponseTypeSync)
+	result := rsp.Result.(map[string]any)
+	c.Check(result["jsonrpc"], Equals, "2.0")
+	c.Check(result["id"], Equals, float64(1))
+	c.Check(result["result"], DeepEquals, map[string]any{})
+}
+
+func (s *mcpSuite) TestPostMCPWithInvalidJSONReturnsParseError(c *C) {
+	d := s.daemon(c)
+	s.setFeatureFlag(c, d.Overlord().State())
+	s.expectWriteAccess(daemon.AuthenticatedAccess{Polkit: "io.snapcraft.snapd.mcp"})
+
+	req := httptest.NewRequest("POST", "/v2/mcp", bytes.NewBufferString(`{`))
+	rec := httptest.NewRecorder()
+
+	s.req(c, req, nil, actionIsExpected).ServeHTTP(rec, nil)
+	c.Check(rec.Code, Equals, 200)
+
+	var rsp daemon.RespJSON
+	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
+	result := rsp.Result.(map[string]any)
+	errorObj := result["error"].(map[string]any)
+	c.Check(errorObj["code"], Equals, float64(-32700))
+}
+
+func (s *mcpSuite) TestPostMCPRejectsOversizedRequest(c *C) {
+	d := s.daemon(c)
+	s.setFeatureFlag(c, d.Overlord().State())
+	s.expectWriteAccess(daemon.AuthenticatedAccess{Polkit: "io.snapcraft.snapd.mcp"})
+
+	oversized := strings.Repeat("x", 1024*1024+1)
+	req := httptest.NewRequest("POST", "/v2/mcp", bytes.NewBufferString(oversized))
+	rec := httptest.NewRecorder()
+
+	s.req(c, req, nil, actionIsExpected).ServeHTTP(rec, nil)
+	c.Check(rec.Code, Equals, 400)
+
+	var rsp daemon.RespJSON
+	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
+	c.Check(rsp.Type, Equals, daemon.ResponseTypeError)
+	errResult := rsp.Result.(map[string]any)
+	c.Check(errResult["message"], Matches, "request body too large.*")
+}
+
+func (s *mcpSuite) TestPostMCPFeatureFlagDisabled(c *C) {
+	s.daemon(c)
+	s.expectWriteAccess(daemon.AuthenticatedAccess{Polkit: "io.snapcraft.snapd.mcp"})
+
+	req := httptest.NewRequest("POST", "/v2/mcp", bytes.NewBufferString(`{"jsonrpc":"2.0","id":1,"method":"ping"}`))
+	rec := httptest.NewRecorder()
+
+	s.req(c, req, nil, actionIsExpected).ServeHTTP(rec, nil)
+	c.Check(rec.Code, Equals, 400)
+
+	var rsp daemon.RespJSON
+	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
+	c.Check(rsp.Type, Equals, daemon.ResponseTypeError)
+	errResult := rsp.Result.(map[string]any)
+	c.Check(errResult["message"], Equals, `feature flag "mcp" is disabled, enable with: snap set system experimental.mcp=true`)
+}
+
+func (s *mcpSuite) TestPostMCPNotificationReturnsNilResult(c *C) {
+	d := s.daemon(c)
+	s.setFeatureFlag(c, d.Overlord().State())
+	s.expectWriteAccess(daemon.AuthenticatedAccess{Polkit: "io.snapcraft.snapd.mcp"})
+
+	req := httptest.NewRequest("POST", "/v2/mcp", bytes.NewBufferString(`{"jsonrpc":"2.0","method":"notifications/initialized"}`))
+	rec := httptest.NewRecorder()
+
+	s.req(c, req, nil, actionIsExpected).ServeHTTP(rec, nil)
+	c.Check(rec.Code, Equals, 200)
+	c.Check(rec.Body.String(), Matches, `(?s).*"type":"sync".*"result":null.*`)
+
+	var rsp daemon.RespJSON
+	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
+	c.Check(rsp.Type, Equals, daemon.ResponseTypeSync)
+	c.Check(rsp.Result, IsNil)
+}
+
+func (s *mcpSuite) TestPostMCPReadBodyError(c *C) {
+	d := s.daemon(c)
+	s.setFeatureFlag(c, d.Overlord().State())
+	s.expectWriteAccess(daemon.AuthenticatedAccess{Polkit: "io.snapcraft.snapd.mcp"})
+
+	req := httptest.NewRequest("POST", "/v2/mcp", io.NopCloser(strings.NewReader("")))
+	req.Body = failingReadCloser{}
+	rec := httptest.NewRecorder()
+
+	s.req(c, req, nil, actionIsUnexpected).ServeHTTP(rec, nil)
+	c.Check(rec.Code, Equals, 400)
+
+	var rsp daemon.RespJSON
+	c.Assert(json.Unmarshal(rec.Body.Bytes(), &rsp), IsNil)
+	c.Check(rsp.Type, Equals, daemon.ResponseTypeError)
+	errResult := rsp.Result.(map[string]any)
+	c.Check(errResult["message"], Matches, `cannot read request body: boom`)
+}

--- a/data/polkit/io.snapcraft.snapd.policy
+++ b/data/polkit/io.snapcraft.snapd.policy
@@ -57,4 +57,14 @@
     </defaults>
   </action>
 
+  <action id="io.snapcraft.snapd.mcp">
+    <description gettext-domain="snappy">Use Model Context Protocol</description>
+    <message gettext-domain="snappy">Authentication is required to use the snapd Model Context Protocol server</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+  </action>
+
 </policyconfig>

--- a/features/features.go
+++ b/features/features.go
@@ -85,6 +85,8 @@ const (
 	SeedRefresh
 	// SnapDeltaFormat enables deltas that use the "snap delta" format
 	SnapDeltaFormat
+	// MCP enables experimental model context protocol support.
+	MCP
 	// lastFeature is the final known feature, it is only used for testing.
 	lastFeature
 )
@@ -141,6 +143,8 @@ var featureNames = map[SnapdFeature]string{
 	SeedRefresh: "seed-refresh",
 
 	SnapDeltaFormat: "snap-delta-format",
+
+	MCP: "mcp",
 }
 
 // featuresEnabledWhenUnset contains a set of features that are enabled when not explicitly configured.

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -69,6 +69,7 @@ func (*featureSuite) TestName(c *C) {
 	check(features.RemoteDeviceManagement, "remote-device-management")
 	check(features.SeedRefresh, "seed-refresh")
 	check(features.SnapDeltaFormat, "snap-delta-format")
+	check(features.MCP, "mcp")
 
 	c.Check(tested, Equals, features.NumberOfFeatures())
 	c.Check(func() { _ = features.SnapdFeature(1000).String() }, PanicMatches, "unknown feature flag code 1000")
@@ -114,6 +115,7 @@ func (*featureSuite) TestIsExported(c *C) {
 	check(features.RemoteDeviceManagement, false)
 	check(features.SeedRefresh, false)
 	check(features.SnapDeltaFormat, false)
+	check(features.MCP, false)
 
 	c.Check(tested, Equals, features.NumberOfFeatures())
 }
@@ -244,6 +246,7 @@ func (*featureSuite) TestIsEnabledWhenUnset(c *C) {
 	check(features.RemoteDeviceManagement, false)
 	check(features.SeedRefresh, false)
 	check(features.SnapDeltaFormat, false)
+	check(features.MCP, false)
 
 	c.Check(tested, Equals, features.NumberOfFeatures())
 }

--- a/overlord/ifacestate/export_test.go
+++ b/overlord/ifacestate/export_test.go
@@ -31,6 +31,24 @@ import (
 	"github.com/snapcore/snapd/timings"
 )
 
+type MCPConnectionResult struct {
+	Ref   *interfaces.ConnRef
+	State ConnectionState
+}
+
+func ConnectionsToMap(conns []MCPConnectionResult, snapFilter string) map[string]any {
+	internal := make([]connectionResult, 0, len(conns))
+	for _, conn := range conns {
+		internal = append(internal, connectionResult{ref: conn.Ref, state: conn.State})
+	}
+	return connectionsToMap(internal, snapFilter)
+}
+
+type ListConnectionsTool = listConnectionsTool
+type ListPlugsTool = listPlugsTool
+type ListSlotsTool = listSlotsTool
+type ListInterfaceTypesTool = listInterfaceTypesTool
+
 var (
 	AddImplicitInterfaces        = addImplicitInterfaces
 	SnapsWithSecurityProfiles    = snapsWithSecurityProfiles

--- a/overlord/ifacestate/ifacestate.go
+++ b/overlord/ifacestate/ifacestate.go
@@ -34,6 +34,7 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/hookstate"
+	"github.com/snapcore/snapd/overlord/mcp"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/overlord/swfeats"
@@ -564,6 +565,10 @@ func delayedCrossMgrInit() {
 		snapstate.AddLinkSnapParticipant(snapstate.LinkSnapParticipantFunc(OnSnapLinkageChanged))
 
 		snapstate.ProcessDelayedSecurityBackendEffects = ProcessDelayedSecurityBackendEffects
+		mcp.RegisterTool(listConnectionsTool{})
+		mcp.RegisterTool(listPlugsTool{})
+		mcp.RegisterTool(listSlotsTool{})
+		mcp.RegisterTool(listInterfaceTypesTool{})
 	})
 }
 

--- a/overlord/ifacestate/mcp.go
+++ b/overlord/ifacestate/mcp.go
@@ -1,0 +1,197 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ifacestate
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/configfiles"
+	"github.com/snapcore/snapd/interfaces/dbus"
+	"github.com/snapcore/snapd/interfaces/kmod"
+	"github.com/snapcore/snapd/interfaces/ldconfig"
+	"github.com/snapcore/snapd/interfaces/polkit"
+	"github.com/snapcore/snapd/interfaces/seccomp"
+	"github.com/snapcore/snapd/interfaces/symlinks"
+	"github.com/snapcore/snapd/interfaces/systemd"
+	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
+	"github.com/snapcore/snapd/overlord/mcp"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+)
+
+var readOnlyToolExecution = mcp.ToolExecution{TaskSupport: mcp.ToolTaskSupportForbidden}
+
+func validateOptionalString(args map[string]any, name string) error {
+	v, ok := args[name]
+	if !ok {
+		return nil
+	}
+	if _, ok := v.(string); !ok {
+		return fmt.Errorf("%s must be a string", name)
+	}
+	return nil
+}
+
+func validateOptionalBool(args map[string]any, name string) error {
+	v, ok := args[name]
+	if !ok {
+		return nil
+	}
+	if _, ok := v.(bool); !ok {
+		return fmt.Errorf("%s must be a boolean", name)
+	}
+	return nil
+}
+
+func repoFromState(st *state.State) (repo *interfaces.Repository, err error) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			err = fmt.Errorf("cannot access interface repository: %v", rec)
+		}
+	}()
+
+	st.Lock()
+	defer st.Unlock()
+
+	repo = ifacerepo.Get(st)
+	return repo, nil
+}
+
+func plugToMap(plug *snap.PlugInfo, includeDetails bool) map[string]any {
+	result := map[string]any{
+		"snap_name": plug.Snap.InstanceName(),
+		"name":      plug.Name,
+		"interface": plug.Interface,
+	}
+	if !includeDetails {
+		return result
+	}
+
+	attrs := plug.Attrs
+	if attrs == nil {
+		attrs = map[string]any{}
+	}
+	result["label"] = plug.Label
+	result["attrs"] = attrs
+	result["apps"] = sortedAppNames(plug.Apps)
+	result["unscoped"] = plug.Unscoped
+	return result
+}
+
+func slotToMap(slot *snap.SlotInfo, includeDetails bool) map[string]any {
+	result := map[string]any{
+		"snap_name": slot.Snap.InstanceName(),
+		"name":      slot.Name,
+		"interface": slot.Interface,
+	}
+	if !includeDetails {
+		return result
+	}
+
+	attrs := slot.Attrs
+	if attrs == nil {
+		attrs = map[string]any{}
+	}
+	result["label"] = slot.Label
+	result["attrs"] = attrs
+	result["apps"] = sortedAppNames(slot.Apps)
+	result["unscoped"] = slot.Unscoped
+	result["hotplug_key"] = string(slot.HotplugKey)
+	return result
+}
+
+func sortedAppNames(apps map[string]*snap.AppInfo) []string {
+	names := make([]string, 0, len(apps))
+	for name := range apps {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func implementedBackends(iface interfaces.Interface) []string {
+	type appArmorBackend interface {
+		AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
+	}
+	type seccompBackend interface {
+		SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
+	}
+	type udevBackend interface {
+		UDevConnectedPlug(spec *udev.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
+	}
+	type kmodBackend interface {
+		KModConnectedPlug(spec *kmod.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
+	}
+	type dbusBackend interface {
+		DBusConnectedPlug(spec *dbus.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
+	}
+	type configfilesBackend interface {
+		ConfigfilesConnectedPlug(spec *configfiles.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
+	}
+	type ldconfigBackend interface {
+		LdconfigConnectedPlug(spec *ldconfig.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
+	}
+	type polkitBackend interface {
+		PolkitConnectedPlug(spec *polkit.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
+	}
+	type symlinksBackend interface {
+		SymlinksConnectedPlug(spec *symlinks.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
+	}
+	type systemdBackend interface {
+		SystemdConnectedPlug(spec *systemd.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
+	}
+
+	backends := make([]string, 0, 10)
+	if _, ok := iface.(appArmorBackend); ok {
+		backends = append(backends, string(interfaces.SecurityAppArmor))
+	}
+	if _, ok := iface.(seccompBackend); ok {
+		backends = append(backends, string(interfaces.SecuritySecComp))
+	}
+	if _, ok := iface.(dbusBackend); ok {
+		backends = append(backends, string(interfaces.SecurityDBus))
+	}
+	if _, ok := iface.(udevBackend); ok {
+		backends = append(backends, string(interfaces.SecurityUDev))
+	}
+	if _, ok := iface.(kmodBackend); ok {
+		backends = append(backends, string(interfaces.SecurityKMod))
+	}
+	if _, ok := iface.(systemdBackend); ok {
+		backends = append(backends, string(interfaces.SecuritySystemd))
+	}
+	if _, ok := iface.(polkitBackend); ok {
+		backends = append(backends, string(interfaces.SecurityPolkit))
+	}
+	if _, ok := iface.(ldconfigBackend); ok {
+		backends = append(backends, string(interfaces.SecurityLdconfig))
+	}
+	if _, ok := iface.(configfilesBackend); ok {
+		backends = append(backends, string(interfaces.SecurityConfigfiles))
+	}
+	if _, ok := iface.(symlinksBackend); ok {
+		backends = append(backends, string(interfaces.SecuritySymlinks))
+	}
+	return backends
+}

--- a/overlord/ifacestate/mcp_common_test.go
+++ b/overlord/ifacestate/mcp_common_test.go
@@ -1,0 +1,160 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ifacestate_test
+
+import (
+	"testing"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/configfiles"
+	"github.com/snapcore/snapd/interfaces/dbus"
+	"github.com/snapcore/snapd/interfaces/ifacetest"
+	"github.com/snapcore/snapd/interfaces/kmod"
+	"github.com/snapcore/snapd/interfaces/ldconfig"
+	"github.com/snapcore/snapd/interfaces/polkit"
+	"github.com/snapcore/snapd/interfaces/seccomp"
+	"github.com/snapcore/snapd/interfaces/symlinks"
+	"github.com/snapcore/snapd/interfaces/systemd"
+	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+)
+
+func setupInterfaceRepo(t *testing.T, st *state.State) *interfaces.Repository {
+	t.Helper()
+
+	repo := interfaces.NewRepository()
+	st.Lock()
+	ifacerepo.Replace(st, repo)
+	st.Unlock()
+
+	for _, iface := range []interfaces.Interface{
+		&ifacetest.TestInterface{InterfaceName: "network", InterfaceStaticInfo: interfaces.StaticInfo{Summary: "network"}},
+		&ifacetest.TestInterface{InterfaceName: "audio-playback", InterfaceStaticInfo: interfaces.StaticInfo{Summary: "audio"}},
+	} {
+		if err := repo.AddInterface(iface); err != nil {
+			t.Fatalf("cannot add interface %q: %v", iface.Name(), err)
+		}
+	}
+
+	consumer := mustInfoFromYAML(t, `name: consumer
+version: 1
+apps:
+  app:
+    command: bin/app
+plugs:
+  network-plug:
+    interface: network
+  audio-plug:
+    interface: audio-playback
+`)
+	provider := mustInfoFromYAML(t, `name: provider
+version: 1
+apps:
+  app:
+    command: bin/app
+slots:
+  network-slot:
+    interface: network
+  audio-slot:
+    interface: audio-playback
+`)
+
+	for _, info := range []*snap.Info{consumer, provider} {
+		appSet, err := interfaces.NewSnapAppSet(info, nil)
+		if err != nil {
+			t.Fatalf("cannot create app set for %q: %v", info.InstanceName(), err)
+		}
+		if err := repo.AddAppSet(appSet); err != nil {
+			t.Fatalf("cannot add app set for %q: %v", info.InstanceName(), err)
+		}
+	}
+
+	return repo
+}
+
+func mustInfoFromYAML(t *testing.T, yaml string) *snap.Info {
+	t.Helper()
+	info, err := snap.InfoFromSnapYaml([]byte(yaml))
+	if err != nil {
+		t.Fatalf("cannot parse snap yaml:\n%s\nerror: %v", yaml, err)
+	}
+	return info
+}
+
+type minimalTestInterface struct {
+	name string
+	info interfaces.StaticInfo
+}
+
+func (i minimalTestInterface) Name() string {
+	return i.name
+}
+
+func (i minimalTestInterface) StaticInfo() interfaces.StaticInfo {
+	return i.info
+}
+
+func (minimalTestInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
+	return true
+}
+
+// Keep these compile-time checks local to ensure test interface signatures stay aligned.
+var _ interface {
+	AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
+} = &ifacetest.TestInterface{}
+
+var _ interface {
+	SecCompConnectedPlug(spec *seccomp.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
+} = &ifacetest.TestInterface{}
+
+var _ interface {
+	UDevConnectedPlug(spec *udev.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
+} = &ifacetest.TestInterface{}
+
+var _ interface {
+	KModConnectedPlug(spec *kmod.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
+} = &ifacetest.TestInterface{}
+
+var _ interface {
+	DBusConnectedPlug(spec *dbus.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
+} = &ifacetest.TestInterface{}
+
+var _ interface {
+	ConfigfilesConnectedPlug(spec *configfiles.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
+} = &ifacetest.TestInterface{}
+
+var _ interface {
+	LdconfigConnectedPlug(spec *ldconfig.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
+} = &ifacetest.TestInterface{}
+
+var _ interface {
+	PolkitConnectedPlug(spec *polkit.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
+} = &ifacetest.TestInterface{}
+
+var _ interface {
+	SymlinksConnectedPlug(spec *symlinks.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
+} = &ifacetest.TestInterface{}
+
+var _ interface {
+	SystemdConnectedPlug(spec *systemd.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
+} = &ifacetest.TestInterface{}

--- a/overlord/ifacestate/mcp_connections_tool.go
+++ b/overlord/ifacestate/mcp_connections_tool.go
@@ -1,0 +1,178 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ifacestate
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/overlord/mcp"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+const toolListConnections = "snap_list_connections"
+
+type listConnectionsTool struct{}
+
+type connectionResult struct {
+	ref   *interfaces.ConnRef
+	state ConnectionState
+}
+
+type listConnectionsArgs struct {
+	Snap string `json:"snap,omitempty" mcp:"description=Optional filter connections to a specific snap."`
+}
+
+type connectionAttrsResponse struct {
+	Plug map[string]any `json:"plug"`
+	Slot map[string]any `json:"slot"`
+}
+
+type connectionResponse struct {
+	PlugSnap     string                  `json:"plug_snap"`
+	PlugName     string                  `json:"plug_name"`
+	SlotSnap     string                  `json:"slot_snap"`
+	SlotName     string                  `json:"slot_name"`
+	Interface    string                  `json:"interface"`
+	StaticAttrs  connectionAttrsResponse `json:"static_attrs"`
+	DynamicAttrs connectionAttrsResponse `json:"dynamic_attrs"`
+	Manual       bool                    `json:"manual"`
+}
+
+type listConnectionsResult struct {
+	Connections []connectionResponse `json:"connections"`
+}
+
+var listConnectionsToolDescriptor = mcp.ToolDescriptor{
+	Name:         toolListConnections,
+	Title:        "List interface connections",
+	Description:  "List interface connections and slots for snaps (read-only).",
+	Annotations:  mcp.ToolAnnotations{ReadOnlyHint: true},
+	Execution:    readOnlyToolExecution,
+	InputSchema:  mcp.InputSchemaFromType(listConnectionsArgs{}),
+	OutputSchema: mcp.OutputSchemaFromType(listConnectionsResult{}),
+}
+
+func (listConnectionsTool) Descriptor() mcp.ToolDescriptor {
+	return listConnectionsToolDescriptor
+}
+
+func (listConnectionsTool) ArgsType() any {
+	return &listConnectionsArgs{}
+}
+
+func (listConnectionsTool) ValidateArgs(args any) error {
+	if _, ok := args.(*listConnectionsArgs); !ok {
+		return fmt.Errorf("invalid typed args for list connections tool")
+	}
+	return nil
+}
+
+func (listConnectionsTool) ResultType() any {
+	return &listConnectionsResult{}
+}
+
+func (listConnectionsTool) CallWithArgs(_ context.Context, st *state.State, args any) (any, error) {
+	conns, err := connectionsFromState(st)
+	if err != nil {
+		return nil, fmt.Errorf("cannot list connections: %w", err)
+	}
+
+	filterArgs, ok := args.(*listConnectionsArgs)
+	if !ok {
+		return nil, fmt.Errorf("invalid typed args for list connections tool")
+	}
+
+	return connectionsToResult(conns, filterArgs.Snap), nil
+}
+
+func (listConnectionsTool) Validate(args map[string]any) error {
+	_, err := mcp.ToolArgsFromMap[listConnectionsArgs](args)
+	return err
+}
+
+func (listConnectionsTool) Call(ctx context.Context, st *state.State, args map[string]any) (any, error) {
+	parsedArgs, err := mcp.ToolArgsFromMap[listConnectionsArgs](args)
+	if err != nil {
+		return nil, err
+	}
+	return listConnectionsTool{}.CallWithArgs(ctx, st, parsedArgs)
+}
+
+func connectionsFromState(st *state.State) ([]connectionResult, error) {
+	st.Lock()
+	defer st.Unlock()
+
+	connStateByRef, err := ConnectionStates(st)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read connection state: %w", err)
+	}
+
+	result := make([]connectionResult, 0, len(connStateByRef))
+	for connID, connState := range connStateByRef {
+		if !connState.Active() {
+			continue
+		}
+		connRef, err := interfaces.ParseConnRef(connID)
+		if err != nil {
+			return nil, fmt.Errorf("cannot parse connection reference %q: %w", connID, err)
+		}
+		result = append(result, connectionResult{ref: connRef, state: connState})
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].ref.SortsBefore(result[j].ref)
+	})
+
+	return result, nil
+}
+
+func connectionsToResult(conns []connectionResult, snapFilter string) listConnectionsResult {
+	result := listConnectionsResult{Connections: make([]connectionResponse, 0, len(conns))}
+	for _, conn := range conns {
+		if snapFilter != "" && conn.ref.PlugRef.Snap != snapFilter && conn.ref.SlotRef.Snap != snapFilter {
+			continue
+		}
+		result.Connections = append(result.Connections, connectionResponse{
+			PlugSnap:  conn.ref.PlugRef.Snap,
+			PlugName:  conn.ref.PlugRef.Name,
+			SlotSnap:  conn.ref.SlotRef.Snap,
+			SlotName:  conn.ref.SlotRef.Name,
+			Interface: conn.state.Interface,
+			StaticAttrs: connectionAttrsResponse{
+				Plug: conn.state.StaticPlugAttrs,
+				Slot: conn.state.StaticSlotAttrs,
+			},
+			DynamicAttrs: connectionAttrsResponse{
+				Plug: conn.state.DynamicPlugAttrs,
+				Slot: conn.state.DynamicSlotAttrs,
+			},
+			Manual: !conn.state.Auto && !conn.state.ByGadget,
+		})
+	}
+	return result
+}
+
+func connectionsToMap(conns []connectionResult, snapFilter string) map[string]any {
+	res := connectionsToResult(conns, snapFilter)
+	return map[string]any{"connections": res.Connections}
+}

--- a/overlord/ifacestate/mcp_connections_tool_test.go
+++ b/overlord/ifacestate/mcp_connections_tool_test.go
@@ -1,0 +1,101 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ifacestate_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/overlord/ifacestate"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+func TestConnectionsToMapEmpty(t *testing.T) {
+	result := ifacestate.ConnectionsToMap(nil, "")
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+	conns := obj["connections"].([]any)
+	if len(conns) != 0 {
+		t.Fatalf("expected no connections, got %d", len(conns))
+	}
+}
+
+func TestConnectionsToMapAllFields(t *testing.T) {
+	static := map[string]any{"read-paths": []string{"/etc"}}
+	dynamic := map[string]any{"connect-plug-uid": "1000"}
+	info := []ifacestate.MCPConnectionResult{{
+		Ref: &interfaces.ConnRef{PlugRef: interfaces.PlugRef{Snap: "consumer", Name: "network"}, SlotRef: interfaces.SlotRef{Snap: "core", Name: "network"}},
+		State: ifacestate.ConnectionState{
+			Interface:        "network",
+			StaticPlugAttrs:  static,
+			StaticSlotAttrs:  static,
+			DynamicPlugAttrs: dynamic,
+			DynamicSlotAttrs: dynamic,
+		},
+	}}
+	result := ifacestate.ConnectionsToMap(info, "")
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+	conns := obj["connections"].([]any)
+	if len(conns) != 1 {
+		t.Fatalf("expected one connection, got %d", len(conns))
+	}
+	conn := conns[0].(map[string]any)
+	if conn["plug_snap"] != "consumer" || conn["slot_snap"] != "core" {
+		t.Fatalf("unexpected connection endpoints: %#v", conn)
+	}
+	if conn["manual"] != true {
+		t.Fatalf("expected manual=true, got %#v", conn["manual"])
+	}
+}
+
+func TestListConnectionsToolCallSuccess(t *testing.T) {
+	st := state.New(nil)
+	result, err := (ifacestate.ListConnectionsTool{}).Call(context.Background(), st, map[string]any{"snap": "app"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+	conns := obj["connections"].([]any)
+	if len(conns) != 0 {
+		t.Fatalf("expected no connections, got %d", len(conns))
+	}
+}

--- a/overlord/ifacestate/mcp_interface_types_tool.go
+++ b/overlord/ifacestate/mcp_interface_types_tool.go
@@ -1,0 +1,136 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ifacestate
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/overlord/mcp"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+const toolListInterfaceTypes = "snap_list_interface_types"
+
+type listInterfaceTypesTool struct{}
+
+type listInterfaceTypesArgs struct {
+	Name           string `json:"name,omitempty" mcp:"description=Optional case-insensitive substring filter by interface name."`
+	IncludeDetails bool   `json:"include_details,omitempty" mcp:"description=Optional flag to include base policy and implemented backends. Defaults to false."`
+}
+
+type basePolicyResponse struct {
+	Plugs string `json:"plugs"`
+	Slots string `json:"slots"`
+}
+
+type interfaceTypeResponse struct {
+	Name                string              `json:"name"`
+	Summary             string              `json:"summary,omitempty"`
+	BasePolicy          *basePolicyResponse `json:"base_policy,omitempty"`
+	ImplementedBackends []string            `json:"implemented_backends,omitempty"`
+}
+
+type listInterfaceTypesResult struct {
+	InterfaceTypes []interfaceTypeResponse `json:"interface_types"`
+}
+
+var listInterfaceTypesToolDescriptor = mcp.ToolDescriptor{
+	Name:         toolListInterfaceTypes,
+	Title:        "List interface types",
+	Description:  "List known interface types with summary, base policy snippets, and implemented security backends (read-only).",
+	Annotations:  mcp.ToolAnnotations{ReadOnlyHint: true},
+	Execution:    readOnlyToolExecution,
+	InputSchema:  mcp.InputSchemaFromType(listInterfaceTypesArgs{}),
+	OutputSchema: mcp.OutputSchemaFromType(listInterfaceTypesResult{}),
+}
+
+func (listInterfaceTypesTool) Descriptor() mcp.ToolDescriptor {
+	return listInterfaceTypesToolDescriptor
+}
+
+func (listInterfaceTypesTool) ArgsType() any {
+	return &listInterfaceTypesArgs{}
+}
+
+func (listInterfaceTypesTool) ValidateArgs(args any) error {
+	if _, ok := args.(*listInterfaceTypesArgs); !ok {
+		return fmt.Errorf("invalid typed args for list interface types tool")
+	}
+	return nil
+}
+
+func (listInterfaceTypesTool) ResultType() any {
+	return &listInterfaceTypesResult{}
+}
+
+func (listInterfaceTypesTool) CallWithArgs(_ context.Context, st *state.State, args any) (any, error) {
+	repo, err := repoFromState(st)
+	if err != nil {
+		return nil, fmt.Errorf("cannot list interface types: %w", err)
+	}
+
+	filterArgs, ok := args.(*listInterfaceTypesArgs)
+	if !ok {
+		return nil, fmt.Errorf("invalid typed args for list interface types tool")
+	}
+
+	var nameFilter string
+	if filterArgs.Name != "" {
+		nameFilter = strings.ToLower(filterArgs.Name)
+	}
+
+	includeDetails := filterArgs.IncludeDetails
+
+	ifaces := repo.AllInterfaces()
+	result := listInterfaceTypesResult{InterfaceTypes: make([]interfaceTypeResponse, 0, len(ifaces))}
+	for _, iface := range ifaces {
+		ifaceName := iface.Name()
+		if nameFilter != "" && !strings.Contains(strings.ToLower(ifaceName), nameFilter) {
+			continue
+		}
+
+		si := interfaces.StaticInfoOf(iface)
+		entry := interfaceTypeResponse{Name: ifaceName}
+		if includeDetails {
+			entry.Summary = si.Summary
+			entry.BasePolicy = &basePolicyResponse{Plugs: si.BaseDeclarationPlugs, Slots: si.BaseDeclarationSlots}
+			entry.ImplementedBackends = implementedBackends(iface)
+		}
+		result.InterfaceTypes = append(result.InterfaceTypes, entry)
+	}
+
+	return result, nil
+}
+
+func (listInterfaceTypesTool) Validate(args map[string]any) error {
+	_, err := mcp.ToolArgsFromMap[listInterfaceTypesArgs](args)
+	return err
+}
+
+func (listInterfaceTypesTool) Call(ctx context.Context, st *state.State, args map[string]any) (any, error) {
+	parsedArgs, err := mcp.ToolArgsFromMap[listInterfaceTypesArgs](args)
+	if err != nil {
+		return nil, err
+	}
+	return listInterfaceTypesTool{}.CallWithArgs(ctx, st, parsedArgs)
+}

--- a/overlord/ifacestate/mcp_interface_types_tool_test.go
+++ b/overlord/ifacestate/mcp_interface_types_tool_test.go
@@ -1,0 +1,168 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ifacestate_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/ifacetest"
+	"github.com/snapcore/snapd/overlord/ifacestate"
+	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+func TestListInterfaceTypesToolIncludesStaticInfoAndBackends(t *testing.T) {
+	st := state.New(nil)
+	repo := interfaces.NewRepository()
+	st.Lock()
+	ifacerepo.Replace(st, repo)
+	st.Unlock()
+
+	fullIface := &ifacetest.TestInterface{InterfaceName: "full-iface", InterfaceStaticInfo: interfaces.StaticInfo{
+		Summary:              "full test interface",
+		BaseDeclarationPlugs: "allow-installation: true",
+		BaseDeclarationSlots: "allow-installation: true",
+	}}
+	if err := repo.AddInterface(fullIface); err != nil {
+		t.Fatalf("cannot add full-iface: %v", err)
+	}
+
+	minimalIface := minimalTestInterface{
+		name: "minimal-iface",
+		info: interfaces.StaticInfo{
+			Summary:              "minimal interface",
+			BaseDeclarationPlugs: "deny-auto-connection: true",
+		},
+	}
+	if err := repo.AddInterface(minimalIface); err != nil {
+		t.Fatalf("cannot add minimal-iface: %v", err)
+	}
+
+	result, err := (ifacestate.ListInterfaceTypesTool{}).Call(context.Background(), st, map[string]any{"name": "iface", "include_details": true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	types := obj["interface_types"].([]any)
+	if len(types) != 2 {
+		t.Fatalf("expected two interface types, got %d", len(types))
+	}
+
+	byName := make(map[string]map[string]any, len(types))
+	for _, it := range types {
+		info := it.(map[string]any)
+		byName[info["name"].(string)] = info
+	}
+
+	full := byName["full-iface"]
+	if full == nil {
+		t.Fatalf("missing full-iface in response: %#v", byName)
+	}
+	if full["summary"] != "full test interface" {
+		t.Fatalf("unexpected summary for full-iface: %#v", full["summary"])
+	}
+	fullBasePolicy := full["base_policy"].(map[string]any)
+	if fullBasePolicy["plugs"] != "allow-installation: true" {
+		t.Fatalf("unexpected plugs base policy: %#v", fullBasePolicy)
+	}
+	if fullBasePolicy["slots"] != "allow-installation: true" {
+		t.Fatalf("unexpected slots base policy: %#v", fullBasePolicy)
+	}
+	fullBackendsRaw := full["implemented_backends"].([]any)
+	for _, backend := range []string{"apparmor", "seccomp", "dbus", "udev", "kmod", "systemd", "polkit", "ldconfig", "configfiles", "symlinks"} {
+		found := false
+		for _, b := range fullBackendsRaw {
+			if s, ok := b.(string); ok && s == backend {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expected backend %q in %#v", backend, fullBackendsRaw)
+		}
+	}
+
+	minimal := byName["minimal-iface"]
+	if minimal == nil {
+		t.Fatalf("missing minimal-iface in response: %#v", byName)
+	}
+	minimalBackendsRawIface := minimal["implemented_backends"]
+	minimalBackendsRaw, _ := minimalBackendsRawIface.([]any)
+	if len(minimalBackendsRaw) != 0 {
+		t.Fatalf("expected no implemented backends for minimal-iface, got %#v", minimalBackendsRawIface)
+	}
+}
+
+func TestListInterfaceTypesToolOmitsDetailsByDefault(t *testing.T) {
+	st := state.New(nil)
+	repo := interfaces.NewRepository()
+	st.Lock()
+	ifacerepo.Replace(st, repo)
+	st.Unlock()
+
+	iface := minimalTestInterface{name: "content-like", info: interfaces.StaticInfo{Summary: "summary"}}
+	if err := repo.AddInterface(iface); err != nil {
+		t.Fatalf("cannot add test interface: %v", err)
+	}
+
+	result, err := (ifacestate.ListInterfaceTypesTool{}).Call(context.Background(), st, map[string]any{"name": "content"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	types := obj["interface_types"].([]any)
+	if len(types) != 1 {
+		t.Fatalf("expected one interface type, got %d", len(types))
+	}
+	item := types[0].(map[string]any)
+	if item["name"] != "content-like" {
+		t.Fatalf("unexpected interface type payload: %#v", item)
+	}
+	if summary, ok := item["summary"]; ok && summary != "" {
+		t.Fatalf("expected summary to be empty in concise output, got %#v", summary)
+	}
+	if _, ok := item["base_policy"]; ok {
+		t.Fatalf("did not expect base_policy in concise output: %#v", item)
+	}
+	if _, ok := item["implemented_backends"]; ok {
+		t.Fatalf("did not expect implemented_backends in concise output: %#v", item)
+	}
+}

--- a/overlord/ifacestate/mcp_internal_test.go
+++ b/overlord/ifacestate/mcp_internal_test.go
@@ -1,0 +1,351 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ifacestate
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/ifacetest"
+	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
+	"github.com/snapcore/snapd/overlord/mcp"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+)
+
+func TestMCPOutputSchemas(t *testing.T) {
+	tests := []struct {
+		name          string
+		schema        map[string]any
+		expected      map[string]any
+		requiredField string
+	}{
+		{name: "connections", schema: mcp.OutputSchemaFromType(listConnectionsResult{}), expected: expectedListConnectionsOutputSchema(), requiredField: "connections"},
+		{name: "plugs", schema: mcp.OutputSchemaFromType(listPlugsResult{}), expected: expectedListPlugsOutputSchema(), requiredField: "plugs"},
+		{name: "slots", schema: mcp.OutputSchemaFromType(listSlotsResult{}), expected: expectedListSlotsOutputSchema(), requiredField: "slots"},
+		{name: "interfaceTypes", schema: mcp.OutputSchemaFromType(listInterfaceTypesResult{}), expected: expectedListInterfaceTypesOutputSchema(), requiredField: "interface_types"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if !reflect.DeepEqual(test.schema, test.expected) {
+				t.Fatalf("schema %s does not match expected literal schema", test.name)
+			}
+			if test.schema["type"] != "object" {
+				t.Fatalf("schema %s must have object root, got %#v", test.name, test.schema["type"])
+			}
+			props := test.schema["properties"].(map[string]any)
+			if _, ok := props[test.requiredField]; !ok {
+				t.Fatalf("schema %s missing required property %q", test.name, test.requiredField)
+			}
+		})
+	}
+}
+
+func TestMCPToolDescriptorsUseCustomOutputSchemas(t *testing.T) {
+	tests := []struct {
+		name       string
+		descriptor mcp.ToolDescriptor
+		expected   map[string]any
+	}{
+		{name: "connections", descriptor: listConnectionsToolDescriptor, expected: expectedListConnectionsOutputSchema()},
+		{name: "plugs", descriptor: listPlugsToolDescriptor, expected: expectedListPlugsOutputSchema()},
+		{name: "slots", descriptor: listSlotsToolDescriptor, expected: expectedListSlotsOutputSchema()},
+		{name: "interfaceTypes", descriptor: listInterfaceTypesToolDescriptor, expected: expectedListInterfaceTypesOutputSchema()},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if !reflect.DeepEqual(test.descriptor.OutputSchema, test.expected) {
+				t.Fatalf("descriptor %s advertises unexpected output schema", test.name)
+			}
+		})
+	}
+}
+
+func expectedListConnectionsOutputSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"connections": map[string]any{
+				"type": "array",
+				"items": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"plug_snap": map[string]any{"type": "string"},
+						"plug_name": map[string]any{"type": "string"},
+						"slot_snap": map[string]any{"type": "string"},
+						"slot_name": map[string]any{"type": "string"},
+						"interface": map[string]any{"type": "string"},
+						"static_attrs": map[string]any{
+							"type": "object",
+							"properties": map[string]any{
+								"plug": map[string]any{"type": "object"},
+								"slot": map[string]any{"type": "object"},
+							},
+							"required":             []string{"plug", "slot"},
+							"additionalProperties": false,
+						},
+						"dynamic_attrs": map[string]any{
+							"type": "object",
+							"properties": map[string]any{
+								"plug": map[string]any{"type": "object"},
+								"slot": map[string]any{"type": "object"},
+							},
+							"required":             []string{"plug", "slot"},
+							"additionalProperties": false,
+						},
+						"manual": map[string]any{"type": "boolean"},
+					},
+					"required":             []string{"plug_snap", "plug_name", "slot_snap", "slot_name", "interface", "static_attrs", "dynamic_attrs", "manual"},
+					"additionalProperties": false,
+				},
+			},
+		},
+		"required":             []string{"connections"},
+		"additionalProperties": false,
+	}
+}
+
+func expectedListPlugsOutputSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"plugs": map[string]any{
+				"type": "array",
+				"items": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"snap_name": map[string]any{"type": "string"},
+						"name":      map[string]any{"type": "string"},
+						"interface": map[string]any{"type": "string"},
+						"label":     map[string]any{"type": "string"},
+						"attrs":     map[string]any{"type": "object"},
+						"apps": map[string]any{
+							"type":  "array",
+							"items": map[string]any{"type": "string"},
+						},
+						"unscoped":    map[string]any{"type": "boolean"},
+						"hotplug_key": map[string]any{"type": "string"},
+					},
+					"required":             []string{"snap_name", "name", "interface"},
+					"additionalProperties": false,
+				},
+			},
+		},
+		"required":             []string{"plugs"},
+		"additionalProperties": false,
+	}
+}
+
+func expectedListSlotsOutputSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"slots": map[string]any{
+				"type": "array",
+				"items": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"snap_name": map[string]any{"type": "string"},
+						"name":      map[string]any{"type": "string"},
+						"interface": map[string]any{"type": "string"},
+						"label":     map[string]any{"type": "string"},
+						"attrs":     map[string]any{"type": "object"},
+						"apps": map[string]any{
+							"type":  "array",
+							"items": map[string]any{"type": "string"},
+						},
+						"unscoped":    map[string]any{"type": "boolean"},
+						"hotplug_key": map[string]any{"type": "string"},
+					},
+					"required":             []string{"snap_name", "name", "interface"},
+					"additionalProperties": false,
+				},
+			},
+		},
+		"required":             []string{"slots"},
+		"additionalProperties": false,
+	}
+}
+
+func expectedListInterfaceTypesOutputSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"interface_types": map[string]any{
+				"type": "array",
+				"items": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"name":    map[string]any{"type": "string"},
+						"summary": map[string]any{"type": "string"},
+						"base_policy": map[string]any{
+							"type": "object",
+							"properties": map[string]any{
+								"plugs": map[string]any{"type": "string"},
+								"slots": map[string]any{"type": "string"},
+							},
+							"required":             []string{"plugs", "slots"},
+							"additionalProperties": false,
+						},
+						"implemented_backends": map[string]any{
+							"type":  "array",
+							"items": map[string]any{"type": "string"},
+						},
+					},
+					"required":             []string{"name"},
+					"additionalProperties": false,
+				},
+			},
+		},
+		"required":             []string{"interface_types"},
+		"additionalProperties": false,
+	}
+}
+
+func TestMCPValidationAndMappingHelpers(t *testing.T) {
+	if err := validateOptionalString(map[string]any{"snap": true}, "snap"); err == nil {
+		t.Fatal("validateOptionalString should reject non-string value")
+	}
+	if err := validateOptionalString(map[string]any{"snap": "ok"}, "snap"); err != nil {
+		t.Fatalf("validateOptionalString returned error: %v", err)
+	}
+	if err := validateOptionalBool(map[string]any{"include_details": "yes"}, "include_details"); err == nil {
+		t.Fatal("validateOptionalBool should reject non-bool value")
+	}
+	if err := validateOptionalBool(map[string]any{"include_details": true}, "include_details"); err != nil {
+		t.Fatalf("validateOptionalBool returned error: %v", err)
+	}
+
+	plugSnap := &snap.Info{SuggestedName: "consumer", SideInfo: snap.SideInfo{RealName: "consumer"}}
+	plug := &snap.PlugInfo{
+		Snap:      plugSnap,
+		Name:      "network",
+		Interface: "network",
+		Label:     "Network",
+		Attrs:     map[string]any{"foo": "bar"},
+		Apps: map[string]*snap.AppInfo{
+			"z": {Snap: plugSnap, Name: "z"},
+			"a": {Snap: plugSnap, Name: "a"},
+		},
+		Unscoped: true,
+	}
+	plugMap := plugToMap(plug, true)
+	if plugMap["snap_name"] != "consumer" || plugMap["interface"] != "network" {
+		t.Fatalf("unexpected plug map: %#v", plugMap)
+	}
+	if plugMap["unscoped"] != true {
+		t.Fatalf("expected unscoped=true in plug map, got %#v", plugMap)
+	}
+	if _, ok := plugMap["is_unscoped"]; ok {
+		t.Fatalf("plug map must not expose legacy is_unscoped key: %#v", plugMap)
+	}
+	apps := plugMap["apps"].([]string)
+	if len(apps) != 2 || apps[0] != "a" || apps[1] != "z" {
+		t.Fatalf("apps were not sorted: %#v", apps)
+	}
+	if concise := plugToMap(plug, false); len(concise) != 3 {
+		t.Fatalf("concise plug map should contain only base fields: %#v", concise)
+	}
+
+	slotSnap := &snap.Info{SuggestedName: "provider", SideInfo: snap.SideInfo{RealName: "provider"}}
+	slot := &snap.SlotInfo{
+		Snap:       slotSnap,
+		Name:       "network",
+		Interface:  "network",
+		Label:      "Network slot",
+		Attrs:      map[string]any{"foo": "bar"},
+		Apps:       map[string]*snap.AppInfo{"svc": {Snap: slotSnap, Name: "svc"}},
+		Unscoped:   true,
+		HotplugKey: snap.HotplugKey("hotplug"),
+	}
+	slotMap := slotToMap(slot, true)
+	if slotMap["hotplug_key"] != "hotplug" {
+		t.Fatalf("unexpected slot map: %#v", slotMap)
+	}
+	if slotMap["unscoped"] != true {
+		t.Fatalf("expected unscoped=true in slot map, got %#v", slotMap)
+	}
+	if _, ok := slotMap["is_unscoped"]; ok {
+		t.Fatalf("slot map must not expose legacy is_unscoped key: %#v", slotMap)
+	}
+	if names := sortedAppNames(slot.Apps); len(names) != 1 || names[0] != "svc" {
+		t.Fatalf("unexpected sorted app names: %#v", names)
+	}
+}
+
+func TestMCPToolTypedHelpers(t *testing.T) {
+	st := state.New(nil)
+	repo := interfaces.NewRepository()
+	st.Lock()
+	ifacerepo.Replace(st, repo)
+	st.Unlock()
+
+	if _, ok := (listConnectionsTool{}).ArgsType().(*listConnectionsArgs); !ok {
+		t.Fatal("listConnectionsTool ArgsType returned unexpected type")
+	}
+	if _, ok := (listConnectionsTool{}).ResultType().(*listConnectionsResult); !ok {
+		t.Fatal("listConnectionsTool ResultType returned unexpected type")
+	}
+	if err := (listConnectionsTool{}).ValidateArgs(struct{}{}); err == nil {
+		t.Fatal("listConnectionsTool ValidateArgs should reject wrong type")
+	}
+	if _, err := (listConnectionsTool{}).CallWithArgs(context.Background(), st, struct{}{}); err == nil {
+		t.Fatal("listConnectionsTool CallWithArgs should reject wrong type")
+	}
+
+	if err := (listPlugsTool{}).ValidateArgs(struct{}{}); err == nil {
+		t.Fatal("listPlugsTool ValidateArgs should reject wrong type")
+	}
+	if _, err := (listPlugsTool{}).CallWithArgs(context.Background(), st, struct{}{}); err == nil {
+		t.Fatal("listPlugsTool CallWithArgs should reject wrong type")
+	}
+
+	if err := (listSlotsTool{}).ValidateArgs(struct{}{}); err == nil {
+		t.Fatal("listSlotsTool ValidateArgs should reject wrong type")
+	}
+	if _, err := (listSlotsTool{}).CallWithArgs(context.Background(), st, struct{}{}); err == nil {
+		t.Fatal("listSlotsTool CallWithArgs should reject wrong type")
+	}
+
+	if err := (listInterfaceTypesTool{}).ValidateArgs(struct{}{}); err == nil {
+		t.Fatal("listInterfaceTypesTool ValidateArgs should reject wrong type")
+	}
+	if _, err := (listInterfaceTypesTool{}).CallWithArgs(context.Background(), st, struct{}{}); err == nil {
+		t.Fatal("listInterfaceTypesTool CallWithArgs should reject wrong type")
+	}
+}
+
+func TestRepoFromStateRecover(t *testing.T) {
+	if _, err := repoFromState(nil); err == nil {
+		t.Fatal("repoFromState should recover from nil state access")
+	}
+}
+
+func TestImplementedBackends(t *testing.T) {
+	iface := &ifacetest.TestInterface{InterfaceName: "network"}
+	backends := implementedBackends(iface)
+	if len(backends) == 0 {
+		t.Fatal("implementedBackends should detect supported backends")
+	}
+}

--- a/overlord/ifacestate/mcp_misc_test.go
+++ b/overlord/ifacestate/mcp_misc_test.go
@@ -1,0 +1,95 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ifacestate_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/snapcore/snapd/overlord/ifacestate"
+	"github.com/snapcore/snapd/overlord/mcp"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+func TestInterfaceMCPToolDescriptorsIncludeSchemaAndExecutionMetadata(t *testing.T) {
+	tools := []interface {
+		Descriptor() mcp.ToolDescriptor
+	}{
+		ifacestate.ListConnectionsTool{},
+		ifacestate.ListPlugsTool{},
+		ifacestate.ListSlotsTool{},
+		ifacestate.ListInterfaceTypesTool{},
+	}
+
+	for _, tool := range tools {
+		d := tool.Descriptor()
+		if !d.Annotations.ReadOnlyHint {
+			t.Fatalf("tool %q must be marked read-only", d.Name)
+		}
+		if d.Execution.TaskSupport != mcp.ToolTaskSupportForbidden {
+			t.Fatalf("tool %q must set execution.taskSupport to %q, got %q", d.Name, mcp.ToolTaskSupportForbidden, d.Execution.TaskSupport)
+		}
+		if d.OutputSchema == nil {
+			t.Fatalf("tool %q must provide output schema", d.Name)
+		}
+		if d.OutputSchema["type"] != "object" {
+			t.Fatalf("tool %q output schema must have object root type, got %#v", d.Name, d.OutputSchema["type"])
+		}
+	}
+}
+
+func TestInterfaceRepositoryToolsDoNotRequireCallerStateLock(t *testing.T) {
+	st := state.New(nil)
+	_ = setupInterfaceRepo(t, st)
+
+	tools := []struct {
+		name string
+		call func() (any, error)
+	}{
+		{
+			name: "plugs",
+			call: func() (any, error) {
+				return (ifacestate.ListPlugsTool{}).Call(context.Background(), st, map[string]any{"snap_name": "consumer"})
+			},
+		},
+		{
+			name: "slots",
+			call: func() (any, error) {
+				return (ifacestate.ListSlotsTool{}).Call(context.Background(), st, map[string]any{"snap_name": "provider"})
+			},
+		},
+		{
+			name: "interface types",
+			call: func() (any, error) {
+				return (ifacestate.ListInterfaceTypesTool{}).Call(context.Background(), st, map[string]any{"name": "net"})
+			},
+		},
+	}
+
+	for _, tc := range tools {
+		result, err := tc.call()
+		if err != nil {
+			t.Fatalf("tool %s unexpectedly failed without caller lock: %v", tc.name, err)
+		}
+		if result == nil {
+			t.Fatalf("tool %s returned nil result", tc.name)
+		}
+	}
+}

--- a/overlord/ifacestate/mcp_plugs_tool.go
+++ b/overlord/ifacestate/mcp_plugs_tool.go
@@ -1,0 +1,132 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ifacestate
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/snapcore/snapd/overlord/mcp"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+const toolListPlugs = "snap_list_plugs"
+
+type listPlugsTool struct{}
+
+type listPlugsArgs struct {
+	SnapName       string `json:"snap_name,omitempty" mcp:"description=Optional filter plugs to a specific snap name."`
+	Interface      string `json:"interface,omitempty" mcp:"description=Optional filter plugs by interface name."`
+	IncludeDetails bool   `json:"include_details,omitempty" mcp:"description=Optional flag to include detailed plug fields. Defaults to false."`
+}
+
+type plugSlotResponse struct {
+	SnapName   string          `json:"snap_name"`
+	Name       string          `json:"name"`
+	Interface  string          `json:"interface"`
+	Label      string          `json:"label,omitempty"`
+	Attrs      *map[string]any `json:"attrs,omitempty"`
+	Apps       []string        `json:"apps,omitempty"`
+	Unscoped   bool            `json:"unscoped,omitempty"`
+	HotplugKey string          `json:"hotplug_key,omitempty"`
+}
+
+type listPlugsResult struct {
+	Plugs []plugSlotResponse `json:"plugs"`
+}
+
+var listPlugsToolDescriptor = mcp.ToolDescriptor{
+	Name:         toolListPlugs,
+	Title:        "List interface plugs",
+	Description:  "List interface plugs with optional snap and interface filters (read-only).",
+	Annotations:  mcp.ToolAnnotations{ReadOnlyHint: true},
+	Execution:    readOnlyToolExecution,
+	InputSchema:  mcp.InputSchemaFromType(listPlugsArgs{}),
+	OutputSchema: mcp.OutputSchemaFromType(listPlugsResult{}),
+}
+
+func (listPlugsTool) Descriptor() mcp.ToolDescriptor {
+	return listPlugsToolDescriptor
+}
+
+func (listPlugsTool) ArgsType() any {
+	return &listPlugsArgs{}
+}
+
+func (listPlugsTool) ValidateArgs(args any) error {
+	if _, ok := args.(*listPlugsArgs); !ok {
+		return fmt.Errorf("invalid typed args for list plugs tool")
+	}
+	return nil
+}
+
+func (listPlugsTool) ResultType() any {
+	return &listPlugsResult{}
+}
+
+func (listPlugsTool) CallWithArgs(_ context.Context, st *state.State, args any) (any, error) {
+	repo, err := repoFromState(st)
+	if err != nil {
+		return nil, fmt.Errorf("cannot list plugs: %w", err)
+	}
+
+	filterArgs, ok := args.(*listPlugsArgs)
+	if !ok {
+		return nil, fmt.Errorf("invalid typed args for list plugs tool")
+	}
+
+	plugs := repo.AllPlugs(filterArgs.Interface)
+	result := listPlugsResult{Plugs: make([]plugSlotResponse, 0, len(plugs))}
+	for _, plug := range plugs {
+		if filterArgs.SnapName != "" && plug.Snap.InstanceName() != filterArgs.SnapName {
+			continue
+		}
+		entry := plugSlotResponse{
+			SnapName:  plug.Snap.InstanceName(),
+			Name:      plug.Name,
+			Interface: plug.Interface,
+		}
+		if filterArgs.IncludeDetails {
+			attrs := plug.Attrs
+			if attrs == nil {
+				attrs = map[string]any{}
+			}
+			entry.Label = plug.Label
+			entry.Attrs = &attrs
+			entry.Apps = sortedAppNames(plug.Apps)
+			entry.Unscoped = plug.Unscoped
+		}
+		result.Plugs = append(result.Plugs, entry)
+	}
+	return result, nil
+}
+
+func (listPlugsTool) Validate(args map[string]any) error {
+	_, err := mcp.ToolArgsFromMap[listPlugsArgs](args)
+	return err
+}
+
+func (listPlugsTool) Call(ctx context.Context, st *state.State, args map[string]any) (any, error) {
+	parsedArgs, err := mcp.ToolArgsFromMap[listPlugsArgs](args)
+	if err != nil {
+		return nil, err
+	}
+	return listPlugsTool{}.CallWithArgs(ctx, st, parsedArgs)
+}

--- a/overlord/ifacestate/mcp_plugs_tool_test.go
+++ b/overlord/ifacestate/mcp_plugs_tool_test.go
@@ -1,0 +1,107 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ifacestate_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/snapcore/snapd/overlord/ifacestate"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+func TestListPlugsToolFilters(t *testing.T) {
+	st := state.New(nil)
+	repo := setupInterfaceRepo(t, st)
+
+	result, err := (ifacestate.ListPlugsTool{}).Call(context.Background(), st, map[string]any{"snap_name": "consumer", "interface": "network"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	plugs := obj["plugs"].([]any)
+	if len(plugs) != 1 {
+		t.Fatalf("expected one plug, got %d", len(plugs))
+	}
+	plug := plugs[0].(map[string]any)
+	if plug["snap_name"] != "consumer" || plug["name"] != "network-plug" {
+		t.Fatalf("unexpected plug payload: %#v", plug)
+	}
+	if plug["interface"] != "network" {
+		t.Fatalf("unexpected interface in payload: %#v", plug)
+	}
+	if _, ok := plug["attrs"]; ok {
+		t.Fatalf("did not expect attrs in concise output: %#v", plug)
+	}
+
+	// quick check: setup produced multiple plugs before filtering
+	if total := len(repo.AllPlugs("")); total < 2 {
+		t.Fatalf("expected at least 2 plugs in test setup, got %d", total)
+	}
+}
+
+func TestListPlugsToolIncludesDetailsWhenRequested(t *testing.T) {
+	st := state.New(nil)
+	_ = setupInterfaceRepo(t, st)
+
+	result, err := (ifacestate.ListPlugsTool{}).Call(context.Background(), st, map[string]any{
+		"snap_name":       "consumer",
+		"interface":       "network",
+		"include_details": true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	plugs := obj["plugs"].([]any)
+	if len(plugs) != 1 {
+		t.Fatalf("expected one plug, got %d", len(plugs))
+	}
+	plug := plugs[0].(map[string]any)
+	if apps, ok := plug["apps"].([]any); !ok || len(apps) == 0 {
+		t.Fatalf("expected apps in detailed output, got %#v", plug)
+	}
+	if _, ok := plug["attrs"]; ok {
+		if attrs, ok := plug["attrs"].(map[string]any); !ok {
+			t.Fatalf("expected attrs to be map-like if present, got %#v", plug["attrs"])
+		} else if len(attrs) == 0 {
+			// attrs may be empty/omitted from JSON map; that is acceptable
+		}
+	}
+}

--- a/overlord/ifacestate/mcp_slots_tool.go
+++ b/overlord/ifacestate/mcp_slots_tool.go
@@ -1,0 +1,122 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ifacestate
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/snapcore/snapd/overlord/mcp"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+const toolListSlots = "snap_list_slots"
+
+type listSlotsTool struct{}
+
+type listSlotsArgs struct {
+	SnapName       string `json:"snap_name,omitempty" mcp:"description=Optional filter slots to a specific snap name."`
+	Interface      string `json:"interface,omitempty" mcp:"description=Optional filter slots by interface name."`
+	IncludeDetails bool   `json:"include_details,omitempty" mcp:"description=Optional flag to include detailed slot fields. Defaults to false."`
+}
+
+type listSlotsResult struct {
+	Slots []plugSlotResponse `json:"slots"`
+}
+
+var listSlotsToolDescriptor = mcp.ToolDescriptor{
+	Name:         toolListSlots,
+	Title:        "List interface slots",
+	Description:  "List interface slots with optional snap and interface filters (read-only).",
+	Annotations:  mcp.ToolAnnotations{ReadOnlyHint: true},
+	Execution:    readOnlyToolExecution,
+	InputSchema:  mcp.InputSchemaFromType(listSlotsArgs{}),
+	OutputSchema: mcp.OutputSchemaFromType(listSlotsResult{}),
+}
+
+func (listSlotsTool) Descriptor() mcp.ToolDescriptor {
+	return listSlotsToolDescriptor
+}
+
+func (listSlotsTool) ArgsType() any {
+	return &listSlotsArgs{}
+}
+
+func (listSlotsTool) ValidateArgs(args any) error {
+	if _, ok := args.(*listSlotsArgs); !ok {
+		return fmt.Errorf("invalid typed args for list slots tool")
+	}
+	return nil
+}
+
+func (listSlotsTool) ResultType() any {
+	return &listSlotsResult{}
+}
+
+func (listSlotsTool) CallWithArgs(_ context.Context, st *state.State, args any) (any, error) {
+	repo, err := repoFromState(st)
+	if err != nil {
+		return nil, fmt.Errorf("cannot list slots: %w", err)
+	}
+
+	filterArgs, ok := args.(*listSlotsArgs)
+	if !ok {
+		return nil, fmt.Errorf("invalid typed args for list slots tool")
+	}
+
+	slots := repo.AllSlots(filterArgs.Interface)
+	result := listSlotsResult{Slots: make([]plugSlotResponse, 0, len(slots))}
+	for _, slot := range slots {
+		if filterArgs.SnapName != "" && slot.Snap.InstanceName() != filterArgs.SnapName {
+			continue
+		}
+		entry := plugSlotResponse{
+			SnapName:  slot.Snap.InstanceName(),
+			Name:      slot.Name,
+			Interface: slot.Interface,
+		}
+		if filterArgs.IncludeDetails {
+			attrs := slot.Attrs
+			if attrs == nil {
+				attrs = map[string]any{}
+			}
+			entry.Label = slot.Label
+			entry.Attrs = &attrs
+			entry.Apps = sortedAppNames(slot.Apps)
+			entry.Unscoped = slot.Unscoped
+			entry.HotplugKey = string(slot.HotplugKey)
+		}
+		result.Slots = append(result.Slots, entry)
+	}
+	return result, nil
+}
+
+func (listSlotsTool) Validate(args map[string]any) error {
+	_, err := mcp.ToolArgsFromMap[listSlotsArgs](args)
+	return err
+}
+
+func (listSlotsTool) Call(ctx context.Context, st *state.State, args map[string]any) (any, error) {
+	parsedArgs, err := mcp.ToolArgsFromMap[listSlotsArgs](args)
+	if err != nil {
+		return nil, err
+	}
+	return listSlotsTool{}.CallWithArgs(ctx, st, parsedArgs)
+}

--- a/overlord/ifacestate/mcp_slots_tool_test.go
+++ b/overlord/ifacestate/mcp_slots_tool_test.go
@@ -1,0 +1,102 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ifacestate_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/snapcore/snapd/overlord/ifacestate"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+func TestListSlotsToolFilters(t *testing.T) {
+	st := state.New(nil)
+	_ = setupInterfaceRepo(t, st)
+
+	result, err := (ifacestate.ListSlotsTool{}).Call(context.Background(), st, map[string]any{"snap_name": "provider", "interface": "network"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	slots := obj["slots"].([]any)
+	if len(slots) != 1 {
+		t.Fatalf("expected one slot, got %d", len(slots))
+	}
+	slot := slots[0].(map[string]any)
+	if slot["snap_name"] != "provider" || slot["name"] != "network-slot" {
+		t.Fatalf("unexpected slot payload: %#v", slot)
+	}
+	if slot["interface"] != "network" {
+		t.Fatalf("unexpected interface in payload: %#v", slot)
+	}
+	if _, ok := slot["attrs"]; ok {
+		t.Fatalf("did not expect attrs in concise output: %#v", slot)
+	}
+}
+
+func TestListSlotsToolIncludesDetailsWhenRequested(t *testing.T) {
+	st := state.New(nil)
+	_ = setupInterfaceRepo(t, st)
+
+	result, err := (ifacestate.ListSlotsTool{}).Call(context.Background(), st, map[string]any{
+		"snap_name":       "provider",
+		"interface":       "network",
+		"include_details": true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	slots := obj["slots"].([]any)
+	if len(slots) != 1 {
+		t.Fatalf("expected one slot, got %d", len(slots))
+	}
+	slot := slots[0].(map[string]any)
+	if apps, ok := slot["apps"].([]any); !ok || len(apps) == 0 {
+		t.Fatalf("expected apps in detailed output, got %#v", slot)
+	}
+	if _, ok := slot["attrs"]; ok {
+		if attrs, ok := slot["attrs"].(map[string]any); !ok {
+			t.Fatalf("expected attrs to be map-like if present, got %#v", slot["attrs"])
+		} else if len(attrs) == 0 {
+			// empty attrs is acceptable
+		}
+	}
+}

--- a/overlord/mcp/mcp_test.go
+++ b/overlord/mcp/mcp_test.go
@@ -1,0 +1,28 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package mcp_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+func TestMcp(t *testing.T) { TestingT(t) }

--- a/overlord/mcp/registry.go
+++ b/overlord/mcp/registry.go
@@ -1,0 +1,73 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package mcp
+
+import "github.com/snapcore/snapd/osutil"
+
+var (
+	registeredTools            []Tool
+	registeredToolNames        = make(map[string]struct{})
+	registeredResources        []Resource
+	registeredResourcePatterns = make(map[string]struct{})
+)
+
+// RegisterTool registers an MCP tool contribution.
+// It panics if the tool name was already registered.
+func RegisterTool(tool Tool) {
+	name := tool.Descriptor().Name
+	if _, exists := registeredToolNames[name]; exists {
+		panic("duplicate registered tool name: " + name)
+	}
+	registeredToolNames[name] = struct{}{}
+	registeredTools = append(registeredTools, tool)
+}
+
+// RegisterResource registers an MCP resource contribution.
+// It panics if the resource pattern was already registered.
+func RegisterResource(resource Resource) {
+	pattern := resource.Pattern()
+	if _, exists := registeredResourcePatterns[pattern]; exists {
+		panic("duplicate registered resource pattern: " + pattern)
+	}
+	registeredResourcePatterns[pattern] = struct{}{}
+	registeredResources = append(registeredResources, resource)
+}
+
+// AllTools returns a copy of all registered tools.
+func AllTools() []Tool {
+	return append([]Tool{}, registeredTools...)
+}
+
+// AllResources returns a copy of all registered resources.
+func AllResources() []Resource {
+	return append([]Resource{}, registeredResources...)
+}
+
+// ResetRegistryForTesting resets the global MCP registry.
+func ResetRegistryForTesting() {
+	if !osutil.IsTestBinary() {
+		panic("internal error: ResetRegistryForTesting can only be used in tests")
+	}
+
+	registeredTools = nil
+	registeredToolNames = make(map[string]struct{})
+	registeredResources = nil
+	registeredResourcePatterns = make(map[string]struct{})
+}

--- a/overlord/mcp/registry_test.go
+++ b/overlord/mcp/registry_test.go
@@ -1,0 +1,141 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package mcp_test
+
+import (
+	"context"
+	"net/http"
+	"os"
+
+	"github.com/snapcore/snapd/overlord/mcp"
+	"github.com/snapcore/snapd/overlord/state"
+	. "gopkg.in/check.v1"
+)
+
+type registrySuite struct{}
+
+var _ = Suite(&registrySuite{})
+
+type mockTool struct {
+	name string
+}
+
+func (t *mockTool) Descriptor() mcp.ToolDescriptor {
+	return mcp.ToolDescriptor{Name: t.name, Title: t.name, Description: t.name}
+}
+
+func (t *mockTool) Validate(args map[string]any) error {
+	return nil
+}
+
+func (t *mockTool) Call(ctx context.Context, st *state.State, args map[string]any) (any, error) {
+	return map[string]any{"ok": true}, nil
+}
+
+type mockResource struct {
+	name    string
+	pattern string
+}
+
+func (r *mockResource) Descriptor() mcp.ResourceDescriptor {
+	return mcp.ResourceDescriptor{URI: "snap://" + r.name + "/{id}", Name: r.name, Description: r.name}
+}
+
+func (r *mockResource) Pattern() string {
+	return r.pattern
+}
+
+func (r *mockResource) Read(ctx context.Context, st *state.State, req *http.Request) (any, error) {
+	return map[string]any{"name": r.name}, nil
+}
+
+func (s *registrySuite) SetUpTest(c *C) {
+	mcp.ResetRegistryForTesting()
+}
+
+func (s *registrySuite) TestRegisterToolAndAllToolsCopy(c *C) {
+	mcp.RegisterTool(&mockTool{name: "tool-a"})
+	mcp.RegisterTool(&mockTool{name: "tool-b"})
+
+	allTools := mcp.AllTools()
+	c.Assert(allTools, HasLen, 2)
+	c.Check(allTools[0].Descriptor().Name, Equals, "tool-a")
+	c.Check(allTools[1].Descriptor().Name, Equals, "tool-b")
+
+	allTools[0] = nil
+	c.Check(mcp.AllTools()[0].Descriptor().Name, Equals, "tool-a")
+}
+
+func (s *registrySuite) TestRegisterToolDuplicatePanics(c *C) {
+	mcp.RegisterTool(&mockTool{name: "dup-tool"})
+
+	c.Assert(func() {
+		mcp.RegisterTool(&mockTool{name: "dup-tool"})
+	}, PanicMatches, "duplicate registered tool name: dup-tool")
+}
+
+func (s *registrySuite) TestRegisterResourceAndAllResourcesCopy(c *C) {
+	mcp.RegisterResource(&mockResource{name: "resource-a", pattern: "/resource-a/"})
+	mcp.RegisterResource(&mockResource{name: "resource-b", pattern: "/resource-b/"})
+
+	allResources := mcp.AllResources()
+	c.Assert(allResources, HasLen, 2)
+	c.Check(allResources[0].Descriptor().Name, Equals, "resource-a")
+	c.Check(allResources[1].Descriptor().Name, Equals, "resource-b")
+
+	allResources[0] = nil
+	c.Check(mcp.AllResources()[0].Descriptor().Name, Equals, "resource-a")
+}
+
+func (s *registrySuite) TestRegisterResourceDuplicatePanics(c *C) {
+	mcp.RegisterResource(&mockResource{name: "dup-resource", pattern: "/dup-resource/"})
+
+	c.Assert(func() {
+		mcp.RegisterResource(&mockResource{name: "other", pattern: "/dup-resource/"})
+	}, PanicMatches, "duplicate registered resource pattern: /dup-resource/")
+}
+
+func (s *registrySuite) TestResetRegistryForTestingClearsAll(c *C) {
+	mcp.RegisterTool(&mockTool{name: "tool-a"})
+	mcp.RegisterResource(&mockResource{name: "resource-a", pattern: "/resource-a/"})
+
+	mcp.ResetRegistryForTesting()
+
+	c.Check(mcp.AllTools(), HasLen, 0)
+	c.Check(mcp.AllResources(), HasLen, 0)
+
+	mcp.RegisterTool(&mockTool{name: "tool-a"})
+	mcp.RegisterResource(&mockResource{name: "resource-a", pattern: "/resource-a/"})
+	c.Check(mcp.AllTools(), HasLen, 1)
+	c.Check(mcp.AllResources(), HasLen, 1)
+}
+
+func (s *registrySuite) TestResetRegistryForTestingPanicsOutsideTestBinary(c *C) {
+	oldArgs := os.Args
+	defer func() {
+		os.Args = oldArgs
+	}()
+
+	os.Args = []string{"/tmp/not-a-test-binary"}
+
+	c.Assert(func() {
+		mcp.ResetRegistryForTesting()
+	}, PanicMatches, "internal error: ResetRegistryForTesting can only be used in tests")
+}

--- a/overlord/mcp/types.go
+++ b/overlord/mcp/types.go
@@ -1,0 +1,257 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+var timeType = reflect.TypeOf(time.Time{})
+
+// ToolAnnotations carries MCP tool annotation hints.
+type ToolAnnotations struct {
+	ReadOnlyHint bool `json:"readOnlyHint,omitempty"`
+}
+
+// ToolTaskSupport describes whether a tool supports task-augmented execution.
+type ToolTaskSupport string
+
+const (
+	ToolTaskSupportForbidden ToolTaskSupport = "forbidden"
+	ToolTaskSupportOptional  ToolTaskSupport = "optional"
+	ToolTaskSupportRequired  ToolTaskSupport = "required"
+)
+
+// ToolExecution carries MCP tool execution hints.
+type ToolExecution struct {
+	TaskSupport ToolTaskSupport `json:"taskSupport,omitempty"`
+}
+
+// ToolDescriptor describes a single MCP tool including its input schema.
+type ToolDescriptor struct {
+	Name         string          `json:"name"`
+	Title        string          `json:"title"`
+	Description  string          `json:"description"`
+	Annotations  ToolAnnotations `json:"annotations,omitempty"`
+	InputSchema  map[string]any  `json:"inputSchema"`
+	OutputSchema map[string]any  `json:"outputSchema,omitempty"`
+	Execution    ToolExecution   `json:"execution,omitempty"`
+}
+
+// Tool represents invocable code that LLMs can access through the Model Context Protocol.
+// Tools are exposed via the tools/list RPC method and invoked via tools/call.
+type TypedTool interface {
+	// ArgsType returns a pointer to a struct that represents the tool's arguments.
+	// This object is used as a destination for strict JSON decoding from map values.
+	ArgsType() any
+	// ResultType returns a pointer to a struct that represents the tool output.
+	ResultType() any
+	ValidateArgs(args any) error
+	CallWithArgs(ctx context.Context, st *state.State, args any) (any, error)
+}
+
+// Tool represents invocable code that LLMs can access through the Model Context Protocol.
+// It remains for backward compatibility; typed tools can implement TypedTool as well.
+type Tool interface {
+	Descriptor() ToolDescriptor
+	Validate(args map[string]any) error
+	Call(ctx context.Context, st *state.State, args map[string]any) (any, error)
+}
+
+// DecodeToolArgs decodes a map of raw arguments into a typed argument object.
+// Unknown fields are rejected to keep validation behavior in sync with schemas.
+func DecodeToolArgs(args map[string]any, argPrototype any) (any, error) {
+	if argPrototype == nil {
+		return nil, fmt.Errorf("arg prototype cannot be nil")
+	}
+
+	data, err := json.Marshal(args)
+	if err != nil {
+		return nil, fmt.Errorf("cannot marshal tool args: %w", err)
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(argPrototype); err != nil {
+		return nil, fmt.Errorf("invalid arguments: %w", err)
+	}
+
+	return argPrototype, nil
+}
+
+// ToolArgsFromMap is a convenience wrapper to decode tool args into a typed struct pointer.
+func ToolArgsFromMap[T any](args map[string]any) (*T, error) {
+	var typed T
+	decoded, err := DecodeToolArgs(args, &typed)
+	if err != nil {
+		return nil, err
+	}
+	ret, ok := decoded.(*T)
+	if !ok {
+		return nil, fmt.Errorf("internal error: decoded args are not *%T", typed)
+	}
+	return ret, nil
+}
+
+func schemaFromType(argType any) map[string]any {
+	typ := reflect.TypeOf(argType)
+	if typ == nil {
+		return map[string]any{"type": "object", "properties": map[string]any{}, "additionalProperties": false}
+	}
+	typ = indirectType(typ)
+	if typ.Kind() != reflect.Struct {
+		return map[string]any{"type": "object", "properties": map[string]any{}, "additionalProperties": false}
+	}
+
+	return schemaFromReflectType(typ)
+}
+
+func indirectType(typ reflect.Type) reflect.Type {
+	for typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+	}
+	return typ
+}
+
+func schemaFromReflectType(typ reflect.Type) map[string]any {
+	typ = indirectType(typ)
+
+	if typ == timeType {
+		return map[string]any{"type": "string", "format": "date-time"}
+	}
+
+	switch typ.Kind() {
+	case reflect.Struct:
+		return schemaFromStructType(typ)
+	case reflect.String:
+		return map[string]any{"type": "string"}
+	case reflect.Bool:
+		return map[string]any{"type": "boolean"}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return map[string]any{"type": "integer"}
+	case reflect.Float32, reflect.Float64:
+		return map[string]any{"type": "number"}
+	case reflect.Slice, reflect.Array:
+		return map[string]any{
+			"type":  "array",
+			"items": schemaFromReflectType(typ.Elem()),
+		}
+	case reflect.Map:
+		schema := map[string]any{"type": "object"}
+		elemType := indirectType(typ.Elem())
+		if elemType.Kind() != reflect.Interface {
+			schema["additionalProperties"] = schemaFromReflectType(elemType)
+		}
+		return schema
+	case reflect.Interface:
+		return map[string]any{}
+	default:
+		return map[string]any{"type": "object"}
+	}
+}
+
+func schemaFromStructType(typ reflect.Type) map[string]any {
+	properties := make(map[string]any)
+	required := make([]string, 0)
+
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		if field.PkgPath != "" {
+			continue
+		}
+
+		jsonTag := field.Tag.Get("json")
+		if jsonTag == "-" {
+			continue
+		}
+
+		jsonName := strings.Split(jsonTag, ",")[0]
+		if jsonName == "" {
+			jsonName = field.Name
+		}
+		if jsonName == "" {
+			continue
+		}
+
+		fieldSchema := schemaFromReflectType(field.Type)
+		if desc := field.Tag.Get("mcp"); desc != "" {
+			if strings.HasPrefix(desc, "description=") {
+				fieldSchema["description"] = strings.TrimPrefix(desc, "description=")
+			} else {
+				fieldSchema["description"] = desc
+			}
+		}
+
+		properties[jsonName] = fieldSchema
+		if !strings.Contains(jsonTag, "omitempty") {
+			required = append(required, jsonName)
+		}
+	}
+
+	schema := map[string]any{
+		"type":                 "object",
+		"properties":           properties,
+		"additionalProperties": false,
+	}
+	if len(required) > 0 {
+		schema["required"] = required
+	}
+	return schema
+}
+
+// InputSchemaFromType returns an MCP input schema for the supplied argument struct type.
+// It uses json struct tags and optional mcp:"description=..." tags.
+func InputSchemaFromType(argType any) map[string]any {
+	return schemaFromType(argType)
+}
+
+// OutputSchemaFromType returns an MCP output schema for the supplied result struct type.
+// It mirrors InputSchemaFromType behavior for tool response objects.
+func OutputSchemaFromType(argType any) map[string]any {
+	return schemaFromType(argType)
+}
+
+// ResourceDescriptor describes one resource entry in resources/list.
+type ResourceDescriptor struct {
+	URI         string `json:"uri"`
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	MimeType    string `json:"mimeType,omitempty"`
+}
+
+// Resource describes a readable MCP resource endpoint.
+type Resource interface {
+	// Descriptor returns metadata advertised via resources/list.
+	Descriptor() ResourceDescriptor
+	// Pattern returns the ServeMux path pattern used for resources/read routing.
+	Pattern() string
+	// Read resolves one resource request using explicit request context and state.
+	Read(ctx context.Context, st *state.State, req *http.Request) (any, error)
+}

--- a/overlord/mcp/types_test.go
+++ b/overlord/mcp/types_test.go
@@ -1,0 +1,158 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package mcp_test
+
+import (
+	"time"
+
+	"github.com/snapcore/snapd/overlord/mcp"
+	. "gopkg.in/check.v1"
+)
+
+type typesSuite struct{}
+
+var _ = Suite(&typesSuite{})
+
+type decodeArgs struct {
+	Name string `json:"name"`
+	Age  int    `json:"age,omitempty"`
+}
+
+type schemaInput struct {
+	Name    string            `json:"name" mcp:"description=tool name"`
+	Enabled bool              `json:"enabled,omitempty"`
+	Count   int               `json:"count"`
+	Ratio   float64           `json:"ratio,omitempty"`
+	Meta    map[string]string `json:"meta,omitempty" mcp:"metadata map"`
+	Labels  []string          `json:"labels,omitempty"`
+	Child   struct {
+		ID string `json:"id"`
+	} `json:"child,omitempty"`
+	Dynamic map[string]struct {
+		Value int `json:"value"`
+	} `json:"dynamic,omitempty"`
+	When     time.Time `json:"when,omitempty"`
+	PtrCount *int      `json:"ptrCount,omitempty"`
+	Hidden   string    `json:"-"`
+	Alias    string
+}
+
+func (s *typesSuite) TestDecodeToolArgsNilPrototype(c *C) {
+	_, err := mcp.DecodeToolArgs(map[string]any{"name": "alpha"}, nil)
+	c.Assert(err, ErrorMatches, "arg prototype cannot be nil")
+}
+
+func (s *typesSuite) TestDecodeToolArgsMarshalFailure(c *C) {
+	_, err := mcp.DecodeToolArgs(map[string]any{"cb": func() {}}, &decodeArgs{})
+	c.Assert(err, ErrorMatches, "cannot marshal tool args:.*")
+}
+
+func (s *typesSuite) TestDecodeToolArgsRejectsUnknownFields(c *C) {
+	_, err := mcp.DecodeToolArgs(map[string]any{"name": "alpha", "extra": "nope"}, &decodeArgs{})
+	c.Assert(err, ErrorMatches, "invalid arguments: json: unknown field \"extra\"")
+}
+
+func (s *typesSuite) TestDecodeToolArgsRejectsWrongTypes(c *C) {
+	_, err := mcp.DecodeToolArgs(map[string]any{"name": 99}, &decodeArgs{})
+	c.Assert(err, ErrorMatches, "invalid arguments: json: cannot unmarshal number into Go struct field decodeArgs.name of type string")
+}
+
+func (s *typesSuite) TestDecodeToolArgsSuccess(c *C) {
+	decoded, err := mcp.DecodeToolArgs(map[string]any{"name": "alpha", "age": 42}, &decodeArgs{})
+	c.Assert(err, IsNil)
+
+	typed, ok := decoded.(*decodeArgs)
+	c.Assert(ok, Equals, true)
+	c.Check(typed.Name, Equals, "alpha")
+	c.Check(typed.Age, Equals, 42)
+}
+
+func (s *typesSuite) TestToolArgsFromMap(c *C) {
+	typed, err := mcp.ToolArgsFromMap[decodeArgs](map[string]any{"name": "alpha", "age": 1})
+	c.Assert(err, IsNil)
+	c.Check(typed.Name, Equals, "alpha")
+	c.Check(typed.Age, Equals, 1)
+
+	_, err = mcp.ToolArgsFromMap[decodeArgs](map[string]any{"unknown": true})
+	c.Assert(err, ErrorMatches, "invalid arguments: json: unknown field \"unknown\"")
+}
+
+func (s *typesSuite) TestInputSchemaFromTypeNilAndNonStruct(c *C) {
+	nilSchema := mcp.InputSchemaFromType(nil)
+	c.Check(nilSchema["type"], Equals, "object")
+	c.Check(nilSchema["additionalProperties"], Equals, false)
+	c.Check(nilSchema["properties"], DeepEquals, map[string]any{})
+
+	nonStructSchema := mcp.InputSchemaFromType(5)
+	c.Check(nonStructSchema["type"], Equals, "object")
+	c.Check(nonStructSchema["additionalProperties"], Equals, false)
+	c.Check(nonStructSchema["properties"], DeepEquals, map[string]any{})
+}
+
+func (s *typesSuite) TestInputSchemaFromTypeStruct(c *C) {
+	schema := mcp.InputSchemaFromType(&schemaInput{})
+
+	c.Check(schema["type"], Equals, "object")
+	c.Check(schema["additionalProperties"], Equals, false)
+
+	properties := schema["properties"].(map[string]any)
+	c.Check(properties["name"].(map[string]any)["type"], Equals, "string")
+	c.Check(properties["name"].(map[string]any)["description"], Equals, "tool name")
+	c.Check(properties["enabled"].(map[string]any)["type"], Equals, "boolean")
+	c.Check(properties["count"].(map[string]any)["type"], Equals, "integer")
+	c.Check(properties["ratio"].(map[string]any)["type"], Equals, "number")
+	c.Check(properties["meta"].(map[string]any)["type"], Equals, "object")
+	c.Check(properties["meta"].(map[string]any)["description"], Equals, "metadata map")
+	c.Check(properties["when"].(map[string]any)["type"], Equals, "string")
+	c.Check(properties["when"].(map[string]any)["format"], Equals, "date-time")
+	c.Check(properties["ptrCount"].(map[string]any)["type"], Equals, "integer")
+	c.Check(properties["Alias"].(map[string]any)["type"], Equals, "string")
+
+	_, hasHidden := properties["hidden"]
+	c.Check(hasHidden, Equals, false)
+	_, hasPrivate := properties["private"]
+	c.Check(hasPrivate, Equals, false)
+
+	required, ok := schema["required"].([]string)
+	c.Assert(ok, Equals, true)
+	c.Check(required, DeepEquals, []string{"name", "count", "Alias"})
+}
+
+func (s *typesSuite) TestOutputSchemaFromType(c *C) {
+	input := &struct {
+		Status string `json:"status"`
+		Items  []struct {
+			Name string `json:"name"`
+		} `json:"items,omitempty"`
+	}{Status: "ok"}
+
+	schema := mcp.OutputSchemaFromType(input)
+	properties := schema["properties"].(map[string]any)
+	c.Check(properties["status"].(map[string]any)["type"], Equals, "string")
+	c.Check(properties["items"].(map[string]any), DeepEquals, map[string]any{
+		"type": "array",
+		"items": map[string]any{
+			"type":                 "object",
+			"properties":           map[string]any{"name": map[string]any{"type": "string"}},
+			"required":             []string{"name"},
+			"additionalProperties": false,
+		},
+	})
+}

--- a/overlord/mcpstate/doc.go
+++ b/overlord/mcpstate/doc.go
@@ -1,0 +1,39 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Package mcpstate implements a Model Context Protocol server.
+//
+// The end-to-end request flow is:
+//
+//  1. An MCP host writes line-delimited JSON-RPC frames to "snap mcp" over
+//     stdio.
+//  2. The "snap mcp" bridge forwards each frame to snapd as POST /v2/mcp over
+//     the snapd socket.
+//  3. The daemon endpoint retrieves the MCP manager from the overlord and calls
+//     MCPManager.ProcessRequest with the request body.
+//  4. MCPManager routes the JSON-RPC method to initialize, tools/list,
+//     tools/call, resources/list, or resources/read handlers. Tools are
+//     interface implementations resolved by name; resources are interface
+//     implementations resolved through an internal stdlib HTTP router.
+//  5. For daemon-side use, state-backed helpers read snap and connection data
+//     directly from overlord state, including manual connection flags.
+//  6. MCPManager returns a JSON-RPC response payload.
+//  7. The daemon wraps the response and the "snap mcp" bridge unwraps it
+//     and writes the inner JSON-RPC response to stdout.
+package mcpstate

--- a/overlord/mcpstate/export_test.go
+++ b/overlord/mcpstate/export_test.go
@@ -1,0 +1,64 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package mcpstate
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// Export private constants for testing.
+const (
+	RPCInvalidParams  = rpcInvalidParams
+	RPCParseError     = rpcParseError
+	RPCInvalidRequest = rpcInvalidRequest
+	RPCMethodNotFound = rpcMethodNotFound
+	RPCInternalError  = rpcInternalError
+)
+
+// Export private methods for testing.
+
+func (m *MCPManager) Initialize(params json.RawMessage) (any, *ResponseError) {
+	return m.initialize(params)
+}
+
+func (m *MCPManager) CallTool(ctx context.Context, params json.RawMessage) (any, *ResponseError) {
+	return m.callTool(ctx, params)
+}
+
+func (m *MCPManager) ReadResource(ctx context.Context, params json.RawMessage) (any, *ResponseError) {
+	return m.readResource(ctx, params)
+}
+
+func (m *MCPManager) ListResources() map[string]any {
+	return m.listResources()
+}
+
+func (m *MCPManager) ListTools() []ToolDescriptor {
+	return m.listTools()
+}
+
+// ValidateResourceReadInput calls the private validateResourceReadInput function.
+func ValidateResourceReadInput(uri string) error {
+	return validateResourceReadInput(uri)
+}
+
+// ResponseError is the exported type for response errors.
+type ResponseError = responseError

--- a/overlord/mcpstate/mcpstate.go
+++ b/overlord/mcpstate/mcpstate.go
@@ -1,0 +1,240 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package mcpstate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/overlord/mcp"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snapdtool"
+)
+
+const defaultProtocolVersion = "2024-11-05"
+
+// MCPManager handles MCP JSON-RPC requests backed by snapd state.
+type MCPManager struct {
+	st             *state.State
+	tools          []Tool
+	toolByName     map[string]Tool
+	resources      []Resource
+	resourceRouter *http.ServeMux
+}
+
+// Ensure implements the overlord StateManager interface.
+func (p *MCPManager) Ensure() error {
+	return nil
+}
+
+// Manager constructs an MCP manager.
+//
+// It panics if mandatory runtime dependencies are invalid or if the provided
+// tool/resource registrations cannot be safely wired (for example conflicting
+// resource route patterns).
+func Manager(st *state.State, tools []Tool, resources []Resource) *MCPManager {
+	if st == nil {
+		panic("state cannot be nil")
+	}
+
+	if tools == nil {
+		tools = mcp.AllTools()
+	}
+
+	if resources == nil {
+		resources = mcp.AllResources()
+	}
+
+	acceptedTools := make([]Tool, 0, len(tools))
+	toolByName := make(map[string]Tool, len(tools))
+	for _, t := range tools {
+		name := t.Descriptor().Name
+		if _, exists := toolByName[name]; exists {
+			logger.Noticef("WARNING: duplicate mcp tool name %q ignored", name)
+			continue
+		}
+		toolByName[name] = t
+		acceptedTools = append(acceptedTools, t)
+	}
+
+	router := http.NewServeMux()
+	acceptedResources := make([]Resource, 0, len(resources))
+	resourceByPattern := make(map[string]struct{}, len(resources))
+	for _, resource := range resources {
+		pattern := resource.Pattern()
+		if _, exists := resourceByPattern[pattern]; exists {
+			logger.Noticef("WARNING: duplicate mcp resource pattern %q ignored", pattern)
+			continue
+		}
+		resourceByPattern[pattern] = struct{}{}
+
+		registered := false
+		func() {
+			defer func() {
+				if rec := recover(); rec != nil {
+					logger.Noticef("WARNING: mcp resource route pattern %q ignored: %v", pattern, rec)
+				}
+			}()
+
+			router.Handle(pattern, resourceRouteHandler{resource: resource})
+			registered = true
+		}()
+
+		if registered {
+			acceptedResources = append(acceptedResources, resource)
+		}
+	}
+
+	return &MCPManager{
+		st:             st,
+		tools:          acceptedTools,
+		toolByName:     toolByName,
+		resources:      acceptedResources,
+		resourceRouter: router,
+	}
+}
+
+type requestEnvelope struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type initializeParams struct {
+	ProtocolVersion string `json:"protocolVersion"`
+}
+
+type responseEnvelope struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Result  any             `json:"result,omitempty"`
+	Error   *responseError  `json:"error,omitempty"`
+}
+
+type responseError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// Error codes defined by the JSON-RPC 2.0 specification.
+// See https://www.jsonrpc.org/specification#error_object
+const (
+	rpcParseError     = -32700
+	rpcInvalidRequest = -32600
+	rpcMethodNotFound = -32601
+	rpcInvalidParams  = -32602
+	rpcInternalError  = -32603
+)
+
+// ProcessRequest processes a single JSON-RPC request payload.
+//
+// The JSON-RPC 2.0 specification is at https://www.jsonrpc.org/specification
+//
+// It returns nil response bytes for notifications (requests without an id).
+func (p *MCPManager) ProcessRequest(ctx context.Context, payload []byte) ([]byte, error) {
+	var req requestEnvelope
+	if err := json.Unmarshal(payload, &req); err != nil {
+		return json.Marshal(&responseEnvelope{
+			JSONRPC: "2.0",
+			Error:   &responseError{Code: rpcParseError, Message: err.Error()},
+		})
+	}
+
+	if req.JSONRPC != "2.0" || strings.TrimSpace(req.Method) == "" {
+		return json.Marshal(&responseEnvelope{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error:   &responseError{Code: rpcInvalidRequest, Message: "invalid request"},
+		})
+	}
+
+	result, rpcErr := p.handleRequest(ctx, req.Method, req.Params)
+	if len(req.ID) == 0 {
+		msg := fmt.Sprintf("received mcp notification method=%s", req.Method)
+		if len(req.Params) > 0 {
+			msg += fmt.Sprintf(" params=%s", req.Params)
+		}
+		if rpcErr != nil {
+			msg += fmt.Sprintf(" error_code=%d error=%q", rpcErr.Code, rpcErr.Message)
+		}
+		logger.Debugf(msg)
+		return nil, nil
+	}
+
+	resp := &responseEnvelope{JSONRPC: "2.0", ID: req.ID}
+	if rpcErr != nil {
+		resp.Error = rpcErr
+	} else {
+		resp.Result = result
+	}
+
+	return json.Marshal(resp)
+}
+
+func (p *MCPManager) handleRequest(ctx context.Context, method string, params json.RawMessage) (any, *responseError) {
+	switch method {
+	case "initialize":
+		return p.initialize(params)
+	case "notifications/initialized":
+		return nil, nil
+	case "ping":
+		return map[string]any{}, nil
+	case "tools/list":
+		return map[string]any{"tools": p.listTools()}, nil
+	case "tools/call":
+		return p.callTool(ctx, params)
+	case "resources/list":
+		return p.listResources(), nil
+	case "resources/read":
+		return p.readResource(ctx, params)
+	default:
+		return nil, &responseError{Code: rpcMethodNotFound, Message: "method not found"}
+	}
+}
+
+func (p *MCPManager) initialize(params json.RawMessage) (any, *responseError) {
+	version := defaultProtocolVersion
+	if len(params) > 0 {
+		var req initializeParams
+		if err := json.Unmarshal(params, &req); err != nil {
+			return nil, &responseError{Code: rpcInvalidParams, Message: "invalid initialize params"}
+		}
+		if strings.TrimSpace(req.ProtocolVersion) != "" {
+			version = strings.TrimSpace(req.ProtocolVersion)
+		}
+	}
+
+	return map[string]any{
+		"protocolVersion": version,
+		"capabilities": map[string]any{
+			"tools":     map[string]any{},
+			"resources": map[string]any{},
+		},
+		"serverInfo": map[string]any{
+			"name":    "snapd-mcp",
+			"version": snapdtool.Version,
+		},
+	}, nil
+}

--- a/overlord/mcpstate/mcpstate_test.go
+++ b/overlord/mcpstate/mcpstate_test.go
@@ -1,0 +1,317 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package mcpstate_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/overlord/mcpstate"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snapdtool"
+	. "gopkg.in/check.v1"
+)
+
+func TestMcpstate(t *testing.T) { TestingT(t) }
+
+type serverSuite struct{}
+
+var _ = Suite(&serverSuite{})
+
+func (s *serverSuite) TestNotificationIsLogged(c *C) {
+	buf, restore := logger.MockDebugLogger()
+	defer restore()
+	p := mcpstate.Manager(state.New(nil), nil, nil)
+
+	payload := []byte(`{"jsonrpc":"2.0","method":"notifications/initialized"}`)
+	respBytes, err := p.ProcessRequest(context.Background(), payload)
+	c.Assert(err, IsNil)
+	c.Check(respBytes, IsNil)
+
+	logOutput := buf.String()
+	c.Check(strings.Contains(logOutput, "received mcp notification"), Equals, true)
+	c.Check(strings.Contains(logOutput, "method=notifications/initialized"), Equals, true)
+}
+
+type processorStateToolsSuite struct{}
+
+var _ = Suite(&processorStateToolsSuite{})
+
+func (s *processorStateToolsSuite) TestNewProcessorNilState(c *C) {
+	c.Assert(func() {
+		_ = mcpstate.Manager(nil, nil, nil)
+	}, PanicMatches, "state cannot be nil")
+}
+
+func (s *processorStateToolsSuite) TestInitializeDefaults(c *C) {
+	p := mcpstate.Manager(state.New(nil), nil, nil)
+
+	result, rpcErr := p.Initialize(nil)
+	c.Assert(rpcErr, IsNil)
+	c.Assert(result.(map[string]any)["protocolVersion"], Equals, "2024-11-05")
+}
+
+func (s *processorStateToolsSuite) TestInitializeCustomVersionTrimmed(c *C) {
+	p := mcpstate.Manager(state.New(nil), nil, nil)
+
+	result, rpcErr := p.Initialize(json.RawMessage(`{"protocolVersion":"2025-01-01"}`))
+	c.Assert(rpcErr, IsNil)
+	res := result.(map[string]any)
+	c.Check(res["protocolVersion"], Equals, "2025-01-01")
+}
+
+func (s *processorStateToolsSuite) TestInitializeInvalidParams(c *C) {
+	p := mcpstate.Manager(state.New(nil), nil, nil)
+
+	_, rpcErr := p.Initialize(json.RawMessage(`{"protocolVersion":{}}`))
+	c.Assert(rpcErr, NotNil)
+	c.Check(rpcErr.Code, Equals, mcpstate.RPCInvalidParams)
+	c.Check(rpcErr.Message, Equals, "invalid initialize params")
+}
+
+func (s *processorStateToolsSuite) TestInitializeServerInfoVersion(c *C) {
+	restore := snapdtool.MockVersion("9.9.9-test")
+	defer restore()
+
+	p := mcpstate.Manager(state.New(nil), nil, nil)
+
+	result, rpcErr := p.Initialize(nil)
+	c.Assert(rpcErr, IsNil)
+
+	res := result.(map[string]any)
+	serverInfo := res["serverInfo"].(map[string]any)
+	c.Check(serverInfo["name"], Equals, "snapd-mcp")
+	c.Check(serverInfo["version"], Equals, "9.9.9-test")
+}
+
+func (s *processorStateToolsSuite) TestCallToolInvalidParamsJSON(c *C) {
+	p := mcpstate.Manager(state.New(nil), nil, nil)
+
+	result, rpcErr := p.CallTool(context.Background(), json.RawMessage(`{"name":`))
+	c.Check(result, IsNil)
+	c.Assert(rpcErr, NotNil)
+	c.Check(rpcErr.Code, Equals, mcpstate.RPCInvalidParams)
+	c.Check(rpcErr.Message, Equals, "invalid tools/call params")
+}
+
+func (s *processorStateToolsSuite) TestCallToolRejectsUnknownTool(c *C) {
+	p := mcpstate.Manager(state.New(nil), nil, nil)
+
+	params := json.RawMessage(`{"name":"snap_bad_tool","arguments":{}}`)
+	result, rpcErr := p.CallTool(context.Background(), params)
+	c.Check(result, IsNil)
+	c.Assert(rpcErr, NotNil)
+	c.Check(rpcErr.Code, Equals, mcpstate.RPCInvalidParams)
+	c.Check(rpcErr.Message, Equals, "unknown tool")
+}
+
+func (s *processorStateToolsSuite) TestNewProcessorIgnoresDuplicateToolNames(c *C) {
+	buf, restore := logger.MockLogger()
+	defer restore()
+
+	p := mcpstate.Manager(state.New(nil), []mcpstate.Tool{TestTool{}, TestTool{}}, nil)
+	c.Assert(p, NotNil)
+
+	tools := p.ListTools()
+	c.Check(len(tools), Equals, 1)
+	c.Check(strings.Contains(buf.String(), `WARNING: duplicate mcp tool name "test_tool" ignored`), Equals, true)
+}
+
+func (s *processorStateToolsSuite) TestNewProcessorIgnoresDuplicateResourcePatterns(c *C) {
+	buf, restore := logger.MockLogger()
+	defer restore()
+
+	p := mcpstate.Manager(state.New(nil), nil, []mcpstate.Resource{TestResource{}, TestResource{}})
+	c.Assert(p, NotNil)
+
+	resources := p.ListResources()
+	c.Check(len(resources), Equals, 1)
+	c.Check(strings.Contains(buf.String(), `WARNING: duplicate mcp resource pattern "/test/" ignored`), Equals, true)
+}
+
+func (s *processorStateToolsSuite) TestProcessRequestInvalidJSON(c *C) {
+	p := mcpstate.Manager(state.New(nil), nil, nil)
+
+	payload := []byte(`{invalid json`)
+	respBytes, err := p.ProcessRequest(context.Background(), payload)
+	c.Assert(err, IsNil)
+
+	var resp map[string]any
+	err = json.Unmarshal(respBytes, &resp)
+	c.Assert(err, IsNil)
+	c.Check(resp["jsonrpc"], Equals, "2.0")
+	c.Check(resp["error"], NotNil)
+	errMap := resp["error"].(map[string]any)
+	c.Check(errMap["code"], Equals, float64(mcpstate.RPCParseError))
+}
+
+func (s *processorStateToolsSuite) TestProcessRequestInvalidVersion(c *C) {
+	p := mcpstate.Manager(state.New(nil), nil, nil)
+
+	payload := []byte(`{"jsonrpc":"1.0","id":1,"method":"ping"}`)
+	respBytes, err := p.ProcessRequest(context.Background(), payload)
+	c.Assert(err, IsNil)
+
+	var resp map[string]any
+	err = json.Unmarshal(respBytes, &resp)
+	c.Assert(err, IsNil)
+	c.Check(resp["error"], NotNil)
+	errMap := resp["error"].(map[string]any)
+	c.Check(errMap["code"], Equals, float64(mcpstate.RPCInvalidRequest))
+}
+
+func (s *processorStateToolsSuite) TestProcessRequestMissingMethod(c *C) {
+	p := mcpstate.Manager(state.New(nil), nil, nil)
+
+	payload := []byte(`{"jsonrpc":"2.0","id":1,"method":""}`)
+	respBytes, err := p.ProcessRequest(context.Background(), payload)
+	c.Assert(err, IsNil)
+
+	var resp map[string]any
+	err = json.Unmarshal(respBytes, &resp)
+	c.Assert(err, IsNil)
+	errMap := resp["error"].(map[string]any)
+	c.Check(errMap["code"], Equals, float64(mcpstate.RPCInvalidRequest))
+}
+
+func (s *processorStateToolsSuite) TestProcessRequestPing(c *C) {
+	p := mcpstate.Manager(state.New(nil), nil, nil)
+
+	payload := []byte(`{"jsonrpc":"2.0","id":"123","method":"ping"}`)
+	respBytes, err := p.ProcessRequest(context.Background(), payload)
+	c.Assert(err, IsNil)
+
+	var resp map[string]any
+	err = json.Unmarshal(respBytes, &resp)
+	c.Assert(err, IsNil)
+	c.Check(resp["jsonrpc"], Equals, "2.0")
+	c.Check(resp["id"], NotNil)
+	c.Check(resp["error"], IsNil)
+	c.Check(resp["result"], NotNil)
+}
+
+func (s *processorStateToolsSuite) TestProcessRequestToolsList(c *C) {
+	tool := TestTool{}
+	p := mcpstate.Manager(state.New(nil), []mcpstate.Tool{tool}, nil)
+
+	payload := []byte(`{"jsonrpc":"2.0","id":"123","method":"tools/list"}`)
+	respBytes, err := p.ProcessRequest(context.Background(), payload)
+	c.Assert(err, IsNil)
+
+	var resp map[string]any
+	err = json.Unmarshal(respBytes, &resp)
+	c.Assert(err, IsNil)
+	c.Check(resp["result"], NotNil)
+	result := resp["result"].(map[string]any)
+	c.Check(result["tools"], NotNil)
+	tools := result["tools"].([]any)
+	c.Check(len(tools), Equals, 1)
+}
+
+func (s *processorStateToolsSuite) TestProcessRequestResourcesList(c *C) {
+	resource := TestResource{}
+	p := mcpstate.Manager(state.New(nil), nil, []mcpstate.Resource{resource})
+
+	payload := []byte(`{"jsonrpc":"2.0","id":"123","method":"resources/list"}`)
+	respBytes, err := p.ProcessRequest(context.Background(), payload)
+	c.Assert(err, IsNil)
+
+	var resp map[string]any
+	err = json.Unmarshal(respBytes, &resp)
+	c.Assert(err, IsNil)
+	c.Check(resp["result"], NotNil)
+	result := resp["result"].(map[string]any)
+	c.Check(result["resources"], NotNil)
+	resources := result["resources"].([]any)
+	c.Check(len(resources), Equals, 1)
+}
+
+func (s *processorStateToolsSuite) TestProcessRequestNotificationNoResponse(c *C) {
+	p := mcpstate.Manager(state.New(nil), nil, nil)
+
+	payload := []byte(`{"jsonrpc":"2.0","method":"ping"}`)
+	respBytes, err := p.ProcessRequest(context.Background(), payload)
+	c.Assert(err, IsNil)
+	c.Check(respBytes, IsNil)
+}
+
+func (s *processorStateToolsSuite) TestProcessRequestUnknownMethod(c *C) {
+	p := mcpstate.Manager(state.New(nil), nil, nil)
+
+	payload := []byte(`{"jsonrpc":"2.0","id":"123","method":"unknown/method"}`)
+	respBytes, err := p.ProcessRequest(context.Background(), payload)
+	c.Assert(err, IsNil)
+
+	var resp map[string]any
+	err = json.Unmarshal(respBytes, &resp)
+	c.Assert(err, IsNil)
+	errMap := resp["error"].(map[string]any)
+	c.Check(errMap["code"], Equals, float64(mcpstate.RPCMethodNotFound))
+}
+
+func (s *processorStateToolsSuite) TestInitializeWithWhitespaceVersion(c *C) {
+	p := mcpstate.Manager(state.New(nil), nil, nil)
+
+	result, rpcErr := p.Initialize(json.RawMessage(`{"protocolVersion":"  2025-01-01  "}`))
+	c.Assert(rpcErr, IsNil)
+	res := result.(map[string]any)
+	c.Check(res["protocolVersion"], Equals, "2025-01-01")
+}
+
+func (s *processorStateToolsSuite) TestInitializeWithEmptyVersion(c *C) {
+	p := mcpstate.Manager(state.New(nil), nil, nil)
+
+	result, rpcErr := p.Initialize(json.RawMessage(`{"protocolVersion":"   "}`))
+	c.Assert(rpcErr, IsNil)
+	res := result.(map[string]any)
+	c.Check(res["protocolVersion"], Equals, "2024-11-05")
+}
+
+type TestTool struct{}
+
+func (t TestTool) Descriptor() mcpstate.ToolDescriptor {
+	return mcpstate.ToolDescriptor{Name: "test_tool"}
+}
+
+func (t TestTool) Validate(args map[string]any) error {
+	return nil
+}
+
+func (t TestTool) Call(ctx context.Context, st *state.State, args map[string]any) (any, error) {
+	return nil, nil
+}
+
+type TestResource struct{}
+
+func (r TestResource) Descriptor() mcpstate.ResourceDescriptor {
+	return mcpstate.ResourceDescriptor{URI: "snap://test/{id}"}
+}
+
+func (r TestResource) Pattern() string {
+	return "/test/"
+}
+
+func (r TestResource) Read(ctx context.Context, st *state.State, req *http.Request) (any, error) {
+	return nil, nil
+}

--- a/overlord/mcpstate/registry_test.go
+++ b/overlord/mcpstate/registry_test.go
@@ -1,0 +1,211 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package mcpstate_test
+
+import (
+	"github.com/snapcore/snapd/overlord/mcp"
+	"github.com/snapcore/snapd/overlord/mcpstate"
+	"github.com/snapcore/snapd/overlord/state"
+	. "gopkg.in/check.v1"
+)
+
+type registrySuite struct{}
+
+var _ = Suite(&registrySuite{})
+
+func (s *registrySuite) SetUpTest(c *C) {
+	mcp.ResetRegistryForTesting()
+}
+
+func (s *registrySuite) TestRegisterToolSuccess(c *C) {
+	tool := &mockTool{
+		descriptor: mcpstate.ToolDescriptor{
+			Name:        "registered_tool",
+			Title:       "Registered Tool",
+			Description: "A registered tool",
+		},
+	}
+
+	mcp.RegisterTool(tool)
+
+	// Verify it's registered
+	tools := mcp.AllTools()
+	found := false
+	for _, t := range tools {
+		if t.Descriptor().Name == "registered_tool" {
+			found = true
+			break
+		}
+	}
+	c.Check(found, Equals, true)
+}
+
+func (s *registrySuite) TestRegisterToolDuplicatePanics(c *C) {
+	tool := &mockTool{
+		descriptor: mcpstate.ToolDescriptor{Name: "dup_tool"},
+	}
+
+	mcp.RegisterTool(tool)
+
+	c.Assert(func() {
+		mcp.RegisterTool(tool)
+	}, PanicMatches, "duplicate registered tool name.*")
+}
+
+func (s *registrySuite) TestRegisterResourceSuccess(c *C) {
+	resource := &mockResource{
+		descriptor: mcpstate.ResourceDescriptor{
+			URI:         "snap://custom/{id}",
+			Name:        "custom",
+			Description: "Custom resource",
+		},
+		pattern: "/custom/",
+	}
+
+	mcp.RegisterResource(resource)
+
+	// Verify it's registered
+	resources := mcp.AllResources()
+	found := false
+	for _, r := range resources {
+		if r.Descriptor().Name == "custom" {
+			found = true
+			break
+		}
+	}
+	c.Check(found, Equals, true)
+}
+
+func (s *registrySuite) TestRegisterResourceDuplicatePanics(c *C) {
+	resource := &mockResource{
+		descriptor: mcpstate.ResourceDescriptor{
+			URI:  "snap://dup/{id}",
+			Name: "dup",
+		},
+		pattern: "/dup/",
+	}
+
+	mcp.RegisterResource(resource)
+
+	c.Assert(func() {
+		mcp.RegisterResource(resource)
+	}, PanicMatches, "duplicate registered resource pattern.*")
+}
+
+func (s *registrySuite) TestAllToolsIntegration(c *C) {
+	tool1 := &mockTool{
+		descriptor: mcpstate.ToolDescriptor{Name: "tool1"},
+	}
+	tool2 := &mockTool{
+		descriptor: mcpstate.ToolDescriptor{Name: "tool2"},
+	}
+
+	mcp.RegisterTool(tool1)
+	mcp.RegisterTool(tool2)
+
+	allTools := mcp.AllTools()
+	c.Assert(len(allTools) >= 2, Equals, true)
+
+	names := make(map[string]bool)
+	for _, t := range allTools {
+		names[t.Descriptor().Name] = true
+	}
+	c.Check(names["tool1"], Equals, true)
+	c.Check(names["tool2"], Equals, true)
+}
+
+func (s *registrySuite) TestAllResourcesIntegration(c *C) {
+	r1 := &mockResource{
+		descriptor: mcpstate.ResourceDescriptor{
+			URI:  "snap://res1/{id}",
+			Name: "res1",
+		},
+		pattern: "/res1/",
+	}
+	r2 := &mockResource{
+		descriptor: mcpstate.ResourceDescriptor{
+			URI:  "snap://res2/{id}",
+			Name: "res2",
+		},
+		pattern: "/res2/",
+	}
+
+	mcp.RegisterResource(r1)
+	mcp.RegisterResource(r2)
+
+	allResources := mcp.AllResources()
+	c.Assert(len(allResources) >= 2, Equals, true)
+
+	names := make(map[string]bool)
+	for _, r := range allResources {
+		names[r.Descriptor().Name] = true
+	}
+	c.Check(names["res1"], Equals, true)
+	c.Check(names["res2"], Equals, true)
+}
+
+func (s *registrySuite) TestManagerWithRegisteredTools(c *C) {
+	mcp.ResetRegistryForTesting()
+
+	tool := &mockTool{
+		descriptor: mcpstate.ToolDescriptor{Name: "mgr_tool"},
+	}
+	mcp.RegisterTool(tool)
+
+	// Create manager with nil tools - should pick up registered ones
+	p := mcpstate.Manager(state.New(nil), nil, nil)
+	tools := p.ListTools()
+
+	found := false
+	for _, t := range tools {
+		if t.Name == "mgr_tool" {
+			found = true
+			break
+		}
+	}
+	c.Check(found, Equals, true)
+}
+
+func (s *registrySuite) TestManagerWithRegisteredResources(c *C) {
+	mcp.ResetRegistryForTesting()
+
+	resource := &mockResource{
+		descriptor: mcpstate.ResourceDescriptor{
+			URI:  "snap://mgr_res/{id}",
+			Name: "mgr_res",
+		},
+		pattern: "/mgr_res/",
+	}
+	mcp.RegisterResource(resource)
+
+	// Create manager with nil resources - should pick up registered ones
+	p := mcpstate.Manager(state.New(nil), nil, nil)
+	result := p.ListResources()
+
+	resources := result["resources"].([]mcpstate.ResourceDescriptor)
+	found := false
+	for _, r := range resources {
+		if r.Name == "mgr_res" {
+			found = true
+			break
+		}
+	}
+	c.Check(found, Equals, true)
+}

--- a/overlord/mcpstate/resources.go
+++ b/overlord/mcpstate/resources.go
@@ -1,0 +1,126 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package mcpstate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+func (p *MCPManager) listResources() map[string]any {
+	descriptors := make([]ResourceDescriptor, 0, len(p.resources))
+	for _, resource := range p.resources {
+		descriptors = append(descriptors, resource.Descriptor())
+	}
+	return map[string]any{"resources": descriptors}
+}
+
+func (p *MCPManager) readResource(ctx context.Context, params json.RawMessage) (any, *responseError) {
+	var req struct {
+		URI string `json:"uri"`
+	}
+	if err := json.Unmarshal(params, &req); err != nil {
+		return nil, &responseError{Code: rpcInvalidParams, Message: "invalid resources/read params"}
+	}
+
+	if err := validateResourceReadInput(req.URI); err != nil {
+		return nil, &responseError{Code: rpcInvalidParams, Message: fmt.Sprintf("invalid arguments: %v", err)}
+	}
+
+	parsedURI, err := url.Parse(req.URI)
+	if err != nil {
+		return nil, &responseError{Code: rpcInvalidParams, Message: fmt.Sprintf("invalid arguments: %v", err)}
+	}
+
+	routePath := "/" + parsedURI.Host + parsedURI.EscapedPath()
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, routePath, nil)
+	if err != nil {
+		return nil, &responseError{Code: rpcInternalError, Message: err.Error()}
+	}
+
+	routeWriter := &resourceRouteWriter{}
+	p.resourceRouter.ServeHTTP(routeWriter, httpReq)
+	if routeWriter.resource == nil {
+		return nil, &responseError{Code: rpcInvalidParams, Message: fmt.Sprintf("invalid arguments: unsupported resource uri: %s", req.URI)}
+	}
+
+	result, err := routeWriter.resource.Read(httpReq.Context(), p.st, httpReq)
+	if err != nil {
+		return nil, &responseError{Code: rpcInternalError, Message: err.Error()}
+	}
+	return result, nil
+}
+
+func validateResourceReadInput(uri string) error {
+	if strings.TrimSpace(uri) == "" {
+		return fmt.Errorf("uri is required")
+	}
+
+	parsedURI, err := url.Parse(uri)
+	if err != nil {
+		return err
+	}
+	if parsedURI.Scheme != "snap" {
+		return fmt.Errorf("unsupported resource uri: %s", uri)
+	}
+	if strings.TrimSpace(parsedURI.Host) == "" {
+		return fmt.Errorf("resource endpoint is required in uri")
+	}
+	if strings.TrimSpace(strings.Trim(parsedURI.Path, "/")) == "" {
+		return fmt.Errorf("resource id is required in uri")
+	}
+	return nil
+}
+
+type resourceRouteHandler struct {
+	resource Resource
+}
+
+func (h resourceRouteHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	rw, ok := w.(*resourceRouteWriter)
+	if !ok {
+		return
+	}
+	rw.resource = h.resource
+}
+
+type resourceRouteWriter struct {
+	resource Resource
+	header   http.Header
+}
+
+func (w *resourceRouteWriter) Header() http.Header {
+	if w.header == nil {
+		w.header = make(http.Header)
+	}
+	return w.header
+}
+
+func (w *resourceRouteWriter) Write(data []byte) (int, error) {
+	return len(data), nil
+}
+
+func (w *resourceRouteWriter) WriteHeader(statusCode int) {
+	_ = statusCode
+}

--- a/overlord/mcpstate/resources_test.go
+++ b/overlord/mcpstate/resources_test.go
@@ -1,0 +1,285 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package mcpstate_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/snapcore/snapd/overlord/mcp"
+	"github.com/snapcore/snapd/overlord/mcpstate"
+	"github.com/snapcore/snapd/overlord/state"
+	. "gopkg.in/check.v1"
+)
+
+type resourcesSuite struct{}
+
+var _ = Suite(&resourcesSuite{})
+
+func (s *resourcesSuite) SetUpTest(c *C) {
+	mcp.ResetRegistryForTesting()
+}
+
+func (s *resourcesSuite) TestListResourcesEmpty(c *C) {
+	p := mcpstate.Manager(state.New(nil), nil, nil)
+
+	result := p.ListResources()
+	c.Assert(result, NotNil)
+	resources := result["resources"].([]mcpstate.ResourceDescriptor)
+	c.Check(len(resources), Equals, 0)
+}
+
+func (s *resourcesSuite) TestListResourcesWithResources(c *C) {
+	r1 := &mockResource{
+		descriptor: mcpstate.ResourceDescriptor{
+			URI:         "snap://info/{id}",
+			Name:        "info",
+			Description: "Snap info",
+		},
+		pattern: "/info/",
+	}
+	r2 := &mockResource{
+		descriptor: mcpstate.ResourceDescriptor{
+			URI:         "snap://services/{id}",
+			Name:        "services",
+			Description: "Snap services",
+		},
+		pattern: "/services/",
+	}
+
+	p := mcpstate.Manager(state.New(nil), nil, []mcpstate.Resource{r1, r2})
+	result := p.ListResources()
+	c.Assert(result, NotNil)
+	resources := result["resources"].([]mcpstate.ResourceDescriptor)
+	c.Check(len(resources), Equals, 2)
+	c.Check(resources[0].Name, Equals, "info")
+	c.Check(resources[1].Name, Equals, "services")
+}
+
+func (s *resourcesSuite) TestReadResourceInvalidJSON(c *C) {
+	p := mcpstate.Manager(state.New(nil), nil, nil)
+
+	params := json.RawMessage(`{"uri":`)
+	result, rpcErr := p.ReadResource(context.Background(), params)
+	c.Check(result, IsNil)
+	c.Assert(rpcErr, NotNil)
+	c.Check(rpcErr.Code, Equals, mcpstate.RPCInvalidParams)
+}
+
+func (s *resourcesSuite) TestReadResourceEmptyURI(c *C) {
+	p := mcpstate.Manager(state.New(nil), nil, nil)
+
+	params := json.RawMessage(`{"uri":""}`)
+	result, rpcErr := p.ReadResource(context.Background(), params)
+	c.Check(result, IsNil)
+	c.Assert(rpcErr, NotNil)
+	c.Check(rpcErr.Code, Equals, mcpstate.RPCInvalidParams)
+	c.Check(rpcErr.Message, Matches, "invalid arguments.*")
+}
+
+func (s *resourcesSuite) TestReadResourceInvalidScheme(c *C) {
+	p := mcpstate.Manager(state.New(nil), nil, nil)
+
+	params := json.RawMessage(`{"uri":"file://info/core"}`)
+	result, rpcErr := p.ReadResource(context.Background(), params)
+	c.Check(result, IsNil)
+	c.Assert(rpcErr, NotNil)
+	c.Check(rpcErr.Code, Equals, mcpstate.RPCInvalidParams)
+}
+
+func (s *resourcesSuite) TestReadResourceMissingEndpoint(c *C) {
+	p := mcpstate.Manager(state.New(nil), nil, nil)
+
+	params := json.RawMessage(`{"uri":"snap:///core"}`)
+	result, rpcErr := p.ReadResource(context.Background(), params)
+	c.Check(result, IsNil)
+	c.Assert(rpcErr, NotNil)
+	c.Check(rpcErr.Code, Equals, mcpstate.RPCInvalidParams)
+}
+
+func (s *resourcesSuite) TestReadResourceMissingID(c *C) {
+	p := mcpstate.Manager(state.New(nil), nil, nil)
+
+	params := json.RawMessage(`{"uri":"snap://info/"}`)
+	result, rpcErr := p.ReadResource(context.Background(), params)
+	c.Check(result, IsNil)
+	c.Assert(rpcErr, NotNil)
+	c.Check(rpcErr.Code, Equals, mcpstate.RPCInvalidParams)
+}
+
+func (s *resourcesSuite) TestReadResourceUnsupportedPattern(c *C) {
+	p := mcpstate.Manager(state.New(nil), nil, nil)
+
+	params := json.RawMessage(`{"uri":"snap://unknown/core"}`)
+	result, rpcErr := p.ReadResource(context.Background(), params)
+	c.Check(result, IsNil)
+	c.Assert(rpcErr, NotNil)
+	c.Check(rpcErr.Code, Equals, mcpstate.RPCInvalidParams)
+	c.Check(rpcErr.Message, Matches, "invalid arguments.*")
+}
+
+func (s *resourcesSuite) TestReadResourceSuccess(c *C) {
+	resource := &mockResource{
+		descriptor: mcpstate.ResourceDescriptor{
+			URI:         "snap://info/{id}",
+			Name:        "info",
+			Description: "Snap info",
+		},
+		pattern:    "/info/",
+		readResult: map[string]any{"name": "core", "status": "active"},
+	}
+
+	p := mcpstate.Manager(state.New(nil), nil, []mcpstate.Resource{resource})
+
+	params := json.RawMessage(`{"uri":"snap://info/core"}`)
+	result, rpcErr := p.ReadResource(context.Background(), params)
+	c.Assert(rpcErr, IsNil)
+	c.Assert(result, NotNil)
+
+	resultMap := result.(map[string]any)
+	c.Check(resultMap["name"], Equals, "core")
+	c.Check(resultMap["status"], Equals, "active")
+}
+
+func (s *resourcesSuite) TestReadResourceError(c *C) {
+	resource := &mockResource{
+		descriptor: mcpstate.ResourceDescriptor{
+			URI:         "snap://info/{id}",
+			Name:        "info",
+			Description: "Snap info",
+		},
+		pattern: "/info/",
+		readErr: fmt.Errorf("not found"),
+	}
+
+	p := mcpstate.Manager(state.New(nil), nil, []mcpstate.Resource{resource})
+
+	params := json.RawMessage(`{"uri":"snap://info/core"}`)
+	result, rpcErr := p.ReadResource(context.Background(), params)
+	c.Check(result, IsNil)
+	c.Assert(rpcErr, NotNil)
+	c.Check(rpcErr.Code, Equals, mcpstate.RPCInternalError)
+	c.Check(rpcErr.Message, Matches, "not found")
+}
+
+func (s *resourcesSuite) TestReadResourceEncodedURI(c *C) {
+	resource := &mockResource{
+		descriptor: mcpstate.ResourceDescriptor{
+			URI:         "snap://info/{id}",
+			Name:        "info",
+			Description: "Snap info",
+		},
+		pattern:    "/info/",
+		readResult: map[string]any{"name": "encoded-name"},
+	}
+
+	p := mcpstate.Manager(state.New(nil), nil, []mcpstate.Resource{resource})
+
+	params := json.RawMessage(`{"uri":"snap://info/encoded%2Dname"}`)
+	result, rpcErr := p.ReadResource(context.Background(), params)
+	c.Assert(rpcErr, IsNil)
+	c.Assert(result, NotNil)
+}
+
+func (s *resourcesSuite) TestReadResourcePassesContextToResource(c *C) {
+	resource := &mockResource{
+		descriptor: mcpstate.ResourceDescriptor{
+			URI:         "snap://info/{id}",
+			Name:        "info",
+			Description: "Snap info",
+		},
+		pattern:    "/info/",
+		readResult: map[string]any{"name": "core"},
+	}
+
+	p := mcpstate.Manager(state.New(nil), nil, []mcpstate.Resource{resource})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	params := json.RawMessage(`{"uri":"snap://info/core"}`)
+	result, rpcErr := p.ReadResource(ctx, params)
+	c.Assert(rpcErr, IsNil)
+	c.Assert(result, NotNil)
+	c.Assert(resource.readCtx, NotNil)
+	c.Check(resource.readCtx.Err(), Equals, context.Canceled)
+}
+
+func (s *resourcesSuite) TestReadResourceQueryAndFragmentAreIgnored(c *C) {
+	resource := &mockResource{
+		descriptor: mcpstate.ResourceDescriptor{
+			URI:         "snap://info/{id}",
+			Name:        "info",
+			Description: "Snap info",
+		},
+		pattern:    "/info/",
+		readResult: map[string]any{"name": "core"},
+	}
+
+	p := mcpstate.Manager(state.New(nil), nil, []mcpstate.Resource{resource})
+
+	params := json.RawMessage(`{"uri":"snap://info/core?channel=stable#details"}`)
+	result, rpcErr := p.ReadResource(context.Background(), params)
+	c.Assert(rpcErr, IsNil)
+	c.Assert(result, NotNil)
+
+	c.Assert(resource.readReq, NotNil)
+	c.Check(resource.readReq.URL.Path, Equals, "/info/core")
+	c.Check(resource.readReq.URL.RawQuery, Equals, "")
+	c.Check(resource.readReq.URL.Fragment, Equals, "")
+}
+
+func (s *resourcesSuite) TestReadResourceMissingURI(c *C) {
+	p := mcpstate.Manager(state.New(nil), nil, nil)
+
+	params := json.RawMessage(`{}`)
+	result, rpcErr := p.ReadResource(context.Background(), params)
+	c.Check(result, IsNil)
+	c.Assert(rpcErr, NotNil)
+	c.Check(rpcErr.Code, Equals, mcpstate.RPCInvalidParams)
+}
+
+type mockResource struct {
+	descriptor mcpstate.ResourceDescriptor
+	pattern    string
+	readResult any
+	readErr    error
+	readReq    *http.Request
+	readCtx    context.Context
+}
+
+func (r *mockResource) Descriptor() mcpstate.ResourceDescriptor {
+	return r.descriptor
+}
+
+func (r *mockResource) Pattern() string {
+	return r.pattern
+}
+
+func (r *mockResource) Read(ctx context.Context, st *state.State, req *http.Request) (any, error) {
+	r.readCtx = ctx
+	r.readReq = req
+	if r.readErr != nil {
+		return nil, r.readErr
+	}
+	return r.readResult, nil
+}

--- a/overlord/mcpstate/schema_test.go
+++ b/overlord/mcpstate/schema_test.go
@@ -1,0 +1,50 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package mcpstate_test
+
+import (
+	"testing"
+
+	"github.com/snapcore/snapd/overlord/mcpstate"
+)
+
+func TestValidateResourceReadInput(t *testing.T) {
+	tests := []struct {
+		name    string
+		uri     string
+		wantErr bool
+	}{
+		{"valid resource uri", "snap://info/core", false},
+		{"valid encoded resource uri", "snap://info/core%2022", false},
+		{"empty uri", "", true},
+		{"unknown resource endpoint", "snap://connections/core", false},
+		{"unsupported scheme", "file://info/core", true},
+		{"missing snap name", "snap://info/", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := mcpstate.ValidateResourceReadInput(tt.uri)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateResourceReadInput() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/overlord/mcpstate/tools.go
+++ b/overlord/mcpstate/tools.go
@@ -1,0 +1,136 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package mcpstate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/snapcore/snapd/overlord/mcp"
+)
+
+type Tool = mcp.Tool
+type ToolDescriptor = mcp.ToolDescriptor
+type ToolAnnotations = mcp.ToolAnnotations
+type Resource = mcp.Resource
+type ResourceDescriptor = mcp.ResourceDescriptor
+
+func (p *MCPManager) listTools() []ToolDescriptor {
+	descriptors := make([]ToolDescriptor, 0, len(p.tools))
+	for _, t := range p.tools {
+		descriptors = append(descriptors, t.Descriptor())
+	}
+	return descriptors
+}
+
+func (p *MCPManager) callTool(ctx context.Context, params json.RawMessage) (any, *responseError) {
+	var req struct {
+		Name      string         `json:"name"`
+		Arguments map[string]any `json:"arguments"`
+	}
+	if err := json.Unmarshal(params, &req); err != nil {
+		return nil, &responseError{Code: rpcInvalidParams, Message: "invalid tools/call params"}
+	}
+
+	t, ok := p.toolByName[req.Name]
+	if !ok {
+		return nil, &responseError{Code: rpcInvalidParams, Message: "unknown tool"}
+	}
+
+	if typed, ok := t.(mcp.TypedTool); ok {
+		decodedArgs, err := mcp.DecodeToolArgs(req.Arguments, typed.ArgsType())
+		if err != nil {
+			return nil, &responseError{Code: rpcInvalidParams, Message: err.Error()}
+		}
+
+		if err := typed.ValidateArgs(decodedArgs); err != nil {
+			return nil, &responseError{Code: rpcInvalidParams, Message: fmt.Sprintf("invalid arguments: %v", err)}
+		}
+
+		result, err := typed.CallWithArgs(ctx, p.st, decodedArgs)
+		if err != nil {
+			return toolError(err), nil
+		}
+		return toolSuccess(result), nil
+	}
+
+	if err := t.Validate(req.Arguments); err != nil {
+		return nil, &responseError{Code: rpcInvalidParams, Message: fmt.Sprintf("invalid arguments: %v", err)}
+	}
+
+	result, err := t.Call(ctx, p.st, req.Arguments)
+	if err != nil {
+		return toolError(err), nil
+	}
+	return toolSuccess(result), nil
+}
+
+func toolSuccess(result any) map[string]any {
+	return map[string]any{
+		"isError":           false,
+		"structuredContent": structuredContentObject(result),
+		"content": []map[string]any{{
+			"type": "text",
+			"text": jsonString(result),
+		}},
+	}
+}
+
+func structuredContentObject(result any) map[string]any {
+	if result == nil {
+		return map[string]any{}
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		return map[string]any{"marshal_error": err.Error()}
+	}
+
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err == nil && obj != nil {
+		return obj
+	}
+
+	var value any
+	if err := json.Unmarshal(data, &value); err != nil {
+		return map[string]any{"marshal_error": err.Error()}
+	}
+
+	return map[string]any{"result": value}
+}
+
+func toolError(err error) map[string]any {
+	return map[string]any{
+		"isError": true,
+		"content": []map[string]any{{
+			"type": "text",
+			"text": err.Error(),
+		}},
+	}
+}
+
+func jsonString(v any) string {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err.Error()
+	}
+	return string(data)
+}

--- a/overlord/mcpstate/tools_test.go
+++ b/overlord/mcpstate/tools_test.go
@@ -1,0 +1,366 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package mcpstate_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/snapcore/snapd/overlord/mcp"
+	"github.com/snapcore/snapd/overlord/mcpstate"
+	"github.com/snapcore/snapd/overlord/state"
+	. "gopkg.in/check.v1"
+)
+
+type toolsSuite struct{}
+
+var _ = Suite(&toolsSuite{})
+
+func (s *toolsSuite) SetUpTest(c *C) {
+	mcp.ResetRegistryForTesting()
+}
+
+func (s *toolsSuite) TestListToolsEmpty(c *C) {
+	p := mcpstate.Manager(state.New(nil), nil, nil)
+
+	tools := p.ListTools()
+	c.Assert(tools, HasLen, 0)
+}
+
+func (s *toolsSuite) TestListToolsWithTools(c *C) {
+	tool1 := &mockTool{
+		descriptor: mcpstate.ToolDescriptor{
+			Name:        "tool1",
+			Title:       "Tool 1",
+			Description: "First tool",
+		},
+	}
+	tool2 := &mockTool{
+		descriptor: mcpstate.ToolDescriptor{
+			Name:        "tool2",
+			Title:       "Tool 2",
+			Description: "Second tool",
+		},
+	}
+
+	p := mcpstate.Manager(state.New(nil), []mcpstate.Tool{tool1, tool2}, nil)
+	tools := p.ListTools()
+	c.Assert(tools, HasLen, 2)
+	c.Check(tools[0].Name, Equals, "tool1")
+	c.Check(tools[1].Name, Equals, "tool2")
+}
+
+func (s *toolsSuite) TestCallToolValidationFailure(c *C) {
+	tool := &mockTool{
+		descriptor:  mcpstate.ToolDescriptor{Name: "my_tool"},
+		validateErr: fmt.Errorf("missing required field"),
+	}
+
+	p := mcpstate.Manager(state.New(nil), []mcpstate.Tool{tool}, nil)
+
+	params := json.RawMessage(`{"name":"my_tool","arguments":{"key":"value"}}`)
+	result, rpcErr := p.CallTool(context.Background(), params)
+	c.Check(result, IsNil)
+	c.Assert(rpcErr, NotNil)
+	c.Check(rpcErr.Code, Equals, mcpstate.RPCInvalidParams)
+	c.Check(rpcErr.Message, Matches, "invalid arguments.*")
+}
+
+func (s *toolsSuite) TestCallToolExecutionSuccess(c *C) {
+	tool := &mockTool{
+		descriptor: mcpstate.ToolDescriptor{Name: "my_tool"},
+		callResult: map[string]any{"status": "success"},
+	}
+
+	p := mcpstate.Manager(state.New(nil), []mcpstate.Tool{tool}, nil)
+
+	params := json.RawMessage(`{"name":"my_tool","arguments":{"key":"value"}}`)
+	result, rpcErr := p.CallTool(context.Background(), params)
+	c.Assert(rpcErr, IsNil)
+	c.Assert(result, NotNil)
+
+	resultMap := result.(map[string]any)
+	c.Check(resultMap["isError"], Equals, false)
+	c.Check(resultMap["content"], NotNil)
+	structured := resultMap["structuredContent"].(map[string]any)
+	c.Check(structured["status"], Equals, "success")
+}
+
+func (s *toolsSuite) TestCallToolExecutionError(c *C) {
+	tool := &mockTool{
+		descriptor: mcpstate.ToolDescriptor{Name: "my_tool"},
+		callErr:    fmt.Errorf("execution failed"),
+	}
+
+	p := mcpstate.Manager(state.New(nil), []mcpstate.Tool{tool}, nil)
+
+	params := json.RawMessage(`{"name":"my_tool","arguments":{"key":"value"}}`)
+	result, rpcErr := p.CallTool(context.Background(), params)
+	c.Assert(rpcErr, IsNil)
+	c.Assert(result, NotNil)
+
+	resultMap := result.(map[string]any)
+	c.Check(resultMap["isError"], Equals, true)
+	content := resultMap["content"].([]map[string]any)
+	c.Check(len(content) > 0, Equals, true)
+}
+
+func (s *toolsSuite) TestCallToolMissingName(c *C) {
+	p := mcpstate.Manager(state.New(nil), nil, nil)
+
+	params := json.RawMessage(`{"arguments":{"key":"value"}}`)
+	result, rpcErr := p.CallTool(context.Background(), params)
+	c.Check(result, IsNil)
+	c.Assert(rpcErr, NotNil)
+	c.Check(rpcErr.Code, Equals, mcpstate.RPCInvalidParams)
+}
+
+func (s *toolsSuite) TestCallToolMissingArguments(c *C) {
+	tool := &mockTool{
+		descriptor: mcpstate.ToolDescriptor{Name: "my_tool"},
+	}
+
+	p := mcpstate.Manager(state.New(nil), []mcpstate.Tool{tool}, nil)
+
+	params := json.RawMessage(`{"name":"my_tool"}`)
+	result, rpcErr := p.CallTool(context.Background(), params)
+	c.Assert(rpcErr, IsNil)
+	c.Assert(result, NotNil)
+	c.Check(tool.validateArgs, DeepEquals, map[string]any(nil))
+	c.Check(tool.callArgs, DeepEquals, map[string]any(nil))
+}
+
+func (s *toolsSuite) TestCallToolPassesArgumentsToValidateAndCall(c *C) {
+	tool := &mockTool{
+		descriptor: mcpstate.ToolDescriptor{Name: "my_tool"},
+		callResult: map[string]any{"ok": true},
+	}
+
+	p := mcpstate.Manager(state.New(nil), []mcpstate.Tool{tool}, nil)
+
+	params := json.RawMessage(`{"name":"my_tool","arguments":{"count":3,"name":"core"}}`)
+	result, rpcErr := p.CallTool(context.Background(), params)
+	c.Assert(rpcErr, IsNil)
+	c.Assert(result, NotNil)
+
+	expectedArgs := map[string]any{"count": float64(3), "name": "core"}
+	c.Check(tool.validateArgs, DeepEquals, expectedArgs)
+	c.Check(tool.callArgs, DeepEquals, expectedArgs)
+}
+
+func (s *toolsSuite) TestCallToolPassesContextToCall(c *C) {
+	tool := &mockTool{
+		descriptor: mcpstate.ToolDescriptor{Name: "my_tool"},
+		callResult: map[string]any{"ok": true},
+	}
+
+	p := mcpstate.Manager(state.New(nil), []mcpstate.Tool{tool}, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	params := json.RawMessage(`{"name":"my_tool","arguments":{}}`)
+	result, rpcErr := p.CallTool(ctx, params)
+	c.Assert(rpcErr, IsNil)
+	c.Assert(result, NotNil)
+	c.Assert(tool.callCtx, NotNil)
+	c.Check(tool.callCtx.Err(), Equals, context.Canceled)
+}
+
+func (s *toolsSuite) TestCallToolResultMarshalFallback(c *C) {
+	tool := &mockTool{
+		descriptor: mcpstate.ToolDescriptor{Name: "my_tool"},
+		callResult: map[string]any{"bad": make(chan int)},
+	}
+
+	p := mcpstate.Manager(state.New(nil), []mcpstate.Tool{tool}, nil)
+
+	params := json.RawMessage(`{"name":"my_tool","arguments":{}}`)
+	result, rpcErr := p.CallTool(context.Background(), params)
+	c.Assert(rpcErr, IsNil)
+	c.Assert(result, NotNil)
+
+	resultMap := result.(map[string]any)
+	content := resultMap["content"].([]map[string]any)
+	text := content[0]["text"].(string)
+	c.Check(strings.Contains(text, "unsupported type"), Equals, true)
+	structured := resultMap["structuredContent"].(map[string]any)
+	c.Check(strings.Contains(structured["marshal_error"].(string), "unsupported type"), Equals, true)
+}
+
+func (s *toolsSuite) TestCallToolSuccessWrapsNonObjectStructuredContent(c *C) {
+	tool := &mockTool{
+		descriptor: mcpstate.ToolDescriptor{Name: "my_tool"},
+		callResult: []string{"a", "b"},
+	}
+
+	p := mcpstate.Manager(state.New(nil), []mcpstate.Tool{tool}, nil)
+
+	params := json.RawMessage(`{"name":"my_tool","arguments":{}}`)
+	result, rpcErr := p.CallTool(context.Background(), params)
+	c.Assert(rpcErr, IsNil)
+	c.Assert(result, NotNil)
+
+	resultMap := result.(map[string]any)
+	structured := resultMap["structuredContent"].(map[string]any)
+	wrapped := structured["result"].([]any)
+	c.Check(wrapped, DeepEquals, []any{"a", "b"})
+}
+
+func (s *toolsSuite) TestCallToolNameIsCaseSensitive(c *C) {
+	tool := &mockTool{
+		descriptor: mcpstate.ToolDescriptor{Name: "my_tool"},
+	}
+
+	p := mcpstate.Manager(state.New(nil), []mcpstate.Tool{tool}, nil)
+
+	params := json.RawMessage(`{"name":"MY_TOOL","arguments":{}}`)
+	result, rpcErr := p.CallTool(context.Background(), params)
+	c.Check(result, IsNil)
+	c.Assert(rpcErr, NotNil)
+	c.Check(rpcErr.Code, Equals, mcpstate.RPCInvalidParams)
+	c.Check(rpcErr.Message, Equals, "unknown tool")
+}
+
+func (s *toolsSuite) TestCallToolTypedToolDecodesTypedArgs(c *C) {
+	tool := &typedTool{}
+	p := mcpstate.Manager(state.New(nil), []mcpstate.Tool{tool}, nil)
+
+	params := json.RawMessage(`{"name":"typed_tool","arguments":{"value":"hello"}}`)
+	result, rpcErr := p.CallTool(context.Background(), params)
+	c.Assert(rpcErr, IsNil)
+	c.Assert(result, NotNil)
+
+	resultMap := result.(map[string]any)
+	structured := resultMap["structuredContent"].(map[string]any)
+	c.Check(structured["hello"], Equals, "world")
+}
+
+func (s *toolsSuite) TestCallToolTypedToolRejectsUnknownField(c *C) {
+	tool := &typedTool{}
+	p := mcpstate.Manager(state.New(nil), []mcpstate.Tool{tool}, nil)
+
+	params := json.RawMessage(`{"name":"typed_tool","arguments":{"unknown":"x"}}`)
+	result, rpcErr := p.CallTool(context.Background(), params)
+	c.Assert(result, IsNil)
+	c.Assert(rpcErr, NotNil)
+	c.Check(rpcErr.Code, Equals, mcpstate.RPCInvalidParams)
+	c.Check(strings.Contains(rpcErr.Message, "invalid arguments"), Equals, true)
+}
+
+func (s *toolsSuite) TestCallToolTypedToolValidateArgsFail(c *C) {
+	tool := &typedTool{validateFail: true}
+	p := mcpstate.Manager(state.New(nil), []mcpstate.Tool{tool}, nil)
+
+	params := json.RawMessage(`{"name":"typed_tool","arguments":{"value":"hello"}}`)
+	result, rpcErr := p.CallTool(context.Background(), params)
+	c.Assert(result, IsNil)
+	c.Assert(rpcErr, NotNil)
+	c.Check(rpcErr.Code, Equals, mcpstate.RPCInvalidParams)
+	c.Check(strings.Contains(rpcErr.Message, "invalid arguments"), Equals, true)
+}
+
+type typedTool struct {
+	validateFail bool
+}
+
+func (t *typedTool) Descriptor() mcpstate.ToolDescriptor {
+	return mcpstate.ToolDescriptor{Name: "typed_tool"}
+}
+
+func (t *typedTool) ArgsType() any {
+	return &struct {
+		Value string `json:"value"`
+	}{}
+}
+
+func (t *typedTool) ValidateArgs(args any) error {
+	if t.validateFail {
+		return fmt.Errorf("bad value")
+	}
+	return nil
+}
+
+func (t *typedTool) ResultType() any {
+	return &struct {
+		Hello string `json:"hello"`
+	}{}
+}
+
+func (t *typedTool) CallWithArgs(ctx context.Context, st *state.State, args any) (any, error) {
+	return map[string]any{"hello": "world"}, nil
+}
+
+func (t *typedTool) Validate(args map[string]any) error {
+	return nil
+}
+
+func (t *typedTool) Call(ctx context.Context, st *state.State, args map[string]any) (any, error) {
+	return nil, nil
+}
+
+type mockTool struct {
+	descriptor   mcpstate.ToolDescriptor
+	validateErr  error
+	callResult   any
+	callErr      error
+	validateArgs map[string]any
+	callArgs     map[string]any
+	callCtx      context.Context
+}
+
+func (t *mockTool) Descriptor() mcpstate.ToolDescriptor {
+	return t.descriptor
+}
+
+func (t *mockTool) Validate(args map[string]any) error {
+	t.validateArgs = args
+	return t.validateErr
+}
+
+func (t *mockTool) Call(ctx context.Context, st *state.State, args map[string]any) (any, error) {
+	t.callCtx = ctx
+	t.callArgs = args
+	if t.callErr != nil {
+		return nil, t.callErr
+	}
+	return t.callResult, nil
+}

--- a/overlord/overlord.go
+++ b/overlord/overlord.go
@@ -50,6 +50,7 @@ import (
 	"github.com/snapcore/snapd/overlord/healthstate"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/ifacestate"
+	"github.com/snapcore/snapd/overlord/mcpstate"
 	"github.com/snapcore/snapd/overlord/notices"
 	"github.com/snapcore/snapd/overlord/patch"
 	"github.com/snapcore/snapd/overlord/restart"
@@ -114,6 +115,7 @@ type Overlord struct {
 	serviceMgr    *servicestate.ServiceManager
 	assertMgr     *assertstate.AssertManager
 	ifaceMgr      *ifacestate.InterfaceManager
+	mcpMgr        *mcpstate.MCPManager
 	hookMgr       *hookstate.HookManager
 	deviceMgr     *devicestate.DeviceManager
 	clusterMgr    *clusterstate.ClusterManager
@@ -216,6 +218,7 @@ func New(restartHandler restart.Handler) (*Overlord, error) {
 	healthstate.Init(hookMgr)
 
 	o.addManager(devicemgmtstate.Manager(s, o.runner, deviceMgr))
+	o.addManager(mcpstate.Manager(s, nil, nil))
 
 	// the shared task runner should be added last!
 	o.stateEng.AddManager(o.runner)
@@ -244,6 +247,8 @@ func (o *Overlord) addManager(mgr StateManager) {
 		o.assertMgr = x
 	case *ifacestate.InterfaceManager:
 		o.ifaceMgr = x
+	case *mcpstate.MCPManager:
+		o.mcpMgr = x
 	case *devicestate.DeviceManager:
 		o.deviceMgr = x
 	case *clusterstate.ClusterManager:
@@ -715,6 +720,12 @@ func (o *Overlord) AssertManager() *assertstate.AssertManager {
 // interface connections under the overlord.
 func (o *Overlord) InterfaceManager() *ifacestate.InterfaceManager {
 	return o.ifaceMgr
+}
+
+// ModelContextProtocolManager returns the MCP manager handling MCP JSON-RPC
+// requests under the overlord.
+func (o *Overlord) ModelContextProtocolManager() *mcpstate.MCPManager {
+	return o.mcpMgr
 }
 
 // HookManager returns the hook manager responsible for running hooks

--- a/overlord/overlord_test.go
+++ b/overlord/overlord_test.go
@@ -124,6 +124,7 @@ func (ovs *overlordSuite) TestNew(c *C) {
 	c.Check(o.ServiceManager(), NotNil)
 	c.Check(o.AssertManager(), NotNil)
 	c.Check(o.InterfaceManager(), NotNil)
+	c.Check(o.ModelContextProtocolManager(), NotNil)
 	c.Check(o.HookManager(), NotNil)
 	c.Check(o.DeviceManager(), NotNil)
 	c.Check(o.ClusterManager(), NotNil)

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -33,6 +33,38 @@ import (
 	userclient "github.com/snapcore/snapd/usersession/client"
 )
 
+func SnapToMapForTest(info *snap.Info, channel string, installed bool, status string) map[string]any {
+	return snapToMap(&snapResult{info: info, channel: channel, installed: installed, status: status})
+}
+
+type ListSnapsTool = listSnapsTool
+type GetSnapTool = getSnapTool
+type SearchStoreSnapsTool = searchStoreSnapsTool
+type GetStoreSnapTool = getStoreSnapTool
+type ListChangesTool = listChangesTool
+type ListChangeTasksTool = listChangeTasksTool
+type ListServicesTool = listServicesTool
+type GetServiceLogsTool = getServiceLogsTool
+
+type GetSnapResult = getSnapResult
+type ListSnapsResult = listSnapsResult
+type StoreSnapSummary = storeSnapSummary
+type SearchStoreSnapsResult = searchStoreSnapsResult
+type GetStoreSnapResult = getStoreSnapResult
+type ListChangesResult = listChangesResult
+type ListChangeTasksResult = listChangeTasksResult
+type ListServicesResult = listServicesResult
+type GetServiceLogsResult = getServiceLogsResult
+
+var ListSnapsToolDescriptor = listSnapsToolDescriptor
+var GetSnapToolDescriptor = getSnapToolDescriptor
+var SearchStoreSnapsToolDescriptor = searchStoreSnapsToolDescriptor
+var GetStoreSnapToolDescriptor = getStoreSnapToolDescriptor
+var ListChangesToolDescriptor = listChangesToolDescriptor
+var ListChangeTasksToolDescriptor = listChangeTasksToolDescriptor
+var ListServicesToolDescriptor = listServicesToolDescriptor
+var GetServiceLogsToolDescriptor = getServiceLogsToolDescriptor
+
 type (
 	ManagerBackend managerBackend
 
@@ -78,6 +110,16 @@ func MockReadComponentInfo(mock func(compMntDir string, snapInfo *snap.Info, csi
 	old := readComponentInfoAt
 	readComponentInfoAt = mock
 	return func() { readComponentInfoAt = old }
+}
+
+func MockReadServiceLogs(mock func(serviceApp *snap.AppInfo, lines int, since, until string, stderrOnly bool) ([]map[string]any, error)) (restore func()) {
+	old := readServiceLogsFromApp
+	readServiceLogsFromApp = mock
+	return func() { readServiceLogsFromApp = old }
+}
+
+func ReadServiceLogsForTest(serviceApp *snap.AppInfo, lines int, since, until string, stderrOnly bool) ([]map[string]any, error) {
+	return readServiceLogs(serviceApp, lines, since, until, stderrOnly)
 }
 
 func MockMountPollInterval(intv time.Duration) (restore func()) {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -936,14 +936,14 @@ func (m *SnapManager) doDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 		}
 
 		timings.Run(perfTimings, "download", fmt.Sprintf("download snap %q", snapsup.SnapName()), func(timings.Measurer) {
-			err = theStore.Download(tomb.Context(nil), snapsup.SnapName(), targetFn, &result.DownloadInfo, meter, user, dlOpts)
+			err = theStore.Download(tomb.Context(context.TODO()), snapsup.SnapName(), targetFn, &result.DownloadInfo, meter, user, dlOpts)
 		})
 		snapsup.SideInfo = &result.SideInfo
 		if err != nil {
 			return err
 		}
 	} else {
-		ctx := tomb.Context(nil) // XXX: should this be a real context?
+		ctx := tomb.Context(context.TODO())
 		timings.Run(perfTimings, "download", fmt.Sprintf("download snap %q", snapsup.SnapName()), func(timings.Measurer) {
 			err = theStore.Download(ctx, snapsup.SnapName(), targetFn, snapsup.DownloadInfo, meter, user, dlOpts)
 		})
@@ -1032,7 +1032,7 @@ func (m *SnapManager) doPreDownloadSnap(t *state.Task, tomb *tomb.Tomb) error {
 	perfTimings := state.TimingsForTask(t)
 	st.Unlock()
 	timings.Run(perfTimings, "pre-download", fmt.Sprintf("pre-download snap %q", snapsup.SnapName()), func(timings.Measurer) {
-		err = theStore.Download(tomb.Context(nil), snapsup.SnapName(), targetFn, snapsup.DownloadInfo, nil, user, dlOpts)
+		err = theStore.Download(tomb.Context(context.TODO()), snapsup.SnapName(), targetFn, snapsup.DownloadInfo, nil, user, dlOpts)
 	})
 	st.Lock()
 	if err != nil {
@@ -5106,7 +5106,7 @@ func (m *SnapManager) doCheckReRefresh(t *state.Task, tomb *tomb.Tomb) error {
 		}
 	}
 
-	updated, updateTss, err := reRefreshUpdateMany(tomb.Context(nil), st, snaps, nil, re.UserID, reRefreshFilter, re.Flags, chg.ID())
+	updated, updateTss, err := reRefreshUpdateMany(tomb.Context(context.TODO()), st, snaps, nil, re.UserID, reRefreshFilter, re.Flags, chg.ID())
 	if err != nil {
 		return err
 	}

--- a/overlord/snapstate/handlers_components.go
+++ b/overlord/snapstate/handlers_components.go
@@ -20,6 +20,7 @@
 package snapstate
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -205,7 +206,7 @@ func (m *SnapManager) doDownloadComponent(t *state.Task, tomb *tomb.Tomb) error 
 			RateLimit: rate,
 		}
 
-		err = sto.Download(tomb.Context(nil), compRef, target, compsup.DownloadInfo, meter, user, opts)
+		err = sto.Download(tomb.Context(context.TODO()), compRef, target, compsup.DownloadInfo, meter, user, opts)
 	})
 	st.Lock()
 	if err != nil {

--- a/overlord/snapstate/mcp_internal_test.go
+++ b/overlord/snapstate/mcp_internal_test.go
@@ -1,0 +1,476 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/snapcore/snapd/overlord/snapstate/sequence"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+)
+
+func TestMCPToolTypedHelpers(t *testing.T) {
+	st := state.New(nil)
+
+	if _, ok := (listSnapsTool{}).ArgsType().(*listSnapsArgs); !ok {
+		t.Fatal("listSnapsTool ArgsType returned unexpected type")
+	}
+	if _, ok := (listSnapsTool{}).ResultType().(*listSnapsResult); !ok {
+		t.Fatal("listSnapsTool ResultType returned unexpected type")
+	}
+	if err := (listSnapsTool{}).ValidateArgs(struct{}{}); err == nil {
+		t.Fatal("listSnapsTool ValidateArgs should reject wrong type")
+	}
+	if _, err := (listSnapsTool{}).CallWithArgs(context.Background(), st, struct{}{}); err == nil {
+		t.Fatal("listSnapsTool CallWithArgs should reject wrong type")
+	}
+
+	if err := (getSnapTool{}).ValidateArgs(&getSnapArgs{}); err == nil {
+		t.Fatal("getSnapTool ValidateArgs should reject empty snap name")
+	}
+	if _, err := (getSnapTool{}).CallWithArgs(context.Background(), st, struct{}{}); err == nil {
+		t.Fatal("getSnapTool CallWithArgs should reject wrong type")
+	}
+
+	if err := (searchStoreSnapsTool{}).ValidateArgs(&searchStoreSnapsArgs{}); err == nil {
+		t.Fatal("searchStoreSnapsTool ValidateArgs should reject empty name")
+	}
+	if _, err := (searchStoreSnapsTool{}).CallWithArgs(context.Background(), st, &searchStoreSnapsArgs{Name: "  "}); err == nil {
+		t.Fatal("searchStoreSnapsTool CallWithArgs should reject empty query")
+	}
+
+	if err := (getStoreSnapTool{}).ValidateArgs(&getStoreSnapArgs{}); err == nil {
+		t.Fatal("getStoreSnapTool ValidateArgs should reject empty snap name")
+	}
+	if _, err := (getStoreSnapTool{}).CallWithArgs(context.Background(), st, &getStoreSnapArgs{SnapName: "  "}); err == nil {
+		t.Fatal("getStoreSnapTool CallWithArgs should reject empty snap name")
+	}
+
+	if err := (listChangesTool{}).ValidateArgs(&listChangesArgs{Select: "bogus"}); err == nil {
+		t.Fatal("listChangesTool ValidateArgs should reject invalid select")
+	}
+	if err := (listChangesTool{}).ValidateArgs(&listChangesArgs{Kind: "bogus"}); err == nil {
+		t.Fatal("listChangesTool ValidateArgs should reject invalid kind")
+	}
+	if err := (listChangesTool{}).ValidateArgs(&listChangesArgs{Status: "bogus"}); err == nil {
+		t.Fatal("listChangesTool ValidateArgs should reject invalid status")
+	}
+	now := time.Now()
+	later := now.Add(-time.Hour)
+	if err := (listChangesTool{}).ValidateArgs(&listChangesArgs{Since: &now, Until: &later}); err == nil {
+		t.Fatal("listChangesTool ValidateArgs should reject reversed time range")
+	}
+	if _, err := (listChangesTool{}).CallWithArgs(context.Background(), st, struct{}{}); err == nil {
+		t.Fatal("listChangesTool CallWithArgs should reject wrong type")
+	}
+
+	if err := (listChangeTasksTool{}).ValidateArgs(&listChangeTasksArgs{}); err == nil {
+		t.Fatal("listChangeTasksTool ValidateArgs should reject empty change id")
+	}
+	if _, err := (listChangeTasksTool{}).CallWithArgs(context.Background(), st, struct{}{}); err == nil {
+		t.Fatal("listChangeTasksTool CallWithArgs should reject wrong type")
+	}
+
+	if err := (listServicesTool{}).ValidateArgs(struct{}{}); err == nil {
+		t.Fatal("listServicesTool ValidateArgs should reject wrong type")
+	}
+	if _, err := (listServicesTool{}).CallWithArgs(context.Background(), st, struct{}{}); err == nil {
+		t.Fatal("listServicesTool CallWithArgs should reject wrong type")
+	}
+
+	if err := (getServiceLogsTool{}).ValidateArgs(&getServiceLogsArgs{}); err == nil {
+		t.Fatal("getServiceLogsTool ValidateArgs should reject empty service name")
+	}
+	if err := (getServiceLogsTool{}).ValidateArgs(&getServiceLogsArgs{ServiceName: "snap.app"}); err != nil {
+		t.Fatalf("getServiceLogsTool ValidateArgs should allow omitted lines value: %v", err)
+	}
+	if err := (getServiceLogsTool{}).ValidateArgs(&getServiceLogsArgs{ServiceName: "snap"}); err == nil {
+		t.Fatal("getServiceLogsTool ValidateArgs should reject malformed service name")
+	}
+	if err := (getServiceLogsTool{}).ValidateArgs(&getServiceLogsArgs{ServiceName: "snap.app", Lines: -2}); err == nil {
+		t.Fatal("getServiceLogsTool ValidateArgs should reject invalid line count")
+	}
+	if err := (getServiceLogsTool{}).ValidateArgs(&getServiceLogsArgs{ServiceName: "snap.app", Since: &now, Until: &later}); err == nil {
+		t.Fatal("getServiceLogsTool ValidateArgs should reject reversed time range")
+	}
+	if _, err := (getServiceLogsTool{}).CallWithArgs(context.Background(), st, struct{}{}); err == nil {
+		t.Fatal("getServiceLogsTool CallWithArgs should reject wrong type")
+	}
+}
+
+func TestMCPStateHelpers(t *testing.T) {
+	st := state.New(nil)
+	st.Lock()
+	chg := st.NewChange("install-snap", "install snap")
+	chg.Set("snap-names", []string{"snap-a.app", "snap-b"})
+	task := st.NewTask("download-snap", "Download snap")
+	task.SetProgress("downloading", 1, 2)
+	task.Logf("line one")
+	chg.AddTask(task)
+	st.Unlock()
+
+	if !matchesChangeSelect(chg, "all") {
+		t.Fatal("matchesChangeSelect should accept all")
+	}
+	if !matchesChangeSelect(chg, "in-progress") {
+		t.Fatal("matchesChangeSelect should match in-progress change")
+	}
+	if matchesChangeSelect(chg, "ready") {
+		t.Fatal("matchesChangeSelect should not match non-ready change as ready")
+	}
+	if matchesChangeSelect(chg, "bogus") {
+		t.Fatal("matchesChangeSelect should reject unknown selector")
+	}
+
+	st.Lock()
+	chg.SetStatus(state.ErrorStatus)
+	if !matchesChangeStatus(chg, "failed") {
+		st.Unlock()
+		t.Fatal("matchesChangeStatus should treat failed as error")
+	}
+	if matchesChangeStatus(chg, "done") {
+		st.Unlock()
+		t.Fatal("matchesChangeStatus should not match wrong status")
+	}
+
+	snapNames := changeSnapNames(chg)
+	if len(snapNames) != 2 {
+		st.Unlock()
+		t.Fatalf("expected 2 snap names, got %d", len(snapNames))
+	}
+	if !containsSnapName(snapNames, "snap-a") {
+		st.Unlock()
+		t.Fatal("containsSnapName should match snap name before app suffix")
+	}
+	if containsSnapName(snapNames, "snap-c") {
+		st.Unlock()
+		t.Fatal("containsSnapName should not match missing snap")
+	}
+
+	item := changeToItem(chg, snapNames)
+	if item.ID != chg.ID() || item.Kind != "install-snap" {
+		st.Unlock()
+		t.Fatalf("unexpected change item: %#v", item)
+	}
+	if len(item.SnapNames) != 2 {
+		st.Unlock()
+		t.Fatalf("expected snap names in change item, got %#v", item.SnapNames)
+	}
+
+	changeMap := changeToMap(chg, snapNames)
+	if changeMap["id"] != chg.ID() {
+		st.Unlock()
+		t.Fatalf("unexpected change map id: %#v", changeMap)
+	}
+	if _, ok := changeMap["snap_names"]; !ok {
+		st.Unlock()
+		t.Fatalf("expected snap_names in change map: %#v", changeMap)
+	}
+
+	taskItem := taskToItem(task)
+	if taskItem.Progress.Label != "downloading" || len(taskItem.Log) != 1 {
+		st.Unlock()
+		t.Fatalf("unexpected task item: %#v", taskItem)
+	}
+	taskMap := taskToMap(task)
+	if taskMap["kind"] != "download-snap" {
+		st.Unlock()
+		t.Fatalf("unexpected task map: %#v", taskMap)
+	}
+	if _, ok := taskMap["log"]; !ok {
+		st.Unlock()
+		t.Fatalf("expected task log in map: %#v", taskMap)
+	}
+	st.Unlock()
+}
+
+func TestListSnapsToResultFiltersByNameCaseInsensitiveSubstring(t *testing.T) {
+	snaps := []snapResult{
+		{info: &snap.Info{SuggestedName: "core-snap", SideInfo: snap.SideInfo{RealName: "core-snap"}}},
+		{info: &snap.Info{SuggestedName: "Hello-World", SideInfo: snap.SideInfo{RealName: "Hello-World"}}},
+	}
+
+	result := listSnapsToResult(snaps, "heLLo")
+	if len(result.Snaps) != 1 {
+		t.Fatalf("expected one snap after filter, got %d", len(result.Snaps))
+	}
+	if result.Snaps[0].Name != "Hello-World" {
+		t.Fatalf("unexpected filtered snap: %#v", result.Snaps[0])
+	}
+}
+
+func TestListSnapsToResultNoFilterIncludesAll(t *testing.T) {
+	snaps := []snapResult{
+		{info: &snap.Info{SuggestedName: "snap-a", SideInfo: snap.SideInfo{RealName: "snap-a"}}},
+		{info: &snap.Info{SuggestedName: "snap-b", SideInfo: snap.SideInfo{RealName: "snap-b"}}},
+	}
+
+	result := listSnapsToResult(snaps, "")
+	if len(result.Snaps) != 2 {
+		t.Fatalf("expected all snaps without filter, got %d", len(result.Snaps))
+	}
+}
+
+func TestIntArg(t *testing.T) {
+	if _, err := intArg(map[string]any{}, "lines"); err == nil {
+		t.Fatal("intArg should require key")
+	}
+	if _, err := intArg(map[string]any{"lines": "1"}, "lines"); err == nil {
+		t.Fatal("intArg should reject non-number")
+	}
+	if _, err := intArg(map[string]any{"lines": 1.5}, "lines"); err == nil {
+		t.Fatal("intArg should reject fractional values")
+	}
+	v, err := intArg(map[string]any{"lines": 2.0}, "lines")
+	if err != nil || v != 2 {
+		t.Fatalf("unexpected intArg result: %d, %v", v, err)
+	}
+}
+
+func TestSnapInfoResourceAndJSONString(t *testing.T) {
+	if got := jsonString(map[string]any{"hello": "world"}); got != `{"hello":"world"}` {
+		t.Fatalf("unexpected jsonString output: %q", got)
+	}
+
+	resource := snapInfoResource{}
+	if resource.Pattern() != "/info/" {
+		t.Fatalf("unexpected pattern: %q", resource.Pattern())
+	}
+	if resource.Descriptor().URI != "snap://info/{snap}" {
+		t.Fatalf("unexpected descriptor: %#v", resource.Descriptor())
+	}
+
+	st := state.New(nil)
+	restore := MockSnapReadInfo(func(name string, si *snap.SideInfo) (*snap.Info, error) {
+		return &snap.Info{
+			SuggestedName:   name,
+			Version:         "1.0",
+			OriginalTitle:   "Title",
+			OriginalSummary: "Summary",
+			Publisher:       snap.StoreAccount{Username: "publisher"},
+			SideInfo:        *si,
+		}, nil
+	})
+	defer restore()
+
+	st.Lock()
+	Set(st, "test-snap", &SnapState{
+		Sequence:        sequence.SnapSequence{Revisions: []*sequence.RevisionSideState{sequence.NewRevisionSideState(&snap.SideInfo{RealName: "test-snap", Revision: snap.R(1)}, nil)}},
+		Current:         snap.R(1),
+		Active:          true,
+		TrackingChannel: "latest/stable",
+	})
+	st.Unlock()
+
+	missingReq := httptest.NewRequest("GET", "http://example/info/missing", nil)
+	if _, err := resource.Read(context.Background(), st, missingReq); err == nil {
+		t.Fatal("snapInfoResource should report missing snap")
+	}
+
+	req := httptest.NewRequest("GET", "http://example/info/test-snap", nil)
+	result, err := resource.Read(context.Background(), st, req)
+	if err != nil {
+		t.Fatalf("snapInfoResource returned error: %v", err)
+	}
+	contents := result.(map[string]any)["contents"].([]map[string]any)
+	if len(contents) != 1 {
+		t.Fatalf("unexpected contents: %#v", result)
+	}
+	if contents[0]["uri"] != "snap://info/test-snap" {
+		t.Fatalf("unexpected resource uri: %#v", contents[0])
+	}
+}
+
+func TestStoreMappingHelpers(t *testing.T) {
+	info := &snap.Info{
+		SuggestedName:       "store-snap",
+		Version:             "1.2",
+		Architectures:       []string{"amd64"},
+		Base:                "core24",
+		Confinement:         snap.StrictConfinement,
+		License:             "GPL-3.0",
+		Tracks:              []string{"latest"},
+		OriginalTitle:       "Store Snap",
+		OriginalSummary:     "Store Summary",
+		OriginalDescription: "Store Description",
+		Publisher:           snap.StoreAccount{Username: "publisher", DisplayName: "Publisher Name"},
+		StoreURL:            "https://snapcraft.io/store-snap",
+		OriginalLinks:       map[string][]string{"website": {"https://example.com"}, "contact": {"mailto:test@example.com"}},
+		Channels:            map[string]*snap.ChannelSnapInfo{"latest/stable": {Channel: "latest/stable", Version: "1.2", Revision: snap.R(7), Confinement: snap.StrictConfinement, ReleasedAt: time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)}},
+		SideInfo:            snap.SideInfo{RealName: "store-snap", Revision: snap.R(7), SnapID: "snapid-1"},
+		SnapType:            snap.TypeApp,
+	}
+
+	summary := storeSnapSummaryToMap(info)
+	if summary["name"] != "store-snap" || summary["snap_id"] != "snapid-1" {
+		t.Fatalf("unexpected store snap summary: %#v", summary)
+	}
+
+	details := storeSnapDetailsToMap(info)
+	if details["publisher"] != "Publisher Name" || details["website"] != "https://example.com" || details["contact"] != "mailto:test@example.com" {
+		t.Fatalf("unexpected store snap details: %#v", details)
+	}
+	channels := details["channels"].(map[string]map[string]any)
+	if channels["latest/stable"]["revision"] != 7 {
+		t.Fatalf("unexpected channel details: %#v", channels)
+	}
+
+	if firstStoreLink(nil, "website") != "" {
+		t.Fatal("firstStoreLink should return empty string for missing links")
+	}
+	if firstStoreLink(info.Links(), "website") != "https://example.com" {
+		t.Fatal("firstStoreLink should return first link value")
+	}
+
+	if statusFromSnapState(&SnapState{Active: true}) != "active" {
+		t.Fatal("statusFromSnapState should report active")
+	}
+	if statusFromSnapState(&SnapState{}) != "installed" {
+		t.Fatal("statusFromSnapState should report installed for inactive snaps")
+	}
+}
+
+func TestStoreFromStateErrors(t *testing.T) {
+	if _, err := storeFromState(state.New(nil)); err == nil {
+		t.Fatal("storeFromState should fail when no store service is available")
+	}
+}
+
+func TestDecodeJournalEntriesAndPriority(t *testing.T) {
+	entries, err := decodeJournalEntries(strings.NewReader(
+		`{"__REALTIME_TIMESTAMP":"1700000000000000","MESSAGE":"hello","SYSLOG_IDENTIFIER":"svc","_PID":"123","PRIORITY":"4"}` + "\n" +
+			`{"MESSAGE":["line1","line2"],"SYSLOG_PID":"321","PRIORITY":["2"]}` + "\n"))
+	if err != nil {
+		t.Fatalf("decodeJournalEntries returned error: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("unexpected decoded entries: %#v", entries)
+	}
+	if entries[0]["message"] != "hello" || entries[0]["sid"] != "svc" || entries[0]["pid"] != "123" || entries[0]["priority"] != 4 {
+		t.Fatalf("unexpected first log entry: %#v", entries[0])
+	}
+	if entries[1]["message"] != "line1\nline2" || entries[1]["sid"] != "-" || entries[1]["pid"] != "321" || entries[1]["priority"] != 2 {
+		t.Fatalf("unexpected second log entry: %#v", entries[1])
+	}
+	if _, ok := entries[0]["timestamp"].(time.Time); !ok {
+		t.Fatalf("expected time.Time timestamp in first entry, got %#v", entries[0]["timestamp"])
+	}
+	if _, ok := entries[1]["timestamp"].(time.Time); !ok {
+		t.Fatalf("expected time.Time timestamp in second entry, got %#v", entries[1]["timestamp"])
+	}
+
+	if _, err := decodeJournalEntries(strings.NewReader(`{"MESSAGE":`)); err == nil {
+		t.Fatal("decodeJournalEntries should reject invalid JSON")
+	}
+
+	if _, ok := journalPriority(nil); ok {
+		t.Fatal("journalPriority should report missing priority")
+	}
+}
+
+func TestServiceHelpers(t *testing.T) {
+	serviceInfo, err := snap.InfoFromSnapYaml([]byte(`name: svc-snap
+version: 1
+apps:
+  daemon:
+    command: bin/run
+    daemon: simple
+  cli:
+    command: bin/cli
+`))
+	if err != nil {
+		t.Fatalf("cannot parse service snap yaml: %v", err)
+	}
+	nonServiceInfo, err := snap.InfoFromSnapYaml([]byte(`name: other-snap
+version: 1
+apps:
+  app:
+    command: bin/app
+`))
+	if err != nil {
+		t.Fatalf("cannot parse non-service snap yaml: %v", err)
+	}
+
+	st := state.New(nil)
+	restore := MockSnapReadInfo(func(name string, si *snap.SideInfo) (*snap.Info, error) {
+		switch name {
+		case "svc-snap":
+			return serviceInfo, nil
+		case "other-snap":
+			return nonServiceInfo, nil
+		default:
+			return nil, ErrNoCurrent
+		}
+	})
+	defer restore()
+
+	st.Lock()
+	Set(st, "svc-snap", &SnapState{
+		Sequence: sequence.SnapSequence{Revisions: []*sequence.RevisionSideState{
+			sequence.NewRevisionSideState(&snap.SideInfo{RealName: "svc-snap", Revision: snap.R(1)}, nil),
+		}},
+		Current: snap.R(1),
+		Active:  true,
+	})
+	Set(st, "other-snap", &SnapState{
+		Sequence: sequence.SnapSequence{Revisions: []*sequence.RevisionSideState{
+			sequence.NewRevisionSideState(&snap.SideInfo{RealName: "other-snap", Revision: snap.R(1)}, nil),
+		}},
+		Current: snap.R(1),
+		Active:  true,
+	})
+	st.Unlock()
+
+	services, err := listServicesFromState(st, "", "")
+	if err != nil {
+		t.Fatalf("listServicesFromState returned error: %v", err)
+	}
+	if len(services) != 1 || services[0].ServiceName != "svc-snap.daemon" {
+		t.Fatalf("unexpected services: %#v", services)
+	}
+
+	filtered, err := listServicesFromState(st, "svc-snap", "daemon")
+	if err != nil || len(filtered) != 1 {
+		t.Fatalf("unexpected filtered services: %#v, err=%v", filtered, err)
+	}
+
+	app, err := serviceFromState(st, "svc-snap.daemon")
+	if err != nil {
+		t.Fatalf("serviceFromState returned error: %v", err)
+	}
+	if app.Name != "daemon" || !app.IsService() {
+		t.Fatalf("unexpected app: %#v", app)
+	}
+
+	if _, err := serviceFromState(st, "badname"); err == nil {
+		t.Fatal("serviceFromState should reject malformed names")
+	}
+	if _, err := serviceFromState(st, "svc-snap.missing"); err == nil {
+		t.Fatal("serviceFromState should reject missing service")
+	}
+	if _, err := serviceFromState(st, "other-snap.app"); err == nil {
+		t.Fatal("serviceFromState should reject non-service app")
+	}
+}

--- a/overlord/snapstate/mcp_registration.go
+++ b/overlord/snapstate/mcp_registration.go
@@ -1,0 +1,47 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate
+
+import (
+	"sync"
+
+	"github.com/snapcore/snapd/overlord/mcp"
+)
+
+var (
+	mcpRegistrationOnce sync.Once
+)
+
+// delayedCrossMgrInit registers snap-specific MCP tools and resources.
+// This is called once from the snap manager's Manager() function to handle
+// cross-manager initialization similar to how ifacestate does it.
+func delayedCrossMgrInit() {
+	mcpRegistrationOnce.Do(func() {
+		mcp.RegisterTool(listSnapsTool{})
+		mcp.RegisterTool(getSnapTool{})
+		mcp.RegisterTool(searchStoreSnapsTool{})
+		mcp.RegisterTool(getStoreSnapTool{})
+		mcp.RegisterTool(listChangesTool{})
+		mcp.RegisterTool(listChangeTasksTool{})
+		mcp.RegisterTool(listServicesTool{})
+		mcp.RegisterTool(getServiceLogsTool{})
+		mcp.RegisterResource(snapInfoResource{})
+	})
+}

--- a/overlord/snapstate/mcp_resource.go
+++ b/overlord/snapstate/mcp_resource.go
@@ -1,0 +1,76 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/snapcore/snapd/overlord/mcp"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+type snapInfoResource struct{}
+
+func (snapInfoResource) Descriptor() mcp.ResourceDescriptor {
+	return mcp.ResourceDescriptor{
+		URI:         "snap://info/{snap}",
+		Name:        "snap info",
+		Description: "Read-only JSON details for a specific snap.",
+		MimeType:    "application/json",
+	}
+}
+
+func (snapInfoResource) Pattern() string {
+	return "/info/"
+}
+
+func (snapInfoResource) Read(_ context.Context, st *state.State, req *http.Request) (any, error) {
+	snapName, err := url.PathUnescape(strings.TrimPrefix(req.URL.EscapedPath(), "/info/"))
+	if err != nil {
+		return nil, fmt.Errorf("invalid snap name in uri")
+	}
+
+	snap, err := snapFromState(st, snapName)
+	if err != nil {
+		return nil, err
+	}
+	if snap == nil {
+		return nil, fmt.Errorf("cannot find snap %q", snapName)
+	}
+
+	return map[string]any{
+		"contents": []map[string]any{{
+			"uri":      "snap://" + strings.TrimPrefix(req.URL.EscapedPath(), "/"),
+			"mimeType": "application/json",
+			"text":     jsonString(snapToMap(snap)),
+		}},
+	}, nil
+}
+
+// jsonString returns a string representation of a value suitable for embedding in JSON.
+func jsonString(v any) string {
+	b, _ := json.Marshal(v)
+	return string(b)
+}

--- a/overlord/snapstate/mcp_schema_test.go
+++ b/overlord/snapstate/mcp_schema_test.go
@@ -1,0 +1,310 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/snapcore/snapd/overlord/mcp"
+	"github.com/snapcore/snapd/overlord/snapstate"
+)
+
+func TestMCPSchemaHelpers(t *testing.T) {
+	tests := []struct {
+		name          string
+		schema        map[string]any
+		expected      map[string]any
+		requiredField string
+	}{
+		{name: "snapSummary", schema: mcp.OutputSchemaFromType(snapstate.GetSnapResult{}), expected: expectedSnapSummarySchema(), requiredField: "name"},
+		{name: "listSnaps", schema: mcp.OutputSchemaFromType(snapstate.ListSnapsResult{}), expected: expectedListSnapsOutputSchema(), requiredField: "snaps"},
+		{name: "storeSnapSummary", schema: mcp.OutputSchemaFromType(snapstate.StoreSnapSummary{}), expected: expectedStoreSnapSummarySchema(), requiredField: "name"},
+		{name: "searchStoreSnaps", schema: mcp.OutputSchemaFromType(snapstate.SearchStoreSnapsResult{}), expected: expectedSearchStoreSnapsOutputSchema(), requiredField: "store_snaps"},
+		{name: "storeSnapDetails", schema: mcp.OutputSchemaFromType(snapstate.GetStoreSnapResult{}), expected: expectedStoreSnapDetailsSchema(), requiredField: "channels"},
+		{name: "listChanges", schema: mcp.OutputSchemaFromType(snapstate.ListChangesResult{}), expected: expectedListChangesOutputSchema(), requiredField: "changes"},
+		{name: "listChangeTasks", schema: mcp.OutputSchemaFromType(snapstate.ListChangeTasksResult{}), expected: expectedListChangeTasksOutputSchema(), requiredField: "tasks"},
+		{name: "listServices", schema: mcp.OutputSchemaFromType(snapstate.ListServicesResult{}), expected: expectedListServicesOutputSchema(), requiredField: "services"},
+		{name: "serviceLogs", schema: mcp.OutputSchemaFromType(snapstate.GetServiceLogsResult{}), expected: expectedServiceLogsOutputSchema(), requiredField: "logs"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if !reflect.DeepEqual(test.schema, test.expected) {
+				t.Fatalf("schema %s does not match expected literal schema", test.name)
+			}
+			if test.schema["type"] != "object" {
+				t.Fatalf("schema %s must have object root, got %#v", test.name, test.schema["type"])
+			}
+			props, ok := test.schema["properties"].(map[string]any)
+			if !ok {
+				t.Fatalf("schema %s must expose properties", test.name)
+			}
+			if _, ok := props[test.requiredField]; !ok {
+				t.Fatalf("schema %s missing expected property %q", test.name, test.requiredField)
+			}
+		})
+	}
+
+	channels := expectedStoreSnapDetailsSchema()["properties"].(map[string]any)["channels"].(map[string]any)
+	if channels["type"] != "object" {
+		t.Fatalf("store snap details channels must be object, got %#v", channels["type"])
+	}
+}
+
+func TestMCPToolDescriptorsUseCustomOutputSchemas(t *testing.T) {
+	tests := []struct {
+		name       string
+		descriptor mcp.ToolDescriptor
+		expected   map[string]any
+	}{
+		{name: "listSnaps", descriptor: snapstate.ListSnapsToolDescriptor, expected: expectedListSnapsOutputSchema()},
+		{name: "getSnap", descriptor: snapstate.GetSnapToolDescriptor, expected: expectedSnapSummarySchema()},
+		{name: "searchStoreSnaps", descriptor: snapstate.SearchStoreSnapsToolDescriptor, expected: expectedSearchStoreSnapsOutputSchema()},
+		{name: "getStoreSnap", descriptor: snapstate.GetStoreSnapToolDescriptor, expected: expectedStoreSnapDetailsSchema()},
+		{name: "listChanges", descriptor: snapstate.ListChangesToolDescriptor, expected: expectedListChangesOutputSchema()},
+		{name: "listChangeTasks", descriptor: snapstate.ListChangeTasksToolDescriptor, expected: expectedListChangeTasksOutputSchema()},
+		{name: "listServices", descriptor: snapstate.ListServicesToolDescriptor, expected: expectedListServicesOutputSchema()},
+		{name: "getServiceLogs", descriptor: snapstate.GetServiceLogsToolDescriptor, expected: expectedServiceLogsOutputSchema()},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if !reflect.DeepEqual(test.descriptor.OutputSchema, test.expected) {
+				t.Fatalf("descriptor %s advertises unexpected output schema", test.name)
+			}
+		})
+	}
+}
+
+func expectedSnapSummarySchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"name":      map[string]any{"type": "string"},
+			"version":   map[string]any{"type": "string"},
+			"revision":  map[string]any{"type": "integer"},
+			"channel":   map[string]any{"type": "string"},
+			"installed": map[string]any{"type": "boolean"},
+			"developer": map[string]any{"type": "string"},
+			"status":    map[string]any{"type": "string"},
+			"title":     map[string]any{"type": "string"},
+			"summary":   map[string]any{"type": "string"},
+		},
+		"required":             []string{"name", "version", "revision", "channel", "installed", "developer", "status", "title", "summary"},
+		"additionalProperties": false,
+	}
+}
+
+func expectedListSnapsOutputSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"snaps": map[string]any{
+				"type":  "array",
+				"items": expectedSnapSummarySchema(),
+			},
+		},
+		"required":             []string{"snaps"},
+		"additionalProperties": false,
+	}
+}
+
+func expectedStoreSnapSummarySchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"name":      map[string]any{"type": "string"},
+			"version":   map[string]any{"type": "string"},
+			"revision":  map[string]any{"type": "integer"},
+			"developer": map[string]any{"type": "string"},
+			"title":     map[string]any{"type": "string"},
+			"summary":   map[string]any{"type": "string"},
+			"snap_id":   map[string]any{"type": "string"},
+			"store_url": map[string]any{"type": "string"},
+		},
+		"required":             []string{"name", "version", "revision", "developer", "title", "summary", "snap_id", "store_url"},
+		"additionalProperties": false,
+	}
+}
+
+func expectedSearchStoreSnapsOutputSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"store_snaps": map[string]any{
+				"type":  "array",
+				"items": expectedStoreSnapSummarySchema(),
+			},
+		},
+		"required":             []string{"store_snaps"},
+		"additionalProperties": false,
+	}
+}
+
+func expectedStoreSnapDetailsSchema() map[string]any {
+	base := expectedStoreSnapSummarySchema()
+	properties := base["properties"].(map[string]any)
+	properties["description"] = map[string]any{"type": "string"}
+	properties["type"] = map[string]any{"type": "string"}
+	properties["confinement"] = map[string]any{"type": "string"}
+	properties["license"] = map[string]any{"type": "string"}
+	properties["base"] = map[string]any{"type": "string"}
+	properties["architectures"] = map[string]any{"type": "array", "items": map[string]any{"type": "string"}}
+	properties["tracks"] = map[string]any{"type": "array", "items": map[string]any{"type": "string"}}
+	properties["publisher"] = map[string]any{"type": "string"}
+	properties["website"] = map[string]any{"type": "string"}
+	properties["contact"] = map[string]any{"type": "string"}
+	properties["channels"] = map[string]any{
+		"type": "object",
+		"additionalProperties": map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"channel":     map[string]any{"type": "string"},
+				"version":     map[string]any{"type": "string"},
+				"revision":    map[string]any{"type": "integer"},
+				"confinement": map[string]any{"type": "string"},
+				"size":        map[string]any{"type": "integer"},
+				"released_at": map[string]any{"type": "string", "format": "date-time"},
+			},
+			"required":             []string{"channel", "version", "revision", "confinement", "size", "released_at"},
+			"additionalProperties": false,
+		},
+	}
+	base["required"] = []string{"name", "version", "revision", "developer", "title", "summary", "snap_id", "store_url", "description", "type", "confinement", "license", "base", "architectures", "tracks", "publisher", "website", "contact", "channels"}
+	return base
+}
+
+func expectedListChangesOutputSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"changes": map[string]any{
+				"type": "array",
+				"items": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"id":         map[string]any{"type": "string"},
+						"kind":       map[string]any{"type": "string"},
+						"summary":    map[string]any{"type": "string"},
+						"status":     map[string]any{"type": "string"},
+						"ready":      map[string]any{"type": "boolean"},
+						"spawn_time": map[string]any{"type": "string", "format": "date-time"},
+						"ready_time": map[string]any{"type": "string", "format": "date-time"},
+						"snap_names": map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+						"err":        map[string]any{"type": "string"},
+					},
+					"required":             []string{"id", "kind", "summary", "status", "ready", "spawn_time"},
+					"additionalProperties": false,
+				},
+			},
+		},
+		"required":             []string{"changes"},
+		"additionalProperties": false,
+	}
+}
+
+func expectedListChangeTasksOutputSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"change_id": map[string]any{"type": "string"},
+			"tasks": map[string]any{
+				"type": "array",
+				"items": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"id":      map[string]any{"type": "string"},
+						"kind":    map[string]any{"type": "string"},
+						"summary": map[string]any{"type": "string"},
+						"status":  map[string]any{"type": "string"},
+						"progress": map[string]any{
+							"type": "object",
+							"properties": map[string]any{
+								"label": map[string]any{"type": "string"},
+								"done":  map[string]any{"type": "integer"},
+								"total": map[string]any{"type": "integer"},
+							},
+							"required":             []string{"label", "done", "total"},
+							"additionalProperties": false,
+						},
+						"log": map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+					},
+					"required":             []string{"id", "kind", "summary", "status", "progress"},
+					"additionalProperties": false,
+				},
+			},
+		},
+		"required":             []string{"change_id", "tasks"},
+		"additionalProperties": false,
+	}
+}
+
+func expectedListServicesOutputSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"services": map[string]any{
+				"type": "array",
+				"items": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"service_name": map[string]any{"type": "string"},
+						"snap_name":    map[string]any{"type": "string"},
+						"app_name":     map[string]any{"type": "string"},
+						"daemon":       map[string]any{"type": "string"},
+						"daemon_scope": map[string]any{"type": "string"},
+						"service_unit": map[string]any{"type": "string"},
+					},
+					"required":             []string{"service_name", "snap_name", "app_name", "daemon", "daemon_scope", "service_unit"},
+					"additionalProperties": false,
+				},
+			},
+		},
+		"required":             []string{"services"},
+		"additionalProperties": false,
+	}
+}
+
+func expectedServiceLogsOutputSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"service_name": map[string]any{"type": "string"},
+			"logs": map[string]any{
+				"type": "array",
+				"items": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"timestamp": map[string]any{"type": "string", "format": "date-time"},
+						"message":   map[string]any{"type": "string"},
+						"sid":       map[string]any{"type": "string"},
+						"pid":       map[string]any{"type": "string"},
+						"priority":  map[string]any{"type": "integer"},
+					},
+					"required":             []string{"timestamp", "message", "sid", "pid"},
+					"additionalProperties": false,
+				},
+			},
+		},
+		"required":             []string{"service_name", "logs"},
+		"additionalProperties": false,
+	}
+}

--- a/overlord/snapstate/mcp_tool_get_service_logs.go
+++ b/overlord/snapstate/mcp_tool_get_service_logs.go
@@ -1,0 +1,338 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/overlord/mcp"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/systemd"
+)
+
+const toolGetServiceLogs = "snap_get_service_logs"
+
+type getServiceLogsTool struct{}
+
+var readServiceLogsFromApp = readServiceLogs
+
+type getServiceLogsArgs struct {
+	ServiceName string     `json:"service_name" mcp:"description=Service name in the form <snap>.<app>."`
+	Lines       int        `json:"lines,omitempty" mcp:"description=Maximum number of log lines to fetch (default: 100, use -1 for all)."`
+	Since       *time.Time `json:"since,omitempty" mcp:"description=Optional inclusive lower time bound in RFC3339 format."`
+	Until       *time.Time `json:"until,omitempty" mcp:"description=Optional inclusive upper time bound in RFC3339 format."`
+	StderrOnly  bool       `json:"stderr_only,omitempty" mcp:"description=If true, only include high-priority journal entries (priority 0..3)."`
+}
+
+type getServiceLogsItem struct {
+	Timestamp time.Time `json:"timestamp"`
+	Message   string    `json:"message"`
+	SID       string    `json:"sid"`
+	PID       string    `json:"pid"`
+	Priority  int       `json:"priority,omitempty"`
+}
+
+type getServiceLogsResult struct {
+	ServiceName string               `json:"service_name"`
+	Logs        []getServiceLogsItem `json:"logs"`
+}
+
+var getServiceLogsToolDescriptor = mcp.ToolDescriptor{
+	Name:         toolGetServiceLogs,
+	Title:        "Get snap service logs",
+	Description:  "Get logs for one snap service with optional journalctl time-window and stderr-only filtering (read-only).",
+	Annotations:  mcp.ToolAnnotations{ReadOnlyHint: true},
+	Execution:    readOnlyToolExecution,
+	InputSchema:  mcp.InputSchemaFromType(getServiceLogsArgs{}),
+	OutputSchema: mcp.OutputSchemaFromType(getServiceLogsResult{}),
+}
+
+func (getServiceLogsTool) Descriptor() mcp.ToolDescriptor {
+	return getServiceLogsToolDescriptor
+}
+
+func (getServiceLogsTool) ArgsType() any {
+	return &getServiceLogsArgs{}
+}
+
+func (getServiceLogsTool) ValidateArgs(args any) error {
+	v, ok := args.(*getServiceLogsArgs)
+	if !ok {
+		return fmt.Errorf("invalid typed args for get service logs tool")
+	}
+	if strings.TrimSpace(v.ServiceName) == "" {
+		return fmt.Errorf("service_name must not be empty")
+	}
+	if !strings.Contains(v.ServiceName, ".") {
+		return fmt.Errorf("service_name must be in the form <snap>.<app>")
+	}
+	if v.Lines < -1 {
+		return fmt.Errorf("lines must be greater than zero, or -1")
+	}
+	if v.Since != nil && v.Until != nil && v.Since.After(*v.Until) {
+		return fmt.Errorf("since must not be after until")
+	}
+	return nil
+}
+
+func (getServiceLogsTool) ResultType() any {
+	return &getServiceLogsResult{}
+}
+
+func (getServiceLogsTool) CallWithArgs(_ context.Context, st *state.State, args any) (any, error) {
+	filterArgs, ok := args.(*getServiceLogsArgs)
+	if !ok {
+		return nil, fmt.Errorf("invalid typed args for get service logs tool")
+	}
+	serviceName := strings.TrimSpace(filterArgs.ServiceName)
+	if serviceName == "" {
+		return nil, errors.New("service_name must not be empty")
+	}
+	if !strings.Contains(serviceName, ".") {
+		return nil, errors.New("service_name must be in the form <snap>.<app>")
+	}
+
+	lines := 100
+	if filterArgs.Lines != 0 {
+		if filterArgs.Lines < -1 {
+			return nil, errors.New("lines must be greater than zero, or -1")
+		}
+		lines = filterArgs.Lines
+	}
+
+	sinceValue := ""
+	var sinceTime time.Time
+	if filterArgs.Since != nil {
+		sinceValue = filterArgs.Since.Format(time.RFC3339)
+		sinceTime = *filterArgs.Since
+	}
+
+	untilValue := ""
+	var untilTime time.Time
+	if filterArgs.Until != nil {
+		untilValue = filterArgs.Until.Format(time.RFC3339)
+		untilTime = *filterArgs.Until
+	}
+
+	if !sinceTime.IsZero() && !untilTime.IsZero() && sinceTime.After(untilTime) {
+		return nil, errors.New("since must not be after until")
+	}
+
+	stderrOnly := filterArgs.StderrOnly
+
+	serviceApp, err := serviceFromState(st, serviceName)
+	if err != nil {
+		return nil, err
+	}
+
+	entries, err := readServiceLogsFromApp(serviceApp, lines, sinceValue, untilValue, stderrOnly)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get logs for %q: %w", serviceName, err)
+	}
+
+	logs := make([]getServiceLogsItem, 0, len(entries))
+	for _, entry := range entries {
+		item := getServiceLogsItem{}
+		if v, ok := entry["timestamp"].(time.Time); ok {
+			item.Timestamp = v
+		} else if v, ok := entry["timestamp"].(string); ok {
+			if parsed, err := time.Parse(time.RFC3339, v); err == nil {
+				item.Timestamp = parsed
+			}
+		}
+		if v, ok := entry["message"].(string); ok {
+			item.Message = v
+		}
+		if v, ok := entry["sid"].(string); ok {
+			item.SID = v
+		}
+		if v, ok := entry["pid"].(string); ok {
+			item.PID = v
+		}
+		if v, ok := entry["priority"].(float64); ok {
+			item.Priority = int(v)
+		} else if v, ok := entry["priority"].(int); ok {
+			item.Priority = v
+		}
+		logs = append(logs, item)
+	}
+
+	return getServiceLogsResult{ServiceName: serviceName, Logs: logs}, nil
+}
+
+func (getServiceLogsTool) Validate(args map[string]any) error {
+	_, err := mcp.ToolArgsFromMap[getServiceLogsArgs](args)
+	return err
+}
+
+func (getServiceLogsTool) Call(ctx context.Context, st *state.State, args map[string]any) (any, error) {
+	parsedArgs, err := mcp.ToolArgsFromMap[getServiceLogsArgs](args)
+	if err != nil {
+		return nil, err
+	}
+	return getServiceLogsTool{}.CallWithArgs(ctx, st, parsedArgs)
+}
+
+func serviceFromState(st *state.State, serviceName string) (*snap.AppInfo, error) {
+	snapName, appName, found := strings.Cut(serviceName, ".")
+	if !found || snapName == "" || appName == "" {
+		return nil, fmt.Errorf("service_name must be in the form <snap>.<app>")
+	}
+
+	st.Lock()
+	defer st.Unlock()
+
+	var snapst SnapState
+	if err := Get(st, snapName, &snapst); err != nil {
+		if errors.Is(err, state.ErrNoState) {
+			return nil, fmt.Errorf("cannot find service %q", serviceName)
+		}
+		return nil, fmt.Errorf("cannot consult state for %q: %w", serviceName, err)
+	}
+
+	info, err := snapst.CurrentInfo()
+	if err != nil {
+		if err == ErrNoCurrent {
+			return nil, fmt.Errorf("cannot find service %q", serviceName)
+		}
+		return nil, fmt.Errorf("cannot read snap details for %q: %w", snapName, err)
+	}
+
+	app := info.Apps[appName]
+	if app == nil || !app.IsService() {
+		return nil, fmt.Errorf("cannot find service %q", serviceName)
+	}
+
+	return app, nil
+}
+
+func readServiceLogs(serviceApp *snap.AppInfo, lines int, since, until string, stderrOnly bool) ([]map[string]any, error) {
+	if serviceApp == nil {
+		return nil, errors.New("service app must not be nil")
+	}
+
+	args := []string{"-o", "json", "--no-pager"}
+	if lines < 0 {
+		args = append(args, "--no-tail")
+	} else {
+		args = append(args, "-n", strconv.Itoa(lines))
+	}
+	if since != "" {
+		args = append(args, "--since", since)
+	}
+	if until != "" {
+		args = append(args, "--until", until)
+	}
+	if stderrOnly {
+		args = append(args, "-p", "0..3")
+	}
+
+	includeNamespaces := false
+	if err := systemd.EnsureAtLeast(245); err == nil {
+		includeNamespaces = true
+	} else if !systemd.IsSystemdTooOld(err) {
+		return nil, fmt.Errorf("cannot get systemd version: %v", err)
+	}
+	if includeNamespaces {
+		args = append(args, "--namespace=*")
+	}
+
+	args = append(args, "-u", serviceApp.ServiceName())
+
+	rc, err := osutil.StreamCommand("journalctl", args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+
+	entries, err := decodeJournalEntries(rc)
+	if err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+func decodeJournalEntries(reader io.Reader) ([]map[string]any, error) {
+	decoder := json.NewDecoder(reader)
+	entries := make([]map[string]any, 0)
+	for {
+		var entry systemd.Log
+		if err := decoder.Decode(&entry); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, err
+		}
+
+		timestamp, err := entry.Time()
+		if err != nil {
+			timestamp = time.Time{}
+		}
+
+		mapped := map[string]any{
+			"timestamp": timestamp.UTC(),
+			"message":   entry.Message(),
+			"sid":       entry.SID(),
+			"pid":       entry.PID(),
+		}
+		if priority, ok := journalPriority(entry); ok {
+			mapped["priority"] = priority
+		}
+
+		entries = append(entries, mapped)
+	}
+
+	return entries, nil
+}
+
+func journalPriority(entry systemd.Log) (int, bool) {
+	rawPriority, ok := entry["PRIORITY"]
+	if !ok || rawPriority == nil {
+		return 0, false
+	}
+
+	var single string
+	if err := json.Unmarshal(*rawPriority, &single); err == nil {
+		priority, err := strconv.Atoi(single)
+		if err != nil {
+			return 0, false
+		}
+		return priority, true
+	}
+
+	var list []string
+	if err := json.Unmarshal(*rawPriority, &list); err != nil || len(list) == 0 {
+		return 0, false
+	}
+	priority, err := strconv.Atoi(list[0])
+	if err != nil {
+		return 0, false
+	}
+	return priority, true
+}

--- a/overlord/snapstate/mcp_tool_get_snap.go
+++ b/overlord/snapstate/mcp_tool_get_snap.go
@@ -1,0 +1,112 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/snapcore/snapd/overlord/mcp"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+const toolGetSnap = "snap_get_snap"
+
+type getSnapTool struct{}
+
+type getSnapArgs struct {
+	SnapName string `json:"snap_name" mcp:"description=Name of the snap to query."`
+}
+
+type getSnapResult = snapSummary
+
+var getSnapToolDescriptor = mcp.ToolDescriptor{
+	Name:         toolGetSnap,
+	Title:        "Get snap details",
+	Description:  "Get detailed information about a specific snap by name (read-only).",
+	Annotations:  mcp.ToolAnnotations{ReadOnlyHint: true},
+	Execution:    readOnlyToolExecution,
+	InputSchema:  mcp.InputSchemaFromType(getSnapArgs{}),
+	OutputSchema: mcp.OutputSchemaFromType(getSnapResult{}),
+}
+
+func (getSnapTool) Descriptor() mcp.ToolDescriptor {
+	return getSnapToolDescriptor
+}
+
+func (getSnapTool) ArgsType() any {
+	return &getSnapArgs{}
+}
+
+func (getSnapTool) ValidateArgs(args any) error {
+	v, ok := args.(*getSnapArgs)
+	if !ok {
+		return fmt.Errorf("invalid typed args for get snap tool")
+	}
+	if strings.TrimSpace(v.SnapName) == "" {
+		return fmt.Errorf("snap_name is required")
+	}
+	return nil
+}
+
+func (getSnapTool) ResultType() any {
+	return &getSnapResult{}
+}
+
+func (getSnapTool) CallWithArgs(_ context.Context, st *state.State, args any) (any, error) {
+	filterArgs, ok := args.(*getSnapArgs)
+	if !ok {
+		return nil, fmt.Errorf("invalid typed args for get snap tool")
+	}
+
+	snapResult, err := snapFromState(st, filterArgs.SnapName)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get snap %q: %w", filterArgs.SnapName, err)
+	}
+
+	return snapSummary{
+		Name:      snapResult.info.InstanceName(),
+		Version:   snapResult.info.Version,
+		Revision:  snapResult.info.Revision.N,
+		Channel:   snapResult.channel,
+		Installed: snapResult.installed,
+		Developer: snapResult.info.Publisher.Username,
+		Status:    snapResult.status,
+		Title:     snapResult.info.Title(),
+		Summary:   snapResult.info.Summary(),
+	}, nil
+}
+
+func (getSnapTool) Validate(args map[string]any) error {
+	parsedArgs, err := mcp.ToolArgsFromMap[getSnapArgs](args)
+	if err != nil {
+		return err
+	}
+	return getSnapTool{}.ValidateArgs(parsedArgs)
+}
+
+func (getSnapTool) Call(ctx context.Context, st *state.State, args map[string]any) (any, error) {
+	parsedArgs, err := mcp.ToolArgsFromMap[getSnapArgs](args)
+	if err != nil {
+		return nil, err
+	}
+	return getSnapTool{}.CallWithArgs(ctx, st, parsedArgs)
+}

--- a/overlord/snapstate/mcp_tool_get_store_snap.go
+++ b/overlord/snapstate/mcp_tool_get_store_snap.go
@@ -1,0 +1,171 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/snapcore/snapd/overlord/mcp"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/store"
+)
+
+const toolGetStoreSnap = "snap_get_store_snap"
+
+type getStoreSnapTool struct{}
+
+type getStoreSnapArgs struct {
+	SnapName string `json:"snap_name" mcp:"description=Name of the store snap to query."`
+}
+
+type storeChannelEntry struct {
+	Channel     string    `json:"channel"`
+	Version     string    `json:"version"`
+	Revision    int       `json:"revision"`
+	Confinement string    `json:"confinement"`
+	Size        int       `json:"size"`
+	ReleasedAt  time.Time `json:"released_at"`
+}
+
+type getStoreSnapResult struct {
+	Name          string                       `json:"name"`
+	Version       string                       `json:"version"`
+	Revision      int                          `json:"revision"`
+	Developer     string                       `json:"developer"`
+	Title         string                       `json:"title"`
+	Summary       string                       `json:"summary"`
+	SnapID        string                       `json:"snap_id"`
+	StoreURL      string                       `json:"store_url"`
+	Description   string                       `json:"description"`
+	Type          string                       `json:"type"`
+	Confinement   string                       `json:"confinement"`
+	License       string                       `json:"license"`
+	Base          string                       `json:"base"`
+	Architectures []string                     `json:"architectures"`
+	Tracks        []string                     `json:"tracks"`
+	Publisher     string                       `json:"publisher"`
+	Website       string                       `json:"website"`
+	Contact       string                       `json:"contact"`
+	Channels      map[string]storeChannelEntry `json:"channels"`
+}
+
+var getStoreSnapToolDescriptor = mcp.ToolDescriptor{
+	Name:         toolGetStoreSnap,
+	Title:        "Get store snap details",
+	Description:  "Get details about a specific snap from the Snap Store by name (read-only).",
+	Annotations:  mcp.ToolAnnotations{ReadOnlyHint: true},
+	Execution:    readOnlyToolExecution,
+	InputSchema:  mcp.InputSchemaFromType(getStoreSnapArgs{}),
+	OutputSchema: mcp.OutputSchemaFromType(getStoreSnapResult{}),
+}
+
+func (getStoreSnapTool) Descriptor() mcp.ToolDescriptor {
+	return getStoreSnapToolDescriptor
+}
+
+func (getStoreSnapTool) ArgsType() any {
+	return &getStoreSnapArgs{}
+}
+
+func (getStoreSnapTool) ValidateArgs(args any) error {
+	v, ok := args.(*getStoreSnapArgs)
+	if !ok {
+		return fmt.Errorf("invalid typed args for get store snap tool")
+	}
+	if strings.TrimSpace(v.SnapName) == "" {
+		return fmt.Errorf("snap_name must not be empty")
+	}
+	return nil
+}
+
+func (getStoreSnapTool) ResultType() any {
+	return &getStoreSnapResult{}
+}
+
+func (getStoreSnapTool) CallWithArgs(ctx context.Context, st *state.State, args any) (any, error) {
+	filterArgs, ok := args.(*getStoreSnapArgs)
+	if !ok {
+		return nil, fmt.Errorf("invalid typed args for get store snap tool")
+	}
+	if strings.TrimSpace(filterArgs.SnapName) == "" {
+		return nil, fmt.Errorf("snap_name must not be empty")
+	}
+	snapName := strings.TrimSpace(filterArgs.SnapName)
+
+	storeService, err := storeFromState(st)
+	if err != nil {
+		return nil, err
+	}
+
+	storeSnap, err := storeService.SnapInfo(ctx, store.SnapSpec{Name: snapName}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get store snap %q: %w", snapName, err)
+	}
+
+	result := getStoreSnapResult{
+		Name:          storeSnap.SnapName(),
+		Version:       storeSnap.Version,
+		Revision:      storeSnap.Revision.N,
+		Developer:     storeSnap.Publisher.Username,
+		Title:         storeSnap.Title(),
+		Summary:       storeSnap.Summary(),
+		SnapID:        storeSnap.SnapID,
+		StoreURL:      storeSnap.StoreURL,
+		Description:   storeSnap.Description(),
+		Type:          string(storeSnap.SnapType),
+		Confinement:   string(storeSnap.Confinement),
+		License:       storeSnap.License,
+		Base:          storeSnap.Base,
+		Architectures: storeSnap.Architectures,
+		Tracks:        storeSnap.Tracks,
+		Publisher:     storeSnap.Publisher.DisplayName,
+		Website:       firstStoreLink(storeSnap.Links(), "website"),
+		Contact:       firstStoreLink(storeSnap.Links(), "contact"),
+		Channels:      make(map[string]storeChannelEntry, 0),
+	}
+	for channelName, channelInfo := range storeSnap.Channels {
+		result.Channels[channelName] = storeChannelEntry{
+			Channel:     channelInfo.Channel,
+			Version:     channelInfo.Version,
+			Revision:    channelInfo.Revision.N,
+			Confinement: string(channelInfo.Confinement),
+			Size:        int(channelInfo.Size),
+			ReleasedAt:  channelInfo.ReleasedAt,
+		}
+	}
+
+	return result, nil
+}
+
+func (getStoreSnapTool) Validate(args map[string]any) error {
+	_, err := mcp.ToolArgsFromMap[getStoreSnapArgs](args)
+	return err
+}
+
+func (getStoreSnapTool) Call(ctx context.Context, st *state.State, args map[string]any) (any, error) {
+	parsedArgs, err := mcp.ToolArgsFromMap[getStoreSnapArgs](args)
+	if err != nil {
+		return nil, err
+	}
+	return getStoreSnapTool{}.CallWithArgs(ctx, st, parsedArgs)
+}

--- a/overlord/snapstate/mcp_tool_list_change_tasks.go
+++ b/overlord/snapstate/mcp_tool_list_change_tasks.go
@@ -1,0 +1,174 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/snapcore/snapd/overlord/mcp"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+const toolListChangeTasks = "snap_list_change_tasks"
+
+type listChangeTasksTool struct{}
+
+type listChangeTasksArgs struct {
+	ChangeID string `json:"change_id" mcp:"description=ID of the change to inspect."`
+}
+
+type listChangeTasksItem struct {
+	ID       string `json:"id"`
+	Kind     string `json:"kind"`
+	Summary  string `json:"summary"`
+	Status   string `json:"status"`
+	Progress struct {
+		Label string `json:"label"`
+		Done  int    `json:"done"`
+		Total int    `json:"total"`
+	} `json:"progress"`
+	Log []string `json:"log,omitempty"`
+}
+
+type listChangeTasksResult struct {
+	ChangeID string                `json:"change_id"`
+	Tasks    []listChangeTasksItem `json:"tasks"`
+}
+
+var listChangeTasksToolDescriptor = mcp.ToolDescriptor{
+	Name:         toolListChangeTasks,
+	Title:        "List tasks for a change",
+	Description:  "List all tasks associated with a specific change (read-only).",
+	Annotations:  mcp.ToolAnnotations{ReadOnlyHint: true},
+	Execution:    readOnlyToolExecution,
+	InputSchema:  mcp.InputSchemaFromType(listChangeTasksArgs{}),
+	OutputSchema: mcp.OutputSchemaFromType(listChangeTasksResult{}),
+}
+
+func (listChangeTasksTool) Descriptor() mcp.ToolDescriptor {
+	return listChangeTasksToolDescriptor
+}
+
+func (listChangeTasksTool) ArgsType() any {
+	return &listChangeTasksArgs{}
+}
+
+func (listChangeTasksTool) ValidateArgs(args any) error {
+	v, ok := args.(*listChangeTasksArgs)
+	if !ok {
+		return fmt.Errorf("invalid typed args for list change tasks tool")
+	}
+	if strings.TrimSpace(v.ChangeID) == "" {
+		return fmt.Errorf("change_id must not be empty")
+	}
+	return nil
+}
+
+func (listChangeTasksTool) ResultType() any {
+	return &listChangeTasksResult{}
+}
+
+func (listChangeTasksTool) CallWithArgs(_ context.Context, st *state.State, args any) (any, error) {
+	filterArgs, ok := args.(*listChangeTasksArgs)
+	if !ok {
+		return nil, fmt.Errorf("invalid typed args for list change tasks tool")
+	}
+	changeID := strings.TrimSpace(filterArgs.ChangeID)
+	if changeID == "" {
+		return nil, errors.New("change_id must not be empty")
+	}
+
+	st.Lock()
+	defer st.Unlock()
+
+	chg := st.Change(changeID)
+	if chg == nil {
+		return nil, fmt.Errorf("cannot find change with id %q", changeID)
+	}
+
+	tasks := chg.Tasks()
+	items := make([]listChangeTasksItem, len(tasks))
+	for i, task := range tasks {
+		items[i] = taskToItem(task)
+	}
+
+	return listChangeTasksResult{ChangeID: changeID, Tasks: items}, nil
+}
+
+func (listChangeTasksTool) Validate(args map[string]any) error {
+	parsedArgs, err := mcp.ToolArgsFromMap[listChangeTasksArgs](args)
+	if err != nil {
+		return err
+	}
+	return listChangeTasksTool{}.ValidateArgs(parsedArgs)
+}
+
+func (listChangeTasksTool) Call(ctx context.Context, st *state.State, args map[string]any) (any, error) {
+	parsedArgs, err := mcp.ToolArgsFromMap[listChangeTasksArgs](args)
+	if err != nil {
+		return nil, err
+	}
+	return listChangeTasksTool{}.CallWithArgs(ctx, st, parsedArgs)
+}
+
+func taskToItem(task *state.Task) listChangeTasksItem {
+	label, done, total := task.Progress()
+	item := listChangeTasksItem{
+		ID:      task.ID(),
+		Kind:    task.Kind(),
+		Summary: task.Summary(),
+		Status:  task.Status().String(),
+		Progress: struct {
+			Label string `json:"label"`
+			Done  int    `json:"done"`
+			Total int    `json:"total"`
+		}{
+			Label: label,
+			Done:  done,
+			Total: total,
+		},
+	}
+	if log := task.Log(); len(log) > 0 {
+		item.Log = log
+	}
+	return item
+}
+
+func taskToMap(task *state.Task) map[string]any {
+	label, done, total := task.Progress()
+	result := map[string]any{
+		"id":      task.ID(),
+		"kind":    task.Kind(),
+		"summary": task.Summary(),
+		"status":  task.Status().String(),
+		"progress": map[string]any{
+			"label": label,
+			"done":  done,
+			"total": total,
+		},
+	}
+	if log := task.Log(); len(log) > 0 {
+		result["log"] = log
+	}
+	return result
+}

--- a/overlord/snapstate/mcp_tool_list_changes.go
+++ b/overlord/snapstate/mcp_tool_list_changes.go
@@ -1,0 +1,324 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/snapcore/snapd/overlord/mcp"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/strutil"
+)
+
+const toolListChanges = "snap_list_changes"
+
+type listChangesTool struct{}
+
+type listChangesArgs struct {
+	Select   string     `json:"select,omitempty" mcp:"description=Optional readiness filter: all, in-progress, or ready (default: in-progress)."`
+	SnapName string     `json:"snap_name,omitempty" mcp:"description=Optional filter to include only changes affecting a given snap."`
+	Kind     string     `json:"kind,omitempty" mcp:"description=Optional filter to include only changes with the given kind (case-insensitive)."`
+	Status   string     `json:"status,omitempty" mcp:"description=Optional filter to include only changes with the given status (case-insensitive)."`
+	Since    *time.Time `json:"since,omitempty" mcp:"description=Optional inclusive lower bound on change spawn time in RFC3339 format."`
+	Until    *time.Time `json:"until,omitempty" mcp:"description=Optional inclusive upper bound on change spawn time in RFC3339 format."`
+}
+
+type listChangesItem struct {
+	ID        string     `json:"id"`
+	Kind      string     `json:"kind"`
+	Summary   string     `json:"summary"`
+	Status    string     `json:"status"`
+	Ready     bool       `json:"ready"`
+	SpawnTime time.Time  `json:"spawn_time"`
+	ReadyTime *time.Time `json:"ready_time,omitempty"`
+	SnapNames []string   `json:"snap_names,omitempty"`
+	Err       string     `json:"err,omitempty"`
+}
+
+type listChangesResult struct {
+	Changes []listChangesItem `json:"changes"`
+}
+
+var listChangesSelectEnum = []string{"all", "in-progress", "ready"}
+
+var listChangesKindEnum = []string{
+	"alias",
+	"auto-refresh",
+	"create-recovery-system",
+	"disable",
+	"enable",
+	"enable-snap",
+	"install",
+	"install-component",
+	"install-snap",
+	"migrate-home",
+	"pre-download",
+	"prefer",
+	"refresh",
+	"refresh-snap",
+	"refresh-to-enforce",
+	"remodel",
+	"remove",
+	"resolve-validation-sets",
+	"revert",
+	"snapd-refresh",
+	"start-services",
+	"stop-services",
+	"switch-snap",
+	"transition-to-snapd-snap",
+	"transition-ubuntu-core",
+	"try",
+	"unalias",
+	"update-snap",
+}
+
+var listChangesStatusEnum = []string{
+	"do",
+	"doing",
+	"done",
+	"abort",
+	"error",
+	"hold",
+	"undo",
+	"undoing",
+	"undone",
+	"wait",
+	"fail",
+	"failed",
+}
+
+var listChangesToolDescriptor = mcp.ToolDescriptor{
+	Name:         toolListChanges,
+	Title:        "List snap changes",
+	Description:  "List snap changes with optional readiness, snap-name, kind, status, and date filters (read-only; task details are omitted).",
+	Annotations:  mcp.ToolAnnotations{ReadOnlyHint: true},
+	Execution:    readOnlyToolExecution,
+	InputSchema:  mcp.InputSchemaFromType(listChangesArgs{}),
+	OutputSchema: mcp.OutputSchemaFromType(listChangesResult{}),
+}
+
+func (listChangesTool) Descriptor() mcp.ToolDescriptor {
+	return listChangesToolDescriptor
+}
+
+func (listChangesTool) ArgsType() any {
+	return &listChangesArgs{}
+}
+
+func (listChangesTool) ValidateArgs(args any) error {
+	v, ok := args.(*listChangesArgs)
+	if !ok {
+		return fmt.Errorf("invalid typed args for list changes tool")
+	}
+	if v.Select != "" && !strutil.ListContains(listChangesSelectEnum, v.Select) {
+		return fmt.Errorf("select should be one of: all,in-progress,ready")
+	}
+	if v.Kind != "" && !strutil.ListContainsFold(listChangesKindEnum, v.Kind) {
+		return fmt.Errorf("kind should be one of: %s", strings.Join(listChangesKindEnum, ","))
+	}
+	if v.Status != "" && !strutil.ListContainsFold(listChangesStatusEnum, v.Status) {
+		return fmt.Errorf("status should be one of: %s", strings.Join(listChangesStatusEnum, ","))
+	}
+
+	if v.Since != nil && v.Until != nil && v.Since.After(*v.Until) {
+		return fmt.Errorf("since must not be after until")
+	}
+
+	return nil
+}
+
+func (listChangesTool) ResultType() any {
+	return &listChangesResult{}
+}
+
+func (listChangesTool) CallWithArgs(_ context.Context, st *state.State, args any) (any, error) {
+	filterArgs, ok := args.(*listChangesArgs)
+	if !ok {
+		return nil, fmt.Errorf("invalid typed args for list changes tool")
+	}
+
+	selectValue := "in-progress"
+	if filterArgs.Select != "" {
+		selectValue = filterArgs.Select
+	}
+
+	var snapNameFilter string
+	if filterArgs.SnapName != "" {
+		snapNameFilter = filterArgs.SnapName
+	}
+
+	var kindFilter string
+	if filterArgs.Kind != "" {
+		kindFilter = strings.ToLower(filterArgs.Kind)
+	}
+
+	var statusFilter string
+	if filterArgs.Status != "" {
+		statusFilter = filterArgs.Status
+	}
+
+	var sinceTime time.Time
+	if filterArgs.Since != nil {
+		sinceTime = *filterArgs.Since
+	}
+
+	var untilTime time.Time
+	if filterArgs.Until != nil {
+		untilTime = *filterArgs.Until
+	}
+
+	if !sinceTime.IsZero() && !untilTime.IsZero() && sinceTime.After(untilTime) {
+		return nil, errors.New("since must not be after until")
+	}
+
+	st.Lock()
+	defer st.Unlock()
+
+	changes := st.Changes()
+	items := make([]listChangesItem, 0, len(changes))
+	for _, chg := range changes {
+		if !matchesChangeSelect(chg, selectValue) {
+			continue
+		}
+		if kindFilter != "" && strings.ToLower(chg.Kind()) != kindFilter {
+			continue
+		}
+		if statusFilter != "" && !matchesChangeStatus(chg, statusFilter) {
+			continue
+		}
+		spawnTime := chg.SpawnTime()
+		if !sinceTime.IsZero() && spawnTime.Before(sinceTime) {
+			continue
+		}
+		if !untilTime.IsZero() && spawnTime.After(untilTime) {
+			continue
+		}
+		snapNames := changeSnapNames(chg)
+		if snapNameFilter != "" && !containsSnapName(snapNames, snapNameFilter) {
+			continue
+		}
+
+		items = append(items, changeToItem(chg, snapNames))
+	}
+
+	return listChangesResult{Changes: items}, nil
+}
+
+func (listChangesTool) Validate(args map[string]any) error {
+	_, err := mcp.ToolArgsFromMap[listChangesArgs](args)
+	return err
+}
+
+func (listChangesTool) Call(ctx context.Context, st *state.State, args map[string]any) (any, error) {
+	parsedArgs, err := mcp.ToolArgsFromMap[listChangesArgs](args)
+	if err != nil {
+		return nil, err
+	}
+	return listChangesTool{}.CallWithArgs(ctx, st, parsedArgs)
+}
+
+func matchesChangeSelect(chg *state.Change, selectValue string) bool {
+	switch selectValue {
+	case "all":
+		return true
+	case "ready":
+		return chg.IsReady()
+	case "in-progress":
+		return !chg.IsReady()
+	default:
+		return false
+	}
+}
+
+func matchesChangeStatus(chg *state.Change, statusFilter string) bool {
+	current := strings.ToLower(chg.Status().String())
+	filter := strings.ToLower(strings.TrimSpace(statusFilter))
+	if filter == "failed" || filter == "fail" {
+		filter = "error"
+	}
+	return current == filter
+}
+
+func changeSnapNames(chg *state.Change) []string {
+	var snapNames []string
+	if err := chg.Get("snap-names", &snapNames); err != nil {
+		return nil
+	}
+	return snapNames
+}
+
+func containsSnapName(snapNames []string, wanted string) bool {
+	for _, name := range snapNames {
+		snapName, _ := snap.SplitSnapApp(name)
+		if snapName == wanted {
+			return true
+		}
+	}
+	return false
+}
+
+func changeToItem(chg *state.Change, snapNames []string) listChangesItem {
+	status := chg.Status()
+	item := listChangesItem{
+		ID:        chg.ID(),
+		Kind:      chg.Kind(),
+		Summary:   chg.Summary(),
+		Status:    status.String(),
+		Ready:     status.Ready(),
+		SpawnTime: chg.SpawnTime(),
+	}
+	if readyTime := chg.ReadyTime(); !readyTime.IsZero() {
+		item.ReadyTime = &readyTime
+	}
+	if len(snapNames) > 0 {
+		item.SnapNames = snapNames
+	}
+	if err := chg.Err(); err != nil {
+		item.Err = err.Error()
+	}
+	return item
+}
+
+func changeToMap(chg *state.Change, snapNames []string) map[string]any {
+	status := chg.Status()
+	result := map[string]any{
+		"id":         chg.ID(),
+		"kind":       chg.Kind(),
+		"summary":    chg.Summary(),
+		"status":     status.String(),
+		"ready":      status.Ready(),
+		"spawn_time": chg.SpawnTime(),
+	}
+	if readyTime := chg.ReadyTime(); !readyTime.IsZero() {
+		result["ready_time"] = readyTime
+	}
+	if len(snapNames) > 0 {
+		result["snap_names"] = snapNames
+	}
+	if err := chg.Err(); err != nil {
+		result["err"] = err.Error()
+	}
+	return result
+}

--- a/overlord/snapstate/mcp_tool_list_services.go
+++ b/overlord/snapstate/mcp_tool_list_services.go
@@ -1,0 +1,161 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/snapcore/snapd/overlord/mcp"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+const toolListServices = "snap_list_services"
+
+type listServicesTool struct{}
+
+type listServicesArgs struct {
+	SnapName    string `json:"snap_name,omitempty" mcp:"description=Optional filter by snap instance name."`
+	ServiceName string `json:"service_name,omitempty" mcp:"description=Optional case-insensitive substring filter on <snap>.<app> service name."`
+}
+
+type listServicesItem struct {
+	ServiceName string `json:"service_name"`
+	SnapName    string `json:"snap_name"`
+	AppName     string `json:"app_name"`
+	Daemon      string `json:"daemon"`
+	DaemonScope string `json:"daemon_scope"`
+	ServiceUnit string `json:"service_unit"`
+}
+
+type listServicesResult struct {
+	Services []listServicesItem `json:"services"`
+}
+
+var listServicesToolDescriptor = mcp.ToolDescriptor{
+	Name:         toolListServices,
+	Title:        "List snap services",
+	Description:  "List services provided by installed snaps (read-only).",
+	Annotations:  mcp.ToolAnnotations{ReadOnlyHint: true},
+	Execution:    readOnlyToolExecution,
+	InputSchema:  mcp.InputSchemaFromType(listServicesArgs{}),
+	OutputSchema: mcp.OutputSchemaFromType(listServicesResult{}),
+}
+
+func (listServicesTool) Descriptor() mcp.ToolDescriptor {
+	return listServicesToolDescriptor
+}
+
+func (listServicesTool) ArgsType() any {
+	return &listServicesArgs{}
+}
+
+func (listServicesTool) ValidateArgs(args any) error {
+	_, ok := args.(*listServicesArgs)
+	if !ok {
+		return fmt.Errorf("invalid typed args for list services tool")
+	}
+	return nil
+}
+
+func (listServicesTool) ResultType() any {
+	return &listServicesResult{}
+}
+
+func (listServicesTool) CallWithArgs(_ context.Context, st *state.State, args any) (any, error) {
+	filterArgs, ok := args.(*listServicesArgs)
+	if !ok {
+		return nil, fmt.Errorf("invalid typed args for list services tool")
+	}
+
+	snapNameFilter := strings.TrimSpace(filterArgs.SnapName)
+	serviceNameFilter := strings.ToLower(strings.TrimSpace(filterArgs.ServiceName))
+
+	services, err := listServicesFromState(st, snapNameFilter, serviceNameFilter)
+	if err != nil {
+		return nil, fmt.Errorf("cannot list services: %w", err)
+	}
+
+	return listServicesResult{Services: services}, nil
+}
+
+func (listServicesTool) Validate(args map[string]any) error {
+	_, err := mcp.ToolArgsFromMap[listServicesArgs](args)
+	return err
+}
+
+func (listServicesTool) Call(ctx context.Context, st *state.State, args map[string]any) (any, error) {
+	parsedArgs, err := mcp.ToolArgsFromMap[listServicesArgs](args)
+	if err != nil {
+		return nil, err
+	}
+	return listServicesTool{}.CallWithArgs(ctx, st, parsedArgs)
+}
+
+func listServicesFromState(st *state.State, snapNameFilter, serviceNameFilter string) ([]listServicesItem, error) {
+	st.Lock()
+	defer st.Unlock()
+
+	snapStates, err := All(st)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get snaps: %w", err)
+	}
+
+	result := make([]listServicesItem, 0)
+	for snapName, snapst := range snapStates {
+		if snapNameFilter != "" && snapName != snapNameFilter {
+			continue
+		}
+
+		info, err := snapst.CurrentInfo()
+		if err == ErrNoCurrent {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("cannot read snap details for %q: %w", snapName, err)
+		}
+
+		for _, app := range info.Apps {
+			if !app.IsService() {
+				continue
+			}
+			serviceName := fmt.Sprintf("%s.%s", info.InstanceName(), app.Name)
+			if serviceNameFilter != "" && !strings.Contains(strings.ToLower(serviceName), serviceNameFilter) {
+				continue
+			}
+			result = append(result, listServicesItem{
+				ServiceName: serviceName,
+				SnapName:    info.InstanceName(),
+				AppName:     app.Name,
+				Daemon:      string(app.Daemon),
+				DaemonScope: string(app.DaemonScope),
+				ServiceUnit: app.ServiceName(),
+			})
+		}
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].ServiceName < result[j].ServiceName
+	})
+
+	return result, nil
+}

--- a/overlord/snapstate/mcp_tool_list_snaps.go
+++ b/overlord/snapstate/mcp_tool_list_snaps.go
@@ -1,0 +1,232 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/snapcore/snapd/overlord/mcp"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+)
+
+const toolListSnaps = "snap_list_snaps"
+
+type listSnapsTool struct{}
+
+// snapResult is an internal representation used to build MCP responses.
+type snapResult struct {
+	info      *snap.Info
+	channel   string
+	installed bool
+	status    string
+}
+
+type listSnapsArgs struct {
+	Name string `json:"name,omitempty" mcp:"description=Optional filter by snap name (case-insensitive substring match)."`
+}
+
+type snapSummary struct {
+	Name      string `json:"name"`
+	Version   string `json:"version"`
+	Revision  int    `json:"revision"`
+	Channel   string `json:"channel"`
+	Installed bool   `json:"installed"`
+	Developer string `json:"developer"`
+	Status    string `json:"status"`
+	Title     string `json:"title"`
+	Summary   string `json:"summary"`
+}
+
+type listSnapsResult struct {
+	Snaps []snapSummary `json:"snaps"`
+}
+
+var listSnapsToolDescriptor = mcp.ToolDescriptor{
+	Name:         toolListSnaps,
+	Title:        "List installed snaps",
+	Description:  "List all installed snaps with basic information (read-only).",
+	Annotations:  mcp.ToolAnnotations{ReadOnlyHint: true},
+	Execution:    readOnlyToolExecution,
+	InputSchema:  mcp.InputSchemaFromType(listSnapsArgs{}),
+	OutputSchema: mcp.OutputSchemaFromType(listSnapsResult{}),
+}
+
+func (listSnapsTool) Descriptor() mcp.ToolDescriptor {
+	return listSnapsToolDescriptor
+}
+
+func (listSnapsTool) ArgsType() any {
+	return &listSnapsArgs{}
+}
+
+func (listSnapsTool) ValidateArgs(args any) error {
+	if _, ok := args.(*listSnapsArgs); !ok {
+		return fmt.Errorf("invalid typed args for list snaps tool")
+	}
+	return nil
+}
+
+func (listSnapsTool) ResultType() any {
+	return &listSnapsResult{}
+}
+
+func (listSnapsTool) CallWithArgs(_ context.Context, st *state.State, args any) (any, error) {
+	snaps, err := listSnapsFromState(st)
+	if err != nil {
+		return nil, fmt.Errorf("cannot list snaps: %w", err)
+	}
+
+	filterArgs, ok := args.(*listSnapsArgs)
+	if !ok {
+		return nil, fmt.Errorf("invalid typed args for list snaps tool")
+	}
+
+	return listSnapsToResult(snaps, filterArgs.Name), nil
+}
+
+func listSnapsToResult(snaps []snapResult, nameFilter string) listSnapsResult {
+	filter := strings.ToLower(nameFilter)
+
+	output := listSnapsResult{Snaps: make([]snapSummary, 0, len(snaps))}
+	for _, snapState := range snaps {
+		name := snapState.info.InstanceName()
+		if filter != "" && !strings.Contains(strings.ToLower(name), filter) {
+			continue
+		}
+		output.Snaps = append(output.Snaps, snapSummary{
+			Name:      name,
+			Version:   snapState.info.Version,
+			Revision:  snapState.info.Revision.N,
+			Channel:   snapState.channel,
+			Installed: snapState.installed,
+			Developer: snapState.info.Publisher.Username,
+			Status:    snapState.status,
+			Title:     snapState.info.Title(),
+			Summary:   snapState.info.Summary(),
+		})
+	}
+
+	return output
+}
+
+// listSnapsFromState returns installed snaps from overlord state.
+func listSnapsFromState(st *state.State) ([]snapResult, error) {
+	st.Lock()
+	defer st.Unlock()
+
+	snapStates, err := All(st)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get snaps: %w", err)
+	}
+
+	result := make([]snapResult, 0, len(snapStates))
+	for snapName, snapst := range snapStates {
+		info, err := snapst.CurrentInfo()
+		if err == ErrNoCurrent {
+			// Skip snaps without current info (removed but with state)
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("cannot read snap details for %q: %w", snapName, err)
+		}
+
+		result = append(result, snapResult{
+			info:      info,
+			channel:   snapst.TrackingChannel,
+			installed: snapst.Active,
+			status:    statusFromSnapState(snapst),
+		})
+	}
+
+	return result, nil
+}
+
+// statusFromSnapState returns the status string for a snap from its SnapState.
+func statusFromSnapState(snapst *SnapState) string {
+	if snapst.Active {
+		return "active"
+	}
+	return "installed"
+}
+
+// snapFromState returns information about a specific snap from overlord state.
+func snapFromState(st *state.State, name string) (*snapResult, error) {
+	st.Lock()
+	defer st.Unlock()
+
+	var snapst SnapState
+	err := Get(st, name, &snapst)
+	if err != nil {
+		if errors.Is(err, state.ErrNoState) {
+			return nil, fmt.Errorf("cannot find snap %q", name)
+		}
+		return nil, fmt.Errorf("cannot consult state for %q: %w", name, err)
+	}
+
+	info, err := snapst.CurrentInfo()
+	if err == ErrNoCurrent {
+		return nil, fmt.Errorf("cannot find active revision for %q", name)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("cannot read snap details for %q: %w", name, err)
+	}
+
+	return &snapResult{
+		info:      info,
+		channel:   snapst.TrackingChannel,
+		installed: snapst.Active,
+		status:    statusFromSnapState(&snapst),
+	}, nil
+}
+
+// snapToMap converts a snapResult to a map suitable for JSON serialization.
+func snapToMap(snap *snapResult) map[string]any {
+	return map[string]any{
+		"name":      snap.info.InstanceName(),
+		"version":   snap.info.Version,
+		"revision":  snap.info.Revision.N,
+		"channel":   snap.channel,
+		"installed": snap.installed,
+		"developer": snap.info.Publisher.Username,
+		"status":    snap.status,
+		"title":     snap.info.Title(),
+		"summary":   snap.info.Summary(),
+	}
+}
+
+func (tool listSnapsTool) Validate(args map[string]any) error {
+	parsedArgs, err := mcp.ToolArgsFromMap[listSnapsArgs](args)
+	if err != nil {
+		return err
+	}
+	return tool.ValidateArgs(parsedArgs)
+}
+
+func (tool listSnapsTool) Call(ctx context.Context, st *state.State, args map[string]any) (any, error) {
+	parsedArgs, err := mcp.ToolArgsFromMap[listSnapsArgs](args)
+	if err != nil {
+		return nil, err
+	}
+	return tool.CallWithArgs(ctx, st, parsedArgs)
+}

--- a/overlord/snapstate/mcp_tool_search_store_snaps.go
+++ b/overlord/snapstate/mcp_tool_search_store_snaps.go
@@ -1,0 +1,139 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/snapcore/snapd/overlord/mcp"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/store"
+)
+
+const toolSearchStoreSnaps = "snap_search_store_snaps"
+
+type searchStoreSnapsTool struct{}
+
+type searchStoreSnapsArgs struct {
+	Name string `json:"name" mcp:"description=Name or search term to query in the Snap Store."`
+}
+
+type storeSnapSummary struct {
+	Name      string `json:"name"`
+	Version   string `json:"version"`
+	Revision  int    `json:"revision"`
+	Developer string `json:"developer"`
+	Title     string `json:"title"`
+	Summary   string `json:"summary"`
+	SnapID    string `json:"snap_id"`
+	StoreURL  string `json:"store_url"`
+}
+
+type searchStoreSnapsResult struct {
+	StoreSnaps []storeSnapSummary `json:"store_snaps"`
+}
+
+var searchStoreSnapsToolDescriptor = mcp.ToolDescriptor{
+	Name:         toolSearchStoreSnaps,
+	Title:        "Search snaps in the store",
+	Description:  "Search for snaps available in the Snap Store by name or search term (read-only).",
+	Annotations:  mcp.ToolAnnotations{ReadOnlyHint: true},
+	Execution:    readOnlyToolExecution,
+	InputSchema:  mcp.InputSchemaFromType(searchStoreSnapsArgs{}),
+	OutputSchema: mcp.OutputSchemaFromType(searchStoreSnapsResult{}),
+}
+
+func (searchStoreSnapsTool) Descriptor() mcp.ToolDescriptor {
+	return searchStoreSnapsToolDescriptor
+}
+
+func (searchStoreSnapsTool) ArgsType() any {
+	return &searchStoreSnapsArgs{}
+}
+
+func (searchStoreSnapsTool) ValidateArgs(args any) error {
+	v, ok := args.(*searchStoreSnapsArgs)
+	if !ok {
+		return fmt.Errorf("invalid typed args for search store snaps tool")
+	}
+	if strings.TrimSpace(v.Name) == "" {
+		return fmt.Errorf("name must not be empty")
+	}
+	return nil
+}
+
+func (searchStoreSnapsTool) ResultType() any {
+	return &searchStoreSnapsResult{}
+}
+
+func (searchStoreSnapsTool) CallWithArgs(ctx context.Context, st *state.State, args any) (any, error) {
+	filterArgs, ok := args.(*searchStoreSnapsArgs)
+	if !ok {
+		return nil, fmt.Errorf("invalid typed args for search store snaps tool")
+	}
+	query := strings.TrimSpace(filterArgs.Name)
+	if query == "" {
+		return nil, fmt.Errorf("name must not be empty")
+	}
+
+	storeService, err := storeFromState(st)
+	if err != nil {
+		return nil, err
+	}
+
+	storeSnaps, err := storeService.Find(ctx, &store.Search{Query: query}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("cannot search store snaps: %w", err)
+	}
+
+	result := searchStoreSnapsResult{StoreSnaps: make([]storeSnapSummary, 0, len(storeSnaps))}
+	for _, info := range storeSnaps {
+		result.StoreSnaps = append(result.StoreSnaps, storeSnapSummary{
+			Name:      info.SnapName(),
+			Version:   info.Version,
+			Revision:  info.Revision.N,
+			Developer: info.Publisher.Username,
+			Title:     info.Title(),
+			Summary:   info.Summary(),
+			SnapID:    info.SnapID,
+			StoreURL:  info.StoreURL,
+		})
+	}
+
+	return result, nil
+}
+
+func (searchStoreSnapsTool) Validate(args map[string]any) error {
+	parsedArgs, err := mcp.ToolArgsFromMap[searchStoreSnapsArgs](args)
+	if err != nil {
+		return err
+	}
+	return searchStoreSnapsTool{}.ValidateArgs(parsedArgs)
+}
+
+func (searchStoreSnapsTool) Call(ctx context.Context, st *state.State, args map[string]any) (any, error) {
+	parsedArgs, err := mcp.ToolArgsFromMap[searchStoreSnapsArgs](args)
+	if err != nil {
+		return nil, err
+	}
+	return searchStoreSnapsTool{}.CallWithArgs(ctx, st, parsedArgs)
+}

--- a/overlord/snapstate/mcp_tools.go
+++ b/overlord/snapstate/mcp_tools.go
@@ -1,0 +1,132 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/snapcore/snapd/overlord/mcp"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+)
+
+var readOnlyToolExecution = mcp.ToolExecution{TaskSupport: mcp.ToolTaskSupportForbidden}
+
+func intArg(args map[string]any, key string) (int, error) {
+	value, ok := args[key]
+	if !ok {
+		return 0, fmt.Errorf("%s is required", key)
+	}
+	floatValue, ok := value.(float64)
+	if !ok {
+		return 0, fmt.Errorf("%s must be an integer", key)
+	}
+	if float64(int(floatValue)) != floatValue {
+		return 0, fmt.Errorf("%s must be an integer", key)
+	}
+	return int(floatValue), nil
+}
+
+func storeSnapSummaryToMap(info *snap.Info) map[string]any {
+	return map[string]any{
+		"name":      info.SnapName(),
+		"version":   info.Version,
+		"revision":  info.Revision.N,
+		"developer": info.Publisher.Username,
+		"title":     info.Title(),
+		"summary":   info.Summary(),
+		"snap_id":   info.SnapID,
+		"store_url": info.StoreURL,
+	}
+}
+
+func storeSnapDetailsToMap(info *snap.Info) map[string]any {
+	result := storeSnapSummaryToMap(info)
+	result["description"] = info.Description()
+	result["type"] = string(info.SnapType)
+	result["confinement"] = string(info.Confinement)
+	result["license"] = info.License
+	result["base"] = info.Base
+	result["architectures"] = info.Architectures
+	result["tracks"] = info.Tracks
+	if info.Publisher.DisplayName != "" {
+		result["publisher"] = info.Publisher.DisplayName
+	}
+	if website := firstStoreLink(info.Links(), "website"); website != "" {
+		result["website"] = website
+	}
+	if contact := firstStoreLink(info.Links(), "contact"); contact != "" {
+		result["contact"] = contact
+	}
+	if len(info.Channels) > 0 {
+		result["channels"] = storeChannelsToMap(info.Channels)
+	}
+	return result
+}
+
+func storeChannelsToMap(channels map[string]*snap.ChannelSnapInfo) map[string]map[string]any {
+	names := make([]string, 0, len(channels))
+	for name := range channels {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	result := make(map[string]map[string]any, len(channels))
+	for _, channelName := range names {
+		channelInfo := channels[channelName]
+		result[channelName] = map[string]any{
+			"channel":     channelInfo.Channel,
+			"version":     channelInfo.Version,
+			"revision":    channelInfo.Revision.N,
+			"confinement": string(channelInfo.Confinement),
+			"size":        channelInfo.Size,
+			"released_at": channelInfo.ReleasedAt,
+		}
+	}
+	return result
+}
+
+func firstStoreLink(links map[string][]string, key string) string {
+	values, ok := links[key]
+	if !ok || len(values) == 0 {
+		return ""
+	}
+	return values[0]
+}
+
+func storeFromState(st *state.State) (_ StoreService, err error) {
+	st.Lock()
+	defer st.Unlock()
+
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			err = fmt.Errorf("cannot access store service: %v", recovered)
+		}
+	}()
+
+	storeService := Store(st, nil)
+	if storeService == nil {
+		return nil, errors.New("cannot access store service")
+	}
+
+	return storeService, nil
+}

--- a/overlord/snapstate/mcp_tools_common_test.go
+++ b/overlord/snapstate/mcp_tools_common_test.go
@@ -1,0 +1,67 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate_test
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/store"
+	"github.com/snapcore/snapd/store/storetest"
+
+	. "gopkg.in/check.v1"
+)
+
+type snapMCPSuite struct{}
+
+var _ = Suite(&snapMCPSuite{})
+
+type mockMCPStore struct {
+	storetest.Store
+
+	findResults []*snap.Info
+	findErr     error
+	lastSearch  *store.Search
+
+	snapInfoResult *snap.Info
+	snapInfoErr    error
+	lastSnapSpec   store.SnapSpec
+}
+
+func (s *mockMCPStore) Find(_ context.Context, search *store.Search, _ *auth.UserState) ([]*snap.Info, error) {
+	s.lastSearch = search
+	return s.findResults, s.findErr
+}
+
+func (s *mockMCPStore) SnapInfo(_ context.Context, snapSpec store.SnapSpec, _ *auth.UserState) (*snap.Info, error) {
+	s.lastSnapSpec = snapSpec
+	return s.snapInfoResult, s.snapInfoErr
+}
+
+func resultToMap(c *C, v any) map[string]any {
+	b, err := json.Marshal(v)
+	c.Assert(err, IsNil)
+	var out map[string]any
+	err = json.Unmarshal(b, &out)
+	c.Assert(err, IsNil)
+	return out
+}

--- a/overlord/snapstate/mcp_tools_descriptors_test.go
+++ b/overlord/snapstate/mcp_tools_descriptors_test.go
@@ -1,0 +1,50 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate_test
+
+import (
+	"github.com/snapcore/snapd/overlord/mcp"
+	"github.com/snapcore/snapd/overlord/snapstate"
+
+	. "gopkg.in/check.v1"
+)
+
+func (s *snapMCPSuite) TestDescriptorsIncludeOutputSchemaAndExecutionMetadata(c *C) {
+	tools := []interface {
+		Descriptor() mcp.ToolDescriptor
+	}{
+		snapstate.ListSnapsTool{},
+		snapstate.GetSnapTool{},
+		snapstate.SearchStoreSnapsTool{},
+		snapstate.GetStoreSnapTool{},
+		snapstate.ListChangesTool{},
+		snapstate.ListChangeTasksTool{},
+		snapstate.ListServicesTool{},
+		snapstate.GetServiceLogsTool{},
+	}
+
+	for _, tool := range tools {
+		d := tool.Descriptor()
+		c.Check(d.Annotations.ReadOnlyHint, Equals, true, Commentf("tool=%s", d.Name))
+		c.Check(d.Execution.TaskSupport, Equals, mcp.ToolTaskSupportForbidden, Commentf("tool=%s", d.Name))
+		c.Assert(d.OutputSchema, NotNil, Commentf("tool=%s", d.Name))
+		c.Check(d.OutputSchema["type"], Equals, "object", Commentf("tool=%s", d.Name))
+	}
+}

--- a/overlord/snapstate/mcp_tools_get_service_logs_test.go
+++ b/overlord/snapstate/mcp_tools_get_service_logs_test.go
@@ -1,0 +1,276 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/sequence"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/systemd"
+	"github.com/snapcore/snapd/testutil"
+
+	. "gopkg.in/check.v1"
+)
+
+func (s *snapMCPSuite) TestGetServiceLogsValidateInvalidRange(c *C) {
+	_, err := (snapstate.GetServiceLogsTool{}).Call(context.Background(), state.New(nil), map[string]any{
+		"service_name": "snap-a.svc1",
+		"since":        "2026-01-11T00:00:00Z",
+		"until":        "2026-01-10T00:00:00Z",
+	})
+	c.Assert(err, NotNil)
+	c.Check(err.Error(), Equals, "since must not be after until")
+}
+
+func (s *snapMCPSuite) TestGetServiceLogsCallMissingService(c *C) {
+	result, callErr := (snapstate.GetServiceLogsTool{}).Call(context.Background(), state.New(nil), map[string]any{"service_name": "snap-a.svc1"})
+	c.Check(result, IsNil)
+	c.Assert(callErr, NotNil)
+	c.Check(callErr.Error(), Equals, `cannot find service "snap-a.svc1"`)
+}
+
+func (s *snapMCPSuite) TestGetServiceLogsPassesSinceUntilLinesAndStderrOnly(c *C) {
+	st := state.New(nil)
+
+	info, err := snap.InfoFromSnapYaml([]byte(`name: svc-snap
+version: 1
+apps:
+  daemon:
+    command: bin/run
+    daemon: simple
+`))
+	c.Assert(err, IsNil)
+
+	restoreReadInfo := snapstate.MockSnapReadInfo(func(name string, _ *snap.SideInfo) (*snap.Info, error) {
+		c.Assert(name, Equals, "svc-snap")
+		return info, nil
+	})
+	defer restoreReadInfo()
+
+	st.Lock()
+	snapstate.Set(st, "svc-snap", &snapstate.SnapState{
+		Sequence: sequence.SnapSequence{Revisions: []*sequence.RevisionSideState{
+			sequence.NewRevisionSideState(&snap.SideInfo{RealName: "svc-snap", Revision: snap.R(1)}, nil),
+		}},
+		Current: snap.R(1),
+		Active:  true,
+	})
+	st.Unlock()
+
+	mockJournalctl := testutil.MockCommand(c, "journalctl", "")
+	defer mockJournalctl.Restore()
+
+	since := time.Date(2026, time.January, 1, 10, 0, 0, 0, time.UTC)
+	until := time.Date(2026, time.January, 1, 11, 0, 0, 0, time.UTC)
+
+	result, callErr := (snapstate.GetServiceLogsTool{}).Call(context.Background(), st, map[string]any{
+		"service_name": "svc-snap.daemon",
+		"lines":        5,
+		"since":        since.Format(time.RFC3339),
+		"until":        until.Format(time.RFC3339),
+		"stderr_only":  true,
+	})
+	c.Assert(callErr, IsNil)
+
+	out := resultToMap(c, result)
+	c.Check(out["service_name"], Equals, "svc-snap.daemon")
+	c.Check(out["logs"], DeepEquals, []any{})
+
+	calls := mockJournalctl.Calls()
+	c.Assert(calls, HasLen, 1)
+	call := calls[0]
+	c.Assert(call[0], Equals, "journalctl")
+
+	joined := strings.Join(call, "\x00")
+	c.Check(strings.Contains(joined, "\x00-o\x00json\x00"), Equals, true)
+	c.Check(strings.Contains(joined, "\x00--no-pager\x00"), Equals, true)
+	c.Check(strings.Contains(joined, "\x00-n\x005\x00"), Equals, true)
+	c.Check(strings.Contains(joined, "\x00--since\x00"+since.Format(time.RFC3339)+"\x00"), Equals, true)
+	c.Check(strings.Contains(joined, "\x00--until\x00"+until.Format(time.RFC3339)+"\x00"), Equals, true)
+	c.Check(strings.Contains(joined, "\x00-p\x000..3\x00"), Equals, true)
+	unit := ""
+	for i := 0; i+1 < len(call); i++ {
+		if call[i] == "-u" {
+			unit = call[i+1]
+			break
+		}
+	}
+	c.Assert(unit, Not(Equals), "")
+	c.Check(strings.Contains(unit, "svc-snap"), Equals, true)
+	c.Check(strings.Contains(unit, "daemon"), Equals, true)
+	c.Check(strings.HasSuffix(unit, ".service"), Equals, true)
+}
+
+func (s *snapMCPSuite) TestGetServiceLogsMapsEntries(c *C) {
+	st := state.New(nil)
+
+	info, err := snap.InfoFromSnapYaml([]byte(`name: svc-snap
+version: 1
+apps:
+  daemon:
+    command: bin/run
+    daemon: simple
+`))
+	c.Assert(err, IsNil)
+
+	restoreReadInfo := snapstate.MockSnapReadInfo(func(name string, _ *snap.SideInfo) (*snap.Info, error) {
+		c.Assert(name, Equals, "svc-snap")
+		return info, nil
+	})
+	defer restoreReadInfo()
+
+	st.Lock()
+	snapstate.Set(st, "svc-snap", &snapstate.SnapState{
+		Sequence: sequence.SnapSequence{Revisions: []*sequence.RevisionSideState{
+			sequence.NewRevisionSideState(&snap.SideInfo{RealName: "svc-snap", Revision: snap.R(1)}, nil),
+		}},
+		Current: snap.R(1),
+		Active:  true,
+	})
+	st.Unlock()
+
+	timeFromString := "2026-02-03T10:11:12Z"
+	parsed, err := time.Parse(time.RFC3339, "2026-02-03T11:12:13Z")
+	c.Assert(err, IsNil)
+
+	restoreReadLogs := snapstate.MockReadServiceLogs(func(serviceApp *snap.AppInfo, lines int, since, until string, stderrOnly bool) ([]map[string]any, error) {
+		c.Assert(serviceApp, NotNil)
+		c.Check(lines, Equals, 100)
+		c.Check(since, Equals, "")
+		c.Check(until, Equals, "")
+		c.Check(stderrOnly, Equals, false)
+
+		return []map[string]any{
+			{
+				"timestamp": timeFromString,
+				"message":   "line one",
+				"sid":       "sid-1",
+				"pid":       "100",
+				"priority":  float64(3),
+			},
+			{
+				"timestamp": parsed,
+				"message":   "line two",
+				"sid":       "sid-2",
+				"pid":       "101",
+				"priority":  2,
+			},
+		}, nil
+	})
+	defer restoreReadLogs()
+
+	result, callErr := (snapstate.GetServiceLogsTool{}).Call(context.Background(), st, map[string]any{
+		"service_name": "svc-snap.daemon",
+	})
+	c.Assert(callErr, IsNil)
+
+	out := resultToMap(c, result)
+	c.Check(out["service_name"], Equals, "svc-snap.daemon")
+
+	logs, ok := out["logs"].([]any)
+	c.Assert(ok, Equals, true)
+	c.Assert(logs, HasLen, 2)
+
+	first, ok := logs[0].(map[string]any)
+	c.Assert(ok, Equals, true)
+	c.Check(first["timestamp"], Equals, timeFromString)
+	c.Check(first["message"], Equals, "line one")
+	c.Check(first["sid"], Equals, "sid-1")
+	c.Check(first["pid"], Equals, "100")
+	c.Check(first["priority"], Equals, float64(3))
+
+	second, ok := logs[1].(map[string]any)
+	c.Assert(ok, Equals, true)
+	c.Check(second["timestamp"], Equals, parsed.Format(time.RFC3339))
+	c.Check(second["message"], Equals, "line two")
+	c.Check(second["sid"], Equals, "sid-2")
+	c.Check(second["pid"], Equals, "101")
+	c.Check(second["priority"], Equals, float64(2))
+}
+
+func (s *snapMCPSuite) TestReadServiceLogsRejectsNilService(c *C) {
+	entries, err := snapstate.ReadServiceLogsForTest(nil, 10, "", "", false)
+	c.Check(entries, IsNil)
+	c.Assert(err, ErrorMatches, "service app must not be nil")
+}
+
+func (s *snapMCPSuite) TestReadServiceLogsNoTailAndNamespace(c *C) {
+	info, err := snap.InfoFromSnapYaml([]byte(`name: svc-snap
+version: 1
+apps:
+  daemon:
+    command: bin/run
+    daemon: simple
+`))
+	c.Assert(err, IsNil)
+	app := info.Apps["daemon"]
+	c.Assert(app, NotNil)
+
+	restoreSystemd := systemd.MockSystemdVersion(245, nil)
+	defer restoreSystemd()
+
+	mockJournalctl := testutil.MockCommand(c, "journalctl", "")
+	defer mockJournalctl.Restore()
+
+	entries, err := snapstate.ReadServiceLogsForTest(app, -1, "2026-01-01T10:00:00Z", "2026-01-01T11:00:00Z", true)
+	c.Assert(err, IsNil)
+	c.Check(entries, DeepEquals, []map[string]any{})
+
+	calls := mockJournalctl.Calls()
+	c.Assert(calls, HasLen, 1)
+	call := calls[0]
+	joined := strings.Join(call, "\x00")
+
+	c.Check(strings.Contains(joined, "\x00-o\x00json\x00"), Equals, true)
+	c.Check(strings.Contains(joined, "\x00--no-pager\x00"), Equals, true)
+	c.Check(strings.Contains(joined, "\x00--no-tail\x00"), Equals, true)
+	c.Check(strings.Contains(joined, "\x00--since\x002026-01-01T10:00:00Z\x00"), Equals, true)
+	c.Check(strings.Contains(joined, "\x00--until\x002026-01-01T11:00:00Z\x00"), Equals, true)
+	c.Check(strings.Contains(joined, "\x00-p\x000..3\x00"), Equals, true)
+	c.Check(strings.Contains(joined, "\x00--namespace=*\x00"), Equals, true)
+	c.Check(strings.Contains(joined, "\x00-u\x00"), Equals, true)
+	c.Check(strings.Contains(joined, app.ServiceName()), Equals, true)
+}
+
+func (s *snapMCPSuite) TestReadServiceLogsSystemdVersionError(c *C) {
+	info, err := snap.InfoFromSnapYaml([]byte(`name: svc-snap
+version: 1
+apps:
+  daemon:
+    command: bin/run
+    daemon: simple
+`))
+	c.Assert(err, IsNil)
+	app := info.Apps["daemon"]
+	c.Assert(app, NotNil)
+
+	restoreSystemd := systemd.MockSystemdVersion(0, errors.New("boom"))
+	defer restoreSystemd()
+
+	entries, err := snapstate.ReadServiceLogsForTest(app, 10, "", "", false)
+	c.Check(entries, IsNil)
+	c.Assert(err, ErrorMatches, "cannot get systemd version: boom")
+}

--- a/overlord/snapstate/mcp_tools_get_snap_test.go
+++ b/overlord/snapstate/mcp_tools_get_snap_test.go
@@ -1,0 +1,97 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate_test
+
+import (
+	"context"
+
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/sequence"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+
+	. "gopkg.in/check.v1"
+)
+
+func (s *snapMCPSuite) TestCallGetSnapRejectsInvalidType(c *C) {
+	result, callErr := (snapstate.GetSnapTool{}).Call(context.Background(), state.New(nil), map[string]any{"snap_name": 1})
+	c.Check(result, IsNil)
+	c.Check(callErr, NotNil)
+	c.Check(callErr.Error(), Matches, `.*invalid arguments:.*snap_name.*`)
+}
+
+func (s *snapMCPSuite) TestCallGetSnapMissingSnap(c *C) {
+	result, callErr := (snapstate.GetSnapTool{}).Call(context.Background(), state.New(nil), map[string]any{"snap_name": "core"})
+	c.Check(result, IsNil)
+	c.Check(callErr.Error(), Equals, `cannot get snap "core": cannot find snap "core"`)
+}
+
+func (s *snapMCPSuite) TestCallGetSnap(c *C) {
+	st := state.New(nil)
+
+	restore := snapstate.MockSnapReadInfo(func(name string, si *snap.SideInfo) (*snap.Info, error) {
+		return &snap.Info{
+			SuggestedName:   name,
+			Version:         "1.2.3",
+			OriginalTitle:   "Test Snap",
+			OriginalSummary: "summary",
+			Publisher:       snap.StoreAccount{Username: "publisher1"},
+			SideInfo:        *si,
+		}, nil
+	})
+	defer restore()
+
+	st.Lock()
+	snapstate.Set(st, "test-snap", &snapstate.SnapState{
+		Sequence: sequence.SnapSequence{Revisions: []*sequence.RevisionSideState{
+			sequence.NewRevisionSideState(&snap.SideInfo{RealName: "test-snap", Revision: snap.R(7)}, nil),
+		}},
+		Current:         snap.R(7),
+		Active:          true,
+		TrackingChannel: "latest/stable",
+	})
+	st.Unlock()
+
+	result, callErr := (snapstate.GetSnapTool{}).Call(context.Background(), st, map[string]any{"snap_name": "test-snap"})
+	c.Assert(callErr, IsNil)
+
+	obj := resultToMap(c, result)
+	c.Check(obj["name"], Equals, "test-snap")
+	c.Check(obj["version"], Equals, "1.2.3")
+	c.Check(obj["revision"], Equals, float64(7))
+	c.Check(obj["channel"], Equals, "latest/stable")
+	c.Check(obj["installed"], Equals, true)
+	c.Check(obj["developer"], Equals, "publisher1")
+	c.Check(obj["status"], Equals, "active")
+	c.Check(obj["title"], Equals, "Test Snap")
+	c.Check(obj["summary"], Equals, "summary")
+}
+
+func (s *snapMCPSuite) TestGetSnapValidateInvalidType(c *C) {
+	err := (snapstate.GetSnapTool{}).Validate(map[string]any{"snap_name": true})
+	c.Assert(err, NotNil)
+	c.Check(err.Error(), Matches, `invalid arguments: .*snap_name.*`)
+}
+
+func (s *snapMCPSuite) TestGetSnapValidateMissingSnapName(c *C) {
+	err := (snapstate.GetSnapTool{}).Validate(map[string]any{})
+	c.Assert(err, NotNil)
+	c.Check(err.Error(), Equals, "snap_name is required")
+}

--- a/overlord/snapstate/mcp_tools_get_store_snap_test.go
+++ b/overlord/snapstate/mcp_tools_get_store_snap_test.go
@@ -1,0 +1,88 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/store"
+
+	. "gopkg.in/check.v1"
+)
+
+func (s *snapMCPSuite) TestCallGetStoreSnap(c *C) {
+	st := state.New(nil)
+	mockStore := &mockMCPStore{
+		snapInfoResult: &snap.Info{
+			SuggestedName:       "foo",
+			Version:             "2.0",
+			Architectures:       []string{"amd64"},
+			Base:                "core24",
+			Confinement:         snap.StrictConfinement,
+			License:             "GPL-3.0",
+			Tracks:              []string{"latest"},
+			OriginalTitle:       "Foo",
+			OriginalSummary:     "foo summary",
+			OriginalDescription: "foo description",
+			Publisher:           snap.StoreAccount{Username: "publisher2", DisplayName: "Publisher Two"},
+			StoreURL:            "https://snapcraft.io/foo",
+			OriginalLinks:       map[string][]string{"website": {"https://example.com/foo"}},
+			Channels:            map[string]*snap.ChannelSnapInfo{"latest/stable": {Channel: "latest/stable", Version: "2.0", Revision: snap.R(11), Confinement: snap.StrictConfinement, ReleasedAt: time.Date(2026, time.January, 10, 0, 0, 0, 0, time.UTC)}},
+			SideInfo:            snap.SideInfo{RealName: "foo", Revision: snap.R(11), SnapID: "snapid-2"},
+			SnapType:            snap.TypeApp,
+		},
+	}
+	st.Lock()
+	snapstate.ReplaceStore(st, mockStore)
+	st.Unlock()
+
+	result, callErr := (snapstate.GetStoreSnapTool{}).Call(context.Background(), st, map[string]any{"snap_name": "foo"})
+	c.Assert(callErr, IsNil)
+
+	c.Check(mockStore.lastSnapSpec.Name, Equals, "foo")
+
+	out := resultToMap(c, result)
+	c.Check(out["name"], Equals, "foo")
+	c.Check(out["description"], Equals, "foo description")
+	c.Check(out["publisher"], Equals, "Publisher Two")
+	c.Check(out["website"], Equals, "https://example.com/foo")
+	channels := out["channels"].(map[string]any)
+	stable := channels["latest/stable"].(map[string]any)
+	c.Assert(stable, NotNil)
+	c.Check(stable["version"], Equals, "2.0")
+	c.Check(stable["revision"], Equals, float64(11))
+}
+
+func (s *snapMCPSuite) TestCallGetStoreSnapMissing(c *C) {
+	st := state.New(nil)
+	mockStore := &mockMCPStore{snapInfoErr: store.ErrSnapNotFound}
+	st.Lock()
+	snapstate.ReplaceStore(st, mockStore)
+	st.Unlock()
+
+	result, callErr := (snapstate.GetStoreSnapTool{}).Call(context.Background(), st, map[string]any{"snap_name": "missing"})
+	c.Check(result, IsNil)
+	c.Assert(callErr, NotNil)
+	c.Check(callErr.Error(), Equals, `cannot get store snap "missing": snap not found`)
+}

--- a/overlord/snapstate/mcp_tools_list_change_tasks_test.go
+++ b/overlord/snapstate/mcp_tools_list_change_tasks_test.go
@@ -1,0 +1,71 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate_test
+
+import (
+	"context"
+
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
+
+	. "gopkg.in/check.v1"
+)
+
+func (s *snapMCPSuite) TestCallListChangeTasksMissingChange(c *C) {
+	result, callErr := (snapstate.ListChangeTasksTool{}).Call(context.Background(), state.New(nil), map[string]any{"change_id": "999"})
+	c.Check(result, IsNil)
+	c.Check(callErr, NotNil)
+	c.Check(callErr.Error(), Equals, `cannot find change with id "999"`)
+}
+
+func (s *snapMCPSuite) TestCallListChangeTasks(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	chg := st.NewChange("install-snap", "install snap")
+	task := st.NewTask("download-snap", "Download snap")
+	task.SetProgress("downloading", 1, 2)
+	chg.AddTask(task)
+	st.Unlock()
+
+	result, callErr := (snapstate.ListChangeTasksTool{}).Call(context.Background(), st, map[string]any{"change_id": chg.ID()})
+	c.Assert(callErr, IsNil)
+	out := resultToMap(c, result)
+	c.Check(out["change_id"], Equals, chg.ID())
+	tasks := out["tasks"].([]any)
+	c.Assert(tasks, HasLen, 1)
+	taskMap := tasks[0].(map[string]any)
+	c.Check(taskMap["kind"], Equals, "download-snap")
+	progress := taskMap["progress"].(map[string]any)
+	c.Check(progress["label"], Equals, "downloading")
+	c.Check(progress["done"], Equals, float64(1))
+	c.Check(progress["total"], Equals, float64(2))
+}
+
+func (s *snapMCPSuite) TestListChangeTasksValidateInvalidType(c *C) {
+	err := (snapstate.ListChangeTasksTool{}).Validate(map[string]any{"change_id": true})
+	c.Assert(err, NotNil)
+	c.Check(err.Error(), Matches, `invalid arguments: .*change_id.*`)
+}
+
+func (s *snapMCPSuite) TestListChangeTasksValidateMissingChangeID(c *C) {
+	err := (snapstate.ListChangeTasksTool{}).Validate(map[string]any{})
+	c.Assert(err, NotNil)
+	c.Check(err.Error(), Equals, "change_id must not be empty")
+}

--- a/overlord/snapstate/mcp_tools_list_changes_test.go
+++ b/overlord/snapstate/mcp_tools_list_changes_test.go
@@ -1,0 +1,167 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
+
+	. "gopkg.in/check.v1"
+)
+
+func (s *snapMCPSuite) TestCallListChangesNoChanges(c *C) {
+	result, callErr := (snapstate.ListChangesTool{}).Call(context.Background(), state.New(nil), map[string]any{"select": "all"})
+	c.Assert(callErr, IsNil)
+	changes := resultToMap(c, result)["changes"].([]any)
+	c.Check(changes, HasLen, 0)
+}
+
+func (s *snapMCPSuite) TestCallListChangesFiltersBySnap(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	chg1 := st.NewChange("install-snap", "install one")
+	chg1.Set("snap-names", []string{"snap-a"})
+	chg2 := st.NewChange("install-snap", "install two")
+	chg2.Set("snap-names", []string{"snap-b"})
+	st.Unlock()
+
+	result, callErr := (snapstate.ListChangesTool{}).Call(context.Background(), st, map[string]any{"select": "all", "snap_name": "snap-a"})
+	c.Assert(callErr, IsNil)
+	changes := resultToMap(c, result)["changes"].([]any)
+	c.Assert(changes, HasLen, 1)
+	c.Check(changes[0].(map[string]any)["id"], Equals, chg1.ID())
+	_ = chg2
+}
+
+func (s *snapMCPSuite) TestCallListChangesOmitsTaskDetails(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	chg := st.NewChange("install-snap", "install one")
+	chg.Set("snap-names", []string{"snap-a"})
+	task := st.NewTask("download-snap", "Download snap")
+	chg.AddTask(task)
+	st.Unlock()
+
+	result, callErr := (snapstate.ListChangesTool{}).Call(context.Background(), st, map[string]any{"select": "all"})
+	c.Assert(callErr, IsNil)
+	changes := resultToMap(c, result)["changes"].([]any)
+	c.Assert(changes, HasLen, 1)
+	_, hasTasks := changes[0].(map[string]any)["tasks"]
+	c.Check(hasTasks, Equals, false)
+}
+
+func (s *snapMCPSuite) TestCallListChangesFiltersByKindAndDate(c *C) {
+	st := state.New(nil)
+
+	firstTime := time.Date(2026, time.January, 10, 10, 0, 0, 0, time.UTC)
+	restoreTime := state.MockTime(firstTime)
+	defer restoreTime()
+
+	st.Lock()
+	_ = st.NewChange("install-snap", "install one")
+	st.Unlock()
+
+	secondTime := firstTime.Add(4 * time.Hour)
+	state.MockTime(secondTime)
+
+	st.Lock()
+	chg2 := st.NewChange("refresh-snap", "refresh one")
+	st.Unlock()
+
+	result, callErr := (snapstate.ListChangesTool{}).Call(context.Background(), st, map[string]any{
+		"select": "all",
+		"kind":   "refresh-snap",
+		"since":  firstTime.Add(2 * time.Hour).Format(time.RFC3339),
+		"until":  secondTime.Add(2 * time.Hour).Format(time.RFC3339),
+	})
+	c.Assert(callErr, IsNil)
+	changes := resultToMap(c, result)["changes"].([]any)
+	c.Assert(changes, HasLen, 1)
+	first := changes[0].(map[string]any)
+	c.Check(first["id"], Equals, chg2.ID())
+	c.Check(first["kind"], Equals, "refresh-snap")
+	c.Check(first["spawn_time"], Equals, secondTime.Format(time.RFC3339))
+}
+
+func (s *snapMCPSuite) TestCallListChangesKindIsCaseInsensitive(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	chg := st.NewChange("refresh-snap", "refresh one")
+	st.Unlock()
+
+	result, callErr := (snapstate.ListChangesTool{}).Call(context.Background(), st, map[string]any{
+		"select": "all",
+		"kind":   "REFRESH-SNAP",
+	})
+	c.Assert(callErr, IsNil)
+	changes := resultToMap(c, result)["changes"].([]any)
+	c.Assert(changes, HasLen, 1)
+	first := changes[0].(map[string]any)
+	c.Check(first["id"], Equals, chg.ID())
+	c.Check(first["kind"], Equals, "refresh-snap")
+}
+
+func (s *snapMCPSuite) TestCallListChangesFiltersByStatus(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	_ = st.NewChange("install-snap", "install one")
+	chg2 := st.NewChange("refresh-snap", "refresh one")
+	chg2.SetStatus(state.ErrorStatus)
+	st.Unlock()
+
+	result, callErr := (snapstate.ListChangesTool{}).Call(context.Background(), st, map[string]any{
+		"select": "all",
+		"status": "failed",
+	})
+	c.Assert(callErr, IsNil)
+	changes := resultToMap(c, result)["changes"].([]any)
+	c.Assert(changes, HasLen, 1)
+	first := changes[0].(map[string]any)
+	c.Check(first["id"], Equals, chg2.ID())
+	c.Check(first["status"], Equals, "Error")
+}
+
+func (s *snapMCPSuite) TestListChangesValidateInvalidDateRange(c *C) {
+	_, err := (snapstate.ListChangesTool{}).Call(context.Background(), state.New(nil), map[string]any{
+		"since": "2026-01-11T00:00:00Z",
+		"until": "2026-01-10T00:00:00Z",
+	})
+	c.Assert(err, NotNil)
+	c.Check(err.Error(), Equals, "since must not be after until")
+}
+
+func (s *snapMCPSuite) TestListChangesValidateInvalidDateFormat(c *C) {
+	err := (snapstate.ListChangesTool{}).Validate(map[string]any{
+		"since": "not-a-date",
+	})
+	c.Assert(err, NotNil)
+	c.Check(err.Error(), Matches, `invalid arguments: .*`)
+}
+
+func (s *snapMCPSuite) TestListChangesValidateInvalidStatusType(c *C) {
+	err := (snapstate.ListChangesTool{}).Validate(map[string]any{
+		"status": 1,
+	})
+	c.Assert(err, NotNil)
+	c.Check(err.Error(), Matches, `invalid arguments: .*status.*`)
+}

--- a/overlord/snapstate/mcp_tools_list_services_test.go
+++ b/overlord/snapstate/mcp_tools_list_services_test.go
@@ -1,0 +1,42 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate_test
+
+import (
+	"context"
+
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
+
+	. "gopkg.in/check.v1"
+)
+
+func (s *snapMCPSuite) TestCallListServicesNoServices(c *C) {
+	result, callErr := (snapstate.ListServicesTool{}).Call(context.Background(), state.New(nil), map[string]any{})
+	c.Assert(callErr, IsNil)
+	services := resultToMap(c, result)["services"].([]any)
+	c.Check(services, HasLen, 0)
+}
+
+func (s *snapMCPSuite) TestListServicesValidateInvalidType(c *C) {
+	err := (snapstate.ListServicesTool{}).Validate(map[string]any{"snap_name": true})
+	c.Assert(err, NotNil)
+	c.Check(err.Error(), Matches, `invalid arguments: .*snap_name.*`)
+}

--- a/overlord/snapstate/mcp_tools_list_snaps_test.go
+++ b/overlord/snapstate/mcp_tools_list_snaps_test.go
@@ -1,0 +1,140 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate_test
+
+import (
+	"context"
+
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/sequence"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+
+	. "gopkg.in/check.v1"
+)
+
+func (s *snapMCPSuite) TestSnapToMapAllFields(c *C) {
+	info := &snap.Info{
+		SuggestedName:   "mysnap",
+		Version:         "1.0",
+		OriginalTitle:   "My Snap",
+		OriginalSummary: "A test snap",
+		Publisher:       snap.StoreAccount{Username: "someone"},
+		SideInfo:        snap.SideInfo{RealName: "mysnap", Revision: snap.R(42)},
+	}
+	m := snapstate.SnapToMapForTest(info, "stable", true, "active")
+	c.Check(m["name"], Equals, "mysnap")
+	c.Check(m["version"], Equals, "1.0")
+	c.Check(m["revision"], Equals, int(42))
+	c.Check(m["channel"], Equals, "stable")
+	c.Check(m["installed"], Equals, true)
+	c.Check(m["developer"], Equals, "someone")
+	c.Check(m["status"], Equals, "active")
+	c.Check(m["title"], Equals, "My Snap")
+	c.Check(m["summary"], Equals, "A test snap")
+}
+
+func (s *snapMCPSuite) TestSnapToMapZeroRevision(c *C) {
+	info := &snap.Info{SuggestedName: "core", SideInfo: snap.SideInfo{RealName: "core", Revision: snap.R(0)}}
+	m := snapstate.SnapToMapForTest(info, "", false, "")
+	c.Check(m["revision"], Equals, int(0))
+}
+
+func (s *snapMCPSuite) TestCallListSnapsNoFilter(c *C) {
+	result, callErr := (snapstate.ListSnapsTool{}).Call(context.Background(), state.New(nil), map[string]any{})
+	c.Assert(callErr, IsNil)
+	data := resultToMap(c, result)
+	snaps := data["snaps"].([]any)
+	c.Check(snaps, HasLen, 0)
+}
+
+func (s *snapMCPSuite) TestCallListSnapsMapsFields(c *C) {
+	st := state.New(nil)
+
+	restore := snapstate.MockSnapReadInfo(func(name string, si *snap.SideInfo) (*snap.Info, error) {
+		if name == "alpha-snap" {
+			return &snap.Info{
+				SuggestedName:   name,
+				Version:         "2.1",
+				OriginalTitle:   "Alpha Snap",
+				OriginalSummary: "alpha summary",
+				Publisher:       snap.StoreAccount{Username: "alpha-dev"},
+				SideInfo:        *si,
+			}, nil
+		}
+		return &snap.Info{
+			SuggestedName:   name,
+			Version:         "1.0",
+			OriginalTitle:   "Other Snap",
+			OriginalSummary: "other summary",
+			Publisher:       snap.StoreAccount{Username: "other-dev"},
+			SideInfo:        *si,
+		}, nil
+	})
+	defer restore()
+
+	st.Lock()
+	snapstate.Set(st, "alpha-snap", &snapstate.SnapState{
+		Sequence: sequence.SnapSequence{Revisions: []*sequence.RevisionSideState{
+			sequence.NewRevisionSideState(&snap.SideInfo{RealName: "alpha-snap", Revision: snap.R(8)}, nil),
+		}},
+		Current:         snap.R(8),
+		Active:          true,
+		TrackingChannel: "latest/stable",
+	})
+	snapstate.Set(st, "other-snap", &snapstate.SnapState{
+		Sequence: sequence.SnapSequence{Revisions: []*sequence.RevisionSideState{
+			sequence.NewRevisionSideState(&snap.SideInfo{RealName: "other-snap", Revision: snap.R(1)}, nil),
+		}},
+		Current:         snap.R(1),
+		Active:          false,
+		TrackingChannel: "latest/edge",
+	})
+	st.Unlock()
+
+	result, callErr := (snapstate.ListSnapsTool{}).Call(context.Background(), st, map[string]any{"name": "ALPHA"})
+	c.Assert(callErr, IsNil)
+
+	data := resultToMap(c, result)
+	snaps := data["snaps"].([]any)
+	c.Assert(snaps, HasLen, 1)
+
+	first := snaps[0].(map[string]any)
+	c.Check(first["name"], Equals, "alpha-snap")
+	c.Check(first["version"], Equals, "2.1")
+	c.Check(first["revision"], Equals, float64(8))
+	c.Check(first["channel"], Equals, "latest/stable")
+	c.Check(first["installed"], Equals, true)
+	c.Check(first["developer"], Equals, "alpha-dev")
+	c.Check(first["status"], Equals, "active")
+	c.Check(first["title"], Equals, "Alpha Snap")
+	c.Check(first["summary"], Equals, "alpha summary")
+}
+
+func (s *snapMCPSuite) TestListSnapsValidateInvalidType(c *C) {
+	err := (snapstate.ListSnapsTool{}).Validate(map[string]any{"name": true})
+	c.Assert(err, NotNil)
+	c.Check(err.Error(), Matches, `invalid arguments: .*name.*`)
+}
+
+func (s *snapMCPSuite) TestListSnapsValidateValidMap(c *C) {
+	err := (snapstate.ListSnapsTool{}).Validate(map[string]any{"name": "alpha"})
+	c.Assert(err, IsNil)
+}

--- a/overlord/snapstate/mcp_tools_search_store_snaps_test.go
+++ b/overlord/snapstate/mcp_tools_search_store_snaps_test.go
@@ -1,0 +1,82 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate_test
+
+import (
+	"context"
+
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+
+	. "gopkg.in/check.v1"
+)
+
+func (s *snapMCPSuite) TestSearchStoreSnapsValidate(c *C) {
+	_, err := (snapstate.SearchStoreSnapsTool{}).Call(context.Background(), state.New(nil), map[string]any{"name": "  "})
+	c.Assert(err, NotNil)
+	c.Check(err.Error(), Equals, "name must not be empty")
+}
+
+func (s *snapMCPSuite) TestSearchStoreSnapsValidateInvalidType(c *C) {
+	err := (snapstate.SearchStoreSnapsTool{}).Validate(map[string]any{"name": true})
+	c.Assert(err, NotNil)
+	c.Check(err.Error(), Matches, `invalid arguments: .*name.*`)
+}
+
+func (s *snapMCPSuite) TestSearchStoreSnapsValidateMissingName(c *C) {
+	err := (snapstate.SearchStoreSnapsTool{}).Validate(map[string]any{})
+	c.Assert(err, NotNil)
+	c.Check(err.Error(), Equals, "name must not be empty")
+}
+
+func (s *snapMCPSuite) TestCallSearchStoreSnaps(c *C) {
+	st := state.New(nil)
+	mockStore := &mockMCPStore{
+		findResults: []*snap.Info{
+			{
+				SuggestedName:   "hello-world",
+				Version:         "1.2",
+				OriginalTitle:   "Hello World",
+				OriginalSummary: "demo snap",
+				Publisher:       snap.StoreAccount{Username: "publisher1"},
+				StoreURL:        "https://snapcraft.io/hello-world",
+				SideInfo:        snap.SideInfo{RealName: "hello-world", Revision: snap.R(7), SnapID: "snapid-1"},
+			},
+		},
+	}
+	st.Lock()
+	snapstate.ReplaceStore(st, mockStore)
+	st.Unlock()
+
+	result, callErr := (snapstate.SearchStoreSnapsTool{}).Call(context.Background(), st, map[string]any{"name": "hello"})
+	c.Assert(callErr, IsNil)
+
+	c.Assert(mockStore.lastSearch, NotNil)
+	c.Check(mockStore.lastSearch.Query, Equals, "hello")
+
+	obj := resultToMap(c, result)
+	storeSnaps := obj["store_snaps"].([]any)
+	c.Assert(storeSnaps, HasLen, 1)
+	first := storeSnaps[0].(map[string]any)
+	c.Check(first["name"], Equals, "hello-world")
+	c.Check(first["snap_id"], Equals, "snapid-1")
+	c.Check(first["summary"], Equals, "demo snap")
+}

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -917,6 +917,9 @@ func Manager(st *state.State, runner *state.TaskRunner) (*SnapManager, error) {
 
 	RegisterAffectedSnapsByKind("conditional-auto-refresh", conditionalAutoRefreshAffectedSnaps)
 
+	// Register MCP tools and resources
+	delayedCrossMgrInit()
+
 	return m, nil
 }
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -1524,6 +1524,21 @@ suites:
             if [ "$SPREAD_DEBUG_EACH" = 1 ]; then
                 systemctl status snapd.socket || true
             fi
+    tests/mcp/:
+        summary: MCP command and API integration tests
+        systems: [-ubuntu-secboot-*, -ubuntu-fips-*]
+        prepare: |
+            "$TESTSLIB"/prepare-restore.sh --prepare-suite
+        prepare-each: |
+            "$TESTSLIB"/prepare-restore.sh --prepare-suite-each
+        restore-each: |
+            "$TESTSLIB"/prepare-restore.sh --restore-suite-each
+        restore: |
+            "$TESTSLIB"/prepare-restore.sh --restore-suite
+        debug: |
+            if [ "$SPREAD_DEBUG_EACH" = 1 ]; then
+                systemctl status snapd.socket || true
+            fi
     tests/core/:
         summary: Subset of Ubuntu Core specific tests
         systems: [ubuntu-core-*]

--- a/strutil/strutil.go
+++ b/strutil/strutil.go
@@ -76,6 +76,17 @@ func ListContains(list []string, str string) bool {
 	return false
 }
 
+// ListContainsFold determines whether the given string is contained in the
+// given list of strings, with case-insensitive matching.
+func ListContainsFold(list []string, str string) bool {
+	for _, k := range list {
+		if strings.EqualFold(k, str) {
+			return true
+		}
+	}
+	return false
+}
+
 // SortedListContains determines whether the given string is contained
 // in the given list of strings, which must be sorted.
 func SortedListContains(list []string, str string) bool {

--- a/strutil/strutil_test.go
+++ b/strutil/strutil_test.go
@@ -112,6 +112,27 @@ func (ts *strutilSuite) TestListContains(c *check.C) {
 	}
 }
 
+func (ts *strutilSuite) TestListContainsFold(c *check.C) {
+	for _, xs := range [][]string{
+		{},
+		nil,
+		{"foo"},
+		{"foo", "baz", "barbar"},
+	} {
+		c.Check(strutil.ListContainsFold(xs, "bar"), check.Equals, false)
+	}
+
+	for _, xs := range [][]string{
+		{"bar"},
+		{"foo", "bar", "baz"},
+		{"foo", "BAR", "baz"},
+		{"foo", "BaR", "baz"},
+		{"bar", "bar", "bar", "bar", "bar", "bar"},
+	} {
+		c.Check(strutil.ListContainsFold(xs, "bar"), check.Equals, true)
+	}
+}
+
 func (ts *strutilSuite) TestTruncateOutput(c *check.C) {
 	data := []byte("ab\ncd\nef\ngh\nij")
 	out := strutil.TruncateOutput(data, 3, 500)

--- a/tests/mcp/feature-flag-disabled/task.yaml
+++ b/tests/mcp/feature-flag-disabled/task.yaml
@@ -1,0 +1,17 @@
+summary: Verify feature flag requirement via snap mcp
+
+details: |
+    Verify that snap mcp reports a feature-flag-disabled error
+    when experimental.mcp is set to false.
+
+execute: |
+    snap set system experimental.mcp=false
+
+    req='{"jsonrpc":"2.0","id":"feature-flag-disabled","method":"ping"}'
+    printf '%s\n' "$req" | snap mcp > response.json
+    NOMATCH "Structured content does not match the tool's output schema" < response.json
+
+    gojq -r '.jsonrpc' < response.json | MATCH '^2.0$'
+    gojq -r 'has("id")' < response.json | MATCH '^false$'
+    gojq -r '.error.code' < response.json | MATCH '^-32603$'
+    gojq -r '.error.message' < response.json | MATCH '^cannot send request to snapd: feature flag "mcp" is disabled, enable with: snap set system experimental.mcp=true$'

--- a/tests/mcp/resource-snap-info/task.yaml
+++ b/tests/mcp/resource-snap-info/task.yaml
@@ -1,0 +1,23 @@
+summary: Verify resource snap info via snap mcp
+
+details: |
+    Verify that snap mcp can invoke resources/read for
+    snap://info/{snap} and returns key resource fields and snap details.
+
+prepare: |
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
+
+execute: |
+    snap set system experimental.mcp=true
+
+    req='{"jsonrpc":"2.0","id":"resource-snap-info","method":"resources/read","params":{"uri":"snap://info/test-snapd-sh"}}'
+    printf '%s\n' "$req" | snap mcp > response.json
+    NOMATCH "Structured content does not match the tool's output schema" < response.json
+
+    gojq -r '.jsonrpc' < response.json | MATCH '^2.0$'
+    gojq -r '.id' < response.json | MATCH '^resource-snap-info$'
+    gojq -r 'has("error")' < response.json | MATCH '^false$'
+
+    gojq -r '.result.contents[0].uri' < response.json | MATCH '^snap://info/test-snapd-sh$'
+    gojq -r '.result.contents[0].mimeType' < response.json | MATCH '^application/json$'
+    gojq -r '.result.contents[0].text | fromjson | .name' < response.json | MATCH '^test-snapd-sh$'

--- a/tests/mcp/resources-list/task.yaml
+++ b/tests/mcp/resources-list/task.yaml
@@ -1,0 +1,19 @@
+summary: Verify resources/list via snap mcp
+
+details: |
+    Verify that snap mcp can invoke resources/list and
+    that the snap info resource is advertised.
+
+execute: |
+    snap set core experimental.mcp=true
+
+    req='{"jsonrpc":"2.0","id":"resources-list","method":"resources/list"}'
+    printf '%s\n' "$req" | snap mcp > response.json
+    NOMATCH "Structured content does not match the tool's output schema" < response.json
+
+    gojq -r '.jsonrpc' < response.json | MATCH '^2.0$'
+    gojq -r '.id' < response.json | MATCH '^resources-list$'
+    gojq -r 'has("error")' < response.json | MATCH '^false$'
+
+    gojq -r '.result.resources | map(.uri) | index("snap://info/{snap}") != null' < response.json | MATCH '^true$'
+    gojq -r '.result.resources[] | select(.uri == "snap://info/{snap}") | .mimeType' < response.json | MATCH '^application/json$'

--- a/tests/mcp/tool-snap-get-snap/task.yaml
+++ b/tests/mcp/tool-snap-get-snap/task.yaml
@@ -1,0 +1,25 @@
+summary: Verify tool snap_get_snap via snap mcp
+
+details: |
+    Verify that snap mcp can invoke the snap_get_snap tool
+    and returns key details for an installed snap.
+
+prepare: |
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
+
+execute: |
+    snap set system experimental.mcp=true
+
+    req='{"jsonrpc":"2.0","id":"tool-snap-get-snap","method":"tools/call","params":{"name":"snap_get_snap","arguments":{"snap_name":"test-snapd-sh"}}}'
+    printf '%s\n' "$req" | snap mcp > response.json
+    NOMATCH "Structured content does not match the tool's output schema" < response.json
+
+    gojq -r '.jsonrpc' < response.json | MATCH '^2.0$'
+    gojq -r '.id' < response.json | MATCH '^tool-snap-get-snap$'
+    gojq -r 'has("error")' < response.json | MATCH '^false$'
+
+    gojq -r '.result.isError' < response.json | MATCH '^false$'
+    gojq -r '.result.content[0].type' < response.json | MATCH '^text$'
+    gojq -r '.result.content[0].text | fromjson | .name' < response.json | MATCH '^test-snapd-sh$'
+    gojq -r '.result.content[0].text | fromjson | has("version")' < response.json | MATCH '^true$'
+    gojq -r '.result.content[0].text | fromjson | has("revision")' < response.json | MATCH '^true$'

--- a/tests/mcp/tool-snap-get-store-snap/task.yaml
+++ b/tests/mcp/tool-snap-get-store-snap/task.yaml
@@ -1,0 +1,22 @@
+summary: Verify tool snap_get_store_snap via snap mcp
+
+details: |
+    Verify that snap mcp can invoke the snap_get_store_snap
+    tool and return key details for a known store snap.
+
+execute: |
+    snap set system experimental.mcp=true
+
+    req='{"jsonrpc":"2.0","id":"tool-snap-get-store-snap","method":"tools/call","params":{"name":"snap_get_store_snap","arguments":{"snap_name":"core"}}}'
+    printf '%s\n' "$req" | snap mcp > response.json
+    NOMATCH "Structured content does not match the tool's output schema" < response.json
+
+    gojq -r '.jsonrpc' < response.json | MATCH '^2.0$'
+    gojq -r '.id' < response.json | MATCH '^tool-snap-get-store-snap$'
+    gojq -r 'has("error")' < response.json | MATCH '^false$'
+
+    gojq -r '.result.isError' < response.json | MATCH '^false$'
+    gojq -r '.result.content[0].type' < response.json | MATCH '^text$'
+    gojq -r '.result.content[0].text | fromjson | .name' < response.json | MATCH '^core$'
+    gojq -r '.result.content[0].text | fromjson | has("snap_id")' < response.json | MATCH '^true$'
+    gojq -r '.result.content[0].text | fromjson | has("channels")' < response.json | MATCH '^true$'

--- a/tests/mcp/tool-snap-list-change-tasks/task.yaml
+++ b/tests/mcp/tool-snap-list-change-tasks/task.yaml
@@ -1,0 +1,37 @@
+summary: Verify tool snap_list_change_tasks via snap mcp
+
+details: |
+    Verify that snap mcp can invoke snap_list_change_tasks
+    for a known ready change and return a non-empty task list.
+
+prepare: |
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-content-slot
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-content-plug
+
+execute: |
+    snap set system experimental.mcp=true
+
+    list_req='{"jsonrpc":"2.0","id":"tool-snap-list-changes-for-tasks","method":"tools/call","params":{"name":"snap_list_changes","arguments":{"select":"ready","snap_name":"test-snapd-content-plug"}}}'
+    printf '%s\n' "$list_req" | snap mcp > list_response.json
+    NOMATCH "Structured content does not match the tool's output schema" < list_response.json
+
+    gojq -r '.jsonrpc' < list_response.json | MATCH '^2.0$'
+    gojq -r '.id' < list_response.json | MATCH '^tool-snap-list-changes-for-tasks$'
+    gojq -r 'has("error")' < list_response.json | MATCH '^false$'
+    gojq -r '.result.isError' < list_response.json | MATCH '^false$'
+
+    change_id=$(gojq -r '.result.content[0].text | fromjson | .changes[0].id' < list_response.json)
+    printf '%s\n' "$change_id" | MATCH '^[0-9]+$'
+
+    tasks_req=$(printf '{"jsonrpc":"2.0","id":"tool-snap-list-change-tasks","method":"tools/call","params":{"name":"snap_list_change_tasks","arguments":{"change_id":"%s"}}}' "$change_id")
+    printf '%s\n' "$tasks_req" | snap mcp > tasks_response.json
+    NOMATCH "Structured content does not match the tool's output schema" < tasks_response.json
+
+    gojq -r '.jsonrpc' < tasks_response.json | MATCH '^2.0$'
+    gojq -r '.id' < tasks_response.json | MATCH '^tool-snap-list-change-tasks$'
+    gojq -r 'has("error")' < tasks_response.json | MATCH '^false$'
+
+    gojq -r '.result.isError' < tasks_response.json | MATCH '^false$'
+    gojq -r '.result.content[0].type' < tasks_response.json | MATCH '^text$'
+    gojq -r '.result.content[0].text | fromjson | .change_id' < tasks_response.json | MATCH "^$change_id$"
+    gojq -r '.result.content[0].text | fromjson | .tasks | length > 0' < tasks_response.json | MATCH '^true$'

--- a/tests/mcp/tool-snap-list-changes/task.yaml
+++ b/tests/mcp/tool-snap-list-changes/task.yaml
@@ -1,0 +1,43 @@
+summary: Verify tool snap_list_changes via snap mcp
+
+details: |
+    Verify that snap mcp can invoke the snap_list_changes
+    tool and return at least one ready change for a known snap.
+
+prepare: |
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-content-slot
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-content-plug
+
+execute: |
+    snap set core experimental.mcp=true
+
+    req='{"jsonrpc":"2.0","id":"tool-snap-list-changes","method":"tools/call","params":{"name":"snap_list_changes","arguments":{"select":"ready","snap_name":"test-snapd-content-plug"}}}'
+    printf '%s\n' "$req" | snap mcp > response.json
+    NOMATCH "Structured content does not match the tool's output schema" < response.json
+
+    gojq -r '.jsonrpc' < response.json | MATCH '^2.0$'
+    gojq -r '.id' < response.json | MATCH '^tool-snap-list-changes$'
+    gojq -r 'has("error")' < response.json | MATCH '^false$'
+
+    gojq -r '.result.isError' < response.json | MATCH '^false$'
+    gojq -r '.result.content[0].type' < response.json | MATCH '^text$'
+    gojq -r '.result.content[0].text | fromjson | .changes | length > 0' < response.json | MATCH '^true$'
+    gojq -r '.result.content[0].text | fromjson | .changes | map(.snap_names // [] | map(startswith("test-snapd-content-plug"))) | flatten | any' < response.json | MATCH '^true$'
+    gojq -r '.result.content[0].text | fromjson | .changes | map(has("tasks")) | any' < response.json | MATCH '^false$'
+
+    change_kind=$(gojq -r '.result.content[0].text | fromjson | .changes[0].kind' < response.json)
+    change_status=$(gojq -r '.result.content[0].text | fromjson | .changes[0].status' < response.json)
+    since='2000-01-01T00:00:00Z'
+    until='2100-01-01T00:00:00Z'
+    req_kind=$(printf '{"jsonrpc":"2.0","id":"tool-snap-list-changes-kind-date","method":"tools/call","params":{"name":"snap_list_changes","arguments":{"select":"ready","snap_name":"test-snapd-content-plug","kind":"%s","status":"%s","since":"%s","until":"%s"}}}' "$change_kind" "$change_status" "$since" "$until")
+    printf '%s\n' "$req_kind" | snap mcp > response_kind.json
+    NOMATCH "Structured content does not match the tool's output schema" < response_kind.json
+
+    gojq -r '.jsonrpc' < response_kind.json | MATCH '^2.0$'
+    gojq -r '.id' < response_kind.json | MATCH '^tool-snap-list-changes-kind-date$'
+    gojq -r 'has("error")' < response_kind.json | MATCH '^false$'
+    gojq -r '.result.isError' < response_kind.json | MATCH '^false$'
+    gojq -r '.result.content[0].text | fromjson | .changes | length > 0' < response_kind.json | MATCH '^true$'
+    gojq -r '.result.content[0].text | fromjson | .changes | all(.kind == "'"$change_kind"'")' < response_kind.json | MATCH '^true$'
+    gojq -r '.result.content[0].text | fromjson | .changes | all(.status == "'"$change_status"'")' < response_kind.json | MATCH '^true$'
+    gojq -r '.result.content[0].text | fromjson | .changes | map(has("tasks")) | any' < response_kind.json | MATCH '^false$'

--- a/tests/mcp/tool-snap-list-connections/task.yaml
+++ b/tests/mcp/tool-snap-list-connections/task.yaml
@@ -1,0 +1,25 @@
+summary: Verify tool snap_list_connections via snap mcp
+
+details: |
+    Verify that snap mcp can invoke the snap_list_connections
+    tool and report key fields for a known active connection.
+
+prepare: |
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-content-slot
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-content-plug
+    snap connect test-snapd-content-plug:shared-content-plug test-snapd-content-slot:shared-content-slot
+
+execute: |
+    snap set system experimental.mcp=true
+
+    req='{"jsonrpc":"2.0","id":"tool-snap-list-connections","method":"tools/call","params":{"name":"snap_list_connections","arguments":{"snap":"test-snapd-content-plug"}}}'
+    printf '%s\n' "$req" | snap mcp > response.json
+    NOMATCH "Structured content does not match the tool's output schema" < response.json
+
+    gojq -r '.jsonrpc' < response.json | MATCH '^2.0$'
+    gojq -r '.id' < response.json | MATCH '^tool-snap-list-connections$'
+    gojq -r 'has("error")' < response.json | MATCH '^false$'
+
+    gojq -r '.result.isError' < response.json | MATCH '^false$'
+    gojq -r '.result.content[0].type' < response.json | MATCH '^text$'
+    gojq -r '.result.content[0].text | fromjson | .connections | map(.plug_snap == "test-snapd-content-plug" and .slot_snap == "test-snapd-content-slot" and .interface == "content") | any' < response.json | MATCH '^true$'

--- a/tests/mcp/tool-snap-list-interface-types/task.yaml
+++ b/tests/mcp/tool-snap-list-interface-types/task.yaml
@@ -1,0 +1,31 @@
+summary: Verify tool snap_list_interface_types via snap mcp
+
+details: |
+    Verify that snap mcp can invoke the snap_list_interface_types
+    tool and report an expected interface type.
+    Verify concise output by default and that details are returned
+    only when include_details=true.
+
+execute: |
+    snap set system experimental.mcp=true
+
+    req='{"jsonrpc":"2.0","id":"tool-snap-list-interface-types","method":"tools/call","params":{"name":"snap_list_interface_types","arguments":{"name":"content"}}}'
+    printf '%s\n' "$req" | snap mcp > response.json
+    NOMATCH "Structured content does not match the tool's output schema" < response.json
+
+    gojq -r '.jsonrpc' < response.json | MATCH '^2.0$'
+    gojq -r '.id' < response.json | MATCH '^tool-snap-list-interface-types$'
+    gojq -r 'has("error")' < response.json | MATCH '^false$'
+
+    gojq -r '.result.isError' < response.json | MATCH '^false$'
+    gojq -r '.result.content[0].type' < response.json | MATCH '^text$'
+    gojq -r '.result.content[0].text | fromjson | .interface_types | map(.name == "content") | any' < response.json | MATCH '^true$'
+    gojq -r '.result.content[0].text | fromjson | [.interface_types[] | has("summary") | not] | all' < response.json | MATCH '^true$'
+
+    req_details='{"jsonrpc":"2.0","id":"tool-snap-list-interface-types-details","method":"tools/call","params":{"name":"snap_list_interface_types","arguments":{"name":"content","include_details":true}}}'
+    printf '%s\n' "$req_details" | snap mcp > response_details.json
+    NOMATCH "Structured content does not match the tool's output schema" < response_details.json
+
+    gojq -r 'has("error")' < response_details.json | MATCH '^false$'
+    gojq -r '.result.isError' < response_details.json | MATCH '^false$'
+    gojq -r '.result.content[0].text | fromjson | .interface_types | map(.name == "content" and has("summary") and has("base_policy") and has("implemented_backends")) | any' < response_details.json | MATCH '^true$'

--- a/tests/mcp/tool-snap-list-plugs/task.yaml
+++ b/tests/mcp/tool-snap-list-plugs/task.yaml
@@ -1,0 +1,44 @@
+summary: Verify tool snap_list_plugs via snap mcp
+
+details: |
+    Verify that snap mcp can invoke the snap_list_plugs
+    tool and report expected plug details for a known snap.
+    Verify that concise output is returned by default.
+    Verify also that detailed output can be requested and that
+    every detailed plug's attrs field is a JSON object (never
+    null) so the output matches the schema.
+
+prepare: |
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-content-slot
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-content-plug
+
+execute: |
+    snap set system experimental.mcp=true
+
+    req='{"jsonrpc":"2.0","id":"tool-snap-list-plugs","method":"tools/call","params":{"name":"snap_list_plugs","arguments":{"snap_name":"test-snapd-content-plug","interface":"content"}}}'
+    printf '%s\n' "$req" | snap mcp > response.json
+    NOMATCH "Structured content does not match the tool's output schema" < response.json
+
+    gojq -r '.jsonrpc' < response.json | MATCH '^2.0$'
+    gojq -r '.id' < response.json | MATCH '^tool-snap-list-plugs$'
+    gojq -r 'has("error")' < response.json | MATCH '^false$'
+
+    gojq -r '.result.isError' < response.json | MATCH '^false$'
+    gojq -r '.result.content[0].type' < response.json | MATCH '^text$'
+    gojq -r '.result.content[0].text | fromjson | .plugs | map(.snap_name == "test-snapd-content-plug" and .name == "shared-content-plug" and .interface == "content") | any' < response.json | MATCH '^true$'
+    # By default, detailed fields are omitted.
+    gojq -r '.result.content[0].text | fromjson | [.plugs[] | has("attrs") | not] | all' < response.json | MATCH '^true$'
+
+    # List all plugs with include_details=true and verify every plug's attrs is
+    # a JSON object, never null. This guards against a regression where nil Attrs
+    # in snap.PlugInfo serialised as JSON null and failed the output schema check.
+    req_all='{"jsonrpc":"2.0","id":"tool-snap-list-plugs-all","method":"tools/call","params":{"name":"snap_list_plugs","arguments":{"include_details":true}}}'
+    printf '%s\n' "$req_all" | snap mcp > response_all.json
+    NOMATCH "Structured content does not match the tool's output schema" < response_all.json
+
+    gojq -r 'has("error")' < response_all.json | MATCH '^false$'
+    gojq -r '.result.isError' < response_all.json | MATCH '^false$'
+    # At least one plug must be present (we just installed test-snapd-content-plug)
+    gojq -r '.result.content[0].text | fromjson | .plugs | length > 0' < response_all.json | MATCH '^true$'
+    # Every plug's attrs must be a JSON object, not null
+    gojq -r '.result.content[0].text | fromjson | [.plugs[] | .attrs | type == "object"] | all' < response_all.json | MATCH '^true$'

--- a/tests/mcp/tool-snap-list-slots/task.yaml
+++ b/tests/mcp/tool-snap-list-slots/task.yaml
@@ -1,0 +1,44 @@
+summary: Verify tool snap_list_slots via snap mcp
+
+details: |
+    Verify that snap mcp can invoke the snap_list_slots
+    tool and report expected slot details for a known snap.
+    Verify that concise output is returned by default.
+    Verify also that detailed output can be requested and that
+    every detailed slot's attrs field is a JSON object (never
+    null) so the output matches the schema.
+
+prepare: |
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-content-slot
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-content-plug
+
+execute: |
+    snap set system experimental.mcp=true
+
+    req='{"jsonrpc":"2.0","id":"tool-snap-list-slots","method":"tools/call","params":{"name":"snap_list_slots","arguments":{"snap_name":"test-snapd-content-slot","interface":"content"}}}'
+    printf '%s\n' "$req" | snap mcp > response.json
+    NOMATCH "Structured content does not match the tool's output schema" < response.json
+
+    gojq -r '.jsonrpc' < response.json | MATCH '^2.0$'
+    gojq -r '.id' < response.json | MATCH '^tool-snap-list-slots$'
+    gojq -r 'has("error")' < response.json | MATCH '^false$'
+
+    gojq -r '.result.isError' < response.json | MATCH '^false$'
+    gojq -r '.result.content[0].type' < response.json | MATCH '^text$'
+    gojq -r '.result.content[0].text | fromjson | .slots | map(.snap_name == "test-snapd-content-slot" and .name == "shared-content-slot" and .interface == "content") | any' < response.json | MATCH '^true$'
+    # By default, detailed fields are omitted.
+    gojq -r '.result.content[0].text | fromjson | [.slots[] | has("attrs") | not] | all' < response.json | MATCH '^true$'
+
+    # List all slots with include_details=true and verify every slot's attrs is
+    # a JSON object, never null. This guards against a regression where nil Attrs
+    # in snap.SlotInfo serialised as JSON null and failed the output schema check.
+    req_all='{"jsonrpc":"2.0","id":"tool-snap-list-slots-all","method":"tools/call","params":{"name":"snap_list_slots","arguments":{"include_details":true}}}'
+    printf '%s\n' "$req_all" | snap mcp > response_all.json
+    NOMATCH "Structured content does not match the tool's output schema" < response_all.json
+
+    gojq -r 'has("error")' < response_all.json | MATCH '^false$'
+    gojq -r '.result.isError' < response_all.json | MATCH '^false$'
+    # At least one slot must be present (we just installed test-snapd-content-slot)
+    gojq -r '.result.content[0].text | fromjson | .slots | length > 0' < response_all.json | MATCH '^true$'
+    # Every slot's attrs must be a JSON object, not null
+    gojq -r '.result.content[0].text | fromjson | [.slots[] | .attrs | type == "object"] | all' < response_all.json | MATCH '^true$'

--- a/tests/mcp/tool-snap-list-snaps/task.yaml
+++ b/tests/mcp/tool-snap-list-snaps/task.yaml
@@ -1,0 +1,23 @@
+summary: Verify tool snap_list_snaps via snap mcp
+
+details: |
+    Verify that snap mcp can invoke the snap_list_snaps tool
+    and that the response includes an expected installed snap.
+
+prepare: |
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
+
+execute: |
+    snap set system experimental.mcp=true
+
+    req='{"jsonrpc":"2.0","id":"tool-snap-list-snaps","method":"tools/call","params":{"name":"snap_list_snaps","arguments":{"name":"test-snapd-sh"}}}'
+    printf '%s\n' "$req" | snap mcp > response.json
+    NOMATCH "Structured content does not match the tool's output schema" < response.json
+
+    gojq -r '.jsonrpc' < response.json | MATCH '^2.0$'
+    gojq -r '.id' < response.json | MATCH '^tool-snap-list-snaps$'
+    gojq -r 'has("error")' < response.json | MATCH '^false$'
+
+    gojq -r '.result.isError' < response.json | MATCH '^false$'
+    gojq -r '.result.content[0].type' < response.json | MATCH '^text$'
+    gojq -r '.result.content[0].text | fromjson | .snaps | map(.name == "test-snapd-sh") | any' < response.json | MATCH '^true$'

--- a/tests/mcp/tool-snap-search-store-snaps/task.yaml
+++ b/tests/mcp/tool-snap-search-store-snaps/task.yaml
@@ -1,0 +1,21 @@
+summary: Verify tool snap_search_store_snaps via snap mcp
+
+details: |
+    Verify that snap mcp can invoke the snap_search_store_snaps
+    tool and return at least one expected store result.
+
+execute: |
+    snap set system experimental.mcp=true
+
+    req='{"jsonrpc":"2.0","id":"tool-snap-search-store-snaps","method":"tools/call","params":{"name":"snap_search_store_snaps","arguments":{"name":"core"}}}'
+    printf '%s\n' "$req" | snap mcp > response.json
+    NOMATCH "Structured content does not match the tool's output schema" < response.json
+
+    gojq -r '.jsonrpc' < response.json | MATCH '^2.0$'
+    gojq -r '.id' < response.json | MATCH '^tool-snap-search-store-snaps$'
+    gojq -r 'has("error")' < response.json | MATCH '^false$'
+
+    gojq -r '.result.isError' < response.json | MATCH '^false$'
+    gojq -r '.result.content[0].type' < response.json | MATCH '^text$'
+    gojq -r '.result.content[0].text | fromjson | .store_snaps | length > 0' < response.json | MATCH '^true$'
+    gojq -r '.result.content[0].text | fromjson | .store_snaps | map(.name == "core") | any' < response.json | MATCH '^true$'

--- a/tests/mcp/tools-list/task.yaml
+++ b/tests/mcp/tools-list/task.yaml
@@ -1,0 +1,22 @@
+summary: Verify tools/list via snap mcp
+
+details: |
+    Verify that snap mcp can invoke tools/list and that
+    key tool names are present in the response.
+
+execute: |
+    snap set core experimental.mcp=true
+
+    req='{"jsonrpc":"2.0","id":"tools-list","method":"tools/list"}'
+    printf '%s\n' "$req" | snap mcp > response.json
+    NOMATCH "Structured content does not match the tool's output schema" < response.json
+
+    gojq -r '.jsonrpc' < response.json | MATCH '^2.0$'
+    gojq -r '.id' < response.json | MATCH '^tools-list$'
+    gojq -r 'has("error")' < response.json | MATCH '^false$'
+
+    gojq -r '.result.tools | map(.name) | index("snap_list_snaps") != null' < response.json | MATCH '^true$'
+    gojq -r '.result.tools | map(.name) | index("snap_get_snap") != null' < response.json | MATCH '^true$'
+    gojq -r '.result.tools | map(.name) | index("snap_list_changes") != null' < response.json | MATCH '^true$'
+    gojq -r '.result.tools | map(.name) | index("snap_list_change_tasks") != null' < response.json | MATCH '^true$'
+    gojq -r '.result.tools | map(.name) | index("snap_list_connections") != null' < response.json | MATCH '^true$'


### PR DESCRIPTION
This patch-set allows snapd to act as an Model Context Protocol server and contribute MCP tools and resources from across state managers.

The architecture allows running "snap mcp" as a stdio MCP server in any compatible client. This, coupled with our existing polkit authentication, allows a LLM client running in the user session to retrieve information from snapd. At present all the tools are read only but this is not an architectural limitation. In a way this is a parallel API layer but unlike our REST API, it does not need to be stable from release to release as the agent learns about the available tools each time, so we can tweak and tune them for the right balance of input and output that agents expect.

The actual protocol for MCP servers is JSON-RPC. Internally this is framed in our REST API and exposed by "snap mcp" in the form expected by clients.

A few sample MCP tools allow looking at tasks, changes, snaps and interface connections. This can enable a surprisingly nuanced conversation in a local client.

To use this you need to enable the experimental feature flag mcp:

```sh
sudo snap set system experimental.mcp=true
```