### PR TITLE
o/h/ctlcmd,i/builtin: allow a snap to masquerade as the core sound server

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -295,7 +295,7 @@ encourage you to add tests.
 Install the following package(s) to satisfy test dependencies.
 
 ```
-sudo apt-get install python3-yamlordereddictloader dbus-x11
+sudo apt-get install python3-yamlordereddictloader dbus-x11 clang-format
 ```
 
 ### Running unit-tests

--- a/interfaces/builtin/pipewire.go
+++ b/interfaces/builtin/pipewire.go
@@ -69,6 +69,11 @@ owner /run/user/[0-9]*/pipewire-[0-9] rwk,
 owner /run/user/[0-9]*/pipewire-[0-9].lock rwk,
 owner /run/user/[0-9]*/pipewire-[0-9]-manager rwk,
 owner /run/user/[0-9]*/pipewire-[0-9]-manager.lock rwk,
+
+# snap-policy.c: aa_getpeercon() on connecting snap clients
+ptrace (read) peer=snap.*,
+# snap-policy.c: aa_getcon() to read own AppArmor label
+@{PROC}/@{pid}/attr/{apparmor/,}current r,
 `
 
 const pipewirePermanentSlotSecComp = `

--- a/interfaces/builtin/pipewire.go
+++ b/interfaces/builtin/pipewire.go
@@ -66,7 +66,9 @@ network netlink raw,
 /sys/**/sound/** r,
 
 owner /run/user/[0-9]*/pipewire-[0-9] rwk,
+owner /run/user/[0-9]*/pipewire-[0-9].lock rwk,
 owner /run/user/[0-9]*/pipewire-[0-9]-manager rwk,
+owner /run/user/[0-9]*/pipewire-[0-9]-manager.lock rwk,
 `
 
 const pipewirePermanentSlotSecComp = `

--- a/interfaces/builtin/pulseaudio.go
+++ b/interfaces/builtin/pulseaudio.go
@@ -121,6 +121,13 @@ owner /{,var/}run/pulse/** rwk,
 
 owner /run/user/[0-9]*/ r,
 owner /run/user/[0-9]*/pulse/ rw,
+owner /run/user/[0-9]*/pulse/native rwk,
+owner /run/user/[0-9]*/pulse/pid rw,
+
+# snap-policy.c: aa_getpeercon() on connecting snap clients
+ptrace (read) peer=snap.*,
+# snap-policy.c: aa_getcon() to read own AppArmor label
+@{PROC}/@{pid}/attr/{apparmor/,}current r,
 `
 
 const pulseaudioPermanentSlotSecComp = `

--- a/overlord/hookstate/ctlcmd/is_connected.go
+++ b/overlord/hookstate/ctlcmd/is_connected.go
@@ -47,7 +47,7 @@ type isConnectedCommand struct {
 	} `positional-args:"true"`
 	Pid             int    `long:"pid" description:"Process ID for a plausibly connected process"`
 	AppArmorLabel   string `long:"apparmor-label" description:"AppArmor label for a plausibly connected process"`
-	CheckSystemSlot bool   `long:"check-system-slot" description:"With --pid or --apparmor-label, also treat the equivalent core/snapd audio slot as connected"`
+	CheckSystemSlot bool   `long:"check-system-slot" description:"With --pid or --apparmor-label, also check the connection to equivalent system snap audio slots as acceptable"`
 	List            bool   `long:"list" description:"List all connected plugs and slots"`
 }
 

--- a/overlord/hookstate/ctlcmd/is_connected.go
+++ b/overlord/hookstate/ctlcmd/is_connected.go
@@ -45,9 +45,10 @@ type isConnectedCommand struct {
 	Positional struct {
 		PlugOrSlotSpec string `positional-args:"true" positional-arg-name:"<plug|slot>"`
 	} `positional-args:"true"`
-	Pid           int    `long:"pid" description:"Process ID for a plausibly connected process"`
-	AppArmorLabel string `long:"apparmor-label" description:"AppArmor label for a plausibly connected process"`
-	List          bool   `long:"list" description:"List all connected plugs and slots"`
+	Pid             int    `long:"pid" description:"Process ID for a plausibly connected process"`
+	AppArmorLabel   string `long:"apparmor-label" description:"AppArmor label for a plausibly connected process"`
+	CheckSystemSlot bool   `long:"check-system-slot" description:"With --pid or --apparmor-label, also treat the equivalent core/snapd audio slot as connected"`
+	List            bool   `long:"list" description:"List all connected plugs and slots"`
 }
 
 var shortIsConnectedHelp = i18n.G(`Return success if the given plug or slot is connected`)
@@ -71,7 +72,13 @@ codes may be returned: 10 if the other snap is not connected but uses
 classic confinement, or 11 if the other process is not snap confined.
 
 The --pid and --apparmor-label options may only be used with slots of
