### PR TITLE
cmd/snap: display information about components in snap info

### DIFF
--- a/cmd/snap/cmd_info.go
+++ b/cmd/snap/cmd_info.go
@@ -186,26 +186,66 @@ func (iw *infoWriter) setupSnap(localSnap, remoteSnap *client.Snap, resInfo *cli
 }
 
 func (iw *infoWriter) maybePrintComponents() {
-	totalCount := 0
-	localCount := 0
-
-	if iw.localSnap != nil {
-		for _, comp := range iw.localSnap.Components {
-			if !comp.Revision.Unset() {
-				localCount++
-			}
-		}
-	}
-
-	if iw.theSnap != nil {
-		totalCount = len(iw.theSnap.Components)
-	}
-
-	if totalCount == 0 && localCount == 0 {
+	if iw.theSnap == nil || len(iw.theSnap.Components) == 0 {
 		return
 	}
 
-	fmt.Fprintf(iw, "components: %d/%d\n", localCount, totalCount)
+	iw.Flush()
+	defer iw.Flush()
+	fmt.Fprintln(iw, "components:")
+
+	sort.Slice(iw.theSnap.Components, componentsByInstallStatusAndSnapName(iw.theSnap.Components))
+
+	releasedfmt := "2006-01-02"
+	if iw.absTime {
+		releasedfmt = time.RFC3339
+	}
+
+	for idx := range iw.theSnap.Components {
+		comp := &iw.theSnap.Components[idx]
+		// This mimics the design of track display, on purpose.
+		fmt.Fprintf(iw, "  +%s:\t", comp.Name)
+		if comp.Version != "" {
+			fmt.Fprintf(iw, "%s\t", comp.Version)
+		} else {
+			fmt.Fprintf(iw, "%s\t", iw.esc.dash)
+		}
+		if comp.InstallDate != nil {
+			fmt.Fprintf(iw, "%s\t", comp.InstallDate.Format(releasedfmt))
+		} else {
+			fmt.Fprintf(iw, "%s\t", iw.esc.dash)
+		}
+		if !comp.Revision.Unset() {
+			// NOTE: Surprisingly component revisions are not unique within a snap, so
+			// for a given snap revision, we may see all the components corresponding
+			// to it share one revision number. This may be confusing to users.
+			// For the moment we DO print the component revision, but over time we
+			// may revise that decision and just omit it in this view.
+			fmt.Fprintf(iw, "%s\t", fmt.Sprintf("(%s)", comp.Revision))
+		} else {
+			fmt.Fprintf(iw, "%s\t", iw.esc.dash)
+		}
+		if comp.InstalledSize != 0 {
+			fmt.Fprintf(iw, "%s\t", fmtSize(comp.InstalledSize))
+		} else {
+			fmt.Fprintf(iw, "%s\t", iw.esc.dash)
+		}
+
+		var notes []string
+
+		if comp.Type != snap.StandardComponent {
+			notes = append(notes, string(comp.Type))
+		}
+		if comp.InstallDate == nil {
+			notes = append(notes, "not installed")
+		}
+		if len(notes) > 0 {
+			fmt.Fprintf(iw, "%s", strings.Join(notes, ", "))
+		} else {
+			fmt.Fprintf(iw, "%s", iw.esc.dash)
+		}
+		fmt.Fprintln(iw)
+	}
 }
 
 func (iw *infoWriter) maybePrintPrice() {
@@ -709,6 +749,7 @@ func (x *infoCmd) Execute([]string) error {
 		iw.printDescr()
 		iw.maybePrintCommands()
 		iw.maybePrintServices()
+		iw.maybePrintComponents()
 		iw.maybePrintNotes()
 		// stops the notes etc trying to be aligned with channels
 		iw.Flush()
@@ -720,7 +761,6 @@ func (x *infoCmd) Execute([]string) error {
 		iw.maybePrintTrackingChannel()
 		iw.maybePrintRefreshInfo()
 		iw.maybePrintChinfo()
-		iw.maybePrintComponents()
 	}
 	w.Flush()
 

--- a/cmd/snap/cmd_info_test.go
+++ b/cmd/snap/cmd_info_test.go
@@ -97,33 +97,86 @@ func (s *infoSuite) TestMaybePrintServicesNoServices(c *check.C) {
 	}
 }
 
-func (s *infoSuite) TestMaybePrintComponents(c *check.C) {
+func (s *infoSuite) TestMaybePrintComponentsNoneInstalled(c *check.C) {
 	var buf flushBuffer
 	iw := snap.NewInfoWriter(&buf)
 
-	// c1 is "installed" (revision != 0), c2 is "not installed" (revision == 0)
-	c1 := client.Component{Name: "comp-1", Revision: snaplib.R(10)}
-	c2 := client.Component{Name: "comp-2", Revision: snaplib.R(0)}
+	// both components available in the store but not installed (revision unset)
+	c1 := client.Component{Name: "comp-1", Type: "standard"}
+	c2 := client.Component{Name: "comp-2", Type: "standard"}
 
-	remoteSnap := &client.Snap{Components: []client.Component{c1, c2}}
-	snap.SetupSnap(iw, nil, remoteSnap, nil)
-
+	snap.SetupSnap(iw, nil, &client.Snap{
+		Name:       "foo",
+		Components: []client.Component{c1, c2},
+	}, nil)
 	snap.MaybePrintComponents(iw)
 
-	c.Check(buf.String(), check.Equals, "components: 0/2\n")
+	c.Check(buf.String(), check.Equals, "components:\n"+
+		"  +comp-1:\t--\t--\t--\t--\tnot installed\n"+
+		"  +comp-2:\t--\t--\t--\t--\tnot installed\n")
+}
 
-	buf.Reset()
+func (s *infoSuite) TestMaybePrintComponentsMixedInstall(c *check.C) {
+	var buf flushBuffer
+	iw := snap.NewInfoWriter(&buf)
+
+	// c1 is installed with revision, c2 is not installed (revision unset)
+	c1 := client.Component{
+		Name:          "comp-1",
+		Type:          "standard",
+		Version:       "1.0",
+		Revision:      snaplib.R(10),
+		InstalledSize: 1024,
+		InstallDate:   func() *time.Time { t := time.Date(2022, time.August, 19, 12, 34, 56, 0, time.UTC); return &t }(),
+	}
+	c2 := client.Component{Name: "comp-2", Type: "standard"}
 
 	snap.SetupSnap(iw, &client.Snap{
 		Name:       "foo",
 		Components: []client.Component{c1, c2},
-	}, remoteSnap, nil)
-
+	}, nil, nil)
 	snap.MaybePrintComponents(iw)
 
-	c.Check(buf.String(), check.Equals, "components: 1/2\n")
+	c.Check(buf.String(), check.Equals, "components:\n"+
+		"  +comp-1:\t1.0\t2022-08-19\t(10)\t1024B\t--\n"+
+		"  +comp-2:\t--\t--\t--\t--\tnot installed\n")
+}
 
-	buf.Reset()
+func (s *infoSuite) TestMaybePrintComponentsBothInstalled(c *check.C) {
+	var buf flushBuffer
+	iw := snap.NewInfoWriter(&buf)
+
+	c1 := client.Component{
+		Name:          "comp-1",
+		Type:          "standard",
+		Version:       "1.0",
+		Revision:      snaplib.R(10),
+		InstalledSize: 1024,
+		InstallDate:   func() *time.Time { t := time.Date(2022, time.August, 19, 12, 34, 56, 0, time.UTC); return &t }(),
+	}
+	c2 := client.Component{
+		Name:          "comp-2",
+		Type:          "kernel-modules",
+		Version:       "2.0",
+		Revision:      snaplib.R(20),
+		InstalledSize: 65536,
+		InstallDate:   func() *time.Time { t := time.Date(2022, time.August, 19, 12, 34, 56, 0, time.UTC); return &t }(),
+	}
+
+	snap.SetupSnap(iw, &client.Snap{
+		Name:       "foo",
+		Components: []client.Component{c1, c2},
+	}, nil, nil)
+	snap.MaybePrintComponents(iw)
+
+	c.Check(buf.String(), check.Equals, "components:\n"+
+		"  +comp-1:\t1.0\t2022-08-19\t(10)\t1024B\t--\n"+
+		"  +comp-2:\t2.0\t2022-08-19\t(20)\t65.5kB\tkernel-modules\n")
+}
+
+func (s *infoSuite) TestMaybePrintComponentsEmpty(c *check.C) {
+	var buf flushBuffer
+	iw := snap.NewInfoWriter(&buf)
 
 	snap.SetupSnap(iw, nil, &client.Snap{Components: []client.Component{}}, nil)
 	snap.MaybePrintComponents(iw)
@@ -131,26 +184,15 @@ func (s *infoSuite) TestMaybePrintComponents(c *check.C) {
 	c.Check(buf.String(), check.Equals, "")
 }
 
-func (s *infoSuite) TestMaybePrintComponentsBothInstalled(c *check.C) {
+func (s *infoSuite) TestMaybePrintComponents(c *check.C) {
+	// Keep a variant that exercises theSnap == nil path (no snap set up yet)
+	// which is covered by SetupSnap leaving theSnap as nil when both snaps are nil.
 	var buf flushBuffer
 	iw := snap.NewInfoWriter(&buf)
 
-	c1 := client.Component{Name: "comp-1", Revision: snaplib.R(10)}
-	c2 := client.Component{Name: "comp-2", Revision: snaplib.R(20)}
-
-	remoteSnap := &client.Snap{Components: []client.Component{c1, c2}}
-	snap.SetupSnap(iw, nil, remoteSnap, nil)
-
-	snap.SetupSnap(iw, &client.Snap{
-		Name:       "foo",
-		Components: []client.Component{c1, c2},
-	}, remoteSnap, nil)
-
 	snap.MaybePrintComponents(iw)
 
-	c.Check(buf.String(), check.Equals, "components: 2/2\n")
-
-	buf.Reset()
+	c.Check(buf.String(), check.Equals, "")
 }
 
 func (s *infoSuite) TestMaybePrintCommands(c *check.C) {

--- a/tests/main/snap-info-components/task.yaml
+++ b/tests/main/snap-info-components/task.yaml
@@ -1,12 +1,12 @@
 summary: Test that snap info command handles components as expected
 
 details: |
-  This test verifies that snap info prints components installed/available
-  counts correctly for various scenarios:
-  - No components installed using test-snap-with-components
-  - Snap installed but no components installed using test-snap-with-components
-  - 2/3 (installed/total) using test-snap-with-components
-  - No components anywhere using test-snapd-sh
+  This test verifies that snap info prints a `components:` section with
+  tabular per-component entries. Scenarios:
+  - No components section when snap is only available in the store.
+  - Components are shown in an abbreviated form `+comp` instead of `snap+comp`.
+  - Version, revision and installed size are only shown when available (when installed).
+  - No components section for a snap that has no components (test-snapd-sh).
 
 prepare: |
   snap install test-snapd-sh
@@ -16,13 +16,29 @@ restore: |
   snap remove --purge test-snap-with-components || true
 
 execute: |
-  # The snap-info command does not print component info if it is not installed
-  snap info test-snap-with-components | NOMATCH 'components: 0/3'
+  # The snap-info command does not print a components section for a store-only snap
+  snap info test-snap-with-components | NOMATCH 'components:'
   snap info test-snapd-sh | NOMATCH 'components:'
 
   snap install test-snap-with-components
-  snap info test-snap-with-components | MATCH 'components: 0/3'
+  snap info test-snap-with-components | MATCH 'components:'
+  # All components show 'not installed' before any are installed
+  snap info test-snap-with-components | MATCH '\+one:[[:space:]]*-- -- -- -- test, not installed'
+  snap info test-snap-with-components | MATCH '\+two:[[:space:]]*-- -- -- -- test, not installed'
+  snap info test-snap-with-components | MATCH '\+three:[[:space:]]*-- -- -- -- test, not installed'
 
   snap install test-snap-with-components+one+two
 
-  snap info test-snap-with-components | MATCH 'components: 2/3'
+  # Installed components show revision and size
+  snap info test-snap-with-components | MATCH '\+one:[[:space:]]*[[:digit:]]+\.[[:digit:]]+ [[:digit:]]+-[[:digit:]]+-[[:digit:]]+ \([[:digit:]]+\) [[:digit:]]+\.[[:digit:]]+kB test$'
+  snap info test-snap-with-components | MATCH '\+two:[[:space:]]*[[:digit:]]+\.[[:digit:]]+ [[:digit:]]+-[[:digit:]]+-[[:digit:]]+ \([[:digit:]]+\) [[:digit:]]+\.[[:digit:]]+kB test$'
+
+  # Exactly two components are installed
+  snap info test-snap-with-components | grep -c -E '[[:space:]]*[+].*\([[:digit:]]+\)' | MATCH '^2$'
+  # Installed components do not show 'not installed'
+  snap info test-snap-with-components | NOMATCH '\+one.*test, not installed'
+  snap info test-snap-with-components | NOMATCH '\+two.*test, not installed'
+  # Uninstalled component still shows 'not installed'
+  snap info test-snap-with-components | MATCH '\+three.*test, not installed'
+  # Exactly one component is not installed
+  snap info test-snap-with-components | grep -c 'not installed' | MATCH '^1$'


### PR DESCRIPTION
The existing abbreviated `components: N/M` is now expanded to give information about all the components and their installation state. This effectively makes info sufficient to discover the existence of components.

This is https://warthogs.atlassian.net/browse/SNAPDENG-36612