### PR TITLE
github: update feature tagging to generate coverage and introduce snapd snap build action

### DIFF
--- a/.github/actions/build-snapd-snap/action.yaml
+++ b/.github/actions/build-snapd-snap/action.yaml
@@ -1,0 +1,103 @@
+name: 'Build Snap Checks'
+description: 'Prepare toolchain, build snapd snap, and validate the artifact'
+
+inputs:
+  toolchain:
+    description: 'The go toolchain to use {default, FIPS}'
+    required: true
+  variant:
+    description: 'The type of snapd build {pristine, test}'
+    required: true
+  runs-on:
+    description: 'A json list of tags to indicate which runner to use'
+    required: true
+  pr-number:
+    description: 'Pull request number for label checking'
+    required: false
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set artifact name
+      id: set_artifact_name
+      shell: bash
+      run: |
+        postfix="${{ inputs.toolchain }}-${{ inputs.variant }}"
+        if grep -iq "arm" <<<"${{ inputs.runs-on }}"; then
+          echo "artifact_name=snap-files-arm64-${postfix}" >> $GITHUB_OUTPUT
+        else
+          echo "artifact_name=snap-files-amd64-${postfix}" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Set PR label as environment variables
+      if: ${{ inputs.pr-number != '' }}
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+          labels=$(gh pr view ${{ inputs.pr-number }} --json labels | jq -r '.labels[].name')
+          if grep -q '^Skip spread$' <<<$labels; then
+            echo "SKIP_SPREAD_LABEL=true" >> $GITHUB_ENV
+          fi
+
+    - name: Select Go toolchain
+      if: ${{ env.SKIP_SPREAD_LABEL != 'true' }}
+      shell: bash
+      run: |
+        case "${{ inputs.toolchain }}" in
+            default)
+                rm -f fips-build
+                ;;
+            FIPS)
+                touch fips-build
+                ;;
+            *)
+                echo "unknown toolchain ${{ inputs.toolchain }}"
+                exit 1
+                ;;
+        esac
+        case "${{ inputs.variant }}" in
+            pristine)
+                rm -f test-build
+                ;;
+            test)
+                touch test-build
+                ;;
+        esac
+
+    - name: Build snapd snap
+      if: ${{ env.SKIP_SPREAD_LABEL != 'true' }}
+      uses: snapcore/action-build@v1.3.0
+      with:
+        snapcraft-channel: 8.x/stable
+        snapcraft-args: --verbose
+
+    - name: Check built artifact
+      if: ${{ env.SKIP_SPREAD_LABEL != 'true' }}
+      shell: bash
+      run: |
+        unsquashfs -no-xattrs snapd*.snap snap/manifest.yaml meta/snap.yaml usr/lib/snapd/
+        if cat squashfs-root/meta/snap.yaml | grep -q "version:.*dirty.*"; then
+          echo "PR produces dirty snapd snap version"
+          cat squashfs-root/usr/lib/snapd/dirty-git-tree-info.txt
+          exit 1
+        elif cat squashfs-root/usr/lib/snapd/info | grep -q "VERSION=.*dirty.*"; then
+          echo "PR produces dirty internal snapd info version"
+          cat squashfs-root/usr/lib/snapd/info
+          cat squashfs-root/usr/lib/snapd/dirty-git-tree-info.txt
+          exit 1
+        fi
+        if yq '.primed-stage-packages' squashfs-root/snap/manifest.yaml | grep -q '^- libseccomp2=.*'; then
+          true
+        else
+          echo "primed-stage-packages missing in manifest" 1>&2
+          exit 1
+        fi
+
+    - name: Uploading snapd snap artifact
+      if: ${{ env.SKIP_SPREAD_LABEL != 'true' }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: ${{ steps.set_artifact_name.outputs.artifact_name }}
+        path: "*.snap"

--- a/.github/workflows/snap-builds.yaml
+++ b/.github/workflows/snap-builds.yaml
@@ -26,79 +26,11 @@ jobs:
       uses: actions/checkout@v6
       with:
         fetch-depth: 0
-    
-    - name: Set artifact name
-      id: set_artifact_name
-      run: |
-        postfix="${{ inputs.toolchain }}-${{ inputs.variant }}"
-        if grep -iq "arm" <<<"${{ inputs.runs-on }}"; then
-          echo "artifact_name=snap-files-arm64-${postfix}" >> $GITHUB_OUTPUT
-        else
-          echo "artifact_name=snap-files-amd64-${postfix}" >> $GITHUB_OUTPUT
-        fi
 
-    - name: Set PR label as environment variables
-      if: ${{ github.event.pull_request.number }}
-      run: |
-          labels=$(gh pr view ${{ github.event.pull_request.number }} --json labels | jq -r '.labels[].name')
-          if grep -q '^Skip spread$' <<<$labels; then
-            echo "SKIP_SPREAD_LABEL=true" >> $GITHUB_ENV
-          fi
-
-    - name: Select Go toolchain
-      run: |
-        case "${{ inputs.toolchain }}" in
-            default)
-                rm -f fips-build
-                ;;
-            FIPS)
-                touch fips-build
-                ;;
-            *)
-                echo "unknown toolchain ${{ inputs.toolchain }}"
-                exit 1
-                ;;
-        esac
-        case "${{ inputs.variant }}" in
-            pristine)
-                rm -f test-build
-                ;;
-            test)
-                touch test-build
-                ;;
-        esac
-
-    - name: Build snapd snap
-      if: ${{ env.SKIP_SPREAD_LABEL != 'true' }}
-      uses: snapcore/action-build@v1.3.0
+    - name: Build and upload snap
+      uses: ./.github/actions/build-snapd-snap
       with:
-        snapcraft-channel: 8.x/stable
-        snapcraft-args: --verbose
-
-    - name: Check built artifact
-      if: ${{ env.SKIP_SPREAD_LABEL != 'true' }}
-      run: |
-        unsquashfs -no-xattrs snapd*.snap snap/manifest.yaml meta/snap.yaml usr/lib/snapd/
-        if cat squashfs-root/meta/snap.yaml | grep -q "version:.*dirty.*"; then
-          echo "PR produces dirty snapd snap version"
-          cat squashfs-root/usr/lib/snapd/dirty-git-tree-info.txt
-          exit 1
-        elif cat squashfs-root/usr/lib/snapd/info | grep -q "VERSION=.*dirty.*"; then
-          echo "PR produces dirty internal snapd info version"
-          cat squashfs-root/usr/lib/snapd/info
-          cat squashfs-root/usr/lib/snapd/dirty-git-tree-info.txt
-          exit 1
-        fi
-        if yq '.primed-stage-packages' squashfs-root/snap/manifest.yaml | grep -q '^- libseccomp2=.*'; then
-          true
-        else
-          echo "primed-stage-packages missing in manifest" 1>&2
-          exit 1
-        fi
-
-    - name: Uploading snapd snap artifact
-      if: ${{ env.SKIP_SPREAD_LABEL != 'true' }}
-      uses: actions/upload-artifact@v7
-      with:
-        name: ${{ steps.set_artifact_name.outputs.artifact_name }}
-        path: "*.snap"
+        runs-on: ${{ inputs.runs-on }}
+        toolchain: ${{ inputs.toolchain }}
+        variant: ${{ inputs.variant }}
+        pr-number: ${{ github.event.pull_request.number || '' }}

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -54,6 +54,11 @@ on:
         description: 'Space-separated list of regex expressions identifying tests to skip. As a regex, they can identify any part of the spread test like an entire suite or a single test. End a single test with $ to avoid inadvertently matching others.'
         required: false
         type: string
+      log-to-grafana:
+        description: 'If true, will filter spread logs and send them to Grafana'
+        type: boolean
+        required: false
+        default: true
 
 
 jobs:
@@ -357,7 +362,7 @@ jobs:
         echo REQUIRED="$required" >> $GITHUB_ENV
 
     - name: Setup grafana parameters
-      if: ${{ env.SKIP_SPREAD_LABEL != 'true' }}
+      if: ${{ env.SKIP_SPREAD_LABEL != 'true' && inputs.log-to-grafana == 'true' }}
       run: |
           # Configure parameters to filter logs (these logs are sent read by grafana agent)
           CHANGE_ID="${{ github.event.number }}"