-interface type "pulseaudio", "audio-record", or "cups-control".
+interface type "pulseaudio", "audio-record", "audio-playback", or
+"cups-control".
+
+The --check-system-slot option may be used together with --pid or
+--apparmor-label on a snap that has a "pipewire" or "pulseaudio" slot.
+For audio interfaces, it also treats the equivalent core/snapd slot as
+connected.
 `)
 
 func init() {
@@ -84,11 +91,45 @@ func isConnectedPidCheckAllowed(info *snap.Info, plugOrSlot string) bool {
 	slot := info.Slots[plugOrSlot]
 	if slot != nil {
 		switch slot.Interface {
-		case "pulseaudio", "audio-record", "cups-control":
+		case "pulseaudio", "audio-record", "audio-playback", "cups-control":
 			return true
 		}
 	}
 	return false
+}
+
+// isSoundServerSnap returns true if the snap has a pipewire or pulseaudio
+// slot, indicating it is a registered audio provider that may replace the
+// system (core/snapd) audio slots.
+func isSoundServerSnap(info *snap.Info) bool {
+	for _, slot := range info.Slots {
+		if slot.Interface == "pipewire" || slot.Interface == "pulseaudio" {
+			return true
+		}
+	}
+	return false
+}
+
+// isAudioInterface returns true for audio interfaces where an audio server
+// snap's own slot and the system (core/snapd) slot may be treated as
+// equivalent when checking permissions.
+func isAudioInterface(name string) bool {
+	switch name {
+	case "audio-record", "audio-playback", "pulseaudio", "pipewire":
+		return true
+	}
+	return false
+}
+
+// equivalentSystemAudioSlot returns the name of the equivalent system slot for
+// the given slot of an audio server snap. System audio slots use the interface
+// name as the slot name, which may differ from the calling snap's slot name.
+func equivalentSystemAudioSlot(info *snap.Info, slotName string) (string, bool) {
+	slot := info.Slots[slotName]
+	if slot == nil || !isSoundServerSnap(info) || !isAudioInterface(slot.Interface) {
+		return "", false
+	}
+	return slot.Interface, true
 }
 
 func (c *isConnectedCommand) Execute(args []string) error {
@@ -123,6 +164,16 @@ func (c *isConnectedCommand) Execute(args []string) error {
 	// is-connected, so the limitation is probably moot.
 	if plugOrSlot != "" && info.Plugs[plugOrSlot] == nil && info.Slots[plugOrSlot] == nil {
 		return fmt.Errorf("snap %q has no plug or slot named %q", snapName, plugOrSlot)
+	}
+
+	systemSlotName, canCheckSystemSlot := equivalentSystemAudioSlot(info, plugOrSlot)
+	if c.CheckSystemSlot {
+		if c.Pid == 0 && c.AppArmorLabel == "" {
+			return fmt.Errorf("cannot use --check-system-slot without --pid or --apparmor-label")
+		}
+		if !canCheckSystemSlot {
+			return fmt.Errorf("cannot use --check-system-slot with %s:%s", snapName, plugOrSlot)
+		}
 	}
 
 	conns, err := ifacestate.ConnectionStates(st)
@@ -212,6 +263,12 @@ func (c *isConnectedCommand) Execute(args []string) error {
 		matchingSlot := connRef.SlotRef.Snap == snapName && connRef.SlotRef.Name == plugOrSlot
 		if otherSnap != nil {
 			if matchingPlug && connRef.SlotRef.Snap == otherSnap.InstanceName() || matchingSlot && connRef.PlugRef.Snap == otherSnap.InstanceName() {
+				return nil
+			}
+			if c.CheckSystemSlot &&
+				(connRef.SlotRef.Snap == "core" || connRef.SlotRef.Snap == "snapd") &&
+				connRef.SlotRef.Name == systemSlotName &&
+				connRef.PlugRef.Snap == otherSnap.InstanceName() {
 				return nil
 			}
 		} else {

--- a/overlord/hookstate/ctlcmd/is_connected_test.go
+++ b/overlord/hookstate/ctlcmd/is_connected_test.go
@@ -106,6 +106,20 @@ var isConnectedTests = []struct {
 	args:     []string{"is-connected", "--pid", "1005", "audio-record"},
 	exitCode: ctlcmd.ClassicSnapCode,
 }, {
+	args: []string{"is-connected", "--check-system-slot", "server-record"},
+	err:  `cannot use --check-system-slot without --pid or --apparmor-label`,
+}, {
+	args: []string{"is-connected", "--pid", "1003", "--check-system-slot", "cc"},
+	err:  `cannot use --check-system-slot with snap1:cc`,
+}, {
+	// snap1:server-record slot is not connected to snap6 unless the system audio slot is considered
+	args:     []string{"is-connected", "--pid", "1006", "server-record"},
+	exitCode: 1,
+}, {
+	// snap1:server-record slot is treated as connected to snap6 via core:audio-record
+	args:     []string{"is-connected", "--pid", "1006", "--check-system-slot", "server-record"},
+	exitCode: 0,
+}, {
 	// snap1:plug1 does not use an allowed interface
 	args: []string{"is-connected", "--apparmor-label", "snap.snap2.app", "plug1"},
 	err:  `cannot use --apparmor-label check with snap1:plug1`,
@@ -133,6 +147,14 @@ var isConnectedTests = []struct {
 	// snap1:audio-record slot is not connected to classic snap5
 	args:     []string{"is-connected", "--apparmor-label", "snap.snap5.app", "audio-record"},
 	exitCode: ctlcmd.ClassicSnapCode,
+}, {
+	// snap1:server-record slot is not connected to snap6 unless the system audio slot is considered
+	args:     []string{"is-connected", "--apparmor-label", "snap.snap6.app", "server-record"},
+	exitCode: 1,
+}, {
+	// snap1:server-record slot is treated as connected to snap6 via core:audio-record
+	args:     []string{"is-connected", "--apparmor-label", "snap.snap6.app", "--check-system-slot", "server-record"},
+	exitCode: 0,
 }}
 
 func mockInstalledSnap(c *C, st *state.State, snapYaml, cohortKey string) *snap.Info {
@@ -168,7 +190,11 @@ slots:
   cc:
     interface: cups-control
   audio-record:
-    interface: audio-record`, "")
+    interface: audio-record
+  server-record:
+    interface: audio-record
+  pipewire:
+    interface: pipewire`, "")
 	mockInstalledSnap(c, s.st, `name: snap2
 slots:
   slot2:
