### PR TITLE
apparmor: template optimisation

### DIFF
--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -667,6 +667,19 @@ var (
 	coreRuntimePattern = regexp.MustCompile("^core([0-9][0-9])?$")
 )
 
+// coreRuntimeExtraRules returns additional apparmor rules for core* base
+// runtimes, including perl/python runtime rules based on the base version.
+// Returns an empty string for core26+ (no perl/python) and non-core bases.
+var coreRuntimeExtraRules = func(base string) string {
+	coreVer, _ := strconv.Atoi(strings.TrimPrefix(base, "core"))
+	if coreVer >= 26 {
+		return ""
+	} else if base == "core24" {
+		return defaultPythonTemplateRules + defaultCoreRuntimePythonTemplateRules
+	}
+	return defaultPerlTemplateRules + defaultCoreRuntimePerlTemplateRules + defaultPythonTemplateRules + defaultCoreRuntimePythonTemplateRules
+}
+
 func (b *Backend) deriveContent(spec *Specification, appSet *interfaces.SnapAppSet, opts interfaces.ConfinementOptions) (content map[string]osutil.FileState) {
 	runnables := appSet.Runnables()
 	content = make(map[string]osutil.FileState, len(runnables))
@@ -743,19 +756,6 @@ func addUpdateNSProfile(snapInfo *snap.Info, snippets string, content map[string
 // Allow optional trailing ' ' after "###PROMPT###"
 var promptReplacer = regexp.MustCompile("###PROMPT### ?")
 
-// coreRuntimeExtraRules returns the additional perl/python rules to insert into
-// the core runtime template based on the snap's base. It is a variable to allow
-// suppression in tests via MockTemplate.
-var coreRuntimeExtraRules = func(base string) string {
-	coreVer, _ := strconv.Atoi(strings.TrimPrefix(base, "core"))
-	if coreVer >= 26 {
-		return ""
-	} else if base == "core24" {
-		return defaultPythonTemplateRules + defaultCoreRuntimePythonTemplateRules
-	}
-	return defaultPerlTemplateRules + defaultCoreRuntimePerlTemplateRules + defaultPythonTemplateRules + defaultCoreRuntimePythonTemplateRules
-}
-
 func (b *Backend) addContent(securityTag string, snapInfo *snap.Info, cmdName string, opts interfaces.ConfinementOptions, snippetForTag string, content map[string]osutil.FileState, spec *Specification) {
 	// If base is specified and it doesn't match the core snaps (not
 	// specifying a base should use the default core policy since in this
@@ -765,14 +765,7 @@ func (b *Backend) addContent(securityTag string, snapInfo *snap.Info, cmdName st
 	if snapInfo.Base != "" && !coreRuntimePattern.MatchString(snapInfo.Base) {
 		policy = defaultOtherBaseTemplate
 	} else {
-		// bases before core24 included perl, after core24 do not have python
-		// anything else include python and perl by default
-		extras := coreRuntimeExtraRules(snapInfo.Base)
-		if extras != "" {
-			policy = strings.Replace(defaultCoreRuntimeTemplate, templateFooter, extras+templateFooter, 1)
-		} else {
-			policy = defaultCoreRuntimeTemplate
-		}
+		policy = defaultCoreRuntimeTemplate
 	}
 
 	ignoreSnippets := false
@@ -784,6 +777,8 @@ func (b *Backend) addContent(securityTag string, snapInfo *snap.Info, cmdName st
 	}
 	policy = templatePattern.ReplaceAllStringFunc(policy, func(placeholder string) string {
 		switch placeholder {
+		case "###CORE_RUNTIME_EXTRA###":
+			return coreRuntimeExtraRules(snapInfo.Base)
 		case "###KERNEL_MODULES_AND_FIRMWARE###":
 			if opts.KernelSnap != "" {
 				return fmt.Sprintf(`

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -45,6 +45,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/snapcore/snapd/dirs"
@@ -742,6 +743,19 @@ func addUpdateNSProfile(snapInfo *snap.Info, snippets string, content map[string
 // Allow optional trailing ' ' after "###PROMPT###"
 var promptReplacer = regexp.MustCompile("###PROMPT### ?")
 
+// coreRuntimeExtraRules returns the additional perl/python rules to insert into
+// the core runtime template based on the snap's base. It is a variable to allow
+// suppression in tests via MockTemplate.
+var coreRuntimeExtraRules = func(base string) string {
+	coreVer, _ := strconv.Atoi(strings.TrimPrefix(base, "core"))
+	if coreVer >= 26 {
+		return ""
+	} else if base == "core24" {
+		return defaultPythonTemplateRules + defaultCoreRuntimePythonTemplateRules
+	}
+	return defaultPerlTemplateRules + defaultCoreRuntimePerlTemplateRules + defaultPythonTemplateRules + defaultCoreRuntimePythonTemplateRules
+}
+
 func (b *Backend) addContent(securityTag string, snapInfo *snap.Info, cmdName string, opts interfaces.ConfinementOptions, snippetForTag string, content map[string]osutil.FileState, spec *Specification) {
 	// If base is specified and it doesn't match the core snaps (not
 	// specifying a base should use the default core policy since in this
@@ -751,7 +765,14 @@ func (b *Backend) addContent(securityTag string, snapInfo *snap.Info, cmdName st
 	if snapInfo.Base != "" && !coreRuntimePattern.MatchString(snapInfo.Base) {
 		policy = defaultOtherBaseTemplate
 	} else {
-		policy = defaultCoreRuntimeTemplate
+		// bases before core24 included perl, after core24 do not have python
+		// anything else include python and perl by default
+		extras := coreRuntimeExtraRules(snapInfo.Base)
+		if extras != "" {
+			policy = strings.Replace(defaultCoreRuntimeTemplate, templateFooter, extras+templateFooter, 1)
+		} else {
+			policy = defaultCoreRuntimeTemplate
+		}
 	}
 
 	ignoreSnippets := false

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -667,9 +667,9 @@ var (
 	coreRuntimePattern = regexp.MustCompile("^core([0-9][0-9])?$")
 )
 
-// isNonCoreBase reports whether base names a non-core base.
+// isCustomBase reports whether base names a snap outside the core* family.
 // An empty base is the implicit "core" base, so it returns false.
-func isNonCoreBase(base string) bool {
+func isCustomBase(base string) bool {
 	return base != "" && !coreRuntimePattern.MatchString(base)
 }
 
@@ -682,7 +682,7 @@ var baseRuntimeExtraRules = func(base string, suppressPycacheDeny bool) string {
 		pycacheDeny = ""
 	}
 	pythonRules := defaultPythonTemplateRules + pycacheDeny
-	if isNonCoreBase(base) {
+	if isCustomBase(base) {
 		return defaultPerlTemplateRules + pythonRules
 	}
 	// For base "" (implicit core) or "core" (explicit), TrimPrefix yields ""
@@ -691,7 +691,7 @@ var baseRuntimeExtraRules = func(base string, suppressPycacheDeny bool) string {
 	coreVer, _ := strconv.Atoi(strings.TrimPrefix(base, "core"))
 	if coreVer >= 26 {
 		return ""
-	} else if base == "core24" {
+	} else if coreVer == 24 {
 		return pythonRules + defaultCoreRuntimePythonTemplateRules
 	}
 	return defaultPerlTemplateRules + defaultCoreRuntimePerlTemplateRules + pythonRules + defaultCoreRuntimePythonTemplateRules
@@ -779,7 +779,7 @@ func (b *Backend) addContent(securityTag string, snapInfo *snap.Info, cmdName st
 	// case, the 'core' snap is used for the runtime), use the base
 	// apparmor template, otherwise use the default template.
 	var policy string
-	if isNonCoreBase(snapInfo.Base) {
+	if isCustomBase(snapInfo.Base) {
 		policy = defaultOtherBaseTemplate
 	} else {
 		policy = defaultCoreRuntimeTemplate

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -667,36 +667,34 @@ var (
 	coreRuntimePattern = regexp.MustCompile("^core([0-9][0-9])?$")
 )
 
-// coreRuntimeExtraRules returns additional apparmor rules for core* base
-// runtimes, including perl/python runtime rules based on the base version.
-// Returns an empty string for core26+ (no perl/python) and non-core bases.
-//
-// The returned rules are inserted into the template as replacement text and
-// are therefore not rescanned for ###PATTERN### placeholders, so any embedded
-// placeholder (e.g. ###PYCACHEDENY###) is resolved here, before returning.
-var coreRuntimeExtraRules = func(base string, suppressPycacheDeny bool) string {
-	// Non-core bases carry the perl/python rules directly in
-	// defaultOtherBaseTemplate. Note that an empty base is the implicit
-	// "core" base and does not match coreRuntimePattern, so it is checked
-	// for separately, mirroring the template selection in addContent.
-	if base != "" && !coreRuntimePattern.MatchString(base) {
-		return ""
-	}
-	var rules string
-	coreVer, _ := strconv.Atoi(strings.TrimPrefix(base, "core"))
-	switch {
-	case coreVer >= 26:
-		return ""
-	case base == "core24":
-		rules = defaultPythonTemplateRules + defaultCoreRuntimePythonTemplateRules
-	default:
-		rules = defaultPerlTemplateRules + defaultCoreRuntimePerlTemplateRules + defaultPythonTemplateRules + defaultCoreRuntimePythonTemplateRules
-	}
+// isNonCoreBase reports whether base names a non-core base.
+// An empty base is the implicit "core" base, so it returns false.
+func isNonCoreBase(base string) bool {
+	return base != "" && !coreRuntimePattern.MatchString(base)
+}
+
+// baseRuntimeExtraRules returns additional apparmor rules for perl/python
+// runtimes for all core and non-core bases, including the pycache deny
+// snippet unless suppressPycacheDeny is set.
+var baseRuntimeExtraRules = func(base string, suppressPycacheDeny bool) string {
 	pycacheDeny := pycacheDenySnippet
 	if suppressPycacheDeny {
 		pycacheDeny = ""
 	}
-	return strings.Replace(rules, "###PYCACHEDENY###", pycacheDeny, -1)
+	pythonRules := defaultPythonTemplateRules + pycacheDeny
+	if isNonCoreBase(base) {
+		return defaultPerlTemplateRules + pythonRules
+	}
+	// For base "" (implicit core) or "core" (explicit), TrimPrefix yields ""
+	// so coreVer=0 and Atoi error intentionally ignored. Any other value here
+	// matches ^core[0-9][0-9]$ so TrimPrefix yields two digits and Atoi succeeds.
+	coreVer, _ := strconv.Atoi(strings.TrimPrefix(base, "core"))
+	if coreVer >= 26 {
+		return ""
+	} else if base == "core24" {
+		return pythonRules + defaultCoreRuntimePythonTemplateRules
+	}
+	return defaultPerlTemplateRules + defaultCoreRuntimePerlTemplateRules + pythonRules + defaultCoreRuntimePythonTemplateRules
 }
 
 func (b *Backend) deriveContent(spec *Specification, appSet *interfaces.SnapAppSet, opts interfaces.ConfinementOptions) (content map[string]osutil.FileState) {
@@ -781,7 +779,7 @@ func (b *Backend) addContent(securityTag string, snapInfo *snap.Info, cmdName st
 	// case, the 'core' snap is used for the runtime), use the base
 	// apparmor template, otherwise use the default template.
 	var policy string
-	if snapInfo.Base != "" && !coreRuntimePattern.MatchString(snapInfo.Base) {
+	if isNonCoreBase(snapInfo.Base) {
 		policy = defaultOtherBaseTemplate
 	} else {
 		policy = defaultCoreRuntimeTemplate
@@ -796,8 +794,8 @@ func (b *Backend) addContent(securityTag string, snapInfo *snap.Info, cmdName st
 	}
 	policy = templatePattern.ReplaceAllStringFunc(policy, func(placeholder string) string {
 		switch placeholder {
-		case "###CORE_RUNTIME_EXTRA###":
-			return coreRuntimeExtraRules(snapInfo.Base, spec.SuppressPycacheDeny())
+		case "###BASE_RUNTIME_EXTRA###":
+			return baseRuntimeExtraRules(snapInfo.Base, spec.SuppressPycacheDeny())
 		case "###KERNEL_MODULES_AND_FIRMWARE###":
 			if opts.KernelSnap != "" {
 				return fmt.Sprintf(`
@@ -1006,11 +1004,6 @@ func (b *Backend) addContent(securityTag string, snapInfo *snap.Info, cmdName st
 			} else {
 				return ""
 			}
-		case "###PYCACHEDENY###":
-			if spec.SuppressPycacheDeny() {
-				return ""
-			}
-			return pycacheDenySnippet
 		case "###CHANGEPROFILE_RULE###":
 			features, _ := parserFeatures()
 			if strutil.ListContains(features, "unsafe") {

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -670,14 +670,33 @@ var (
 // coreRuntimeExtraRules returns additional apparmor rules for core* base
 // runtimes, including perl/python runtime rules based on the base version.
 // Returns an empty string for core26+ (no perl/python) and non-core bases.
-var coreRuntimeExtraRules = func(base string) string {
-	coreVer, _ := strconv.Atoi(strings.TrimPrefix(base, "core"))
-	if coreVer >= 26 {
+//
+// The returned rules are inserted into the template as replacement text and
+// are therefore not rescanned for ###PATTERN### placeholders, so any embedded
+// placeholder (e.g. ###PYCACHEDENY###) is resolved here, before returning.
+var coreRuntimeExtraRules = func(base string, suppressPycacheDeny bool) string {
+	// Non-core bases carry the perl/python rules directly in
+	// defaultOtherBaseTemplate. Note that an empty base is the implicit
+	// "core" base and does not match coreRuntimePattern, so it is checked
+	// for separately, mirroring the template selection in addContent.
+	if base != "" && !coreRuntimePattern.MatchString(base) {
 		return ""
-	} else if base == "core24" {
-		return defaultPythonTemplateRules + defaultCoreRuntimePythonTemplateRules
 	}
-	return defaultPerlTemplateRules + defaultCoreRuntimePerlTemplateRules + defaultPythonTemplateRules + defaultCoreRuntimePythonTemplateRules
+	var rules string
+	coreVer, _ := strconv.Atoi(strings.TrimPrefix(base, "core"))
+	switch {
+	case coreVer >= 26:
+		return ""
+	case base == "core24":
+		rules = defaultPythonTemplateRules + defaultCoreRuntimePythonTemplateRules
+	default:
+		rules = defaultPerlTemplateRules + defaultCoreRuntimePerlTemplateRules + defaultPythonTemplateRules + defaultCoreRuntimePythonTemplateRules
+	}
+	pycacheDeny := pycacheDenySnippet
+	if suppressPycacheDeny {
+		pycacheDeny = ""
+	}
+	return strings.Replace(rules, "###PYCACHEDENY###", pycacheDeny, -1)
 }
 
 func (b *Backend) deriveContent(spec *Specification, appSet *interfaces.SnapAppSet, opts interfaces.ConfinementOptions) (content map[string]osutil.FileState) {
@@ -778,7 +797,7 @@ func (b *Backend) addContent(securityTag string, snapInfo *snap.Info, cmdName st
 	policy = templatePattern.ReplaceAllStringFunc(policy, func(placeholder string) string {
 		switch placeholder {
 		case "###CORE_RUNTIME_EXTRA###":
-			return coreRuntimeExtraRules(snapInfo.Base)
+			return coreRuntimeExtraRules(snapInfo.Base, spec.SuppressPycacheDeny())
 		case "###KERNEL_MODULES_AND_FIRMWARE###":
 			if opts.KernelSnap != "" {
 				return fmt.Sprintf(`

--- a/interfaces/apparmor/backend.go
+++ b/interfaces/apparmor/backend.go
@@ -667,6 +667,11 @@ var (
 	coreRuntimePattern = regexp.MustCompile("^core([0-9][0-9])?$")
 )
 
+// joinRules concatenates apparmor rule snippets with a newline separator.
+func joinRules(parts ...string) string {
+	return strings.Join(parts, "\n")
+}
+
 // isCustomBase reports whether base names a snap outside the core* family.
 // An empty base is the implicit "core" base, so it returns false.
 func isCustomBase(base string) bool {
@@ -681,9 +686,9 @@ var baseRuntimeExtraRules = func(base string, suppressPycacheDeny bool) string {
 	if suppressPycacheDeny {
 		pycacheDeny = ""
 	}
-	pythonRules := defaultPythonTemplateRules + pycacheDeny
+	pythonRules := joinRules(defaultPythonTemplateRules, pycacheDeny)
 	if isCustomBase(base) {
-		return defaultPerlTemplateRules + pythonRules
+		return joinRules(defaultPerlTemplateRules, pythonRules)
 	}
 	// For base "" (implicit core) or "core" (explicit), TrimPrefix yields ""
 	// so coreVer=0 and Atoi error intentionally ignored. Any other value here
@@ -692,9 +697,14 @@ var baseRuntimeExtraRules = func(base string, suppressPycacheDeny bool) string {
 	if coreVer >= 26 {
 		return ""
 	} else if coreVer == 24 {
-		return pythonRules + defaultCoreRuntimePythonTemplateRules
+		return joinRules(pythonRules, defaultCoreRuntimePythonTemplateRules)
 	}
-	return defaultPerlTemplateRules + defaultCoreRuntimePerlTemplateRules + pythonRules + defaultCoreRuntimePythonTemplateRules
+	return joinRules(
+		defaultPerlTemplateRules,
+		defaultCoreRuntimePerlTemplateRules,
+		pythonRules,
+		defaultCoreRuntimePythonTemplateRules,
+	)
 }
 
 func (b *Backend) deriveContent(spec *Specification, appSet *interfaces.SnapAppSet, opts interfaces.ConfinementOptions) (content map[string]osutil.FileState) {
@@ -723,7 +733,7 @@ func (b *Backend) deriveContent(spec *Specification, appSet *interfaces.SnapAppS
 	// If we have neither then we don't have any need to create an executing environment.
 	// This applies to, for example, kernel snaps or gadget snaps (unless they have hooks).
 	if len(content) > 0 {
-		snippets := strings.Join(spec.UpdateNS(), "\n")
+		snippets := joinRules(spec.UpdateNS()...)
 		addUpdateNSProfile(snapInfo, snippets, content)
 	}
 
@@ -914,7 +924,7 @@ func (b *Backend) addContent(securityTag string, snapInfo *snap.Info, cmdName st
 				snapdSnapConfineSnippet = fmt.Sprintf("/snap/snapd/*/usr/lib/snapd/snap-confine Pxr -> %s,\n", snapdProfileTarget())
 			}
 
-			nonBaseCoreTransitionSnippet := coreSnapConfineSnippet + "\n" + snapdSnapConfineSnippet
+			nonBaseCoreTransitionSnippet := joinRules(coreSnapConfineSnippet, snapdSnapConfineSnippet)
 
 			// include both rules for the core snap and the snapd snap since
 			// we can't know which one will be used at runtime (for example
@@ -1016,7 +1026,7 @@ func (b *Backend) addContent(securityTag string, snapInfo *snap.Info, cmdName st
 				// Add a special internal snippet for snaps using classic confinement
 				// and jailmode together. This snippet provides access to the core snap
 				// so that the dynamic linker and shared libraries can be used.
-				tagSnippets = classicJailmodeSnippet + "\n" + snippetForTag
+				tagSnippets = joinRules(classicJailmodeSnippet, snippetForTag)
 			} else if ignoreSnippets {
 				// When classic confinement template is in effect we are
 				// ignoring all apparmor snippets as they may conflict with the

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -1318,6 +1318,86 @@ func (s *backendSuite) TestCombineSnippets(c *C) {
 	}
 }
 
+// snapYamlWithBase returns a minimal snap YAML string with the given base set.
+// An empty base string omits the base field entirely (equivalent to base: core).
+func snapYamlWithBase(base string) string {
+	baseField := ""
+	if base != "" {
+		baseField = "base: " + base + "\n"
+	}
+	return "name: samba\nversion: 1\n" + baseField + "apps:\n    smbd:\n"
+}
+
+func (s *backendSuite) TestCoreRuntimeExtraRulesPerBase(c *C) {
+	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.Full)
+	defer restore()
+	restore = osutil.MockIsHomeUsingRemoteFS(func() (bool, error) { return false, nil })
+	defer restore()
+	restore = osutil.MockIsRootWritableOverlay(func() (string, error) { return "", nil })
+	defer restore()
+
+	// Use a minimal template containing templateFooter so that
+	// coreRuntimeExtraRules can insert rules at the correct position.
+	// Unlike MockTemplate, MockCoreRuntimeTemplate does not suppress
+	// coreRuntimeExtraRules, so the perl/python insertion logic is exercised.
+	restoreTemplate := apparmor.MockCoreRuntimeTemplate(
+		"###PROFILEATTACH### ###FLAGS### {\n" +
+			apparmor.TemplateFooter)
+	defer restoreTemplate()
+
+	perlMarker := "#include <abstractions/perl>"
+	pythonMarker := "#include <abstractions/python>"
+
+	type scenario struct {
+		base         string
+		wantPerl     bool
+		wantPython   bool
+		comment      string
+	}
+	scenarios := []scenario{
+		// empty base = implicit core → perl + python
+		{base: "", wantPerl: true, wantPython: true, comment: "empty base (core)"},
+		// core18, core20 → perl + python
+		{base: "core18", wantPerl: true, wantPython: true, comment: "core18"},
+		{base: "core20", wantPerl: true, wantPython: true, comment: "core20"},
+		// core24 → python only, no perl
+		{base: "core24", wantPerl: false, wantPython: true, comment: "core24"},
+		// core26 → no perl, no python
+		{base: "core26", wantPerl: false, wantPython: false, comment: "core26"},
+		// core26+ (core28) → no perl, no python
+		{base: "core28", wantPerl: false, wantPython: false, comment: "core28"},
+	}
+
+	for _, sc := range scenarios {
+		snapInfo := s.InstallSnap(c, interfaces.ConfinementOptions{}, "", snapYamlWithBase(sc.base), 1)
+		profile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.smbd")
+		content, err := os.ReadFile(profile)
+		c.Assert(err, IsNil, Commentf("scenario: %s", sc.comment))
+
+		profileStr := string(content)
+		c.Check(strings.Contains(profileStr, perlMarker), Equals, sc.wantPerl,
+			Commentf("perl rules presence mismatch for scenario: %s", sc.comment))
+		c.Check(strings.Contains(profileStr, pythonMarker), Equals, sc.wantPython,
+			Commentf("python rules presence mismatch for scenario: %s", sc.comment))
+
+		// Verify extra rules are inside the profile block (before the closing brace).
+		closingBrace := strings.Index(profileStr, "\n}\n")
+		c.Assert(closingBrace, Not(Equals), -1, Commentf("no closing brace found for scenario: %s", sc.comment))
+		if sc.wantPerl {
+			perlIdx := strings.Index(profileStr, perlMarker)
+			c.Check(perlIdx < closingBrace, Equals, true,
+				Commentf("perl rules must appear before closing brace for scenario: %s", sc.comment))
+		}
+		if sc.wantPython {
+			pythonIdx := strings.Index(profileStr, pythonMarker)
+			c.Check(pythonIdx < closingBrace, Equals, true,
+				Commentf("python rules must appear before closing brace for scenario: %s", sc.comment))
+		}
+
+		s.RemoveSnap(c, snapInfo)
+	}
+}
+
 func (s *backendSuite) TestUnconfinedFlag(c *C) {
 	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.Full)
 	defer restore()

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -1349,10 +1349,10 @@ func (s *backendSuite) TestCoreRuntimeExtraRulesPerBase(c *C) {
 	pythonMarker := "#include <abstractions/python>"
 
 	type scenario struct {
-		base         string
-		wantPerl     bool
-		wantPython   bool
-		comment      string
+		base       string
+		wantPerl   bool
+		wantPython bool
+		comment    string
 	}
 	scenarios := []scenario{
 		// empty base = implicit core → perl + python

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -1400,6 +1400,55 @@ func (s *backendSuite) TestCoreRuntimeExtraRulesPerBase(c *C) {
 	}
 }
 
+// TestNoUnexpandedTemplatePatterns ensures that no ###PATTERN### placeholder
+// survives template expansion in the generated profiles. Placeholders that
+// leak into the output are silently treated as comments by apparmor (they
+// start with '#'), so such bugs silently drop policy instead of failing.
+func (s *backendSuite) TestNoUnexpandedTemplatePatterns(c *C) {
+	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.Full)
+	defer restore()
+	restore = osutil.MockIsHomeUsingRemoteFS(func() (bool, error) { return false, nil })
+	defer restore()
+	restore = osutil.MockIsRootWritableOverlay(func() (string, error) { return "", nil })
+	defer restore()
+
+	// NOTE: the real (unmocked) templates are used on purpose so that the
+	// expansion of every pattern embedded in them is exercised.
+	unexpandedPattern := regexp.MustCompile(`###[A-Z_]+###`)
+
+	scenarios := []struct {
+		snapYaml string
+		opts     interfaces.ConfinementOptions
+		comment  string
+	}{
+		// core runtime template, implicit core base
+		{snapYaml: snapYamlWithBase(""), comment: "implicit core base"},
+		// core runtime template with per-base extra rules
+		{snapYaml: snapYamlWithBase("core20"), comment: "core20 base"},
+		{snapYaml: snapYamlWithBase("core24"), comment: "core24 base"},
+		{snapYaml: snapYamlWithBase("core26"), comment: "core26 base"},
+		// non-core base template
+		{snapYaml: snapYamlWithBase("other"), comment: "non-core base"},
+		// classic confinement template
+		{snapYaml: snapYamlWithBase(""), opts: interfaces.ConfinementOptions{Classic: true}, comment: "classic confinement"},
+		// devmode snaps exercise ###DEVMODE_SNAP_CONFINE###
+		{snapYaml: snapYamlWithBase(""), opts: interfaces.ConfinementOptions{DevMode: true}, comment: "devmode"},
+	}
+
+	for _, sc := range scenarios {
+		snapInfo := s.InstallSnap(c, sc.opts, "", sc.snapYaml, 1)
+		profile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.smbd")
+		content, err := os.ReadFile(profile)
+		c.Assert(err, IsNil, Commentf("scenario: %s", sc.comment))
+
+		unexpanded := unexpandedPattern.FindAllString(string(content), -1)
+		c.Check(unexpanded, HasLen, 0,
+			Commentf("scenario %q: unexpanded template patterns left in profile: %v", sc.comment, unexpanded))
+
+		s.RemoveSnap(c, snapInfo)
+	}
+}
+
 func (s *backendSuite) TestUnconfinedFlag(c *C) {
 	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.Full)
 	defer restore()
@@ -3050,6 +3099,47 @@ func (s *backendSuite) TestPromptPrefix(c *C) {
 		c.Assert(string(data), testutil.Contains, tc.expected)
 		s.RemoveSnap(c, snapInfo)
 	}
+}
+
+// TestPycacheDenyRuleCoreRuntime checks that the pycache deny rules reach
+// core-based profiles through coreRuntimeExtraRules (they are inserted as
+// replacement text, so the usual ###PYCACHEDENY### switch case never sees
+// them), and that suppression is honoured there too.
+func (s *backendSuite) TestPycacheDenyRuleCoreRuntime(c *C) {
+	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.Full)
+	defer restore()
+	restore = osutil.MockIsHomeUsingRemoteFS(func() (bool, error) { return false, nil })
+	defer restore()
+	restore = osutil.MockIsRootWritableOverlay(func() (string, error) { return "", nil })
+	defer restore()
+	restoreTemplate := apparmor.MockCoreRuntimeTemplate(
+		"###PROFILEATTACH### ###FLAGS### {\n" +
+			apparmor.TemplateFooter)
+	defer restoreTemplate()
+
+	for _, tc := range []struct {
+		suppress bool
+		expected Checker
+	}{
+		{suppress: true, expected: Not(testutil.Contains)},
+		{suppress: false, expected: testutil.Contains},
+	} {
+		s.Iface.AppArmorPermanentSlotCallback = func(spec *apparmor.Specification, slot *snap.SlotInfo) error {
+			if tc.suppress {
+				spec.SetSuppressPycacheDeny()
+			}
+			return nil
+		}
+
+		snapInfo := s.InstallSnap(c, interfaces.ConfinementOptions{}, "", ifacetest.SambaYamlV1Core20Base, 1)
+		profile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.smbd")
+		data, err := os.ReadFile(profile)
+		c.Assert(err, IsNil)
+
+		c.Assert(string(data), tc.expected, "deny /usr/lib/python3*/{,**/}__pycache__/ w,")
+		s.RemoveSnap(c, snapInfo)
+	}
+	s.Iface.AppArmorPermanentSlotCallback = nil
 }
 
 func (s *backendSuite) TestPycacheDenyRule(c *C) {

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -1348,27 +1348,32 @@ func (s *backendSuite) TestBaseRuntimeExtraRulesPerBase(c *C) {
 
 	perlMarker := "#include <abstractions/perl>"
 	pythonMarker := "#include <abstractions/python>"
+	// unique lines present only in defaultCoreRuntime{Perl,Python}TemplateRules
+	coreRuntimePerlMarker := "/usr/bin/perl{,5*} ixr,"
+	coreRuntimePythonMarker := "/usr/bin/python{,2,2.[0-9]*,3,3.[0-9]*} ixr,"
 
 	type scenario struct {
-		base       string
-		wantPerl   bool
-		wantPython bool
-		comment    string
+		base           string
+		wantPerl       bool
+		wantCorePerl   bool
+		wantPython     bool
+		wantCorePython bool
+		comment        string
 	}
 	scenarios := []scenario{
-		// empty base = implicit core → perl + python
-		{base: "", wantPerl: true, wantPython: true, comment: "empty base (core)"},
-		// core18, core20 → perl + python
-		{base: "core18", wantPerl: true, wantPython: true, comment: "core18"},
-		{base: "core20", wantPerl: true, wantPython: true, comment: "core20"},
-		// core24 → python only, no perl
-		{base: "core24", wantPerl: false, wantPython: true, comment: "core24"},
+		// empty base = implicit core → perl + python, including core-specific rules
+		{base: "", wantPerl: true, wantCorePerl: true, wantPython: true, wantCorePython: true, comment: "empty base (core)"},
+		// core18, core20 → same as above
+		{base: "core18", wantPerl: true, wantCorePerl: true, wantPython: true, wantCorePython: true, comment: "core18"},
+		{base: "core20", wantPerl: true, wantCorePerl: true, wantPython: true, wantCorePython: true, comment: "core20"},
+		// core24 → python only, with core-specific python rules; no perl at all
+		{base: "core24", wantPerl: false, wantCorePerl: false, wantPython: true, wantCorePython: true, comment: "core24"},
 		// core26 → no perl, no python
-		{base: "core26", wantPerl: false, wantPython: false, comment: "core26"},
+		{base: "core26", wantPerl: false, wantCorePerl: false, wantPython: false, wantCorePython: false, comment: "core26"},
 		// core26+ (core28) → no perl, no python
-		{base: "core28", wantPerl: false, wantPython: false, comment: "core28"},
-		// non-core bases → perl + python
-		{base: "other", wantPerl: true, wantPython: true, comment: "non-core base"},
+		{base: "core28", wantPerl: false, wantCorePerl: false, wantPython: false, wantCorePython: false, comment: "core28"},
+		// non-core bases → base perl + python rules only; no core-specific rules
+		{base: "other", wantPerl: true, wantCorePerl: false, wantPython: true, wantCorePython: false, comment: "non-core base"},
 	}
 
 	for _, sc := range scenarios {
@@ -1380,21 +1385,29 @@ func (s *backendSuite) TestBaseRuntimeExtraRulesPerBase(c *C) {
 		profileStr := string(content)
 		c.Check(strings.Contains(profileStr, perlMarker), Equals, sc.wantPerl,
 			Commentf("perl rules presence mismatch for scenario: %s", sc.comment))
+		c.Check(strings.Contains(profileStr, coreRuntimePerlMarker), Equals, sc.wantCorePerl,
+			Commentf("core perl rules presence mismatch for scenario: %s", sc.comment))
 		c.Check(strings.Contains(profileStr, pythonMarker), Equals, sc.wantPython,
 			Commentf("python rules presence mismatch for scenario: %s", sc.comment))
+		c.Check(strings.Contains(profileStr, coreRuntimePythonMarker), Equals, sc.wantCorePython,
+			Commentf("core python rules presence mismatch for scenario: %s", sc.comment))
 
 		// Verify extra rules are inside the profile block (before the closing brace).
 		closingBrace := strings.Index(profileStr, "\n}\n")
 		c.Assert(closingBrace, Not(Equals), -1, Commentf("no closing brace found for scenario: %s", sc.comment))
-		if sc.wantPerl {
-			perlIdx := strings.Index(profileStr, perlMarker)
-			c.Check(perlIdx < closingBrace, Equals, true,
-				Commentf("perl rules must appear before closing brace for scenario: %s", sc.comment))
-		}
-		if sc.wantPython {
-			pythonIdx := strings.Index(profileStr, pythonMarker)
-			c.Check(pythonIdx < closingBrace, Equals, true,
-				Commentf("python rules must appear before closing brace for scenario: %s", sc.comment))
+		for _, tc := range []struct {
+			want   bool
+			marker string
+		}{
+			{sc.wantPerl, perlMarker},
+			{sc.wantCorePerl, coreRuntimePerlMarker},
+			{sc.wantPython, pythonMarker},
+			{sc.wantCorePython, coreRuntimePythonMarker},
+		} {
+			if tc.want {
+				c.Check(strings.Index(profileStr, tc.marker) < closingBrace, Equals, true,
+					Commentf("marker %q must appear before closing brace for scenario: %s", tc.marker, sc.comment))
+			}
 		}
 
 		s.RemoveSnap(c, snapInfo)

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -1351,10 +1351,10 @@ func (s *backendSuite) TestCoreRuntimeExtraRulesPerBase(c *C) {
 	pythonMarker := "#include <abstractions/python>"
 
 	type scenario struct {
-		base         string
-		wantPerl     bool
-		wantPython   bool
-		comment      string
+		base       string
+		wantPerl   bool
+		wantPython bool
+		comment    string
 	}
 	scenarios := []scenario{
 		// empty base = implicit core → perl + python

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -1330,7 +1330,7 @@ func snapYamlWithBase(base string) string {
 	return "name: samba\nversion: 1\n" + baseField + "apps:\n    smbd:\n"
 }
 
-func (s *backendSuite) TestCoreRuntimeExtraRulesPerBase(c *C) {
+func (s *backendSuite) TestBaseRuntimeExtraRulesPerBase(c *C) {
 	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.Full)
 	defer restore()
 	restore = osutil.MockIsHomeUsingRemoteFS(func() (bool, error) { return false, nil })
@@ -1338,14 +1338,13 @@ func (s *backendSuite) TestCoreRuntimeExtraRulesPerBase(c *C) {
 	restore = osutil.MockIsRootWritableOverlay(func() (string, error) { return "", nil })
 	defer restore()
 
-	// Use a minimal template containing templateFooter so that
-	// coreRuntimeExtraRules can insert rules at the correct position.
-	// Unlike MockTemplate, MockCoreRuntimeTemplate does not suppress
-	// coreRuntimeExtraRules, so the perl/python insertion logic is exercised.
-	restoreTemplate := apparmor.MockCoreRuntimeTemplate(
-		"###PROFILEATTACH### ###FLAGS### {\n" +
-			apparmor.TemplateFooter)
+	// Use minimal templates containing templateFooter so that baseRuntimeExtraRules
+	// can insert rules at the correct position for both core and non-core bases.
+	minimalTemplate := "###PROFILEATTACH### ###FLAGS### {\n" + apparmor.TemplateFooter
+	restoreTemplate := apparmor.MockCoreRuntimeTemplate(minimalTemplate)
 	defer restoreTemplate()
+	restoreOtherTemplate := apparmor.MockOtherBaseTemplate(minimalTemplate)
+	defer restoreOtherTemplate()
 
 	perlMarker := "#include <abstractions/perl>"
 	pythonMarker := "#include <abstractions/python>"
@@ -1368,6 +1367,8 @@ func (s *backendSuite) TestCoreRuntimeExtraRulesPerBase(c *C) {
 		{base: "core26", wantPerl: false, wantPython: false, comment: "core26"},
 		// core26+ (core28) → no perl, no python
 		{base: "core28", wantPerl: false, wantPython: false, comment: "core28"},
+		// non-core bases → perl + python
+		{base: "other", wantPerl: true, wantPython: true, comment: "non-core base"},
 	}
 
 	for _, sc := range scenarios {
@@ -3101,11 +3102,10 @@ func (s *backendSuite) TestPromptPrefix(c *C) {
 	}
 }
 
-// TestPycacheDenyRuleCoreRuntime checks that the pycache deny rules reach
-// core-based profiles through coreRuntimeExtraRules (they are inserted as
-// replacement text, so the usual ###PYCACHEDENY### switch case never sees
-// them), and that suppression is honoured there too.
-func (s *backendSuite) TestPycacheDenyRuleCoreRuntime(c *C) {
+// TestPycacheDenyRuleCoreBase checks that the pycache deny rules reach
+// core-based profiles through baseRuntimeExtraRules and that suppression
+// is honoured there too.
+func (s *backendSuite) TestPycacheDenyRuleCoreBase(c *C) {
 	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.Full)
 	defer restore()
 	restore = osutil.MockIsHomeUsingRemoteFS(func() (bool, error) { return false, nil })
@@ -3139,32 +3139,39 @@ func (s *backendSuite) TestPycacheDenyRuleCoreRuntime(c *C) {
 		c.Assert(string(data), tc.expected, "deny /usr/lib/python3*/{,**/}__pycache__/ w,")
 		s.RemoveSnap(c, snapInfo)
 	}
-	s.Iface.AppArmorPermanentSlotCallback = nil
 }
 
-func (s *backendSuite) TestPycacheDenyRule(c *C) {
-	restoreTemplate := apparmor.MockTemplate("template\n###PYCACHEDENY###\n")
-	defer restoreTemplate()
+// TestPycacheDenyRuleNonCoreBase checks that the pycache deny rules reach
+// non-core-based profiles through baseRuntimeExtraRules and that suppression
+// is honoured there too.
+func (s *backendSuite) TestPycacheDenyRuleNonCoreBase(c *C) {
 	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.Full)
 	defer restore()
 	restore = osutil.MockIsHomeUsingRemoteFS(func() (bool, error) { return false, nil })
 	defer restore()
+	restore = osutil.MockIsRootWritableOverlay(func() (string, error) { return "", nil })
+	defer restore()
+	restoreTemplate := apparmor.MockOtherBaseTemplate(
+		"###PROFILEATTACH### ###FLAGS### {\n" + apparmor.TemplateFooter)
+	defer restoreTemplate()
 
+	// Snap yaml with a non-core base and a slot so that AppArmorPermanentSlotCallback fires.
+	const sambaYamlOtherBase = `
+name: samba
+base: other
+version: 1
+apps:
+    smbd:
+slots:
+    slot:
+        interface: iface
+`
 	for _, tc := range []struct {
-		opts     interfaces.ConfinementOptions
 		suppress bool
 		expected Checker
 	}{
-		{
-			opts:     interfaces.ConfinementOptions{},
-			suppress: true,
-			expected: Not(testutil.Contains),
-		},
-		{
-			opts:     interfaces.ConfinementOptions{},
-			suppress: false,
-			expected: testutil.Contains,
-		},
+		{suppress: true, expected: Not(testutil.Contains)},
+		{suppress: false, expected: testutil.Contains},
 	} {
 		s.Iface.AppArmorPermanentSlotCallback = func(spec *apparmor.Specification, slot *snap.SlotInfo) error {
 			if tc.suppress {
@@ -3173,7 +3180,7 @@ func (s *backendSuite) TestPycacheDenyRule(c *C) {
 			return nil
 		}
 
-		snapInfo := s.InstallSnap(c, tc.opts, "", ifacetest.SambaYamlV1, 1)
+		snapInfo := s.InstallSnap(c, interfaces.ConfinementOptions{}, "", sambaYamlOtherBase, 1)
 		profile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.smbd")
 		data, err := os.ReadFile(profile)
 		c.Assert(err, IsNil)

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -1320,6 +1320,86 @@ func (s *backendSuite) TestCombineSnippets(c *C) {
 	}
 }
 
+// snapYamlWithBase returns a minimal snap YAML string with the given base set.
+// An empty base string omits the base field entirely (equivalent to base: core).
+func snapYamlWithBase(base string) string {
+	baseField := ""
+	if base != "" {
+		baseField = "base: " + base + "\n"
+	}
+	return "name: samba\nversion: 1\n" + baseField + "apps:\n    smbd:\n"
+}
+
+func (s *backendSuite) TestCoreRuntimeExtraRulesPerBase(c *C) {
+	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.Full)
+	defer restore()
+	restore = osutil.MockIsHomeUsingRemoteFS(func() (bool, error) { return false, nil })
+	defer restore()
+	restore = osutil.MockIsRootWritableOverlay(func() (string, error) { return "", nil })
+	defer restore()
+
+	// Use a minimal template containing templateFooter so that
+	// coreRuntimeExtraRules can insert rules at the correct position.
+	// Unlike MockTemplate, MockCoreRuntimeTemplate does not suppress
+	// coreRuntimeExtraRules, so the perl/python insertion logic is exercised.
+	restoreTemplate := apparmor.MockCoreRuntimeTemplate(
+		"###PROFILEATTACH### ###FLAGS### {\n" +
+			apparmor.TemplateFooter)
+	defer restoreTemplate()
+
+	perlMarker := "#include <abstractions/perl>"
+	pythonMarker := "#include <abstractions/python>"
+
+	type scenario struct {
+		base         string
+		wantPerl     bool
+		wantPython   bool
+		comment      string
+	}
+	scenarios := []scenario{
+		// empty base = implicit core → perl + python
+		{base: "", wantPerl: true, wantPython: true, comment: "empty base (core)"},
+		// core18, core20 → perl + python
+		{base: "core18", wantPerl: true, wantPython: true, comment: "core18"},
+		{base: "core20", wantPerl: true, wantPython: true, comment: "core20"},
+		// core24 → python only, no perl
+		{base: "core24", wantPerl: false, wantPython: true, comment: "core24"},
+		// core26 → no perl, no python
+		{base: "core26", wantPerl: false, wantPython: false, comment: "core26"},
+		// core26+ (core28) → no perl, no python
+		{base: "core28", wantPerl: false, wantPython: false, comment: "core28"},
+	}
+
+	for _, sc := range scenarios {
+		snapInfo := s.InstallSnap(c, interfaces.ConfinementOptions{}, "", snapYamlWithBase(sc.base), 1)
+		profile := filepath.Join(dirs.SnapAppArmorDir, "snap.samba.smbd")
+		content, err := os.ReadFile(profile)
+		c.Assert(err, IsNil, Commentf("scenario: %s", sc.comment))
+
+		profileStr := string(content)
+		c.Check(strings.Contains(profileStr, perlMarker), Equals, sc.wantPerl,
+			Commentf("perl rules presence mismatch for scenario: %s", sc.comment))
+		c.Check(strings.Contains(profileStr, pythonMarker), Equals, sc.wantPython,
+			Commentf("python rules presence mismatch for scenario: %s", sc.comment))
+
+		// Verify extra rules are inside the profile block (before the closing brace).
+		closingBrace := strings.Index(profileStr, "\n}\n")
+		c.Assert(closingBrace, Not(Equals), -1, Commentf("no closing brace found for scenario: %s", sc.comment))
+		if sc.wantPerl {
+			perlIdx := strings.Index(profileStr, perlMarker)
+			c.Check(perlIdx < closingBrace, Equals, true,
+				Commentf("perl rules must appear before closing brace for scenario: %s", sc.comment))
+		}
+		if sc.wantPython {
+			pythonIdx := strings.Index(profileStr, pythonMarker)
+			c.Check(pythonIdx < closingBrace, Equals, true,
+				Commentf("python rules must appear before closing brace for scenario: %s", sc.comment))
+		}
+
+		s.RemoveSnap(c, snapInfo)
+	}
+}
+
 func (s *backendSuite) TestUnconfinedFlag(c *C) {
 	restore := apparmor_sandbox.MockLevel(apparmor_sandbox.Full)
 	defer restore()

--- a/interfaces/apparmor/export_test.go
+++ b/interfaces/apparmor/export_test.go
@@ -28,16 +28,16 @@ import (
 )
 
 var (
-	NsProfile                            = nsProfile
-	ProfileGlobs                         = profileGlobs
-	SnapConfineFromSnapProfile           = snapConfineFromSnapProfile
-	DefaultCoreRuntimeTemplateRules      = defaultCoreRuntimeTemplateRules
-	DefaultOtherBaseTemplateRules        = defaultOtherBaseTemplateRules
-	DefaultPerlTemplateRules             = defaultPerlTemplateRules
-	DefaultCoreRuntimePerlTemplateRules  = defaultCoreRuntimePerlTemplateRules
-	DefaultPythonTemplateRules           = defaultPythonTemplateRules
+	NsProfile                             = nsProfile
+	ProfileGlobs                          = profileGlobs
+	SnapConfineFromSnapProfile            = snapConfineFromSnapProfile
+	DefaultCoreRuntimeTemplateRules       = defaultCoreRuntimeTemplateRules
+	DefaultOtherBaseTemplateRules         = defaultOtherBaseTemplateRules
+	DefaultPerlTemplateRules              = defaultPerlTemplateRules
+	DefaultCoreRuntimePerlTemplateRules   = defaultCoreRuntimePerlTemplateRules
+	DefaultPythonTemplateRules            = defaultPythonTemplateRules
 	DefaultCoreRuntimePythonTemplateRules = defaultCoreRuntimePythonTemplateRules
-	TemplateFooter                       = templateFooter
+	TemplateFooter                        = templateFooter
 )
 
 func MockLoadProfiles(f func(fnames []string, cacheDir string, flags apparmor_sandbox.AaParserFlags) error) (restore func()) {

--- a/interfaces/apparmor/export_test.go
+++ b/interfaces/apparmor/export_test.go
@@ -28,11 +28,16 @@ import (
 )
 
 var (
-	NsProfile                       = nsProfile
-	ProfileGlobs                    = profileGlobs
-	SnapConfineFromSnapProfile      = snapConfineFromSnapProfile
-	DefaultCoreRuntimeTemplateRules = defaultCoreRuntimeTemplateRules
-	DefaultOtherBaseTemplateRules   = defaultOtherBaseTemplateRules
+	NsProfile                            = nsProfile
+	ProfileGlobs                         = profileGlobs
+	SnapConfineFromSnapProfile           = snapConfineFromSnapProfile
+	DefaultCoreRuntimeTemplateRules      = defaultCoreRuntimeTemplateRules
+	DefaultOtherBaseTemplateRules        = defaultOtherBaseTemplateRules
+	DefaultPerlTemplateRules             = defaultPerlTemplateRules
+	DefaultCoreRuntimePerlTemplateRules  = defaultCoreRuntimePerlTemplateRules
+	DefaultPythonTemplateRules           = defaultPythonTemplateRules
+	DefaultCoreRuntimePythonTemplateRules = defaultCoreRuntimePythonTemplateRules
+	TemplateFooter                       = templateFooter
 )
 
 func MockLoadProfiles(f func(fnames []string, cacheDir string, flags apparmor_sandbox.AaParserFlags) error) (restore func()) {
@@ -62,6 +67,20 @@ func MockProcSelfExe(symlink string) (restore func()) {
 // NOTE: The real apparmor template is long. For testing it is convenient for
 // replace it with a shorter snippet.
 func MockTemplate(fakeTemplate string) (restore func()) {
+	origTemplate := defaultCoreRuntimeTemplate
+	origExtraRules := coreRuntimeExtraRules
+	defaultCoreRuntimeTemplate = fakeTemplate
+	coreRuntimeExtraRules = func(string) string { return "" }
+	return func() {
+		defaultCoreRuntimeTemplate = origTemplate
+		coreRuntimeExtraRules = origExtraRules
+	}
+}
+
+// MockCoreRuntimeTemplate replaces the core runtime apparmor template string
+// only, without suppressing the extra rules insertion. Use this when testing
+// that coreRuntimeExtraRules correctly inserts perl/python rules based on base.
+func MockCoreRuntimeTemplate(fakeTemplate string) (restore func()) {
 	orig := defaultCoreRuntimeTemplate
 	defaultCoreRuntimeTemplate = fakeTemplate
 	return func() { defaultCoreRuntimeTemplate = orig }

--- a/interfaces/apparmor/export_test.go
+++ b/interfaces/apparmor/export_test.go
@@ -70,7 +70,7 @@ func MockTemplate(fakeTemplate string) (restore func()) {
 	origTemplate := defaultCoreRuntimeTemplate
 	origExtraRules := coreRuntimeExtraRules
 	defaultCoreRuntimeTemplate = fakeTemplate
-	coreRuntimeExtraRules = func(string) string { return "" }
+	coreRuntimeExtraRules = func(string, bool) string { return "" }
 	return func() {
 		defaultCoreRuntimeTemplate = origTemplate
 		coreRuntimeExtraRules = origExtraRules

--- a/interfaces/apparmor/export_test.go
+++ b/interfaces/apparmor/export_test.go
@@ -28,16 +28,12 @@ import (
 )
 
 var (
-	NsProfile                             = nsProfile
-	ProfileGlobs                          = profileGlobs
-	SnapConfineFromSnapProfile            = snapConfineFromSnapProfile
-	DefaultCoreRuntimeTemplateRules       = defaultCoreRuntimeTemplateRules
-	DefaultOtherBaseTemplateRules         = defaultOtherBaseTemplateRules
-	DefaultPerlTemplateRules              = defaultPerlTemplateRules
-	DefaultCoreRuntimePerlTemplateRules   = defaultCoreRuntimePerlTemplateRules
-	DefaultPythonTemplateRules            = defaultPythonTemplateRules
-	DefaultCoreRuntimePythonTemplateRules = defaultCoreRuntimePythonTemplateRules
-	TemplateFooter                        = templateFooter
+	NsProfile                       = nsProfile
+	ProfileGlobs                    = profileGlobs
+	SnapConfineFromSnapProfile      = snapConfineFromSnapProfile
+	DefaultCoreRuntimeTemplateRules = defaultCoreRuntimeTemplateRules
+	DefaultOtherBaseTemplateRules   = defaultOtherBaseTemplateRules
+	TemplateFooter                  = templateFooter
 )
 
 func MockLoadProfiles(f func(fnames []string, cacheDir string, flags apparmor_sandbox.AaParserFlags) error) (restore func()) {
@@ -62,7 +58,7 @@ func MockProcSelfExe(symlink string) (restore func()) {
 	}
 }
 
-// MockTemplate replaces apprmor template.
+// MockTemplate replaces apparmor template and suppresses the extra rules insertion.
 //
 // NOTE: The real apparmor template is long. For testing it is convenient for
 // replace it with a shorter snippet.
@@ -78,8 +74,7 @@ func MockTemplate(fakeTemplate string) (restore func()) {
 }
 
 // MockCoreRuntimeTemplate replaces the core runtime apparmor template string
-// only, without suppressing the extra rules insertion. Use this when testing
-// that baseRuntimeExtraRules correctly inserts perl/python rules based on base.
+// without suppressing the extra rules insertion.
 func MockCoreRuntimeTemplate(fakeTemplate string) (restore func()) {
 	orig := defaultCoreRuntimeTemplate
 	defaultCoreRuntimeTemplate = fakeTemplate

--- a/interfaces/apparmor/export_test.go
+++ b/interfaces/apparmor/export_test.go
@@ -68,22 +68,30 @@ func MockProcSelfExe(symlink string) (restore func()) {
 // replace it with a shorter snippet.
 func MockTemplate(fakeTemplate string) (restore func()) {
 	origTemplate := defaultCoreRuntimeTemplate
-	origExtraRules := coreRuntimeExtraRules
+	origExtraRules := baseRuntimeExtraRules
 	defaultCoreRuntimeTemplate = fakeTemplate
-	coreRuntimeExtraRules = func(string, bool) string { return "" }
+	baseRuntimeExtraRules = func(string, bool) string { return "" }
 	return func() {
 		defaultCoreRuntimeTemplate = origTemplate
-		coreRuntimeExtraRules = origExtraRules
+		baseRuntimeExtraRules = origExtraRules
 	}
 }
 
 // MockCoreRuntimeTemplate replaces the core runtime apparmor template string
 // only, without suppressing the extra rules insertion. Use this when testing
-// that coreRuntimeExtraRules correctly inserts perl/python rules based on base.
+// that baseRuntimeExtraRules correctly inserts perl/python rules based on base.
 func MockCoreRuntimeTemplate(fakeTemplate string) (restore func()) {
 	orig := defaultCoreRuntimeTemplate
 	defaultCoreRuntimeTemplate = fakeTemplate
 	return func() { defaultCoreRuntimeTemplate = orig }
+}
+
+// MockOtherBaseTemplate replaces the non-core base apparmor template string
+// without suppressing the extra rules insertion.
+func MockOtherBaseTemplate(fakeTemplate string) (restore func()) {
+	orig := defaultOtherBaseTemplate
+	defaultOtherBaseTemplate = fakeTemplate
+	return func() { defaultOtherBaseTemplate = orig }
 }
 
 // MockClassicTemplate replaces the classic apprmor template.

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -503,6 +503,7 @@ var templateCommon = `
 `
 
 var templateFooter = `
+###CORE_RUNTIME_EXTRA###
 ###SNIPPETS###
 }
 `

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -117,17 +117,6 @@ var templateCommon = `
   owner @{HOME}/.Private/ r,
   owner @{HOMEDIRS}/.ecryptfs/*/.Private/ r,
 
-  # for python apps/services
-  #include <abstractions/python>
-  /etc/python3.[0-9]*/**                                r,
-
-  ###PYCACHEDENY###
-
-  # for perl apps/services
-  #include <abstractions/perl>
-  # Missing from perl abstraction
-  /usr/lib/@{multiarch}/perl{,5,-base}/auto/**.so* mr,
-
   # Note: the following dangerous accesses should not be allowed in most
   # policy, but we cannot explicitly deny since other trusted interfaces might
   # add them.
@@ -518,6 +507,25 @@ var templateFooter = `
 }
 `
 
+// defaultPerlTemplateRules contains perl runtime-specific rules.
+// Perl has been removed from the core24 onwards
+var defaultPerlTemplateRules = `
+  # for perl apps/services
+  #include <abstractions/perl>
+  # Missing from perl abstraction
+  /usr/lib/@{multiarch}/perl{,5,-base}/auto/**.so* mr,
+`
+
+// defaultPythonTemplateRules contains python runtime-specific rules.
+// Python has been removed from the base core26 onwards
+var defaultPythonTemplateRules = `
+  # for python apps/services
+  #include <abstractions/python>
+  /etc/python3.[0-9]*/**                                r,
+
+  ###PYCACHEDENY###
+`
+
 // defaultCoreRuntimeTemplateRules contains core* runtime-specific rules. In general,
 // binaries exposed here declare what the core runtime has historically been
 // expected to support.
@@ -528,21 +536,6 @@ var defaultCoreRuntimeTemplateRules = `
   /{,usr/}lib/terminfo/** rk,
   /usr/share/terminfo/** k,
   /usr/share/zoneinfo/** k,
-
-  # for python apps/services
-  /usr/bin/python{,2,2.[0-9]*,3,3.[0-9]*} ixr,
-  # additional accesses needed for newer pythons in later bases
-  /usr/lib{,32,64}/python3.[0-9]*/**.{pyc,so}           mr,
-  /usr/lib{,32,64}/python3.[0-9]*/**.{egg,py,pth}       r,
-  /usr/lib{,32,64}/python3.[0-9]*/{site,dist}-packages/ r,
-  /usr/lib{,32,64}/python3.[0-9]*/lib-dynload/*.so      mr,
-  /usr/include/python3.[0-9]*/pyconfig.h               r,
-
-  # for perl apps/services
-  /usr/bin/perl{,5*} ixr,
-  # AppArmor <2.12 doesn't have rules for perl-base, so add them here
-  /usr/lib/@{multiarch}/perl{,5,-base}/**            r,
-  /usr/lib/@{multiarch}/perl{,5,-base}/[0-9]*/**.so* mr,
 
   # for bash 'binaries' (do *not* use abstractions/bash)
   # user-specific bash files
@@ -698,6 +691,29 @@ var defaultCoreRuntimeTemplateRules = `
   /{,usr/}sbin/killall5 ixr,
 `
 
+// defaultPerlTemplateRules contains perl runtime-specific rules.
+// Perl has been removed from the core24 onwards
+var defaultCoreRuntimePerlTemplateRules = `
+  # for perl apps/services
+  /usr/bin/perl{,5*} ixr,
+  # AppArmor <2.12 doesn't have rules for perl-base, so add them here
+  /usr/lib/@{multiarch}/perl{,5,-base}/**            r,
+  /usr/lib/@{multiarch}/perl{,5,-base}/[0-9]*/**.so* mr,
+`
+
+// defaultCoreRuntimePythonTemplateRules contains python runtime-specific rules
+// python has been removed from base core26 onwards
+var defaultCoreRuntimePythonTemplateRules = `
+  # for python apps/services
+  /usr/bin/python{,2,2.[0-9]*,3,3.[0-9]*} ixr,
+  # additional accesses needed for newer pythons in later bases
+  /usr/lib{,32,64}/python3.[0-9]*/**.{pyc,so}           mr,
+  /usr/lib{,32,64}/python3.[0-9]*/**.{egg,py,pth}       r,
+  /usr/lib{,32,64}/python3.[0-9]*/{site,dist}-packages/ r,
+  /usr/lib{,32,64}/python3.[0-9]*/lib-dynload/*.so      mr,
+  /usr/include/python3.[0-9]*/pyconfig.h               r,
+`
+
 // defaultCoreRuntimeTemplate contains the default apparmor template for core* bases. It
 // can be overridden for testing using MockTemplate().
 var defaultCoreRuntimeTemplate = templateCommon + defaultCoreRuntimeTemplateRules + templateFooter
@@ -806,7 +822,7 @@ var defaultOtherBaseTemplateRules = `
 
 // defaultOtherBaseTemplate contains the default apparmor template for non-core
 // bases
-var defaultOtherBaseTemplate = templateCommon + defaultOtherBaseTemplateRules + templateFooter
+var defaultOtherBaseTemplate = templateCommon + defaultPerlTemplateRules + defaultPythonTemplateRules + defaultOtherBaseTemplateRules + templateFooter
 
 // Template for privilege drop and chown operations. The specific setuid,
 // setgid and chown operations are controlled via seccomp.

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -491,7 +491,7 @@ var templateCommon = `
 `
 
 var templateFooter = `
-###CORE_RUNTIME_EXTRA###
+###BASE_RUNTIME_EXTRA###
 ###SNIPPETS###
 }
 `
@@ -510,9 +510,7 @@ var defaultPerlTemplateRules = `
 var defaultPythonTemplateRules = `
   # for python apps/services
   #include <abstractions/python>
-  /etc/python3.[0-9]*/**                                r,
-
-  ###PYCACHEDENY###
+  /etc/python3.[0-9]*/** r,
 `
 
 // defaultCoreRuntimeTemplateRules contains core* runtime-specific rules. In general,
@@ -811,7 +809,7 @@ var defaultOtherBaseTemplateRules = `
 
 // defaultOtherBaseTemplate contains the default apparmor template for non-core
 // bases
-var defaultOtherBaseTemplate = templateCommon + defaultPerlTemplateRules + defaultPythonTemplateRules + defaultOtherBaseTemplateRules + templateFooter
+var defaultOtherBaseTemplate = templateCommon + defaultOtherBaseTemplateRules + templateFooter
 
 // Template for privilege drop and chown operations. The specific setuid,
 // setgid and chown operations are controlled via seccomp.

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -497,7 +497,7 @@ var templateFooter = `
 `
 
 // defaultPerlTemplateRules contains perl runtime-specific rules.
-// Perl has been removed from the core24 onwards
+// Perl has been removed from core24 onwards.
 var defaultPerlTemplateRules = `
   # for perl apps/services
   #include <abstractions/perl>
@@ -506,7 +506,7 @@ var defaultPerlTemplateRules = `
 `
 
 // defaultPythonTemplateRules contains python runtime-specific rules.
-// Python has been removed from the base core26 onwards
+// Python has been removed from core26 onwards.
 var defaultPythonTemplateRules = `
   # for python apps/services
   #include <abstractions/python>
@@ -680,8 +680,8 @@ var defaultCoreRuntimeTemplateRules = `
   /{,usr/}sbin/killall5 ixr,
 `
 
-// defaultPerlTemplateRules contains perl runtime-specific rules.
-// Perl has been removed from the core24 onwards
+// defaultCoreRuntimePerlTemplateRules contains perl runtime-specific rules
+// for core* bases. Perl has been removed from core24 onwards.
 var defaultCoreRuntimePerlTemplateRules = `
   # for perl apps/services
   /usr/bin/perl{,5*} ixr,
@@ -691,7 +691,7 @@ var defaultCoreRuntimePerlTemplateRules = `
 `
 
 // defaultCoreRuntimePythonTemplateRules contains python runtime-specific rules
-// python has been removed from base core26 onwards
+// for core* bases. Python has been removed from core26 onwards.
 var defaultCoreRuntimePythonTemplateRules = `
   # for python apps/services
   /usr/bin/python{,2,2.[0-9]*,3,3.[0-9]*} ixr,

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -496,7 +496,8 @@ var templateFooter = `
 }
 `
 
-// defaultPerlTemplateRules contains perl runtime-specific rules.
+// defaultPerlTemplateRules contains perl runtime-specific rules
+// common to core* and non-core bases.
 // Perl has been removed from core24 onwards.
 var defaultPerlTemplateRules = `
   # for perl apps/services
@@ -505,7 +506,8 @@ var defaultPerlTemplateRules = `
   /usr/lib/@{multiarch}/perl{,5,-base}/auto/**.so* mr,
 `
 
-// defaultPythonTemplateRules contains python runtime-specific rules.
+// defaultPythonTemplateRules contains python runtime-specific rules
+// common to core* and non-core bases.
 // Python has been removed from core26 onwards.
 var defaultPythonTemplateRules = `
   # for python apps/services

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -491,6 +491,7 @@ var templateCommon = `
 `
 
 var templateFooter = `
+###CORE_RUNTIME_EXTRA###
 ###SNIPPETS###
 }
 `

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -117,17 +117,6 @@ var templateCommon = `
   owner @{HOME}/.Private/ r,
   owner @{HOMEDIRS}/.ecryptfs/*/.Private/ r,
 
-  # for python apps/services
-  #include <abstractions/python>
-  /etc/python3.[0-9]*/**                                r,
-
-  ###PYCACHEDENY###
-
-  # for perl apps/services
-  #include <abstractions/perl>
-  # Missing from perl abstraction
-  /usr/lib/@{multiarch}/perl{,5,-base}/auto/**.so* mr,
-
   # Note: the following dangerous accesses should not be allowed in most
   # policy, but we cannot explicitly deny since other trusted interfaces might
   # add them.
@@ -506,6 +495,25 @@ var templateFooter = `
 }
 `
 
+// defaultPerlTemplateRules contains perl runtime-specific rules.
+// Perl has been removed from the core24 onwards
+var defaultPerlTemplateRules = `
+  # for perl apps/services
+  #include <abstractions/perl>
+  # Missing from perl abstraction
+  /usr/lib/@{multiarch}/perl{,5,-base}/auto/**.so* mr,
+`
+
+// defaultPythonTemplateRules contains python runtime-specific rules.
+// Python has been removed from the base core26 onwards
+var defaultPythonTemplateRules = `
+  # for python apps/services
+  #include <abstractions/python>
+  /etc/python3.[0-9]*/**                                r,
+
+  ###PYCACHEDENY###
+`
+
 // defaultCoreRuntimeTemplateRules contains core* runtime-specific rules. In general,
 // binaries exposed here declare what the core runtime has historically been
 // expected to support.
@@ -516,21 +524,6 @@ var defaultCoreRuntimeTemplateRules = `
   /{,usr/}lib/terminfo/** rk,
   /usr/share/terminfo/** k,
   /usr/share/zoneinfo/** k,
-
-  # for python apps/services
-  /usr/bin/python{,2,2.[0-9]*,3,3.[0-9]*} ixr,
-  # additional accesses needed for newer pythons in later bases
-  /usr/lib{,32,64}/python3.[0-9]*/**.{pyc,so}           mr,
-  /usr/lib{,32,64}/python3.[0-9]*/**.{egg,py,pth}       r,
-  /usr/lib{,32,64}/python3.[0-9]*/{site,dist}-packages/ r,
-  /usr/lib{,32,64}/python3.[0-9]*/lib-dynload/*.so      mr,
-  /usr/include/python3.[0-9]*/pyconfig.h               r,
-
-  # for perl apps/services
-  /usr/bin/perl{,5*} ixr,
-  # AppArmor <2.12 doesn't have rules for perl-base, so add them here
-  /usr/lib/@{multiarch}/perl{,5,-base}/**            r,
-  /usr/lib/@{multiarch}/perl{,5,-base}/[0-9]*/**.so* mr,
 
   # for bash 'binaries' (do *not* use abstractions/bash)
   # user-specific bash files
@@ -686,6 +679,29 @@ var defaultCoreRuntimeTemplateRules = `
   /{,usr/}sbin/killall5 ixr,
 `
 
+// defaultPerlTemplateRules contains perl runtime-specific rules.
+// Perl has been removed from the core24 onwards
+var defaultCoreRuntimePerlTemplateRules = `
+  # for perl apps/services
+  /usr/bin/perl{,5*} ixr,
+  # AppArmor <2.12 doesn't have rules for perl-base, so add them here
+  /usr/lib/@{multiarch}/perl{,5,-base}/**            r,
+  /usr/lib/@{multiarch}/perl{,5,-base}/[0-9]*/**.so* mr,
+`
+
+// defaultCoreRuntimePythonTemplateRules contains python runtime-specific rules
+// python has been removed from base core26 onwards
+var defaultCoreRuntimePythonTemplateRules = `
+  # for python apps/services
+  /usr/bin/python{,2,2.[0-9]*,3,3.[0-9]*} ixr,
+  # additional accesses needed for newer pythons in later bases
+  /usr/lib{,32,64}/python3.[0-9]*/**.{pyc,so}           mr,
+  /usr/lib{,32,64}/python3.[0-9]*/**.{egg,py,pth}       r,
+  /usr/lib{,32,64}/python3.[0-9]*/{site,dist}-packages/ r,
+  /usr/lib{,32,64}/python3.[0-9]*/lib-dynload/*.so      mr,
+  /usr/include/python3.[0-9]*/pyconfig.h               r,
+`
+
 // defaultCoreRuntimeTemplate contains the default apparmor template for core* bases. It
 // can be overridden for testing using MockTemplate().
 var defaultCoreRuntimeTemplate = templateCommon + defaultCoreRuntimeTemplateRules + templateFooter
@@ -794,7 +810,7 @@ var defaultOtherBaseTemplateRules = `
 
 // defaultOtherBaseTemplate contains the default apparmor template for non-core
 // bases
-var defaultOtherBaseTemplate = templateCommon + defaultOtherBaseTemplateRules + templateFooter
+var defaultOtherBaseTemplate = templateCommon + defaultPerlTemplateRules + defaultPythonTemplateRules + defaultOtherBaseTemplateRules + templateFooter
 
 // Template for privilege drop and chown operations. The specific setuid,
 // setgid and chown operations are controlled via seccomp.

--- a/tests/main/base-policy/task.yaml
+++ b/tests/main/base-policy/task.yaml
@@ -6,6 +6,8 @@ details: |
     1. 'base: core' can access a core-only rule that 'base: other' cannot
     2. 'base: other' can access a base-only rule that 'base: core' cannot
     3. both can access something allowed by common rules
+    4. core runtime perl/python rules are present only for bases that still
+       provide those runtimes
     
     While there are no core-only rules at this time for '1', we can at least
     test that 'grep --version' (differently allowed by core-only and
@@ -23,6 +25,7 @@ prepare: |
     echo "Given basic snaps are installed"
     "$TESTSTOOLS"/snaps-state install-local test-snapd-sh-core
     "$TESTSTOOLS"/snaps-state install-local test-snapd-sh-core18
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh-core24
 
     # core26 is currently only available on edge
     if ! snap list core26 2> /dev/null; then
@@ -73,3 +76,11 @@ execute: |
     for variant in /usr/bin/whoami /usr/bin/gnuwhoami /usr/lib/cargo/bin/coreutils/whoami; do
         test-snapd-sh-core26.sh -c "$variant" 2>&1 | MATCH "Permission denied"
     done
+
+    echo "Check if expected core runtime perl/python paths are allowed"
+    MATCH "/usr/bin/python" < /var/lib/snapd/apparmor/profiles/snap.test-snapd-sh-core24.sh
+    NOMATCH "/usr/bin/perl" < /var/lib/snapd/apparmor/profiles/snap.test-snapd-sh-core24.sh
+    NOMATCH "/usr/bin/python" < /var/lib/snapd/apparmor/profiles/snap.test-snapd-sh-core26.sh
+    test-snapd-sh-core24.sh -c '/usr/bin/python3 -c "print(\"python-is-accessible\")"' 2>&1 | MATCH "python-is-accessible"
+    test-snapd-sh-core24.sh -c '/usr/bin/perl -e "print qq(perl-is-accessible\n)"' 2>&1 | MATCH "(Permission denied|not found|No such file or directory)"
+    test-snapd-sh-core26.sh -c '/usr/bin/python3 -c "print(\"python-is-accessible\")"' 2>&1 | MATCH "(Permission denied|not found|No such file or directory)"

--- a/tests/main/base-policy/task.yaml
+++ b/tests/main/base-policy/task.yaml
@@ -6,7 +6,7 @@ details: |
     1. 'base: core' can access a core-only rule that 'base: other' cannot
     2. 'base: other' can access a base-only rule that 'base: core' cannot
     3. both can access something allowed by common rules
-    4. core runtime perl/python rules are present only for bases that still
+    4. runtime perl/python rules are present only for bases that still
        provide those runtimes
     
     While there are no core-only rules at this time for '1', we can at least
@@ -81,6 +81,8 @@ execute: |
     MATCH "/usr/bin/python" < /var/lib/snapd/apparmor/profiles/snap.test-snapd-sh-core24.sh
     NOMATCH "/usr/bin/perl" < /var/lib/snapd/apparmor/profiles/snap.test-snapd-sh-core24.sh
     NOMATCH "/usr/bin/python" < /var/lib/snapd/apparmor/profiles/snap.test-snapd-sh-core26.sh
+    NOMATCH "/usr/bin/perl" < /var/lib/snapd/apparmor/profiles/snap.test-snapd-sh-core26.sh
     test-snapd-sh-core24.sh -c '/usr/bin/python3 -c "print(\"python-is-accessible\")"' 2>&1 | MATCH "python-is-accessible"
     test-snapd-sh-core24.sh -c '/usr/bin/perl -e "print qq(perl-is-accessible\n)"' 2>&1 | MATCH "(Permission denied|not found|No such file or directory)"
     test-snapd-sh-core26.sh -c '/usr/bin/python3 -c "print(\"python-is-accessible\")"' 2>&1 | MATCH "(Permission denied|not found|No such file or directory)"
+    test-snapd-sh-core26.sh -c '/usr/bin/perl -e "print qq(perl-is-accessible\n)"' 2>&1 | MATCH "(Permission denied|not found|No such file or directory)"


### PR DESCRIPTION
With the base `core24` perl was removed; now, with the new `core26`, Python has been removed. This makes the existing AppArmor template used for core bases unnecessarily complex.
Especially, the following section can be quite expensive to compute on the slower hw.
```
 /etc/python3.[0-9]*/**
 deny /usr/lib/python3*/{,**/}__pycache__/ w,
 deny /usr/lib/python3*/{,**/}__pycache__/**.pyc.[0-9]* w,
 # bind mount used here (see 'parallel installs', above)
 deny @{INSTALL_DIR}/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/**/__pycache__/             w,
 deny @{INSTALL_DIR}/{@{SNAP_NAME},@{SNAP_INSTANCE_NAME}}/**/__pycache__/*.pyc.[0-9]* w,

  /usr/lib{,32,64}/python3.[0-9]*/**.{pyc,so}           mr,
  /usr/lib{,32,64}/python3.[0-9]*/**.{egg,py,pth}       r,
  /usr/lib{,32,64}/python3.[0-9]*/{site,dist}-packages/ r,
  /usr/lib{,32,64}/python3.[0-9]*/lib-dynload/*.so      mr,

 /usr/lib/@{multiarch}/perl{,5,-base}/[0-9]*/**.so* mr,
```
At the same time, those paths should no longer be accessed on `core24` or `core26`, respectively.

This is a cheap fix to start tuning the template based on the requested base.

Reference test run on a representative embedded system (arm64 CORTEX A55 1.7GHz)
```
Parsing Full template took: 0m1.025s
Parsing Optimised  template  took: 0m0.550s
```
This represents almost **50%** improvement over the template computation, without any regression to usable policy. For simple profiles, such as hooks or some apps and services, this amounts to a significant gain.
Tested on the fully loaded reference IoT device with ~80 profiles, this yielded a ~30% improvement when parsing all profiles.