@@ -547,7 +552,7 @@ jobs:
         if-no-files-found: ignore
 
     - name: Report spread errors
-      if: always()
+      if: ${{ always() && inputs.log-to-grafana == 'true' }}
       run: |
         if [ -e results.json ]; then
             echo "Adding to the filtered log any spread errors found"

--- a/.github/workflows/weekly-feature-tagging.yaml
+++ b/.github/workflows/weekly-feature-tagging.yaml
@@ -14,7 +14,7 @@ on:
       skip-tests:
         type: string
         description: 'Filters out all matches for each space-separated regex expression when running spread tests'
-        default: 'ubuntu-14.04-64 tests/lib/ tests/unit/ manual/snapd-refresh-from-old core/persistent-journal'
+        default: 'ubuntu-14.04-64 tests/lib/ tests/unit/ tests/utils/cross-build manual/snapd-refresh-from-old core/persistent-journal'
   schedule:
     - cron: '30 4 * * 6'
 
@@ -43,15 +43,54 @@ jobs:
         run: |
           echo "maximum-reruns=${{ inputs.maximum-reruns || 2 }}" >> $GITHUB_OUTPUT
           echo "run-one-system=${{ inputs.run-one-system || '' }}" >> $GITHUB_OUTPUT
-          echo "skip-tests=${{ inputs.skip-tests || 'ubuntu-14.04-64 tests/lib/ tests/unit/ manual/snapd-refresh-from-old core/persistent-journal' }}" >> $GITHUB_OUTPUT
+          echo "skip-tests=${{ inputs.skip-tests || 'ubuntu-14.04-64 tests/lib/ tests/unit/ tests/utils/cross-build manual/snapd-refresh-from-old core/persistent-journal' }}" >> $GITHUB_OUTPUT
 
+  snap-builds:
+    runs-on: ${{ fromJSON(matrix.runs-on) }}
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Patch builds
+      run: |
+        sudo snap install go --classic 
+        go run ./tests/utils/features/instrument-funcs
+
+    - name: Commit changes
+      run: |
+        git config user.name "GitHub Actions"
+        git config user.email "bot@githubactions.com"
+        git add .
+        git commit -m "Patch builds for coverage"
+    
+    - name: Build and upload snap
+      uses: ./.github/actions/build-snapd-snap
+      with:
+        toolchain: ${{ matrix.toolchain }}
+        variant: test
+        runs-on: ${{ matrix.runs-on }}
+        pr-number: ${{ github.event.pull_request.number || '' }}
+    strategy:
+      matrix:
+        runs-on:
+          - '["ubuntu-22.04"]'
+          - ${{ github.event.repository.private && '["self-hosted", "Linux", "jammy", "ARM64", "large"]' || '["ubuntu-22.04-arm"]' }}
+        toolchain:
+          - default
+          - FIPS
+        exclude:
+          - runs-on: ${{ github.event.repository.private && '["self-hosted", "Linux", "jammy", "ARM64", "large"]' || '["ubuntu-22.04-arm"]' }}
+            toolchain: FIPS
+  
   read-systems:
     runs-on: ubuntu-latest
     needs: set-inputs
     outputs:
