### PR TITLE
apparmor: add dfa cache support

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -160,9 +160,10 @@ parts:
       - g++
       - pkg-config
       - wget
-      - libzstd-dev
-    source: https://gitlab.com/apparmor/apparmor/-/archive/v5.0.1/apparmor-v5.0.1.tar.gz
-    source-checksum: sha256/cea1fc638dccea42a0a972bfe6ee2a34cbf52ed98526c25a49bbed39450d2dcc
+    source: https://gitlab.com/kubiko3/apparmor.git
+    source-type: git
+    source-tag: v5.0.1-dfa-cache
+    source-depth: 10
     override-build: |
       # For some reason, some snapcraft version remove the "build-aux" folder
       # and move the contents up when the data is uploaded; this conditional

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -183,7 +183,7 @@ parts:
       # parser gets built to support as many as possible even if glibc in
       # the current build environment does not support them
       cp -a "${LOCAL_APPARMOR_DIR}"/af_names.h .
-      make -j"${CRAFT_PARALLEL_BUILD_COUNT}" WITH_STATIC_LINKING=1
+      make -j"${CRAFT_PARALLEL_BUILD_COUNT}" WITH_STATIC_LINKING=1 USE_DFA_CACHE=1
       install -Dm755 -s -t "${CRAFT_PART_INSTALL}/usr/lib/snapd" apparmor_parser
       install -Dm644 -t "${CRAFT_PART_INSTALL}/usr/lib/snapd/apparmor" parser.conf
       cd "${CRAFT_PART_BUILD}/profiles"

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -46,6 +46,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
@@ -66,6 +67,7 @@ var (
 	parserFeatures        = apparmor_sandbox.ParserFeatures
 	loadProfiles          = apparmor_sandbox.LoadProfiles
 	removeCachedProfiles  = apparmor_sandbox.RemoveCachedProfiles
+	pruneCache            = apparmor_sandbox.PruneCache
 
 	// make sure that apparmor profile fulfills the late discarding backend
 	// interface
@@ -603,6 +605,16 @@ func (b *Backend) SetupMany(appSets []*interfaces.SnapAppSet, confinement func(s
 		}
 	}
 	return errors
+}
+
+// Prune Apparmor cache from unused data
+// At the moment we mostly prune from old dfa files that are not used anymore
+// Good time to call pruning is when snapd updated and all profiles are recalculated
+// as this gives parser chance to mark dfa cached filed that are still in used
+// apparmor parser touches cached dfa on successful hit.
+// PruneCache implements the interfaces.CachePruner interface.
+func (b *Backend) PruneCache(pruneInterval time.Duration) {
+	pruneCache(apparmor_sandbox.CacheDir, pruneInterval)
 }
 
 // Removes all AppArmor profiles from disk but does not unload them from the

--- a/interfaces/backend.go
+++ b/interfaces/backend.go
@@ -21,6 +21,7 @@ package interfaces
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/timings"
@@ -233,4 +234,13 @@ type DelayedSideEffectsBackend interface {
 func SupportsDelayingEffects(backend SecurityBackend) bool {
 	_, ok := backend.(DelayedSideEffectsBackend)
 	return ok
+}
+
+// CachePruner is an optional interface that may be implemented by security
+// backends which maintain a persistent on-disk cache. Callers should check
+// whether a backend implements this interface before invoking it, typically
+// after all snap profiles have been reloaded (e.g. after a snapd update).
+type CachePruner interface {
+	// PruneCache removes stale entries from the backend's on-disk cache.
+	PruneCache(pruneInterval time.Duration)
 }

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/dirs"
@@ -299,6 +300,18 @@ func (m *InterfaceManager) regenerateAllSecurityProfiles(tm timings.Measurer, un
 					logger.Notice(err.Error())
 				}
 				shouldWriteSystemKey = false
+			}
+		}
+
+		// cachePruneInterval is the maximum age of cache data relative to the
+		// the most-recently-accessed entry before it is pruned.
+		// in normal operation, we don't expect more than one snapd refresh per day
+		var cachePruneInterval = 24 * time.Hour
+		// After all profiles have been regenerated, prune stale cache
+		// entries from any backend that supports it.
+		for _, backend := range securityBackends {
+			if pruner, ok := backend.(interfaces.CachePruner); ok {
+				pruner.PruneCache(cachePruneInterval)
 			}
 		}
 	}()