@@ -191,6 +217,10 @@ confinement: classic
 plugs:
   cc:
     interface: cups-control`, "")
+	mockInstalledSnap(c, s.st, `name: snap6
+plugs:
+  client-record:
+    interface: audio-record`, "")
 	restore := ctlcmd.MockCgroupSnapNameFromPid(func(pid int) (string, error) {
 		switch {
 		case 1000 < pid && pid < 1100:
@@ -202,12 +232,13 @@ plugs:
 	defer restore()
 
 	s.st.Set("conns", map[string]any{
-		"snap1:plug1 snap2:slot2": map[string]any{},
-		"snap1:plug2 snap3:slot3": map[string]any{"undesired": true},
-		"snap1:plug3 snap4:slot4": map[string]any{"hotplug-gone": true},
-		"snap3:plug4 snap1:slot1": map[string]any{},
-		"snap3:cc snap1:cc":       map[string]any{},
-		"snap5:cc snap1:cc":       map[string]any{},
+		"snap1:plug1 snap2:slot2":               map[string]any{},
+		"snap1:plug2 snap3:slot3":               map[string]any{"undesired": true},
+		"snap1:plug3 snap4:slot4":               map[string]any{"hotplug-gone": true},
+		"snap3:plug4 snap1:slot1":               map[string]any{},
+		"snap3:cc snap1:cc":                     map[string]any{},
+		"snap5:cc snap1:cc":                     map[string]any{},
+		"snap6:client-record core:audio-record": map[string]any{},
 	})
 
 	s.st.Unlock()


### PR DESCRIPTION
This supports work to enable snapping Pipewire for classic Ubuntu. The goal of that work is support newer releases of Pipewire on older LTS via snaps.

The corresponding changes to the Pipewire snap can be found in two commits,

  - [The first change](https://github.com/quine00/pipewire-snap/commit/c1b03e1f8ba84df3e8ff37d1b1c84653a05cc129) drops the sockets from the app's user-daemon, instead using Pipewire environment variables to allow the daemon to setup its own listeners in the host XDG_RUNTIME_DIR. for which AppArmor permissions are already granted.
  - [The second change](https://github.com/quine00/pipewire-snap/commit/f60a0644b1f0f444e4956b93b23956e4fb1c30aa) modifies the `snapctl is-connected` command to return true when the calling snap is connected to a core audio interface (like `:audio-record` or `:audio-playback`), even though the snapped sound server is registered in `pipewire:audio-record` or `pipewire:audio-playback`. This is used in Pipewire's module access controls when snaps connect to Pipewire via pulse.

I tried two other approaches to get a snapped Pipewire working in classic Ubuntu,

 - Exposed a "$SNAP_REAL_XDG_RUNTIME_DIR" variable in the `sockets:` stanza for user-daemons. This also worked but seemed like it could expose a number of security issues if apps were allowed access to that location, even when restricted to the user-daemon section
 - Introduced a new privileged `sound-server` interface. When used by an app, snapd would internally generate sockets and manage them based on whether it was pulse or pipewire. This got rather complex, and instead I felt key'ing this the pulseaudio or pipewire interfaces was a better idea than introducing new interface