-      fundamental-systems: ${{ steps.read-systems.outputs.fundamental-systems }}
-      non-fundamental-systems: ${{ steps.read-systems.outputs.non-fundamental-systems }}
-      nested-systems: ${{ steps.read-systems.outputs.nested-systems }}
+      systems: ${{ steps.read-systems.outputs.systems }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -81,15 +120,16 @@ jobs:
         id: read-systems
         shell: bash
         run: |
-          echo "fundamental-systems=$fundamental_systems" >> $GITHUB_OUTPUT
-          echo "non-fundamental-systems=$non_fundamental_systems" >> $GITHUB_OUTPUT
-          echo "nested-systems=$nested_systems" >> $GITHUB_OUTPUT
+          echo "systems=$(jq -cs '{include: (map(.include // []) | add)}' \
+            <(echo "${fundamental_systems:-{\"include\":[]}}") \
+            <(echo "${non_fundamental_systems:-{\"include\":[]}}") \
+            <(echo "${nested_systems:-{\"include\":[]}}"))" >> $GITHUB_OUTPUT
 
-  tag-features-fundamental:
+  tag-features:
     uses: ./.github/workflows/spread-tests.yaml
     needs: [set-inputs, read-systems]
     name: "spread ${{ matrix.group }}"
-    if: needs.read-systems.outputs.fundamental-systems != ''
+    if: needs.read-systems.outputs.systems != ''
     secrets: inherit
     with:
       runs-on: '${{ matrix.runs-on }}'
@@ -98,61 +138,18 @@ jobs:
       systems: ${{ matrix.systems }}  
       tasks: ${{ matrix.tasks }}
       rules: ${{ matrix.rules }}
-      is-fundamental: true
-      use-snapd-snap-from-master: true
       spread-env: "SPREAD_TAG_FEATURES=1"
       upload-artifacts: true
       skip-tests: ${{ needs.set-inputs.outputs.skip-tests }}
+      log-to-grafana: false
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.read-systems.outputs.fundamental-systems) }}
-
-  tag-features-non-fundamental:
-    uses: ./.github/workflows/spread-tests.yaml
-    needs: [set-inputs, read-systems]
-    if: needs.read-systems.outputs.non-fundamental-systems != ''
-    name: "spread ${{ matrix.group }}"
-    secrets: inherit
-    with:
-      runs-on: '${{ matrix.runs-on }}'
-      group: ${{ matrix.group }}
-      backend: ${{ matrix.backend }}
-      systems: ${{ matrix.systems }}  
-      tasks: ${{ matrix.tasks }}
-      rules: ${{ matrix.rules }}
-      use-snapd-snap-from-master: true
-      spread-env: "SPREAD_TAG_FEATURES=1"
-      upload-artifacts: true
-      skip-tests: ${{ needs.set-inputs.outputs.skip-tests }}
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.read-systems.outputs.non-fundamental-systems) }}
-
-  tag-features-nested:
-    uses: ./.github/workflows/spread-tests.yaml
-    needs: [set-inputs, read-systems]
-    if: needs.read-systems.outputs.nested-systems != ''
-    name: "spread ${{ matrix.group }}"
-    secrets: inherit
-    with:
-      runs-on: '${{ matrix.runs-on }}'
-      group: ${{ matrix.group }}
-      backend: ${{ matrix.backend }}
-      systems: ${{ matrix.systems }}  
-      tasks: ${{ matrix.tasks }}
-      rules: ${{ matrix.rules }}
-      use-snapd-snap-from-master: true
-      spread-env: "SPREAD_TAG_FEATURES=1"
-      upload-artifacts: true
-      skip-tests: ${{ needs.set-inputs.outputs.skip-tests }}
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.read-systems.outputs.nested-systems) }}
+      matrix: ${{ fromJson(needs.read-systems.outputs.systems) }}
 
   re-run:
     permissions:
       actions: write
-    needs: [set-inputs, tag-features-fundamental, tag-features-non-fundamental, tag-features-nested]
+    needs: [set-inputs, tag-features]
     # If the spread tests ended in failure, rerun the workflow up to maximum-reruns times
     if: failure() && fromJSON(github.run_attempt) <= fromJSON(needs.set-inputs.outputs.maximum-reruns)
     runs-on: ubuntu-latest
@@ -172,7 +169,7 @@ jobs:
       - name: Download snapd snap
         uses: ./.github/actions/download-snapd-snap
         with:
-          use-master-push: true
+          use-master-push: false
           is-amd64: true
           is-arm64: false
           is-fips: false
@@ -189,12 +186,10 @@ jobs:
           path: "all-features.json"
 
   create-reports:
-    needs: [set-inputs, tag-features-fundamental, tag-features-non-fundamental, tag-features-nested, get-all-features]
+    needs: [set-inputs, tag-features, get-all-features]
     runs-on: ["self-hosted", "spread-enabled"]
     if: |