--- a/sandbox/apparmor/profile.go
+++ b/sandbox/apparmor/profile.go
@@ -134,9 +134,14 @@ var LoadProfiles = func(fnames []string, cacheDir string, flags AaParserFlags) e
 		args = append(args, "--quiet")
 	}
 
-	cmd, _, err := AppArmorParser()
+	cmd, vendored, err := AppArmorParser()
 	if err != nil {
 		return err
+	}
+
+	// if we used internal apparmor_parser, we can use the dfa cache feature
+	if vendored {
+		args = append(args, fmt.Sprintf("--dfa-cache-loc=%s/dfa", cacheDir))
 	}
 
 	cmd.Args = append(cmd.Args, args...)

--- a/sandbox/apparmor/profile.go
+++ b/sandbox/apparmor/profile.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
@@ -181,6 +182,67 @@ func RemoveCachedProfiles(names []string, cacheDir string) error {
 		return fmt.Errorf("cannot remove apparmor profile cache: %s", err)
 	}
 	return nil
+}
+
+// PruneCache removes stale entries from the DFA blob cache under cacheDir/dfa.
+// It finds the newest modification time across all cache files, then deletes any
+// file whose modification time is more than pruneInterval older than that.
+// Cache pruning is not critical for correctness, so this function ignores errors
+// and just logs them. It is meant to be called periodically, for instance at
+// snapd refresh when all profiles are recalculated.
+func PruneCache(cacheDir string, pruneInterval time.Duration) {
+	dfaDir := filepath.Join(cacheDir, "dfa")
+
+	entries, err := os.ReadDir(dfaDir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			logger.Noticef("cannot read DFA cache directory %s: %v", dfaDir, err)
+		}
+		return
+	}
+
+	// if interval is zero, nuke the entire directory
+	if pruneInterval == 0 {
+		err := os.RemoveAll(dfaDir)
+		if err != nil {
+			logger.Noticef("failed to clean DFA cache directory %s: %v", dfaDir, err)
+		}
+		return
+	}
+
+	// First pass: find the most recent modification time.
+	var newest time.Time
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		if mtime := info.ModTime(); mtime.After(newest) {
+			newest = mtime
+		}
+	}
+
+	if newest.IsZero() {
+		return
+	}
+
+	// Second pass: remove files older than the pruning interval.
+	cutoff := newest.Add(-pruneInterval)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		if info.ModTime().Before(cutoff) {
+			os.Remove(filepath.Join(dfaDir, entry.Name()))
+		}
+	}
 }
 
 // ReloadAllSnapProfiles reload the AppArmor profiles of all installed snaps,

--- a/sandbox/apparmor/profile_test.go
+++ b/sandbox/apparmor/profile_test.go
@@ -26,6 +26,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	. "gopkg.in/check.v1"
 
