### PR TITLE
logger, tests: add no-repeat logging for structured logging and auto-log generator

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -223,7 +223,7 @@ func newLog(w io.Writer, flag int, opts *LoggerOptions) Logger {
 		log:   log.New(w, "", flag),
 		debug: opts.ForceDebug || debugEnabledOnKernelCmdline(),
 		flags: flag,
-		quiet: opts.Quiet,
+		quiet: quietEnabledOnKernelCmdline(),
 	}
 	return logger
 }
@@ -232,7 +232,6 @@ type LoggerOptions struct {
 	// ForceDebug can be set if we want debug traces even if not directly
 	// enabled by environment or kernel command line.
 	ForceDebug bool
-	Quiet      bool
 }
 
 func buildFlags() int {
@@ -255,14 +254,8 @@ func SimpleSetup(opts *LoggerOptions) {
 // initramfs, where we want to consider the quiet kernel option.
 func BootSetup() error {
 	flags := buildFlags()
-	m, _ := kcmdline.KeyValues("quiet")
-	_, quiet := m["quiet"]
-	opts := &LoggerOptions{
-		Quiet: quiet,
-	}
-	logger := New(os.Stderr, flags, opts)
+	logger := New(os.Stderr, flags, nil)
 	SetLogger(logger)
-
 	return nil
 }
 
@@ -279,6 +272,15 @@ func debugEnabledOnKernelCmdline() bool {
 	}
 	m, _ := kcmdline.KeyValues("snapd.debug")
 	return m["snapd.debug"] == "1"
+}
+
+func quietEnabledOnKernelCmdline() bool {
+	if osutil.IsTestBinary() && procCmdlineUseDefaultMockInTests {
+		return false
+	}
+	m, _ := kcmdline.KeyValues("quiet")
+	_, quiet := m["quiet"]
+	return quiet
 }
 
 var timeNow = time.Now

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -223,6 +223,7 @@ func newLog(w io.Writer, flag int, opts *LoggerOptions) Logger {
 		log:   log.New(w, "", flag),
 		debug: opts.ForceDebug || debugEnabledOnKernelCmdline(),
 		flags: flag,
+		quiet: opts.Quiet,
 	}
 	return logger
 }
