### PR TITLE
cmd/snap, cmd/snap-confine, tests: add observability to device cgroup access control

### DIFF
--- a/cmd/libsnap-confine-private/bpf-support.c
+++ b/cmd/libsnap-confine-private/bpf-support.c
@@ -72,6 +72,23 @@ int bpf_create_map(enum bpf_map_type type, size_t key_size, size_t value_size, s
     return set_cloexec(fd);
 }
 
+int bpf_create_ringbuf(size_t size, const char *map_name) {
+    debug("create bpf ringbuf of size %zu, name '%s'", size, map_name != NULL ? map_name : "(none)");
+    union bpf_attr attr;
+    memset(&attr, 0, sizeof(attr));
+    attr.map_type = BPF_MAP_TYPE_RINGBUF;
+    /* ring buffer maps use max_entries for the buffer size */
+    attr.max_entries = size;
+    if (map_name != NULL) {
+        strncpy(attr.map_name, map_name, sizeof(attr.map_name) - 1);
+    }
+    int fd = sys_bpf(BPF_MAP_CREATE, &attr, sizeof(attr));
+    if (fd < 0) {
+        return fd;
+    }
+    return set_cloexec(fd);
+}
+
 int bpf_update_map(int map_fd, const void *key, const void *value) {
     union bpf_attr attr;
     memset(&attr, 0, sizeof(attr));
@@ -108,6 +125,10 @@ int bpf_get_by_path(const char *path) {
     return set_cloexec(fd);
 }
 
+/* TODO: implement 2-pass loading strategy (like libbpf): first attempt without
+ * log buffer (log_level=0) for performance, then retry with log buffer on
+ * failure to capture verifier diagnostics. This avoids ENOSPC errors when the
+ * log buffer is too small for the full verifier output on successful loads. */
 int bpf_load_prog(enum bpf_prog_type type, const struct bpf_insn *insns, size_t insns_cnt, char *log_buf,
                   size_t log_buf_size, const char *prog_name) {
     if (type == BPF_PROG_TYPE_UNSPEC) {

--- a/cmd/libsnap-confine-private/bpf-support.h
+++ b/cmd/libsnap-confine-private/bpf-support.h
@@ -57,6 +57,13 @@ int bpf_create_map(enum bpf_map_type type, size_t key_size, size_t value_size, s
                    const char *map_name);
 
 /**
+ * bpf_create_ringbuf creates a BPF ring buffer map with the given size (must
+ * be a power of 2 and page-aligned). Returns a file descriptor handle or -1
+ * on error. The returned file descriptor has O_CLOEXEC flag set on it.
+ */
+int bpf_create_ringbuf(size_t size, const char *map_name);
+
+/**
  * bpf_update_map updates the value of element with a given key (or adds it to
  * the map).
  */

--- a/cmd/libsnap-confine-private/device-cgroup-support.c
+++ b/cmd/libsnap-confine-private/device-cgroup-support.c
@@ -60,6 +60,7 @@ struct sc_device_cgroup {
         struct {
             int devmap_fd;
             int prog_fd;
+            int ringbuf_fd;
             char *tag;
             char pretty_name[BPF_OBJ_NAME_LEN]; /* only for presentation */
             struct rlimit old_limit;
@@ -152,7 +153,7 @@ typedef struct sc_cgroup_v2_device_key sc_cgroup_v2_device_key;
 typedef uint8_t sc_cgroup_v2_device_value;
 
 #ifdef ENABLE_BPF
-static int load_devcgroup_prog(int map_fd, const char *name) {
+static int load_devcgroup_prog(int map_fd, int ringbuf_fd, const char *name) {
     /* Basic rules about registers:
      * r0    - return value of built in functions and exit code of the program
      * r1-r5 - respective arguments to built in functions, clobbered by calls
@@ -182,7 +183,152 @@ static int load_devcgroup_prog(int map_fd, const char *name) {
      * described above and such that the whole structure fits on the stack (even
      * with some spare room) */
     size_t key_start = 17;
-    struct bpf_insn prog[] = {
+
+    /* Stack layout (growing down from r10):
+     *   r10 - 17 .. r10 - 8:  device key (9 bytes, packed)
+     *   r10 - 64 .. r10 - 24: deny event (40 bytes) for ring buffer output
+     *                          (placed at -64 for 8-byte alignment of timestamp)
+     *
+     * The deny event struct sc_device_deny_event is 40 bytes:
+     *   offset 0:  dev_type  (u8)
+     *   offset 1:  access    (u8)
+     *   offset 2:  _pad      (u16)
+     *   offset 4:  major     (u32)
+     *   offset 8:  minor     (u32)
+     *   offset 12: pid       (u32)
+     *   offset 16: timestamp (u64)
+     *   offset 24: comm      (16 bytes)
+     */
+    const int evt_start = 64; /* event starts at sp - 64 */
+    const int evt_size = 40;  /* sizeof(struct sc_device_deny_event) */
+
+    /* Build the program. When ringbuf_fd is valid (>= 0), the deny path
+     * emits an event to the ring buffer before returning 0. When ringbuf_fd
+     * is -1 (ring buffers not supported), the deny path simply returns 0
+     * as before. */
+
+    /* We build the program in two parts: the common prefix (device type
+     * detection and map lookups) and the deny epilogue (with or without
+     * ring buffer output). */
+
+    struct bpf_insn prog_with_ringbuf[] = {
+        /* === COMMON PREFIX === */
+        /* r1 holds pointer to bpf_cgroup_dev_ctx */
+        /* initialize r0 */
+        BPF_MOV64_IMM(BPF_REG_0, 0), /* r0 = 0 */
+        /* make some place on the stack for the key */
+        BPF_MOV64_REG(BPF_REG_6, BPF_REG_10), /* r6 = r10 (sp) */
+        /* r6 = where the key starts on the stack */
+        BPF_ALU64_IMM(BPF_ADD, BPF_REG_6, -key_start), /* r6 = sp + (-key start offset) */
+        /* save ctx pointer in r7 for later use in deny path */
+        BPF_MOV64_REG(BPF_REG_7, BPF_REG_1), /* r7 = r1 (ctx) */
+        /* copy major to our key */
+        BPF_LDX_MEM(BPF_W, BPF_REG_2, BPF_REG_1,
+                    offsetof(struct bpf_cgroup_dev_ctx, major)), /* r2 = *(u32)(r1->major) */
+        BPF_STX_MEM(BPF_W, BPF_REG_6, BPF_REG_2,
+                    offsetof(struct sc_cgroup_v2_device_key, major)), /* *(r6 + offsetof(major)) = r2 */
+        /* copy minor to our key */
+        BPF_LDX_MEM(BPF_W, BPF_REG_2, BPF_REG_1,
+                    offsetof(struct bpf_cgroup_dev_ctx, minor)), /* r2 = *(u32)(r1->minor) */
+        BPF_STX_MEM(BPF_W, BPF_REG_6, BPF_REG_2,
+                    offsetof(struct sc_cgroup_v2_device_key, minor)), /* *(r6 + offsetof(minor)) = r2 */
+        /* copy device access_type to r2 */
+        BPF_LDX_MEM(BPF_W, BPF_REG_2, BPF_REG_1,
+                    offsetof(struct bpf_cgroup_dev_ctx, access_type)), /* r2 = *(u32*)(r1->access_type) */
+        /* save access_type in r8 for later use in deny event */
+        BPF_MOV64_REG(BPF_REG_8, BPF_REG_2), /* r8 = r2 (access_type) */
+        /* access_type is encoded as (BPF_DEVCG_ACC_* << 16) | BPF_DEVCG_DEV_*,
+         * but we only care about type */
+        BPF_ALU32_IMM(BPF_AND, BPF_REG_2, 0xffff), /* r2 = r2 & 0xffff */
+        /* is it a block device? */
+        BPF_JMP_IMM(BPF_JNE, BPF_REG_2, BPF_DEVCG_DEV_BLOCK, 2), /* if (r2 != BPF_DEVCG_DEV_BLOCK) goto pc + 2 */
+        BPF_ST_MEM(BPF_B, BPF_REG_6, offsetof(struct sc_cgroup_v2_device_key, type),
+                   'b'), /* *(uint8*)(r6->type) = 'b' */
+        BPF_JMP_A(5),
+        BPF_JMP_IMM(BPF_JNE, BPF_REG_2, BPF_DEVCG_DEV_CHAR, 2), /* if (r2 != BPF_DEVCG_DEV_CHAR) goto pc + 2 */
+        BPF_ST_MEM(BPF_B, BPF_REG_6, offsetof(struct sc_cgroup_v2_device_key, type),
+                   'c'), /* *(uint8*)(r6->type) = 'c' */
+        BPF_JMP_A(2),
+        /* unknown device type */
+        BPF_MOV64_IMM(BPF_REG_0, 0), /* r0 = 0 */
+        BPF_EXIT_INSN(),
+        /* back on happy path, prepare arguments for map lookup */
+        BPF_LD_MAP_FD(BPF_REG_1, map_fd),
+        BPF_MOV64_REG(BPF_REG_2, BPF_REG_6),                                 /* r2 = (struct key *) r6, */
+        BPF_RAW_INSN(BPF_JMP | BPF_CALL, 0, 0, 0, BPF_FUNC_map_lookup_elem), /* r0 = bpf_map_lookup_elem(<map>,
+                                                                                 &key) */
+        BPF_JMP_IMM(BPF_JEQ, BPF_REG_0, 0, 2),                               /* if (value_ptr == 0) goto pc + 2 */
+        /* we found an exact match, allow access */
+        BPF_MOV64_IMM(BPF_REG_0, 1), /* r0 = 1 */
+        BPF_EXIT_INSN(),             /* return 1 (allow) */
+        /* maybe the minor number is using 0xffffffff (any) mask */
+        BPF_ST_MEM(BPF_W, BPF_REG_6, offsetof(struct sc_cgroup_v2_device_key, minor), UINT32_MAX),
+        BPF_LD_MAP_FD(BPF_REG_1, map_fd),
+        BPF_MOV64_REG(BPF_REG_2, BPF_REG_6),                                 /* r2 = (struct key *) r6, */
+        BPF_RAW_INSN(BPF_JMP | BPF_CALL, 0, 0, 0, BPF_FUNC_map_lookup_elem), /* r0 = bpf_map_lookup_elem(<map>,
+                                                                                 &key) */
+        BPF_JMP_IMM(BPF_JEQ, BPF_REG_0, 0, 2),                               /* if (value_ptr == 0) goto pc + 2 */
+        /* we found a match with any minor number for that type|major */
+        BPF_MOV64_IMM(BPF_REG_0, 1), /* r0 = 1 */
+        BPF_EXIT_INSN(),             /* return 1 (allow) */
+
+        /* === DENY PATH WITH RING BUFFER OUTPUT === */
+        /* no match found, access is denied; emit event to ring buffer */
+        BPF_MOV64_IMM(BPF_REG_0, 0), /* r0 = 0 (will be return value) */
+
+        /* zero-initialize the event area on stack (5 x 8-byte stores) */
+        BPF_STX_MEM(BPF_DW, BPF_REG_10, BPF_REG_0, -evt_start + 0),
+        BPF_STX_MEM(BPF_DW, BPF_REG_10, BPF_REG_0, -evt_start + 8),
+        BPF_STX_MEM(BPF_DW, BPF_REG_10, BPF_REG_0, -evt_start + 16),
+        BPF_STX_MEM(BPF_DW, BPF_REG_10, BPF_REG_0, -evt_start + 24),
+        BPF_STX_MEM(BPF_DW, BPF_REG_10, BPF_REG_0, -evt_start + 32),
+
+        /* event.dev_type = key.type (from r6) */
+        BPF_LDX_MEM(BPF_B, BPF_REG_2, BPF_REG_6, offsetof(struct sc_cgroup_v2_device_key, type)),
+        BPF_STX_MEM(BPF_B, BPF_REG_10, BPF_REG_2, -evt_start + 0),
+
+        /* event.access = access_type >> 16 (saved in r8) */
+        BPF_MOV64_REG(BPF_REG_2, BPF_REG_8),
+        BPF_ALU32_IMM(BPF_RSH, BPF_REG_2, 16),
+        BPF_STX_MEM(BPF_B, BPF_REG_10, BPF_REG_2, -evt_start + 1),
+
+        /* event.major = ctx->major (from saved r7) */
+        BPF_LDX_MEM(BPF_W, BPF_REG_2, BPF_REG_7, offsetof(struct bpf_cgroup_dev_ctx, major)),
+        BPF_STX_MEM(BPF_W, BPF_REG_10, BPF_REG_2, -evt_start + 4),
+
+        /* event.minor = ctx->minor */
+        BPF_LDX_MEM(BPF_W, BPF_REG_2, BPF_REG_7, offsetof(struct bpf_cgroup_dev_ctx, minor)),
+        BPF_STX_MEM(BPF_W, BPF_REG_10, BPF_REG_2, -evt_start + 8),
+
+        /* event.pid = bpf_get_current_pid_tgid() >> 32 (tgid = userspace PID) */
+        BPF_RAW_INSN(BPF_JMP | BPF_CALL, 0, 0, 0, BPF_FUNC_get_current_pid_tgid),
+        BPF_ALU64_IMM(BPF_RSH, BPF_REG_0, 32),
+        BPF_STX_MEM(BPF_W, BPF_REG_10, BPF_REG_0, -evt_start + 12),
+
+        /* event.timestamp = bpf_ktime_get_ns() */
+        BPF_RAW_INSN(BPF_JMP | BPF_CALL, 0, 0, 0, BPF_FUNC_ktime_get_ns),
+        BPF_STX_MEM(BPF_DW, BPF_REG_10, BPF_REG_0, -evt_start + 16),
+
+        /* event.comm = bpf_get_current_comm(&event.comm, 16) */
+        BPF_MOV64_REG(BPF_REG_1, BPF_REG_10),
+        BPF_ALU64_IMM(BPF_ADD, BPF_REG_1, -evt_start + 24),
+        BPF_MOV64_IMM(BPF_REG_2, TASK_COMM_LEN),
+        BPF_RAW_INSN(BPF_JMP | BPF_CALL, 0, 0, 0, BPF_FUNC_get_current_comm),
+
+        /* bpf_ringbuf_output(ringbuf_map, &event, sizeof(event), 0) */
+        BPF_LD_MAP_FD(BPF_REG_1, ringbuf_fd),
+        BPF_MOV64_REG(BPF_REG_2, BPF_REG_10),
+        BPF_ALU64_IMM(BPF_ADD, BPF_REG_2, -evt_start),
+        BPF_MOV64_IMM(BPF_REG_3, evt_size),
+        BPF_MOV64_IMM(BPF_REG_4, 0),
+        BPF_RAW_INSN(BPF_JMP | BPF_CALL, 0, 0, 0, BPF_FUNC_ringbuf_output),
+
+        /* return 0 (deny) */
+        BPF_MOV64_IMM(BPF_REG_0, 0),
+        BPF_EXIT_INSN(),
+    };
+
+    struct bpf_insn prog_without_ringbuf[] = {
         /* r1 holds pointer to bpf_cgroup_dev_ctx */
         /* initialize r0 */
         BPF_MOV64_IMM(BPF_REG_0, 0), /* r0 = 0 */
@@ -222,7 +368,7 @@ static int load_devcgroup_prog(int map_fd, const char *name) {
         BPF_LD_MAP_FD(BPF_REG_1, map_fd),
         BPF_MOV64_REG(BPF_REG_2, BPF_REG_6),                                 /* r2 = (struct key *) r6, */
         BPF_RAW_INSN(BPF_JMP | BPF_CALL, 0, 0, 0, BPF_FUNC_map_lookup_elem), /* r0 = bpf_map_lookup_elem(<map>,
-                                                                                &key) */
+                                                                                 &key) */
         BPF_JMP_IMM(BPF_JEQ, BPF_REG_0, 0, 1),                               /* if (value_ptr == 0) goto pc + 1 */
         /* we found an exact match */
         BPF_JMP_A(5), /* else goto pc + 5 */
@@ -231,7 +377,7 @@ static int load_devcgroup_prog(int map_fd, const char *name) {
         BPF_LD_MAP_FD(BPF_REG_1, map_fd),
         BPF_MOV64_REG(BPF_REG_2, BPF_REG_6),                                 /* r2 = (struct key *) r6, */
         BPF_RAW_INSN(BPF_JMP | BPF_CALL, 0, 0, 0, BPF_FUNC_map_lookup_elem), /* r0 = bpf_map_lookup_elem(<map>,
-                                                                                &key) */
+                                                                                 &key) */
         BPF_JMP_IMM(BPF_JEQ, BPF_REG_0, 0, 2),                               /* if (value_ptr == 0) goto pc + 2 */
         /* we found a match with any minor number for that type|major */
         BPF_MOV64_IMM(BPF_REG_0, 1), /* r0 = 1 */
@@ -243,8 +389,15 @@ static int load_devcgroup_prog(int map_fd, const char *name) {
     /* 32kB, should be more than enough to store verifier logs if program
        loading fails */
     char log_buf[32768] = {0};
+    int prog_fd;
 
-    int prog_fd = bpf_load_prog(BPF_PROG_TYPE_CGROUP_DEVICE, prog, SC_ARRAY_SIZE(prog), log_buf, sizeof(log_buf), name);
+    if (ringbuf_fd >= 0) {
+        prog_fd = bpf_load_prog(BPF_PROG_TYPE_CGROUP_DEVICE, prog_with_ringbuf, SC_ARRAY_SIZE(prog_with_ringbuf),
+                                log_buf, sizeof(log_buf), name);
+    } else {
+        prog_fd = bpf_load_prog(BPF_PROG_TYPE_CGROUP_DEVICE, prog_without_ringbuf, SC_ARRAY_SIZE(prog_without_ringbuf),
+                                log_buf, sizeof(log_buf), name);
+    }
     if (prog_fd < 0) {
         die("cannot load program, verifier output:\n%s\n", log_buf);
     }
@@ -325,6 +478,7 @@ static bool _sc_is_snap_cgroup(const char *group, const char *expected_group_nam
 static int _sc_cgroup_v2_init_bpf(sc_device_cgroup *self, int flags) {
     self->v2.devmap_fd = -1;
     self->v2.prog_fd = -1;
+    self->v2.ringbuf_fd = -1;
 
     /* fix the memlock limit if needed, this affects creating maps */
     self->v2.old_limit = _sc_cgroup_v2_adjust_memlock_limit();
@@ -503,8 +657,43 @@ static int _sc_cgroup_v2_init_bpf(sc_device_cgroup *self, int flags) {
     }
 
     if (!from_existing) {
+        /* Try to create a ring buffer for logging denied device accesses.
+         * This requires kernel 5.8+ (BPF_MAP_TYPE_RINGBUF support).
+         * If the kernel doesn't support ring buffers, we gracefully skip
+         * this and load the program without ring buffer output. */
+        char ringbuf_path[PATH_MAX] = {0};
+        static const char bpf_base[] = "/sys/fs/bpf";
+        sc_must_snprintf(ringbuf_path, sizeof ringbuf_path, "%s/snap/%s@denylog", bpf_base, self->v2.tag);
+
+        int ringbuf_fd = bpf_get_by_path(ringbuf_path);
+        if (ringbuf_fd < 0) {
+            if (errno != ENOENT) {
+                debug("cannot get existing deny ring buffer: %s", strerror(errno));
+            }
+            /* try to create a new ring buffer */
+            ringbuf_fd = bpf_create_ringbuf(SC_BPF_DENY_RINGBUF_SIZE, self->v2.pretty_name);
+            if (ringbuf_fd < 0) {
+                debug("ring buffer not supported by kernel, deny logging disabled");
+            } else {
+                debug("created deny ring buffer at fd: %d", ringbuf_fd);
+                if (bpf_pin_to_path(ringbuf_fd, ringbuf_path) < 0) {
+                    debug("cannot pin ring buffer to %s: %s", ringbuf_path, strerror(errno));
+                    close(ringbuf_fd);
+                    ringbuf_fd = -1;
+                } else {
+                    if (chown(ringbuf_path, 0, 0) != 0) {
+                        debug("cannot chown ring buffer path: %s", strerror(errno));
+                    }
+                }
+            }
+        } else {
+            debug("reusing existing deny ring buffer at fd: %d", ringbuf_fd);
+        }
+
+        self->v2.ringbuf_fd = ringbuf_fd;
+
         /* load and attach the BPF program */
-        int prog_fd = load_devcgroup_prog(devmap_fd, self->v2.pretty_name);
+        int prog_fd = load_devcgroup_prog(devmap_fd, ringbuf_fd, self->v2.pretty_name);
         /* keep track of the program */
         self->v2.prog_fd = prog_fd;
     }
@@ -523,6 +712,7 @@ static void _sc_cgroup_v2_close_bpf(sc_device_cgroup *self) {
      * program */
     sc_cleanup_close(&self->v2.devmap_fd);
     sc_cleanup_close(&self->v2.prog_fd);
+    sc_cleanup_close(&self->v2.ringbuf_fd);
 }
 
 static void _sc_cgroup_v2_allow_bpf(sc_device_cgroup *self, int kind, int major, int minor) {

--- a/cmd/libsnap-confine-private/device-cgroup-support.h
+++ b/cmd/libsnap-confine-private/device-cgroup-support.h
@@ -31,6 +31,38 @@ enum {
 };
 
 /**
+ * SC_BPF_DENY_RINGBUF_SIZE is the size of the per-snap ring buffer used
+ * to communicate device access denials from the BPF program to userspace.
+ * Must be a power of 2 and page-aligned. 4096 (1 page) holds approximately
+ * 85 events.
+ */
+#define SC_BPF_DENY_RINGBUF_SIZE 4096
+
+/**
+ * TASK_COMM_LEN is the maximum length of a task's comm field (including
+ * null terminator), matching the kernel's definition.
+ */
+#ifndef TASK_COMM_LEN
+#define TASK_COMM_LEN 16
+#endif
+
+/**
+ * sc_device_deny_event is the structure written to the ring buffer by the BPF
+ * program each time a device access is denied. This structure is shared between
+ * the C (kernel/snap-confine) and Go (snap debug) sides.
+ */
+struct sc_device_deny_event {
+    uint8_t dev_type; /* 'c' for char, 'b' for block */
+    uint8_t access;   /* access_type >> 16: BPF_DEVCG_ACC_* bitmask */
+    uint16_t _pad;
+    uint32_t major;
+    uint32_t minor;
+    uint32_t pid;
+    uint64_t timestamp;       /* ktime_get_ns() */
+    char comm[TASK_COMM_LEN]; /* process comm at time of denial */
+} __attribute__((packed));
+
+/**
  * sc_device_cgroup_new returns a new cgroup device wrapper that is suitable for
  * the current system. Flags can contain SC_DEVICE_CGROUP_FROM_EXISTING in which
  * case an existing cgroup will be used, and a -1 return value with errno set to

--- a/cmd/snap/cmd_debug_device_cgroup.go
+++ b/cmd/snap/cmd_debug_device_cgroup.go
@@ -24,16 +24,20 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"sort"
 	"syscall"
 	"text/tabwriter"
+	"time"
 
 	"github.com/jessevdk/go-flags"
 	"golang.org/x/sys/unix"
 
 	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/sandbox/cgroup"
+	"github.com/snapcore/snapd/sandbox/ebpf"
 )
 
 var shortDeviceCgroupHelp = i18n.G("Show devices allowed in a snap's device cgroup")
@@ -47,6 +51,8 @@ This command requires root privileges.
 `)
 
 type cmdDeviceCgroup struct {
+	Log        bool `long:"log"`
+	Discard    bool `long:"discard"`
 	Positional struct {
 		Snap string `positional-arg-name:"<snap>" required:"yes"`
 	} `positional-args:"yes"`
@@ -64,6 +70,16 @@ func (cmd *cmdDeviceCgroup) Execute(args []string) error {
 	}
 	snapName := cmd.Positional.Snap
 
+	if cmd.Log || cmd.Discard {
+		cgroupVer, err := cgroup.Version()
+		if err != nil {
+			return fmt.Errorf("cannot determine cgroup version: %v", err)
+		}
+		if cgroupVer != cgroup.V2 {
+			return fmt.Errorf("this action requires cgroup v2 support")
+		}
+	}
+
 	tags, err := cgroup.FindActiveDeviceMediationForSnap(snapName)
 	if err != nil {
 		return err
@@ -72,6 +88,22 @@ func (cmd *cmdDeviceCgroup) Execute(args []string) error {
 		return fmt.Errorf("no device cgroup found for snap %q", snapName)
 	}
 
+	if cmd.Log && cmd.Discard {
+		return fmt.Errorf("--log and --discard cannot be used together")
+	}
+
+	if cmd.Log {
+		return monitor(snapName, tags)
+	}
+
+	if cmd.Discard {
+		return discard(tags)
+	}
+
+	return showDevices(tags)
+}
+
+func showDevices(tags []string) error {
 	w := tabWriter()
 	defer w.Flush()
 
@@ -188,4 +220,126 @@ func printDeviceEntries(w *tabwriter.Writer, entries []cgroup.DeviceEntry) {
 			formatNodeNumber(e.Major), formatNodeNumber(e.Minor),
 			e.Access, devNode)
 	}
+}
+
+func monitor(snapName string, tags []string) error {
+	// Open ring buffers for all security tags
+	type tagReader struct {
+		tag    string
+		reader *ebpf.DeviceDenyLogReader
+	}
+
+	var readers []tagReader
+
+	for _, tag := range tags {
+		reader, err := ebpf.OpenDeviceDenyLog(tag)
+		if err != nil {
+			fmt.Fprintf(Stderr, "warning: cannot open deny log for %s: %v\n", tag, err)
+			continue
+		}
+		readers = append(readers, tagReader{tag: tag, reader: reader})
+	}
+
+	if len(readers) == 0 {
+		return fmt.Errorf("no deny ring buffers available for snap %q (kernel may not support BPF ring buffers)", snapName)
+	}
+
+	defer func() {
+		for _, r := range readers {
+			r.reader.Close()
+		}
+	}()
+
+	fmt.Fprintf(Stdout, "Monitoring device access denials for snap %q (Ctrl+C to stop)...\n", snapName)
+
+	// Handle Ctrl+C
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	// Read events from all ring buffers concurrently
+	type eventMsg struct {
+		tag   string
+		event *ebpf.DeviceDenyEvent
+		err   error
+	}
+	eventCh := make(chan eventMsg, 16)
+
+	for _, r := range readers {
+		go func(tag string, rdr *ebpf.DeviceDenyLogReader) {
+			for {
+				record, err := rdr.Read()
+				if err != nil {
+					eventCh <- eventMsg{tag: tag, err: err}
+					return
+				}
+				event, err := ebpf.DecodeDeviceDenyEvent(record.RawSample)
+				if err != nil {
+					eventCh <- eventMsg{tag: tag, err: err}
+					continue
+				}
+				eventCh <- eventMsg{tag: tag, event: event}
+			}
+		}(r.tag, r.reader)
+	}
+
+	// Boot time for converting ktime to wall clock
+	bootTime := osutil.BootTime()
+
+	for {
+		select {
+		case <-sigCh:
+			return nil
+		case msg := <-eventCh:
+			if msg.err != nil {
+				// Reader closed or error
+				fmt.Fprintf(Stderr, "warning: %s: %v\n", msg.tag, msg.err)
+				continue
+			}
+			ev := msg.event
+			var timeStr string
+			if bootTime.IsZero() {
+				// Cannot determine boot time, show relative offset
+				timeStr = fmt.Sprintf("+%fs", float64(ev.Timestamp)/1e9)
+			} else {
+				wallTime := bootTime.Add(time.Duration(ev.Timestamp))
+				timeStr = wallTime.Format("2006-01-02T15:04:05.000Z07:00")
+			}
+			devTypeStr := "char"
+			if ev.DevType == 'b' {
+				devTypeStr = "block"
+			}
+			// TODO: cache resolveDevNode results to avoid repeated /dev
+			// walks for the same device in long-running log sessions.
+			devNode := resolveDevNode(ev.DevType, ev.Major, ev.Minor)
+			devNodeStr := ""
+			if devNode != "" {
+				devNodeStr = fmt.Sprintf("  %s", devNode)
+			}
+			fmt.Fprintf(Stdout, "%s  PID=%-6d %-15s DENY  %s %d:%d (%s)%s\n",
+				timeStr,
+				ev.PID,
+				ev.CommString(),
+				devTypeStr,
+				ev.Major,
+				ev.Minor,
+				ev.AccessString(),
+				devNodeStr,
+			)
+		}
+	}
+}
+
+func discard(tags []string) error {
+	logf := func(format string, a ...any) {
+		fmt.Fprintf(Stderr, format+"\n", a...)
+	}
+
+	var firstErr error
+	for _, tag := range tags {
+		fmt.Fprintf(Stdout, "Discarding BPF objects for %s\n", tag)
+		if err := ebpf.DiscardPinnedMaps(tag, logf); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
 }

--- a/cmd/snapd/cli/cmd_debug_device_cgroup.go
+++ b/cmd/snapd/cli/cmd_debug_device_cgroup.go
@@ -24,16 +24,20 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"sort"
 	"syscall"
 	"text/tabwriter"
+	"time"
 
 	"github.com/jessevdk/go-flags"
 	"golang.org/x/sys/unix"
 
 	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/sandbox/cgroup"
+	"github.com/snapcore/snapd/sandbox/ebpf"
 )
 
 var shortDeviceCgroupHelp = i18n.G("Show devices allowed in a snap's device cgroup")
@@ -47,6 +51,8 @@ This command requires root privileges.
 `)
 
 type cmdDeviceCgroup struct {
+	Log        bool `long:"log"`
+	Discard    bool `long:"discard"`
 	Positional struct {
 		Snap string `positional-arg-name:"<snap>" required:"yes"`
 	} `positional-args:"yes"`
@@ -64,6 +70,16 @@ func (cmd *cmdDeviceCgroup) Execute(args []string) error {
 	}
 	snapName := cmd.Positional.Snap
 
+	if cmd.Log || cmd.Discard {
+		cgroupVer, err := cgroup.Version()
+		if err != nil {
+			return fmt.Errorf("cannot determine cgroup version: %v", err)
+		}
+		if cgroupVer != cgroup.V2 {
+			return fmt.Errorf("this action requires cgroup v2 support")
+		}
+	}
+
 	tags, err := cgroup.FindActiveDeviceMediationForSnap(snapName)
 	if err != nil {
 		return err
@@ -72,6 +88,22 @@ func (cmd *cmdDeviceCgroup) Execute(args []string) error {
 		return fmt.Errorf("no device cgroup found for snap %q", snapName)
 	}
 
+	if cmd.Log && cmd.Discard {
+		return fmt.Errorf("--log and --discard cannot be used together")
+	}
+
+	if cmd.Log {
+		return monitor(snapName, tags)
+	}
+
+	if cmd.Discard {
+		return discard(tags)
+	}
+
+	return showDevices(tags)
+}
+
+func showDevices(tags []string) error {
 	w := tabWriter()
 	defer w.Flush()
 
@@ -188,4 +220,126 @@ func printDeviceEntries(w *tabwriter.Writer, entries []cgroup.DeviceEntry) {
 			formatNodeNumber(e.Major), formatNodeNumber(e.Minor),
 			e.Access, devNode)
 	}
+}
+
+func monitor(snapName string, tags []string) error {
+	// Open ring buffers for all security tags
+	type tagReader struct {
+		tag    string
+		reader *ebpf.DeviceDenyLogReader
+	}
+
+	var readers []tagReader
+
+	for _, tag := range tags {
+		reader, err := ebpf.OpenDeviceDenyLog(tag)
+		if err != nil {
+			fmt.Fprintf(Stderr, "warning: cannot open deny log for %s: %v\n", tag, err)
+			continue
+		}
+		readers = append(readers, tagReader{tag: tag, reader: reader})
+	}
+
+	if len(readers) == 0 {
+		return fmt.Errorf("no deny ring buffers available for snap %q (kernel may not support BPF ring buffers)", snapName)
+	}
+
+	defer func() {
+		for _, r := range readers {
+			r.reader.Close()
+		}
+	}()
+
+	fmt.Fprintf(Stdout, "Monitoring device access denials for snap %q (Ctrl+C to stop)...\n", snapName)
+
+	// Handle Ctrl+C
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	// Read events from all ring buffers concurrently
+	type eventMsg struct {
+		tag   string
+		event *ebpf.DeviceDenyEvent
+		err   error
+	}
+	eventCh := make(chan eventMsg, 16)
+
+	for _, r := range readers {
+		go func(tag string, rdr *ebpf.DeviceDenyLogReader) {
+			for {
+				record, err := rdr.Read()
+				if err != nil {
+					eventCh <- eventMsg{tag: tag, err: err}
+					return
+				}
+				event, err := ebpf.DecodeDeviceDenyEvent(record.RawSample)
+				if err != nil {
+					eventCh <- eventMsg{tag: tag, err: err}
+					continue
+				}
+				eventCh <- eventMsg{tag: tag, event: event}
+			}
+		}(r.tag, r.reader)
+	}
+
+	// Boot time for converting ktime to wall clock
+	bootTime := osutil.BootTime()
+
+	for {
+		select {
+		case <-sigCh:
+			return nil
+		case msg := <-eventCh:
+			if msg.err != nil {
+				// Reader closed or error
+				fmt.Fprintf(Stderr, "warning: %s: %v\n", msg.tag, msg.err)
+				continue
+			}
+			ev := msg.event
+			var timeStr string
+			if bootTime.IsZero() {
+				// Cannot determine boot time, show relative offset
+				timeStr = fmt.Sprintf("+%fs", float64(ev.Timestamp)/1e9)
+			} else {
+				wallTime := bootTime.Add(time.Duration(ev.Timestamp))
+				timeStr = wallTime.Format("2006-01-02T15:04:05.000Z07:00")
+			}
+			devTypeStr := "char"
+			if ev.DevType == 'b' {
+				devTypeStr = "block"
+			}
+			// TODO: cache resolveDevNode results to avoid repeated /dev
+			// walks for the same device in long-running log sessions.
+			devNode := resolveDevNode(ev.DevType, ev.Major, ev.Minor)
+			devNodeStr := ""
+			if devNode != "" {
+				devNodeStr = fmt.Sprintf("  %s", devNode)
+			}
+			fmt.Fprintf(Stdout, "%s  PID=%-6d %-15s DENY  %s %d:%d (%s)%s\n",
+				timeStr,
+				ev.PID,
+				ev.CommString(),
+				devTypeStr,
+				ev.Major,
+				ev.Minor,
+				ev.AccessString(),
+				devNodeStr,
+			)
+		}
+	}
+}
+
+func discard(tags []string) error {
+	logf := func(format string, a ...any) {
+		fmt.Fprintf(Stderr, format+"\n", a...)
+	}
+
+	var firstErr error
+	for _, tag := range tags {
+		fmt.Fprintf(Stdout, "Discarding BPF objects for %s\n", tag)
+		if err := ebpf.DiscardPinnedMaps(tag, logf); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
 }

--- a/osutil/boottime_linux.go
+++ b/osutil/boottime_linux.go
@@ -1,0 +1,43 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+//go:build linux
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package osutil
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+// BootTime returns the approximate system boot time by reading
+// /proc/uptime. Returns a zero time.Time if the boot time cannot be
+// determined.
+func BootTime() time.Time {
+	data, err := os.ReadFile("/proc/uptime")
+	if err != nil {
+		return time.Time{}
+	}
+	var uptime float64
+	if _, err := fmt.Sscanf(string(data), "%f", &uptime); err != nil {
+		return time.Time{}
+	}
+	return time.Now().Add(-time.Duration(uptime * float64(time.Second)))
+}

--- a/sandbox/ebpf/device_cgroup.go
+++ b/sandbox/ebpf/device_cgroup.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/ringbuf"
 
 	"github.com/snapcore/snapd/arch"
 	"github.com/snapcore/snapd/dirs"
@@ -166,4 +167,134 @@ func FindActiveDeviceMapsForSnap(instanceName string) (tags []string, err error)
 	}
 	sort.Strings(tags)
 	return tags, nil
+}
+
+// DeviceDenyEvent is the structure written to the ring buffer by the BPF
+// program when a device access is denied. It must match struct
+// sc_device_deny_event in device-cgroup-support.h.
+type DeviceDenyEvent struct {
+	DevType   uint8  // 'c' or 'b'
+	Access    uint8  // BPF_DEVCG_ACC_* bitmask (1=mknod, 2=read, 4=write)
+	_pad      uint16 //nolint:unused
+	Major     uint32
+	Minor     uint32
+	PID       uint32
+	Timestamp uint64   // ktime_get_ns()
+	Comm      [16]byte // TASK_COMM_LEN
+}
+
+// DeviceDenyEventSize is the size of a packed DeviceDenyEvent.
+const DeviceDenyEventSize = 40
+
+// CommString returns the process comm as a Go string, trimming null bytes.
+func (e *DeviceDenyEvent) CommString() string {
+	n := 0
+	for n < len(e.Comm) && e.Comm[n] != 0 {
+		n++
+	}
+	return string(e.Comm[:n])
+}
+
+// AccessString returns a human-readable representation of the access flags.
+func (e *DeviceDenyEvent) AccessString() string {
+	var parts []string
+	if e.Access&1 != 0 {
+		parts = append(parts, "mknod")
+	}
+	if e.Access&2 != 0 {
+		parts = append(parts, "read")
+	}
+	if e.Access&4 != 0 {
+		parts = append(parts, "write")
+	}
+	if len(parts) == 0 {
+		return fmt.Sprintf("0x%x", e.Access)
+	}
+	return strings.Join(parts, ",")
+}
+
+// DecodeDeviceDenyEvent decodes a DeviceDenyEvent from raw bytes.
+func DecodeDeviceDenyEvent(data []byte) (*DeviceDenyEvent, error) {
+	if len(data) < DeviceDenyEventSize {
+		return nil, fmt.Errorf("short event record: %d bytes, want %d", len(data), DeviceDenyEventSize)
+	}
+
+	// TODO:GOVERSION:use binary.NativeEndian
+	e := arch.Endian()
+
+	ev := &DeviceDenyEvent{
+		DevType:   data[0],
+		Access:    data[1],
+		Major:     e.Uint32(data[4:8]),
+		Minor:     e.Uint32(data[8:12]),
+		PID:       e.Uint32(data[12:16]),
+		Timestamp: e.Uint64(data[16:24]),
+	}
+	copy(ev.Comm[:], data[24:40])
+	return ev, nil
+}
+
+// SecurityTagToDeviceDenyLogPath returns the path to the deny log
+// ring buffer for the given security tag.
+func SecurityTagToDeviceDenyLogPath(securityTag string) string {
+	tag := strings.ReplaceAll(securityTag, ".", "_")
+	return fmt.Sprintf("%s/%s@denylog", dirs.SnapBPFFSDir, tag)
+}
+
+// DiscardPinnedMaps removes the pinned BPF device map and deny ring
+// buffer for the given security tag. It is robust: if either file does
+// not exist, it logs a message via logf and continues. Returns an error
+// only if an actual removal fails for a reason other than the file not
+// existing.
+func DiscardPinnedMaps(securityTag string, logf func(string, ...any)) error {
+	mapPath := SecurityTagToBPFPath(securityTag)
+	ringPath := SecurityTagToDeviceDenyLogPath(securityTag)
+
+	var firstErr error
+	for _, path := range []string{mapPath, ringPath} {
+		if err := os.Remove(path); err != nil {
+			if os.IsNotExist(err) {
+				logf("pinned object %s does not exist, skipping", path)
+			} else {
+				logf("cannot remove %s: %v", path, err)
+				if firstErr == nil {
+					firstErr = fmt.Errorf("cannot remove %s: %v", path, err)
+				}
+			}
+		}
+	}
+	return firstErr
+}
+
+// DeviceDenyLogReader wraps a ringbuf.Reader and ensures the underlying
+// ebpf.Map is also closed when the reader is closed. ringbuf.NewReader
+// does not take ownership of the map, so we must track it separately.
+type DeviceDenyLogReader struct {
+	*ringbuf.Reader
+	m *ebpf.Map
+}
+
+func (r *DeviceDenyLogReader) Close() error {
+	err := r.Reader.Close()
+	if merr := r.m.Close(); merr != nil && err == nil {
+		err = merr
+	}
+	return err
+}
+
+// OpenDeviceDenyLog opens the pinned BPF ring buffer map for the given
+// security tag and returns a DeviceDenyLogReader. The caller is responsible
+// for closing the returned reader.
+func OpenDeviceDenyLog(securityTag string) (*DeviceDenyLogReader, error) {
+	path := SecurityTagToDeviceDenyLogPath(securityTag)
+	m, err := ebpf.LoadPinnedMap(path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("cannot load deny ring buffer at %s: %v", path, err)
+	}
+	r, err := ringbuf.NewReader(m)
+	if err != nil {
+		m.Close()
+		return nil, fmt.Errorf("cannot create ring buffer reader: %v", err)
+	}
+	return &DeviceDenyLogReader{Reader: r, m: m}, nil
 }

--- a/sandbox/ebpf/device_cgroup_test.go
+++ b/sandbox/ebpf/device_cgroup_test.go
@@ -20,6 +20,7 @@
 package ebpf_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -146,4 +147,153 @@ func (s *ebpfSuite) TestFindActiveDeviceMapsForSnapNoDir(c *C) {
 	tags, err := ebpf.FindActiveDeviceMapsForSnap("anything")
 	c.Assert(err, IsNil)
 	c.Check(tags, IsNil)
+}
+
+func (s *ebpfSuite) TestSecurityTagToDeviceDenyLogPath(c *C) {
+	c.Check(ebpf.SecurityTagToDeviceDenyLogPath("snap.foo.bar"), Equals,
+		filepath.Join(dirs.SnapBPFFSDir, "snap_foo_bar@denylog"))
+}
+
+func (s *ebpfSuite) TestDecodeDeviceDenyEvent(c *C) {
+	// Build a 40-byte event payload
+	data := make([]byte, 40)
+	data[0] = 'c'  // dev_type
+	data[1] = 0x06 // access: read|write
+	// padding at [2:4]
+	e := arch.Endian()
+	e.PutUint32(data[4:8], 1)          // major
+	e.PutUint32(data[8:12], 7)         // minor
+	e.PutUint32(data[12:16], 12345)    // pid
+	e.PutUint64(data[16:24], 99999999) // timestamp
+	copy(data[24:40], "my-process\x00\x00\x00\x00\x00\x00")
+
+	ev, err := ebpf.DecodeDeviceDenyEvent(data)
+	c.Assert(err, IsNil)
+	c.Check(ev.DevType, Equals, uint8('c'))
+	c.Check(ev.Access, Equals, uint8(0x06))
+	c.Check(ev.Major, Equals, uint32(1))
+	c.Check(ev.Minor, Equals, uint32(7))
+	c.Check(ev.PID, Equals, uint32(12345))
+	c.Check(ev.Timestamp, Equals, uint64(99999999))
+	c.Check(ev.CommString(), Equals, "my-process")
+}
+
+func (s *ebpfSuite) TestDecodeDeviceDenyEventShort(c *C) {
+	_, err := ebpf.DecodeDeviceDenyEvent(make([]byte, 10))
+	c.Check(err, ErrorMatches, "short event record: 10 bytes, want 40")
+}
+
+func (s *ebpfSuite) TestCommString(c *C) {
+	ev := &ebpf.DeviceDenyEvent{}
+
+	// Full buffer, no null
+	copy(ev.Comm[:], "0123456789abcdef")
+	c.Check(ev.CommString(), Equals, "0123456789abcdef")
+
+	// Null terminated early
+	copy(ev.Comm[:], "foo\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00")
+	c.Check(ev.CommString(), Equals, "foo")
+
+	// Empty
+	ev.Comm = [16]byte{}
+	c.Check(ev.CommString(), Equals, "")
+}
+
+func (s *ebpfSuite) TestAccessString(c *C) {
+	ev := &ebpf.DeviceDenyEvent{}
+
+	ev.Access = 1
+	c.Check(ev.AccessString(), Equals, "mknod")
+
+	ev.Access = 2
+	c.Check(ev.AccessString(), Equals, "read")
+
+	ev.Access = 4
+	c.Check(ev.AccessString(), Equals, "write")
+
+	ev.Access = 7
+	c.Check(ev.AccessString(), Equals, "mknod,read,write")
+
+	ev.Access = 6
+	c.Check(ev.AccessString(), Equals, "read,write")
+
+	ev.Access = 0
+	c.Check(ev.AccessString(), Equals, "0x0")
+}
+
+func (s *ebpfSuite) TestDiscardPinnedMapsBothExist(c *C) {
+	// Create fake pinned files under dirs.SnapBPFFSDir
+	c.Assert(os.MkdirAll(dirs.SnapBPFFSDir, 0755), IsNil)
+	mapPath := filepath.Join(dirs.SnapBPFFSDir, "snap_foo_bar")
+	ringPath := filepath.Join(dirs.SnapBPFFSDir, "snap_foo_bar@denylog")
+	c.Assert(os.WriteFile(mapPath, []byte("map"), 0644), IsNil)
+	c.Assert(os.WriteFile(ringPath, []byte("ring"), 0644), IsNil)
+
+	var logs []string
+	logf := func(format string, a ...any) {
+		logs = append(logs, fmt.Sprintf(format, a...))
+	}
+
+	err := ebpf.DiscardPinnedMaps("snap.foo.bar", logf)
+	c.Assert(err, IsNil)
+	c.Check(logs, HasLen, 0)
+
+	// Both files removed
+	_, err = os.Stat(mapPath)
+	c.Check(os.IsNotExist(err), Equals, true)
+	_, err = os.Stat(ringPath)
+	c.Check(os.IsNotExist(err), Equals, true)
+}
+
+func (s *ebpfSuite) TestDiscardPinnedMapsOneMissing(c *C) {
+	c.Assert(os.MkdirAll(dirs.SnapBPFFSDir, 0755), IsNil)
+
+	// Only create the map, not the ring buffer
+	mapPath := filepath.Join(dirs.SnapBPFFSDir, "snap_foo_bar")
+	c.Assert(os.WriteFile(mapPath, []byte("map"), 0644), IsNil)
+
+	var logs []string
+	logf := func(format string, a ...any) {
+		logs = append(logs, fmt.Sprintf(format, a...))
+	}
+
+	err := ebpf.DiscardPinnedMaps("snap.foo.bar", logf)
+	c.Assert(err, IsNil)
+	// One log about missing ring buffer
+	c.Check(logs, HasLen, 1)
+	c.Check(logs[0], Matches, ".*does not exist.*")
+
+	// Map was removed
+	_, err = os.Stat(mapPath)
+	c.Check(os.IsNotExist(err), Equals, true)
+}
+
+func (s *ebpfSuite) TestDiscardPinnedMapsBothMissing(c *C) {
+	c.Assert(os.MkdirAll(dirs.SnapBPFFSDir, 0755), IsNil)
+
+	var logs []string
+	logf := func(format string, a ...any) {
+		logs = append(logs, fmt.Sprintf(format, a...))
+	}
+
+	err := ebpf.DiscardPinnedMaps("snap.foo.bar", logf)
+	c.Assert(err, IsNil)
+	c.Check(logs, HasLen, 2)
+}
+
+func (s *ebpfSuite) TestDiscardPinnedMapsPermissionError(c *C) {
+	c.Assert(os.MkdirAll(dirs.SnapBPFFSDir, 0755), IsNil)
+
+	// Create a non-empty subdirectory (os.Remove fails with ENOTEMPTY)
+	dirPath := filepath.Join(dirs.SnapBPFFSDir, "snap_foo_bar")
+	c.Assert(os.Mkdir(dirPath, 0755), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dirPath, "child"), []byte("x"), 0644), IsNil)
+
+	var logs []string
+	logf := func(format string, a ...any) {
+		logs = append(logs, fmt.Sprintf(format, a...))
+	}
+
+	err := ebpf.DiscardPinnedMaps("snap.foo.bar", logf)
+	c.Check(err, ErrorMatches, "cannot remove.*")
 }

--- a/tests/main/security-device-cgroups-strict-enforced/task.yaml
+++ b/tests/main/security-device-cgroups-strict-enforced/task.yaml
@@ -39,6 +39,7 @@ execute: |
 
     echo "The application is able to access the device"
     snap run test-strict-cgroup.sh -c 'touch /var/snap/test-strict-cgroup/common/started; until test -e /var/snap/test-strict-cgroup/common/ready; do sleep 1; done; dd if=/dev/zero of=/dev/full bs=1 count=1' > run.log 2>&1 &
+    APP_PID=$!
     retry -n 5 test -e /var/snap/test-strict-cgroup/common/started
 
     echo "Disallow access to /dev/full"
@@ -46,11 +47,30 @@ execute: |
     tests.device-cgroup test-strict-cgroup.sh dump | MATCH 'c 1:7 rwm'
     tests.device-cgroup --verbose test-strict-cgroup.sh deny c 1:7
 
+    # On cgroup v2, start monitoring device access denials before triggering the deny
+    LOG_PID=""
+    if [ "$(stat -f -c %T /sys/fs/cgroup)" = "cgroup2fs" ]; then
+        snap debug device-cgroup --log test-strict-cgroup > deny.log 2>&1 &
+        LOG_PID=$!
+        # give the reader a moment to attach to the ring buffer
+        sleep 0.5
+    fi
+
     # we are ready
     touch /var/snap/test-strict-cgroup/common/ready
 
-    wait || true
+    wait "$APP_PID" || true
     MATCH "dd: failed to open '/dev/full': Operation not permitted" < run.log
+
+    # On cgroup v2, verify the denial was captured in the log
+    if [ -n "$LOG_PID" ]; then
+        # give the event a moment to arrive
+        sleep 1
+        kill "$LOG_PID" 2>/dev/null || true
+        wait "$LOG_PID" 2>/dev/null || true
+        echo "Verify that the device access denial was logged"
+        MATCH "PID=[0-9]+ +dd +DENY.*char 1:7 \(write\) +/dev/full" < deny.log
+    fi
 
     echo "When restated, the device cgroup is reinitialized"
     # thus our temporary change to deny /dev/full is gone


### PR DESCRIPTION
This PR adds observability to device cgroup access control.

The `snap debug` command has grown a new subcommand: `snap debug device-cgroup [devices|log|discard] <snap>`, where:
  - devices - shows the currently allowed devices for a given snap by displaying the contents of device access map (v2) or processing the output of devices.list (v1)
  - log - v2 only, displays access denials logged to the deny ring buffer for a given snap
  - discard - v2 only, removes device access maps for a given snap

The snap-confine has been modified to allocate and pin a ring-buffer, which is used to pass denial events from the device cgroup BPF program back to userspace. The buffer is read from by `snap debug device-cgroup log <snap>` command.

The branchs adds a dependency on `github.com/cilium/ebpf` which is already present in Debian and Fedora. The actual code is just a thin wrapper which we could replace by doing BPF syscalls directly. However, the library is widely used and tested.

Allowed devices dump:
```
$ sudo snap debug device-cgroup devices ohmygiraffe
Security tag: snap.ohmygiraffe.ohmygiraffe
TYPE  MAJOR:MINOR  ACCESS  DEVICE
c     1:3          rwm     /dev/null
c     1:5          rwm     /dev/zero
c     1:7          rwm     /dev/full
c     1:8          rwm     /dev/random
c     1:9          rwm     /dev/urandom
c     10:200       rwm     /dev/net/tun
c     10:239       rwm     /dev/uhid
c     136:*        rwm     -
c     137:*        rwm     -
c     138:*        rwm     -
c     139:*        rwm     -
c     140:*        rwm     -
c     141:*        rwm     -
c     142:*        rwm     -
c     143:*        rwm     -
c     226:0        rwm     /dev/dri/card0
c     226:1        rwm     /dev/dri/card1
c     226:128      rwm     /dev/dri/renderD128
c     226:129      rwm     /dev/dri/renderD129
c     235:0        rwm     /dev/kfd
c     250:0        rwm     /dev/dma_heap/system
c     5:0          rwm     /dev/tty
c     5:1          rwm     /dev/console
c     5:2          rwm     /dev/ptmx
```

Device access denials log:
```
$ sudo snap debug device-cgroup log ohmygiraffe
Monitoring device access denials for snap "ohmygiraffe" (Ctrl+C to stop)...
2026-05-06T07:34:13.324+02:00  PID=830670 cat             DENY  char 1:4 (read)  /dev/port
2026-05-06T07:34:16.368+02:00  PID=830682 cat             DENY  block 8:0 (read)  /dev/sda
2026-05-06T07:34:54.594+02:00  PID=830919 dd              DENY  block 8:16 (write)  /dev/sdb
```

Related: [SNAPDENG-35525](https://warthogs.atlassian.net/browse/SNAPDENG-35525)

[SNAPDENG-35525]: https://warthogs.atlassian.net/browse/SNAPDENG-35525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