@@ -736,4 +737,120 @@ func (s *appArmorSuite) TestRemoveSnapConfineSnippetsNoSnippets(c *C) {
 	files, err := os.ReadDir(apparmor.SnapConfineAppArmorDir)
 	c.Assert(err, IsNil)
 	c.Assert(files, HasLen, 0)
+}
+
+// Tests for PruneCache()
+
+// makeDFACacheDir creates cacheDir/dfa, writes the named files, and sets their
+// atimes using os.Chtimes.  baseTime is the reference "newest" atime; each
+// file's atime offset is added to it.
+func makeDFACacheDir(c *C, cacheDir string, files map[string]time.Duration) {
+	dfaDir := filepath.Join(cacheDir, "dfa")
+	c.Assert(os.MkdirAll(dfaDir, 0755), IsNil)
+	// Capture now once so all offsets are relative to the same instant,
+	// preventing spurious ordering from repeated time.Now() calls.
+	base := time.Now()
+	for name, offset := range files {
+		p := filepath.Join(dfaDir, name)
+		c.Assert(os.WriteFile(p, []byte("blob"), 0600), IsNil)
+		atime := base.Add(offset)
+		c.Assert(os.Chtimes(p, atime, atime), IsNil)
+	}
+}
+
+func dfaCacheNames(c *C, cacheDir string) []string {
+	entries, err := os.ReadDir(filepath.Join(cacheDir, "dfa"))
+	c.Assert(err, IsNil)
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	return names
+}
+
+func (s *appArmorSuite) TestPruneCacheNoDFADir(c *C) {
+	// PruneCache must not fail when the dfa subdirectory does not exist.
+	cacheDir := c.MkDir()
+	apparmor.PruneCache(cacheDir, time.Hour) // must not panic or log an error
+}
+
+func (s *appArmorSuite) TestPruneCacheEmptyDir(c *C) {
+	// PruneCache on an empty dfa directory is a no-op.
+	cacheDir := c.MkDir()
+	c.Assert(os.MkdirAll(filepath.Join(cacheDir, "dfa"), 0755), IsNil)
+	apparmor.PruneCache(cacheDir, time.Hour)
+	c.Check(dfaCacheNames(c, cacheDir), HasLen, 0)
+}
+
+func (s *appArmorSuite) TestPruneCacheKeepsRecentEntries(c *C) {
+	// Files whose atime equals the newest are not older than the cutoff, so none are pruned.
+	cacheDir := c.MkDir()
+	makeDFACacheDir(c, cacheDir, map[string]time.Duration{
+		"aaa.dfa": 0,
+		"bbb.dfa": 0,
+	})
+	apparmor.PruneCache(cacheDir, time.Second)
+	c.Check(dfaCacheNames(c, cacheDir), HasLen, 2)
+}
+
+func (s *appArmorSuite) TestPruneCacheRemovesOldEntries(c *C) {
+	// Use a 1-second interval. Files with atime > 1s older than newest are pruned.
+	cacheDir := c.MkDir()
+	makeDFACacheDir(c, cacheDir, map[string]time.Duration{
+		"new.dfa": 0,                // newest — must survive
+		"old.dfa": -2 * time.Second, // 2s older than newest — must be pruned
+	})
+	apparmor.PruneCache(cacheDir, time.Second)
+	remaining := dfaCacheNames(c, cacheDir)
+	c.Assert(remaining, HasLen, 1)
+	c.Check(remaining[0], Equals, "new.dfa")
+}
+
+func (s *appArmorSuite) TestPruneCacheAllFilesEquallyOld(c *C) {
+	// When all files share the same atime none are pruned regardless of
+	// how old they are in absolute terms.
+	cacheDir := c.MkDir()
+	makeDFACacheDir(c, cacheDir, map[string]time.Duration{
+		"aaa.dfa": -24 * time.Hour,
+		"bbb.dfa": -24 * time.Hour,
+		"ccc.dfa": -24 * time.Hour,
+	})
+	apparmor.PruneCache(cacheDir, time.Second)
+	c.Check(dfaCacheNames(c, cacheDir), HasLen, 3)
+}
+
+func (s *appArmorSuite) TestPruneCacheSkipsSubdirectories(c *C) {
+	// Subdirectories inside the dfa dir are ignored and never removed.
+	cacheDir := c.MkDir()
+	dfaDir := filepath.Join(cacheDir, "dfa")
+	c.Assert(os.MkdirAll(filepath.Join(dfaDir, "subdir"), 0755), IsNil)
+	apparmor.PruneCache(cacheDir, time.Second)
+	_, err := os.Stat(filepath.Join(dfaDir, "subdir"))
+	c.Check(err, IsNil)
+}
+
+func (s *appArmorSuite) TestPruneCacheMultipleOldOneNew(c *C) {
+	// One recent file keeps everything above the cutoff; files below are removed.
+	cacheDir := c.MkDir()
+	makeDFACacheDir(c, cacheDir, map[string]time.Duration{
+		"recent.dfa": 0,
+		"stale1.dfa": -2 * time.Second,
+		"stale2.dfa": -3 * time.Second,
+	})
+	apparmor.PruneCache(cacheDir, time.Second)
+	remaining := dfaCacheNames(c, cacheDir)
+	c.Assert(remaining, HasLen, 1)
+	c.Check(remaining[0], Equals, "recent.dfa")
+}
+
+func (s *appArmorSuite) TestPruneCacheZeroIntervalDropsAll(c *C) {
+	// Passing pruneInterval == 0 removes the entire dfa cache directory.
+	cacheDir := c.MkDir()
+	makeDFACacheDir(c, cacheDir, map[string]time.Duration{
+		"aaa.dfa": 0,
+		"bbb.dfa": -time.Hour,
+	})
+	apparmor.PruneCache(cacheDir, 0)
+	_, err := os.Stat(filepath.Join(cacheDir, "dfa"))
+	c.Check(os.IsNotExist(err), Equals, true)
 }