@@ -231,6 +232,7 @@ type LoggerOptions struct {
 	// ForceDebug can be set if we want debug traces even if not directly
 	// enabled by environment or kernel command line.
 	ForceDebug bool
+	Quiet      bool
 }
 
 func buildFlags() int {
@@ -255,12 +257,10 @@ func BootSetup() error {
 	flags := buildFlags()
 	m, _ := kcmdline.KeyValues("quiet")
 	_, quiet := m["quiet"]
-	logger := &Log{
-		log:   log.New(os.Stderr, "", flags),
-		debug: debugEnabledOnKernelCmdline(),
-		quiet: quiet,
-		flags: flags,
+	opts := &LoggerOptions{
+		Quiet: quiet,
 	}
+	logger := New(os.Stderr, flags, opts)
 	SetLogger(logger)
 
 	return nil

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -223,7 +223,7 @@ func newLog(w io.Writer, flag int, opts *LoggerOptions) Logger {
 		log:   log.New(w, "", flag),
 		debug: opts.ForceDebug || debugEnabledOnKernelCmdline(),
 		flags: flag,
-		quiet: quietEnabledOnKernelCmdline(),
+		quiet: opts.Quiet,
 	}
 	return logger
 }
@@ -232,6 +232,8 @@ type LoggerOptions struct {
 	// ForceDebug can be set if we want debug traces even if not directly
 	// enabled by environment or kernel command line.
 	ForceDebug bool
+	// Quiet suppresses notice-level logs unless debugging is enabled.
+	Quiet bool
 }
 
 func buildFlags() int {
@@ -254,7 +256,12 @@ func SimpleSetup(opts *LoggerOptions) {
 // initramfs, where we want to consider the quiet kernel option.
 func BootSetup() error {
 	flags := buildFlags()
-	logger := New(os.Stderr, flags, nil)
+	m, _ := kcmdline.KeyValues("quiet")
+	_, quiet := m["quiet"]
+	opts := &LoggerOptions{
+		Quiet: quiet,
+	}
+	logger := New(os.Stderr, flags, opts)
 	SetLogger(logger)
 	return nil
 }
@@ -272,15 +279,6 @@ func debugEnabledOnKernelCmdline() bool {
 	}
 	m, _ := kcmdline.KeyValues("snapd.debug")
 	return m["snapd.debug"] == "1"
-}
-
-func quietEnabledOnKernelCmdline() bool {
-	if osutil.IsTestBinary() && procCmdlineUseDefaultMockInTests {
-		return false
-	}
-	m, _ := kcmdline.KeyValues("quiet")
-	_, quiet := m["quiet"]
-	return quiet
 }
 
 var timeNow = time.Now

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -91,6 +91,8 @@ func (s *LogSuite) TestBootSetup(c *C) {
 	// env shenanigans
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
+	restoreProcCmdline := logger.ProcCmdlineMustMock(false)
+	defer restoreProcCmdline()
 
 	oldTerm, hadTerm := os.LookupEnv("TERM")
 	defer func() {

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -91,8 +91,6 @@ func (s *LogSuite) TestBootSetup(c *C) {
 	// env shenanigans
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
-	restoreProcCmdline := logger.ProcCmdlineMustMock(false)
-	defer restoreProcCmdline()
 
 	oldTerm, hadTerm := os.LookupEnv("TERM")
 	defer func() {

--- a/logger/structured_logger.go
+++ b/logger/structured_logger.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/kcmdline"
 )
 
 type StructuredLog struct {
@@ -143,7 +144,7 @@ func New(w io.Writer, flag int, opts *LoggerOptions) Logger {
 	if opts == nil {
 		opts = &LoggerOptions{}
 	}
-	if !osutil.GetenvBool("SNAPD_JSON_LOGGING") {
+	if !osutil.GetenvBool("SNAPD_JSON_LOGGING") && !jsonLoggingEnabledOnKernelCmdline() {
 		return newLog(w, flag, opts)
 	}
 	options := &slog.HandlerOptions{
@@ -188,8 +189,29 @@ func New(w io.Writer, flag int, opts *LoggerOptions) Logger {
 		log:      slog.New(slog.NewJSONHandler(w, options)),
 		debug:    opts.ForceDebug || debugEnabledOnKernelCmdline(),
 		flags:    flag,
-		trace:    false,
+		quiet:    opts.Quiet,
+		trace:    traceEnabledOnKernelCmdline(),
 		seenLogs: make(map[string]bool),
 	}
 	return logger
+}
+
+func traceEnabledOnKernelCmdline() bool {
+	// if this is called during tests, always ignore it so we don't have to mock
+	// the /proc/cmdline for every test that ends up using a logger
+	if osutil.IsTestBinary() && procCmdlineUseDefaultMockInTests {
+		return false
+	}
+	m, _ := kcmdline.KeyValues("tag.features")
+	return m["tag.features"] == "1"
+}
+
+func jsonLoggingEnabledOnKernelCmdline() bool {
+	// if this is called during tests, always ignore it so we don't have to mock
+	// the /proc/cmdline for every test that ends up using a logger
+	if osutil.IsTestBinary() && procCmdlineUseDefaultMockInTests {
+		return false
+	}
+	m, _ := kcmdline.KeyValues("tag.features")
+	return m["tag.features"] == "1"
 }

--- a/logger/structured_logger.go
+++ b/logger/structured_logger.go
@@ -22,22 +22,27 @@ package logger
 
 import (
 	"context"
+	"crypto/md5"
+	"fmt"
 	"io"
 	"log"
 	"log/slog"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"time"
 
 	"github.com/snapcore/snapd/osutil"
 )
 
 type StructuredLog struct {
-	log   *slog.Logger
-	debug bool
-	trace bool
-	quiet bool
-	flags int
+	log      *slog.Logger
+	debug    bool
+	trace    bool
+	quiet    bool
+	flags    int
+	seenMu   sync.RWMutex
+	seenLogs map[string]bool
 }
 
 const (
@@ -94,14 +99,41 @@ func (l *StructuredLog) traceEnabled() bool {
 	return false
 }
 
-// Trace only prints if SNAPD_TRACE is set and structured logging is active
+// logKeyHash generates a unique hash for a message and its attributes
+// to use for deduplication purposes.
+func (l *StructuredLog) logKeyHash(msg string, attrs ...any) string {
+	h := md5.New()
+	fmt.Fprintf(h, "%s", msg)
+	for _, attr := range attrs {
+		fmt.Fprintf(h, "%v", attr)
+	}
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+// alreadyLogged checks if the given message+attrs combination has been logged before
+func (l *StructuredLog) alreadyLogged(msg string, attrs ...any) bool {
+	key := l.logKeyHash(msg, attrs...)
+	l.seenMu.RLock()
+	defer l.seenMu.RUnlock()
+	return l.seenLogs[key]
+}
+
+// markLogged records that a message+attrs combination has been logged
+func (l *StructuredLog) markLogged(msg string, attrs ...any) {
+	key := l.logKeyHash(msg, attrs...)
+	l.seenMu.Lock()
+	defer l.seenMu.Unlock()
+	l.seenLogs[key] = true
+}
+
 func (l *StructuredLog) Trace(msg string, attrs ...any) {
-	if l.traceEnabled() {
+	if l.traceEnabled() && !l.alreadyLogged(msg, attrs...) {
 		var pcs [1]uintptr
 		runtime.Callers(3, pcs[:])
 		r := slog.NewRecord(time.Now(), levelTrace, msg, pcs[0])
 		r.Add(attrs...)
 		l.log.Handler().Handle(context.Background(), r)
+		l.markLogged(msg, attrs...)
 	}
 }
 
@@ -153,10 +185,11 @@ func New(w io.Writer, flag int, opts *LoggerOptions) Logger {
 		},
 	}
 	logger := &StructuredLog{
-		log:   slog.New(slog.NewJSONHandler(w, options)),
-		debug: opts.ForceDebug || debugEnabledOnKernelCmdline(),
-		flags: flag,
-		trace: false,
+		log:      slog.New(slog.NewJSONHandler(w, options)),
+		debug:    opts.ForceDebug || debugEnabledOnKernelCmdline(),
+		flags:    flag,
+		trace:    false,
+		seenLogs: make(map[string]bool),
 	}
 	return logger
 }

--- a/logger/structured_logger.go
+++ b/logger/structured_logger.go
@@ -127,6 +127,8 @@ func (l *StructuredLog) markLogged(msg string, attrs ...any) {
 	l.seenLogs[key] = true
 }
 
+// Trace only prints if SNAPD_TRACE is set, tag.features=1 is on the kernel cmdline,
+// and structured logging is active. It will only log lines that have not already been logged.
 func (l *StructuredLog) Trace(msg string, attrs ...any) {
 	if l.traceEnabled() && !l.alreadyLogged(msg, attrs...) {
 		var pcs [1]uintptr
@@ -144,7 +146,8 @@ func New(w io.Writer, flag int, opts *LoggerOptions) Logger {
 	if opts == nil {
 		opts = &LoggerOptions{}
 	}
-	if !osutil.GetenvBool("SNAPD_JSON_LOGGING") && !jsonLoggingEnabledOnKernelCmdline() {
+	isStructuredLoggingEnabled := osutil.GetenvBool("SNAPD_JSON_LOGGING") || featureTaggingEnabledOnKernelCmdline()
+	if !isStructuredLoggingEnabled {
 		return newLog(w, flag, opts)
 	}
 	options := &slog.HandlerOptions{
@@ -189,24 +192,14 @@ func New(w io.Writer, flag int, opts *LoggerOptions) Logger {
 		log:      slog.New(slog.NewJSONHandler(w, options)),
 		debug:    opts.ForceDebug || debugEnabledOnKernelCmdline(),
 		flags:    flag,
-		quiet:    opts.Quiet,
-		trace:    traceEnabledOnKernelCmdline(),
+		quiet:    quietEnabledOnKernelCmdline(),
+		trace:    featureTaggingEnabledOnKernelCmdline(),
 		seenLogs: make(map[string]bool),
 	}
 	return logger
 }
 
-func traceEnabledOnKernelCmdline() bool {
-	// if this is called during tests, always ignore it so we don't have to mock
-	// the /proc/cmdline for every test that ends up using a logger
-	if osutil.IsTestBinary() && procCmdlineUseDefaultMockInTests {
-		return false
-	}
-	m, _ := kcmdline.KeyValues("tag.features")
-	return m["tag.features"] == "1"
-}
-
-func jsonLoggingEnabledOnKernelCmdline() bool {
+func featureTaggingEnabledOnKernelCmdline() bool {
 	// if this is called during tests, always ignore it so we don't have to mock
 	// the /proc/cmdline for every test that ends up using a logger
 	if osutil.IsTestBinary() && procCmdlineUseDefaultMockInTests {

--- a/logger/structured_logger.go
+++ b/logger/structured_logger.go
@@ -72,7 +72,7 @@ func (l *StructuredLog) Debug(msg string) {
 
 // Notice alerts the user about something, as well as putting in syslog
 func (l *StructuredLog) Notice(msg string) {
-	if !l.quiet {
+	if !l.quiet || l.debugEnabled() || l.traceEnabled() {
 		var pcs [1]uintptr
 		runtime.Callers(3, pcs[:])
 		r := slog.NewRecord(time.Now(), levelNotice, msg, pcs[0])
@@ -192,7 +192,7 @@ func New(w io.Writer, flag int, opts *LoggerOptions) Logger {
 		log:      slog.New(slog.NewJSONHandler(w, options)),
 		debug:    opts.ForceDebug || debugEnabledOnKernelCmdline(),
 		flags:    flag,
-		quiet:    quietEnabledOnKernelCmdline(),
+		quiet:    opts.Quiet,
 		trace:    featureTaggingEnabledOnKernelCmdline(),
 		seenLogs: make(map[string]bool),
 	}

--- a/logger/structured_logger_test.go
+++ b/logger/structured_logger_test.go
@@ -74,6 +74,27 @@ type TestLogEntry struct {
 	Source TestSourceLogEntry
 }
 
+func decodeStructuredEntries(c *C, buf *bytes.Buffer) []TestLogEntry {
+	raw := bytes.TrimSpace(buf.Bytes())
+	if len(raw) == 0 {
+		return nil
+	}
+
+	lines := bytes.Split(raw, []byte("\n"))
+	entries := make([]TestLogEntry, 0, len(lines))
+	for _, line := range lines {
+		if len(line) == 0 {
+			continue
+		}
+		var data TestLogEntry
+		err := json.Unmarshal(line, &data)
+		c.Assert(err, IsNil)
+		entries = append(entries, data)
+	}
+
+	return entries
+}
+
 func (s *LogStructuredSuite) TestNewStructured(c *C) {
 	os.Setenv("SNAPD_JSON_LOGGING", "1")
 	defer os.Unsetenv("SNAPD_JSON_LOGGING")
@@ -104,6 +125,37 @@ func (s *LogStructuredSuite) TestTraceEnvStructured(c *C) {
 	c.Check(data.Level, Equals, "TRACE")
 	c.Check(data.Attr, Equals, "val")
 	c.Check(data.Source.File, Equals, "structured_logger_test.go")
+}
+
+func (s *LogStructuredSuite) TestTraceEnvStructuredDeduplicatesRepeatedEntry(c *C) {
+	os.Setenv("SNAPD_TRACE", "1")
+	defer os.Unsetenv("SNAPD_TRACE")
+
+	logger.Trace("xyzzy", "attr", "val")
+	logger.Trace("xyzzy", "attr", "val")
+
+	entries := decodeStructuredEntries(c, s.logbuf)
+	c.Assert(entries, HasLen, 1)
+	c.Check(entries[0].Msg, Equals, "xyzzy")
+	c.Check(entries[0].Level, Equals, "TRACE")
+	c.Check(entries[0].Attr, Equals, "val")
+}
+
+func (s *LogStructuredSuite) TestTraceEnvStructuredAllowsDistinctEntries(c *C) {
+	os.Setenv("SNAPD_TRACE", "1")
+	defer os.Unsetenv("SNAPD_TRACE")
+
+	logger.Trace("xyzzy", "attr", "val")
+	logger.Trace("xyzzy", "attr", "different")
+
+	entries := decodeStructuredEntries(c, s.logbuf)
+	c.Assert(entries, HasLen, 2)
+	c.Check(entries[0].Msg, Equals, "xyzzy")
+	c.Check(entries[0].Level, Equals, "TRACE")
+	c.Check(entries[0].Attr, Equals, "val")
+	c.Check(entries[1].Msg, Equals, "xyzzy")
+	c.Check(entries[1].Level, Equals, "TRACE")
+	c.Check(entries[1].Attr, Equals, "different")
 }
 
 func (s *LogStructuredSuite) TestTraceEnvDebugStructured(c *C) {

--- a/logger/structured_logger_test.go
+++ b/logger/structured_logger_test.go
@@ -26,6 +26,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -275,6 +276,66 @@ func (s *LogStructuredSuite) TestIntegrationDebugFromKernelCmdlineStructured(c *
 	c.Check(data.Msg, Equals, "xyzzy")
 	c.Check(data.Level, Equals, "DEBUG")
 	c.Check(data.Attr, Equals, "")
+}
+
+func (s *LogStructuredSuite) TestIntegrationTraceFromKernelCmdlineStructured(c *C) {
+	// must enable actually checking the command line, because by default the
+	// logger package will skip checking for the kernel command line parameter
+	// if it detects it is in a test because otherwise we would have to mock the
+	// cmdline in many many many more tests that end up using a logger
+	restore := logger.ProcCmdlineMustMock(false)
+	defer restore()
+
+	mockProcCmdline := filepath.Join(c.MkDir(), "proc-cmdline")
+	err := os.WriteFile(mockProcCmdline, []byte("console=tty panic=-1 snapd.debug=1 tag.features=1\n"), 0644)
+	c.Assert(err, IsNil)
+	restore = kcmdline.MockProcCmdline(mockProcCmdline)
+	defer restore()
+
+	var buf bytes.Buffer
+	l := logger.New(&buf, logger.DefaultFlags, nil)
+	l.Trace("xyzzy")
+	data := TestLogEntry{}
+	err = json.Unmarshal(buf.Bytes(), &data)
+	c.Check(err, IsNil)
+	c.Check(data.Msg, Equals, "xyzzy")
+	c.Check(data.Level, Equals, "TRACE")
+	c.Check(data.Attr, Equals, "")
+}
+
+func (s *LogSuite) TestBootSetupStructuredLogger(c *C) {
+	// env shenanigans
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	restoreProcCmdline := logger.ProcCmdlineMustMock(false)
+	defer restoreProcCmdline()
+
+	oldTerm, hadTerm := os.LookupEnv("TERM")
+	defer func() {
+		if hadTerm {
+			os.Setenv("TERM", oldTerm)
+		} else {
+			os.Unsetenv("TERM")
+		}
+	}()
+
+	if logger.GetLogger() != nil {
+		logger.SetLogger(nil)
+	}
+	c.Check(logger.GetLogger(), IsNil)
+
+	cmdlineFile := filepath.Join(c.MkDir(), "cmdline")
+	err := os.WriteFile(cmdlineFile, []byte("mocked panic=-1 tag.features=1"), 0644)
+	c.Assert(err, IsNil)
+	restore := kcmdline.MockProcCmdline(cmdlineFile)
+	defer restore()
+	os.Setenv("TERM", "dumb")
+	err = logger.BootSetup()
+	c.Assert(err, IsNil)
+	l := logger.GetLogger()
+	c.Check(l, NotNil)
+	_, ok := l.(*logger.StructuredLog)
+	c.Assert(ok, Equals, true)
 }
 
 func (s *LogStructuredSuite) TestStartupTimestampMsgStructured(c *C) {

--- a/logger/structured_logger_test.go
+++ b/logger/structured_logger_test.go
@@ -303,6 +303,73 @@ func (s *LogStructuredSuite) TestIntegrationTraceFromKernelCmdlineStructured(c *
 	c.Check(data.Attr, Equals, "")
 }
 
+func (s *LogStructuredSuite) TestIntegrationQuietFromKernelCmdlineStructured(c *C) {
+	os.Setenv("SNAPD_JSON_LOGGING", "1")
+	defer os.Unsetenv("SNAPD_JSON_LOGGING")
+	restore := logger.ProcCmdlineMustMock(false)
+	defer restore()
+
+	mockProcCmdline := filepath.Join(c.MkDir(), "proc-cmdline")
+	err := os.WriteFile(mockProcCmdline, []byte("console=tty panic=-1 quiet\n"), 0644)
+	c.Assert(err, IsNil)
+	restore = kcmdline.MockProcCmdline(mockProcCmdline)
+	defer restore()
+
+	var buf bytes.Buffer
+	l := logger.New(&buf, logger.DefaultFlags, nil)
+	l.Notice("xyzzy")
+	c.Check(buf.String(), Equals, "")
+}
+
+func (s *LogStructuredSuite) TestIntegrationQuietFromKernelCmdlineStructuredStillLogsDebug(c *C) {
+	os.Setenv("SNAPD_JSON_LOGGING", "1")
+	defer os.Unsetenv("SNAPD_JSON_LOGGING")
+
+	// must enable actually checking the command line, because by default the
+	// logger package will skip checking for the kernel command line parameter
+	// if it detects it is in a test because otherwise we would have to mock the
+	// cmdline in many many many more tests that end up using a logger
+	restore := logger.ProcCmdlineMustMock(false)
+	defer restore()
+
+	mockProcCmdline := filepath.Join(c.MkDir(), "proc-cmdline")
+	err := os.WriteFile(mockProcCmdline, []byte("console=tty panic=-1 quiet snapd.debug=1\n"), 0644)
+	c.Assert(err, IsNil)
+	restore = kcmdline.MockProcCmdline(mockProcCmdline)
+	defer restore()
+
+	var buf bytes.Buffer
+	l := logger.New(&buf, logger.DefaultFlags, nil)
+	l.Notice("hidden")
+	l.Debug("visible")
+
+	entries := decodeStructuredEntries(c, &buf)
+	c.Assert(entries, HasLen, 1)
+	c.Check(entries[0].Msg, Equals, "visible")
+	c.Check(entries[0].Level, Equals, "DEBUG")
+}
+
+func (s *LogStructuredSuite) TestIntegrationQuietFromKernelCmdlineStructuredStillLogsTrace(c *C) {
+	restore := logger.ProcCmdlineMustMock(false)
+	defer restore()
+
+	mockProcCmdline := filepath.Join(c.MkDir(), "proc-cmdline")
+	err := os.WriteFile(mockProcCmdline, []byte("console=tty panic=-1 quiet tag.features=1\n"), 0644)
+	c.Assert(err, IsNil)
+	restore = kcmdline.MockProcCmdline(mockProcCmdline)
+	defer restore()
+
+	var buf bytes.Buffer
+	l := logger.New(&buf, logger.DefaultFlags, nil)
+	l.Notice("hidden")
+	l.Trace("visible")
+
+	entries := decodeStructuredEntries(c, &buf)
+	c.Assert(entries, HasLen, 1)
+	c.Check(entries[0].Msg, Equals, "visible")
+	c.Check(entries[0].Level, Equals, "TRACE")
+}
+
 func (s *LogSuite) TestBootSetupStructuredLogger(c *C) {
 	// env shenanigans
 	runtime.LockOSThread()

--- a/logger/structured_logger_test.go
+++ b/logger/structured_logger_test.go
@@ -303,71 +303,50 @@ func (s *LogStructuredSuite) TestIntegrationTraceFromKernelCmdlineStructured(c *
 	c.Check(data.Attr, Equals, "")
 }
 
-func (s *LogStructuredSuite) TestIntegrationQuietFromKernelCmdlineStructured(c *C) {
+func (s *LogStructuredSuite) TestIntegrationQuietStructured(c *C) {
 	os.Setenv("SNAPD_JSON_LOGGING", "1")
 	defer os.Unsetenv("SNAPD_JSON_LOGGING")
-	restore := logger.ProcCmdlineMustMock(false)
-	defer restore()
-
-	mockProcCmdline := filepath.Join(c.MkDir(), "proc-cmdline")
-	err := os.WriteFile(mockProcCmdline, []byte("console=tty panic=-1 quiet\n"), 0644)
-	c.Assert(err, IsNil)
-	restore = kcmdline.MockProcCmdline(mockProcCmdline)
-	defer restore()
 
 	var buf bytes.Buffer
-	l := logger.New(&buf, logger.DefaultFlags, nil)
+	l := logger.New(&buf, logger.DefaultFlags, &logger.LoggerOptions{Quiet: true})
 	l.Notice("xyzzy")
 	c.Check(buf.String(), Equals, "")
 }
 
-func (s *LogStructuredSuite) TestIntegrationQuietFromKernelCmdlineStructuredStillLogsDebug(c *C) {
+func (s *LogStructuredSuite) TestIntegrationQuietForceDebugStructuredStillLogsDebug(c *C) {
 	os.Setenv("SNAPD_JSON_LOGGING", "1")
 	defer os.Unsetenv("SNAPD_JSON_LOGGING")
 
-	// must enable actually checking the command line, because by default the
-	// logger package will skip checking for the kernel command line parameter
-	// if it detects it is in a test because otherwise we would have to mock the
-	// cmdline in many many many more tests that end up using a logger
-	restore := logger.ProcCmdlineMustMock(false)
-	defer restore()
-
-	mockProcCmdline := filepath.Join(c.MkDir(), "proc-cmdline")
-	err := os.WriteFile(mockProcCmdline, []byte("console=tty panic=-1 quiet snapd.debug=1\n"), 0644)
-	c.Assert(err, IsNil)
-	restore = kcmdline.MockProcCmdline(mockProcCmdline)
-	defer restore()
-
 	var buf bytes.Buffer
-	l := logger.New(&buf, logger.DefaultFlags, nil)
-	l.Notice("hidden")
-	l.Debug("visible")
+	l := logger.New(&buf, logger.DefaultFlags, &logger.LoggerOptions{Quiet: true, ForceDebug: true})
+	l.Notice("notice")
+	l.Debug("debug")
 
 	entries := decodeStructuredEntries(c, &buf)
-	c.Assert(entries, HasLen, 1)
-	c.Check(entries[0].Msg, Equals, "visible")
-	c.Check(entries[0].Level, Equals, "DEBUG")
+	c.Assert(entries, HasLen, 2)
+	c.Check(entries[0].Msg, Equals, "notice")
+	c.Check(entries[0].Level, Equals, "NOTICE")
+	c.Check(entries[1].Msg, Equals, "debug")
+	c.Check(entries[1].Level, Equals, "DEBUG")
 }
 
-func (s *LogStructuredSuite) TestIntegrationQuietFromKernelCmdlineStructuredStillLogsTrace(c *C) {
-	restore := logger.ProcCmdlineMustMock(false)
-	defer restore()
-
-	mockProcCmdline := filepath.Join(c.MkDir(), "proc-cmdline")
-	err := os.WriteFile(mockProcCmdline, []byte("console=tty panic=-1 quiet tag.features=1\n"), 0644)
-	c.Assert(err, IsNil)
-	restore = kcmdline.MockProcCmdline(mockProcCmdline)
-	defer restore()
+func (s *LogStructuredSuite) TestIntegrationQuietStructuredStillLogsTrace(c *C) {
+	os.Setenv("SNAPD_JSON_LOGGING", "1")
+	defer os.Unsetenv("SNAPD_JSON_LOGGING")
+	os.Setenv("SNAPD_TRACE", "1")
+	defer os.Unsetenv("SNAPD_TRACE")
 
 	var buf bytes.Buffer
-	l := logger.New(&buf, logger.DefaultFlags, nil)
-	l.Notice("hidden")
-	l.Trace("visible")
+	l := logger.New(&buf, logger.DefaultFlags, &logger.LoggerOptions{Quiet: true})
+	l.Notice("notice")
+	l.Trace("trace")
 
 	entries := decodeStructuredEntries(c, &buf)
-	c.Assert(entries, HasLen, 1)
-	c.Check(entries[0].Msg, Equals, "visible")
-	c.Check(entries[0].Level, Equals, "TRACE")
+	c.Assert(entries, HasLen, 2)
+	c.Check(entries[0].Msg, Equals, "notice")
+	c.Check(entries[0].Level, Equals, "NOTICE")
+	c.Check(entries[1].Msg, Equals, "trace")
+	c.Check(entries[1].Level, Equals, "TRACE")
 }
 
 func (s *LogSuite) TestBootSetupStructuredLogger(c *C) {

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -570,6 +570,11 @@ prepare_project() {
     esac
 
     if [ "$TAG_FEATURES" = "true" ]; then
+        go_version="$(go env GOVERSION 2>/dev/null | sed 's/^go//')"
+        if [ -n "$go_version" ] && [ "$(printf '%s\n' "$go_version" "1.21" | sort -V | head -n1)" = "1.21" ]; then
+            # slog requires go 1.21, so only add it if go >= 1.21
+            sed -i 's/withtestkeys,/withtestkeys,structuredlogging,/g' packaging/ubuntu*/rules
+        fi
         pushd "$SPREAD_PATH"
         go run ./tests/utils/features/instrument-funcs
         popd

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -569,6 +569,12 @@ prepare_project() {
             ;;
     esac
 
+    if [ "$TAG_FEATURES" = "true" ]; then
+        pushd "$SPREAD_PATH"
+        go run ./tests/utils/features/instrument-funcs
+        popd
+    fi
+
     # Retry go mod vendor to minimize the number of connection errors during the sync
     # It is required in any case because the testing tools like the fakestore are always compiled
     retry -n 10 go mod vendor

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -593,6 +593,12 @@ prepare_project() {
             ;;
     esac
 
+    if [ "$TAG_FEATURES" = "true" ]; then
+        pushd "$SPREAD_PATH"
+        go run ./tests/utils/features/instrument-funcs
+        popd
+    fi
+
     # Retry go mod vendor to minimize the number of connection errors during the sync
     # It is required in any case because the testing tools like the fakestore are always compiled
     retry -n 10 go mod vendor

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -594,6 +594,11 @@ prepare_project() {
     esac
 
     if [ "$TAG_FEATURES" = "true" ]; then
+        go_version="$(go env GOVERSION 2>/dev/null | sed 's/^go//')"
+        if [ -n "$go_version" ] && [ "$(printf '%s\n' "$go_version" "1.21" | sort -V | head -n1)" = "1.21" ]; then
+            # slog requires go 1.21, so only add it if go >= 1.21
+            sed -i 's/withtestkeys,/withtestkeys,structuredlogging,/g' packaging/ubuntu*/rules
+        fi
         pushd "$SPREAD_PATH"
         go run ./tests/utils/features/instrument-funcs
         popd

--- a/tests/utils/features/instrument-funcs/main.go
+++ b/tests/utils/features/instrument-funcs/main.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+func main() {
+	root := "."
+	if len(os.Args) > 1 {
+		root = os.Args[1]
+	}
+
+	wd, _ := os.Getwd()
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "skipping %s: %v\n", path, err)
+			return nil
+		}
+		if info.IsDir() && (info.Name() == "vendor" || info.Name() == ".git" ||
+			info.Name() == "logger" || info.Name() == "osutil" ||
+			info.Name() == "randutil" || info.Name() == "strutil" ||
+			info.Name() == "testutil" || info.Name() == "dbusutil" ||
+			info.Name() == "tests" || info.Name() == "release" ||
+			info.Name() == "blkid" || info.Name() == "snap-seccomp" ||
+			info.Name() == "snap-update-ns" || info.Name() == "dirs") {
+			return filepath.SkipDir
+		}
+		if !strings.HasSuffix(path, ".go") || info.IsDir() || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		if err := instrumentFile(path, wd); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %s: %v\n", path, err)
+		}
+		return nil
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "walk error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func instrumentFile(path, wd string) error {
+	src, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, src, parser.ParseComments)
+	if err != nil {
+		return fmt.Errorf("parse: %v", err)
+	}
+
+	relPath := filepath.ToSlash(path)
+	if r, err := filepath.Rel(wd, path); err == nil {
+		relPath = filepath.ToSlash(r)
+	}
+
+	inLoggerPkg := f.Name.Name == "logger"
+
+	type insertion struct {
+		offset int
+		text   string
+	}
+	var insertions []insertion
+
+	for _, decl := range f.Decls {
+		funcDecl, ok := decl.(*ast.FuncDecl)
+		if !ok || funcDecl.Body == nil {
+			continue
+		}
+
+		if isAlreadyInstrumented(funcDecl.Body) {
+			continue
+		}
+
+		lbrace := fset.Position(funcDecl.Body.Lbrace).Offset
+		insOffset := lbrace + 1
+
+		bodyOnSameLine := insOffset < len(src) && src[insOffset] != '\n'
+
+		funcName := funcDecl.Name.Name
+
+		insText := fmt.Sprintf("\n\t%s(\"coverage\", \"file\", %s, \"func\", %s)",
+			"logger.Trace", strLit(relPath), strLit(funcName))
+		if inLoggerPkg {
+			insText = fmt.Sprintf("\n\t%s(\"coverage\", \"file\", %s, \"func\", %s)",
+				"Trace", strLit(relPath), strLit(funcName))
+		}
+		if bodyOnSameLine {
+			insText += "\n"
+		}
+
+		insertions = append(insertions, insertion{insOffset, insText})
+	}
+
+	if len(insertions) == 0 {
+		return nil
+	}
+
+	sort.Slice(insertions, func(i, j int) bool {
+		return insertions[i].offset > insertions[j].offset
+	})
+
+	for _, ins := range insertions {
+		src = append(src[:ins.offset], append([]byte(ins.text), src[ins.offset:]...)...)
+	}
+
+	if !inLoggerPkg && !hasLoggerImport(f) {
+		src = addImportToSource(src, fset, f, `"github.com/snapcore/snapd/logger"`)
+	}
+
+	result, err := format.Source(src)
+	if err != nil {
+		return fmt.Errorf("format: %v", err)
+	}
+
+	return os.WriteFile(path, result, 0644)
+}
+
+func strLit(s string) string {
+	return fmt.Sprintf("%q", s)
+}
+
+func hasLoggerImport(f *ast.File) bool {
+	for _, imp := range f.Imports {
+		if imp.Path.Value == `"github.com/snapcore/snapd/logger"` {
+			return true
+		}
+	}
+	return false
+}
+
+func isAlreadyInstrumented(body *ast.BlockStmt) bool {
+	if len(body.List) == 0 {
+		return false
+	}
+	stmt, ok := body.List[0].(*ast.ExprStmt)
+	if !ok {
+		return false
+	}
+	call, ok := stmt.X.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+
+	switch fun := call.Fun.(type) {
+	case *ast.SelectorExpr:
+		if x, ok := fun.X.(*ast.Ident); !ok || x.Name != "logger" {
+			return false
+		}
+		if fun.Sel.Name != "Trace" {
+			return false
+		}
+	case *ast.Ident:
+		if fun.Name != "Trace" {
+			return false
+		}
+	default:
+		return false
+	}
+
+	if len(call.Args) < 1 {
+		return false
+	}
+	if lit, ok := call.Args[0].(*ast.BasicLit); !ok || lit.Kind != token.STRING || lit.Value != `"coverage"` {
+		return false
+	}
+
+	return true
+}
+
+func addImportToSource(src []byte, fset *token.FileSet, f *ast.File, importPath string) []byte {
+	importLine := "\n\t" + importPath
+
+	for _, decl := range f.Decls {
+		genDecl, ok := decl.(*ast.GenDecl)
+		if !ok || genDecl.Tok != token.IMPORT {
+			continue
+		}
+
+		if genDecl.Lparen.IsValid() {
+			// Grouped import: `import ( ... )`
+			endOffset := fset.Position(genDecl.End()).Offset
+			insertAt := endOffset - 1
+			src = append(src[:insertAt], append([]byte(importLine+"\n"), src[insertAt:]...)...)
+		} else {
+			// Single import: `import "..."` — convert to grouped form
+			startOffset := fset.Position(genDecl.Pos()).Offset
+			endOffset := fset.Position(genDecl.End()).Offset
+			existingImport := src[startOffset:endOffset]
+			grouped := "import (\n\t" + string(existingImport[len("import "):]) + importLine + "\n)"
+			before := make([]byte, startOffset)
+			copy(before, src[:startOffset])
+			src = append(before, append([]byte(grouped), src[endOffset:]...)...)
+		}
+		return src
+	}
+
+	pkgEnd := fset.Position(f.Name.End()).Offset
+	newImportBlock := "\nimport (" + importLine + "\n)\n"
+	src = append(src[:pkgEnd], append([]byte(newImportBlock), src[pkgEnd:]...)...)
+	return src
+}

--- a/tests/utils/features/instrument-funcs/main.go
+++ b/tests/utils/features/instrument-funcs/main.go
@@ -7,6 +7,7 @@ import (
 	"go/parser"
 	"go/token"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -19,19 +20,26 @@ func main() {
 	}
 
 	wd, _ := os.Getwd()
+	wd, _ = filepath.Abs(wd)
 
-	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+	var excludedDirNames = map[string]bool{
+		"vendor": true,
+		".git":   true,
+		"tests":  true,
+	}
+
+	autoExcludedDirs, err := loggerDependencyDirs()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Could not calculate logger dependencies: %v\n", err)
+		os.Exit(1)
+	}
+
+	err = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "skipping %s: %v\n", path, err)
 			os.Exit(1)
 		}
-		if d.IsDir() && (d.Name() == "vendor" || d.Name() == ".git" ||
-			d.Name() == "logger" || d.Name() == "osutil" ||
-			d.Name() == "randutil" || d.Name() == "strutil" ||
-			d.Name() == "testutil" || d.Name() == "dbusutil" ||
-			d.Name() == "tests" || d.Name() == "release" ||
-			d.Name() == "blkid" || d.Name() == "snap-seccomp" ||
-			d.Name() == "snap-update-ns" || d.Name() == "dirs") {
+		if d.IsDir() && shouldSkipDir(path, d.Name(), excludedDirNames, autoExcludedDirs) {
 			return filepath.SkipDir
 		}
 		if !strings.HasSuffix(path, ".go") || d.IsDir() || strings.HasSuffix(path, "_test.go") {
@@ -47,6 +55,96 @@ func main() {
 		fmt.Fprintf(os.Stderr, "walk error: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+func shouldSkipDir(path, dirName string, excludedDirNames, excludedAbsDirs map[string]bool) bool {
+	if excludedDirNames[dirName] {
+		return true
+	}
+
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return false
+	}
+
+	for ex := range excludedAbsDirs {
+		if absPath == ex || strings.HasPrefix(absPath, ex+string(filepath.Separator)) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func loggerDependencyDirs() (map[string]bool, error) {
+	outDefault, err := runCmdOutput("go", "list", "-e", "-deps", "-f", "{{if and (not .Standard) .Module.Main}}{{.Dir}}{{end}}", "./logger")
+	if err != nil {
+		return nil, err
+	}
+	outStructured, err := runCmdOutput("go", "list", "-e", "-tags", "structuredlogging", "-deps", "-f", "{{if and (not .Standard) .Module.Main}}{{.Dir}}{{end}}", "./logger")
+	if err != nil {
+		return nil, err
+	}
+	outDefaultTest, err := runCmdOutput("go", "list", "-e", "-test", "-deps", "-f", "{{if and (not .Standard) .Module.Main}}{{.Dir}}{{end}}", "./logger")
+	if err != nil {
+		return nil, err
+	}
+	outStructuredTest, err := runCmdOutput("go", "list", "-e", "-test", "-tags", "structuredlogging", "-deps", "-f", "{{if and (not .Standard) .Module.Main}}{{.Dir}}{{end}}", "./logger")
+	if err != nil {
+		return nil, err
+	}
+
+	dirs := map[string]bool{}
+	for _, line := range strings.Split(outDefault, "\n") {
+		d := strings.TrimSpace(line)
+		if d == "" {
+			continue
+		}
+		if abs, err := filepath.Abs(d); err == nil {
+			dirs[abs] = true
+		}
+	}
+	for _, line := range strings.Split(outStructured, "\n") {
+		d := strings.TrimSpace(line)
+		if d == "" {
+			continue
+		}
+		if abs, err := filepath.Abs(d); err == nil {
+			dirs[abs] = true
+		}
+	}
+	for _, line := range strings.Split(outDefaultTest, "\n") {
+		d := strings.TrimSpace(line)
+		if d == "" {
+			continue
+		}
+		if abs, err := filepath.Abs(d); err == nil {
+			dirs[abs] = true
+		}
+	}
+	for _, line := range strings.Split(outStructuredTest, "\n") {
+		d := strings.TrimSpace(line)
+		if d == "" {
+			continue
+		}
+		if abs, err := filepath.Abs(d); err == nil {
+			dirs[abs] = true
+		}
+	}
+
+	return dirs, nil
+}
+
+func runCmdOutput(name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...)
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			return "", fmt.Errorf("%s %s failed: %s", name, strings.Join(args, " "), strings.TrimSpace(string(ee.Stderr)))
+		}
+		return "", fmt.Errorf("%s %s failed: %v", name, strings.Join(args, " "), err)
+	}
+	return string(out), nil
 }
 
 func instrumentFile(path, wd string) error {
@@ -135,10 +233,23 @@ func hasLoggerImport(f *ast.File) bool {
 
 func addImportToSource(src []byte, fset *token.FileSet, f *ast.File, importPath string) []byte {
 	importLine := "\n\t" + importPath
+	var lastImportEnd int
 
 	for _, decl := range f.Decls {
 		genDecl, ok := decl.(*ast.GenDecl)
 		if !ok || genDecl.Tok != token.IMPORT {
+			continue
+		}
+		lastImportEnd = fset.Position(genDecl.End()).Offset
+
+		hasC := false
+		for _, spec := range genDecl.Specs {
+			if ispec, ok := spec.(*ast.ImportSpec); ok && ispec.Path != nil && ispec.Path.Value == `"C"` {
+				hasC = true
+				break
+			}
+		}
+		if hasC {
 			continue
 		}
 
@@ -163,5 +274,11 @@ func addImportToSource(src []byte, fset *token.FileSet, f *ast.File, importPath 
 	pkgEnd := fset.Position(f.Name.End()).Offset
 	newImportBlock := "\nimport (" + importLine + "\n)\n"
 	src = append(src[:pkgEnd], append([]byte(newImportBlock), src[pkgEnd:]...)...)
+	if lastImportEnd > 0 {
+		newImportBlock := "\nimport (" + importLine + "\n)"
+		src = append(src[:lastImportEnd], append([]byte(newImportBlock), src[lastImportEnd:]...)...)
+		return src
+	}
+
 	return src
 }

--- a/tests/utils/features/instrument-funcs/main.go
+++ b/tests/utils/features/instrument-funcs/main.go
@@ -39,7 +39,7 @@ func main() {
 
 	err = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "skipping %s: %v\n", path, err)
+			fmt.Fprintf(os.Stderr, "Error in walking %s: %v\n", path, err)
 			os.Exit(1)
 		}
 		if d.IsDir() && shouldSkipDir(path, d.Name(), excludedDirNames, autoExcludedDirs) {
@@ -80,58 +80,27 @@ func shouldSkipDir(path, dirName string, excludedDirNames, excludedAbsDirs map[s
 }
 
 func loggerDependencyDirs() (map[string]bool, error) {
-	outDefault, err := runCmdOutput("go", "list", "-e", "-deps", "-f", "{{if and (not .Standard) .Module.Main}}{{.Dir}}{{end}}", "./logger")
-	if err != nil {
-		return nil, err
+	goListDirTemplate := "{{if and (not .Standard) .Module.Main}}{{.Dir}}{{end}}"
+	cmds := [][]string{
+		{"list", "-e", "-deps", "-f", goListDirTemplate, "./logger"},
+		{"list", "-e", "-test", "-deps", "-f", goListDirTemplate, "./logger"},
+		{"list", "-e", "-tags", "structuredlogging", "-deps", "-f", goListDirTemplate, "./logger"},
+		{"list", "-e", "-test", "-tags", "structuredlogging", "-deps", "-f", goListDirTemplate, "./logger"},
 	}
-	outStructured, err := runCmdOutput("go", "list", "-e", "-tags", "structuredlogging", "-deps", "-f", "{{if and (not .Standard) .Module.Main}}{{.Dir}}{{end}}", "./logger")
-	if err != nil {
-		return nil, err
-	}
-	outDefaultTest, err := runCmdOutput("go", "list", "-e", "-test", "-deps", "-f", "{{if and (not .Standard) .Module.Main}}{{.Dir}}{{end}}", "./logger")
-	if err != nil {
-		return nil, err
-	}
-	outStructuredTest, err := runCmdOutput("go", "list", "-e", "-test", "-tags", "structuredlogging", "-deps", "-f", "{{if and (not .Standard) .Module.Main}}{{.Dir}}{{end}}", "./logger")
-	if err != nil {
-		return nil, err
-	}
-
 	dirs := map[string]bool{}
-	for _, line := range strings.Split(outDefault, "\n") {
-		d := strings.TrimSpace(line)
-		if d == "" {
-			continue
+	for _, args := range cmds {
+		out, err := runCmdOutput("go", args...)
+		if err != nil {
+			return nil, err
 		}
-		if abs, err := filepath.Abs(d); err == nil {
-			dirs[abs] = true
-		}
-	}
-	for _, line := range strings.Split(outStructured, "\n") {
-		d := strings.TrimSpace(line)
-		if d == "" {
-			continue
-		}
-		if abs, err := filepath.Abs(d); err == nil {
-			dirs[abs] = true
-		}
-	}
-	for _, line := range strings.Split(outDefaultTest, "\n") {
-		d := strings.TrimSpace(line)
-		if d == "" {
-			continue
-		}
-		if abs, err := filepath.Abs(d); err == nil {
-			dirs[abs] = true
-		}
-	}
-	for _, line := range strings.Split(outStructuredTest, "\n") {
-		d := strings.TrimSpace(line)
-		if d == "" {
-			continue
-		}
-		if abs, err := filepath.Abs(d); err == nil {
-			dirs[abs] = true
+		for _, line := range strings.Split(out, "\n") {
+			d := strings.TrimSpace(line)
+			if d == "" {
+				continue
+			}
+			if abs, err := filepath.Abs(d); err == nil {
+				dirs[abs] = true
+			}
 		}
 	}
 
@@ -168,8 +137,6 @@ func instrumentFile(path, wd string) error {
 	if r, err := filepath.Rel(wd, path); err == nil {
 		relPath = filepath.ToSlash(r)
 	}
-
-	inLoggerPkg := f.Name.Name == "logger"
 
 	type insertion struct {
 		offset int
@@ -211,7 +178,7 @@ func instrumentFile(path, wd string) error {
 		src = append(src[:ins.offset], append([]byte(ins.text), src[ins.offset:]...)...)
 	}
 
-	if !inLoggerPkg && !hasLoggerImport(f) {
+	if !hasLoggerImport(f) {
 		src = addImportToSource(src, fset, f, `"github.com/snapcore/snapd/logger"`)
 	}
 

--- a/tests/utils/features/instrument-funcs/main.go
+++ b/tests/utils/features/instrument-funcs/main.go
@@ -15,8 +15,11 @@ import (
 
 func main() {
 	root := "."
-	if len(os.Args) > 1 {
+	if len(os.Args) == 2 {
 		root = os.Args[1]
+	} else if len(os.Args) > 2 {
+		fmt.Fprint(os.Stderr, "Can only provide 0 or 1 args to function.")
+		os.Exit(1)
 	}
 
 	wd, _ := os.Getwd()
@@ -147,6 +150,8 @@ func runCmdOutput(name string, args ...string) (string, error) {
 	return string(out), nil
 }
 
+// instrumentFile adds logger.Trace lines to every func found in the file
+// and includes the logger import if not present
 func instrumentFile(path, wd string) error {
 	src, err := os.ReadFile(path)
 	if err != nil {
@@ -231,6 +236,7 @@ func hasLoggerImport(f *ast.File) bool {
 	return false
 }
 
+// addImportToSource adds a logger import to the source file
 func addImportToSource(src []byte, fset *token.FileSet, f *ast.File, importPath string) []byte {
 	importLine := "\n\t" + importPath
 	var lastImportEnd int

--- a/tests/utils/features/instrument-funcs/main.go
+++ b/tests/utils/features/instrument-funcs/main.go
@@ -20,25 +20,26 @@ func main() {
 
 	wd, _ := os.Getwd()
 
-	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "skipping %s: %v\n", path, err)
-			return nil
+			os.Exit(1)
 		}
-		if info.IsDir() && (info.Name() == "vendor" || info.Name() == ".git" ||
-			info.Name() == "logger" || info.Name() == "osutil" ||
-			info.Name() == "randutil" || info.Name() == "strutil" ||
-			info.Name() == "testutil" || info.Name() == "dbusutil" ||
-			info.Name() == "tests" || info.Name() == "release" ||
-			info.Name() == "blkid" || info.Name() == "snap-seccomp" ||
-			info.Name() == "snap-update-ns" || info.Name() == "dirs") {
+		if d.IsDir() && (d.Name() == "vendor" || d.Name() == ".git" ||
+			d.Name() == "logger" || d.Name() == "osutil" ||
+			d.Name() == "randutil" || d.Name() == "strutil" ||
+			d.Name() == "testutil" || d.Name() == "dbusutil" ||
+			d.Name() == "tests" || d.Name() == "release" ||
+			d.Name() == "blkid" || d.Name() == "snap-seccomp" ||
+			d.Name() == "snap-update-ns" || d.Name() == "dirs") {
 			return filepath.SkipDir
 		}
-		if !strings.HasSuffix(path, ".go") || info.IsDir() || strings.HasSuffix(path, "_test.go") {
+		if !strings.HasSuffix(path, ".go") || d.IsDir() || strings.HasSuffix(path, "_test.go") {
 			return nil
 		}
 		if err := instrumentFile(path, wd); err != nil {
 			fmt.Fprintf(os.Stderr, "error: %s: %v\n", path, err)
+			os.Exit(1)
 		}
 		return nil
 	})
@@ -79,10 +80,6 @@ func instrumentFile(path, wd string) error {
 			continue
 		}
 
-		if isAlreadyInstrumented(funcDecl.Body) {
-			continue
-		}
-
 		lbrace := fset.Position(funcDecl.Body.Lbrace).Offset
 		insOffset := lbrace + 1
 
@@ -92,10 +89,6 @@ func instrumentFile(path, wd string) error {
 
 		insText := fmt.Sprintf("\n\t%s(\"coverage\", \"file\", %s, \"func\", %s)",
 			"logger.Trace", strLit(relPath), strLit(funcName))
-		if inLoggerPkg {
-			insText = fmt.Sprintf("\n\t%s(\"coverage\", \"file\", %s, \"func\", %s)",
-				"Trace", strLit(relPath), strLit(funcName))
-		}
 		if bodyOnSameLine {
 			insText += "\n"
 		}
@@ -138,45 +131,6 @@ func hasLoggerImport(f *ast.File) bool {
 		}
 	}
 	return false
-}
-
-func isAlreadyInstrumented(body *ast.BlockStmt) bool {
-	if len(body.List) == 0 {
-		return false
-	}
-	stmt, ok := body.List[0].(*ast.ExprStmt)
-	if !ok {
-		return false
-	}
-	call, ok := stmt.X.(*ast.CallExpr)
-	if !ok {
-		return false
-	}
-
-	switch fun := call.Fun.(type) {
-	case *ast.SelectorExpr:
-		if x, ok := fun.X.(*ast.Ident); !ok || x.Name != "logger" {
-			return false
-		}
-		if fun.Sel.Name != "Trace" {
-			return false
-		}
-	case *ast.Ident:
-		if fun.Name != "Trace" {
-			return false
-		}
-	default:
-		return false
-	}
-
-	if len(call.Args) < 1 {
-		return false
-	}
-	if lit, ok := call.Args[0].(*ast.BasicLit); !ok || lit.Kind != token.STRING || lit.Value != `"coverage"` {
-		return false
-	}
-
-	return true
 }
 
 func addImportToSource(src []byte, fset *token.FileSet, f *ast.File, importPath string) []byte {


### PR DESCRIPTION
Requires https://github.com/canonical/snapd/pull/17222

The idea of this approach is to use a trace log line added to each function in snapd to gather coverage information of what functions are executed during tests and suite preparation. So as to not burden the code base, this data is added during the feature tagging run. Due to the large number of repeat function calls, this also adds a no-repeat logic to the structured logger. The necessary restarts of snapd to go along with this approach (obviously given the in-memory implementation, snapd needs to be restarted for each test otherwise it won't properly gather that test's features) are found in https://github.com/canonical/snapd/pull/17222