-      (always() && (needs.tag-features-fundamental.result == 'success' || needs.tag-features-fundamental.result == 'skipped')
-      && (needs.tag-features-non-fundamental.result == 'success' || needs.tag-features-non-fundamental.result == 'skipped')
-      && (needs.tag-features-nested.result == 'success' || needs.tag-features-nested.result == 'skipped')) 
+      (always() && needs.tag-features.result == 'success') 
       || fromJSON(github.run_attempt) > fromJSON(needs.set-inputs.outputs.maximum-reruns)
     steps:
       - name: Checkout code

--- a/.github/workflows/weekly-feature-tagging.yaml
+++ b/.github/workflows/weekly-feature-tagging.yaml
@@ -98,9 +98,9 @@ jobs:
       - name: Filter systems
         if: needs.set-inputs.outputs.run-one-system != ''
         run: |
-          echo 'fundamental_systems=""' >> $GITHUB_ENV
-          echo 'non_fundamental_systems=""' >> $GITHUB_ENV
-          echo 'nested_systems=""' >> $GITHUB_ENV
+          echo "fundamental_systems=" >> $GITHUB_ENV
+          echo "non_fundamental_systems=" >> $GITHUB_ENV
+          echo "nested_systems=" >> $GITHUB_ENV
           if grep -q "${{ needs.set-inputs.outputs.run-one-system }}" .github/workflows/data-fundamental-systems.json; then
             echo "fundamental_systems=$(jq -c ".include |= map(select(.systems == \"${{ needs.set-inputs.outputs.run-one-system }}\"))" .github/workflows/data-fundamental-systems.json)" >> $GITHUB_ENV
           elif grep -q "${{ needs.set-inputs.outputs.run-one-system }}" .github/workflows/data-non-fundamental-systems.json; then
@@ -120,10 +120,27 @@ jobs:
         id: read-systems
         shell: bash
         run: |
-          echo "systems=$(jq -cs '{include: (map(.include // []) | add)}' \
-            <(echo "${fundamental_systems:-{\"include\":[]}}") \
-            <(echo "${non_fundamental_systems:-{\"include\":[]}}") \
-            <(echo "${nested_systems:-{\"include\":[]}}"))" >> $GITHUB_OUTPUT
+          fundamental_json="${fundamental_systems:-}"
+          non_fundamental_json="${non_fundamental_systems:-}"
+          nested_json="${nested_systems:-}"
+
+          if [ -z "$fundamental_json" ]; then
+            fundamental_json='{"include":[]}'
+          fi
+          if [ -z "$non_fundamental_json" ]; then
+            non_fundamental_json='{"include":[]}'
+          fi
+          if [ -z "$nested_json" ]; then
+            nested_json='{"include":[]}'
+          fi
+
+          systems_json="$(jq -n -c \
+            --argjson fundamental "$fundamental_json" \
+            --argjson non_fundamental "$non_fundamental_json" \
+            --argjson nested "$nested_json" \
+            '{include: (($fundamental.include // []) + ($non_fundamental.include // []) + ($nested.include // []))}')"
+
+          echo "systems=$systems_json" >> $GITHUB_OUTPUT
 
   tag-features:
     uses: ./.github/workflows/spread-tests.yaml

--- a/.github/workflows/weekly-feature-tagging.yaml
+++ b/.github/workflows/weekly-feature-tagging.yaml
@@ -127,7 +127,7 @@ jobs:
 
   tag-features:
     uses: ./.github/workflows/spread-tests.yaml
-    needs: [set-inputs, read-systems]
+    needs: [set-inputs, read-systems, snap-builds]
     name: "spread ${{ matrix.group }}"
     if: needs.read-systems.outputs.systems != ''
     secrets: inherit
@@ -161,6 +161,7 @@ jobs:
 
   get-all-features:
     runs-on: ubuntu-latest
+    needs: snap-builds
     if: always()
     steps:
       - name: Checkout code


### PR DESCRIPTION
Requires https://github.com/canonical/snapd/pull/17220

This adds a new snapd snap build action that allows the feature tagging workflow to build the snap with the additional log coverage lines.

It also modifies the weekly feature tagging workflow by:
- Using one job instead of three for the spread jobs
- Adds a new variable to indicate whether we should log to grafana (no need to do so during feature tagging)
- Builds a snapd snap with the modified source code to gather coverage information