### PR DESCRIPTION
The nature of the snap refreshes is that we regenerate (reparse) AppArmor profiles, which can be an expensive operation, especially if the profile(s) have multiple connections. Things get more complicated when we refresh snapd (all profiles get regenerated) or when multiple snaps are refreshed at once, because one snap can interact with one or more other snaps, so refreshing one snap often causes the regeneration of profiles for multiple snaps.
This can be an expensive operation as we cascade through the list of snaps to be refreshed.
This means that identical or similar DFA fragments have to be processed repeatedly. DFA cache tries to address this.

While `apparmor_parser` does use internal caching, it is of limited use because it does not cache across multiple threads (it uses fork) and, being memory-bound, it does not help across multiple sessions.

Introduction of the DFA fragments cache can significantly improve `apparmor_parser` performance.
Adding cache adds a requirement for cache management to prevent it from growing indefinitely. An optional `PruneCache` interface is added to the security backend. This is called when all the profiles are regenerated (snapd refresh).
It uses the fact that `apparmor_parser's DFA cache implementation touches every used DFA cache file in the run. So if we regenerate all the profiles (snapd refresh), we can assume that unused DFA cache files can be discarded.

Here is an example of how this benefits `apparmor_parser` when refreshing 5 interconnected snaps.
Timings are pulled directly from snap changes
```
snap-a
  - setup security backend "apparmor" for 2 snaps
  **30785ms**  vs  **11585ms**

snap-b:
  - setup security backend "apparmor" for 6 snaps
  **67498ms**  vs  **45980ms**

snap-c:
  - setup security backend "apparmor" for 3 snaps
  **25815ms**  vs  **15473ms**

snap-d:
  - setup security backend "apparmor" for 6 snaps
  **60496ms**  vs  **2608ms**

snap-e:
  - setup security backend "apparmor" for 4 snaps
  **20032ms**  vs  **2008ms**
```
The benefit of DFA cache is increasing as we go along, and the cache trains itself, providing 90%+ improvement as we progress with multi-snap refresh (there is no digit missing in the last two timings!).

Snapd refresh on its own shows up to **40%**  improvement in time.

Technical explanation for those gains, even when the cache is not trained:
Each snap profile contains a template, while it contains things like `SNAP_REVISION`, `SNAP_NAME`, `SNAP_INSTANCE_NAME`, it is still identical for each application's profile of the given snap, DFA cache helps to avoid reprocessing of those identical fragments. Even if we do a first pass on the profiles, once it parses the template section of the first application profile, it is reused for the rest of the profiles of the given snap. Repeated parsing of almost identical profiles, as we do when multiple snaps are refreshed at once, then further benefits beyond just the template section of the profile.

Related MP for the change in the `apparmor_parser`:
https://gitlab.com/kubiko3/apparmor/-/tree/dfa-cache