### PR TITLE
tests/util/features: add coverages to query features

### DIFF
--- a/tests/utils/features/dashboard_callbacks.py
+++ b/tests/utils/features/dashboard_callbacks.py
@@ -21,9 +21,9 @@ retriever = None
 timestamps = None
 timestamp_options = []
 coverage_matrix = {}
-exclude_list = ['coverages']
-all_features = [feat for feat in qf.KNOWN_FEATURES if feat not in exclude_list]
-feature_options = [{"label": item, "value": item} for item in all_features]
+exclude_features = ['coverages']
+included_features = [feat for feat in qf.KNOWN_FEATURES if feat not in exclude_features]
+feature_options = [{"label": item, "value": item} for item in included_features]
 cached_duplicates = {}
 cached_all_features_diff = {}
 cached_feat_explore = {}
@@ -53,9 +53,9 @@ def set_retriever(_, path):
     global retriever
     if os.path.isfile(path):
         with open(path, "r", encoding="utf-8") as f:
-            retriever = qf.MongoRetriever(f, exclude_list)
+            retriever = qf.MongoRetriever(f, exclude_features)
     elif os.path.isdir(path):
-        retriever = qf.DirRetriever(path, exclude_list)
+        retriever = qf.DirRetriever(path, exclude_features)
     global timestamps
     timestamps = retriever.get_sorted_timestamps_and_systems()
     global timestamp_options
@@ -146,7 +146,7 @@ def update_totals_table(selected_timestamp):
             diff_data.append(d)
 
     columns = [{"name": "System", "id": "system"}] + [
-        {"name": key, "id": key} for key in all_features
+        {"name": key, "id": key} for key in included_features
     ]
 
     return columns, diff_data
@@ -457,15 +457,15 @@ def create_coverage_matrix(timestamp, remove_failed, suite, task, variant):
         return [], []
 
     columns = [{"name": "System", "id": "system"}] + [
-        {"name": key, "id": key} for key in all_features
+        {"name": key, "id": key} for key in included_features
     ]
     global coverage_matrix
     coverage_matrix[timestamp] = [
-        {"system": system, **{key: 0 for key in all_features}}
+        {"system": system, **{key: 0 for key in included_features}}
         for system in systems
     ]
     matrix = [
-        {"system": system, **{key: 0 for key in all_features}}
+        {"system": system, **{key: 0 for key in included_features}}
         for system in systems
     ]
     for i, system in enumerate(systems):
@@ -473,7 +473,7 @@ def create_coverage_matrix(timestamp, remove_failed, suite, task, variant):
             retriever, timestamp, system, remove_failed, suite, task, variant
         )
         coverage_matrix[timestamp][i].update(feats)
-        for feature in all_features:
+        for feature in included_features:
             matrix[i][feature] = len(feats[feature])
 
     return columns, matrix

--- a/tests/utils/features/dashboard_callbacks.py
+++ b/tests/utils/features/dashboard_callbacks.py
@@ -21,7 +21,9 @@ retriever = None
 timestamps = None
 timestamp_options = []
 coverage_matrix = {}
-feature_options = [{"label": item, "value": item} for item in qf.KNOWN_FEATURES]
+exclude_list = ['coverages']
+all_features = [feat for feat in qf.KNOWN_FEATURES if feat not in exclude_list]
+feature_options = [{"label": item, "value": item} for item in all_features]
 cached_duplicates = {}
 cached_all_features_diff = {}
 cached_feat_explore = {}
@@ -51,9 +53,9 @@ def set_retriever(_, path):
     global retriever
     if os.path.isfile(path):
         with open(path, "r", encoding="utf-8") as f:
-            retriever = qf.MongoRetriever(f)
+            retriever = qf.MongoRetriever(f, exclude_list)
     elif os.path.isdir(path):
-        retriever = qf.DirRetriever(path)
+        retriever = qf.DirRetriever(path, exclude_list)
     global timestamps
     timestamps = retriever.get_sorted_timestamps_and_systems()
     global timestamp_options
@@ -144,7 +146,7 @@ def update_totals_table(selected_timestamp):
             diff_data.append(d)
 
     columns = [{"name": "System", "id": "system"}] + [
-        {"name": key, "id": key} for key in qf.KNOWN_FEATURES
+        {"name": key, "id": key} for key in all_features
     ]
 
     return columns, diff_data
@@ -455,15 +457,15 @@ def create_coverage_matrix(timestamp, remove_failed, suite, task, variant):
         return [], []
 
     columns = [{"name": "System", "id": "system"}] + [
-        {"name": key, "id": key} for key in qf.KNOWN_FEATURES
+        {"name": key, "id": key} for key in all_features
     ]
     global coverage_matrix
     coverage_matrix[timestamp] = [
-        {"system": system, **{key: 0 for key in qf.KNOWN_FEATURES}}
+        {"system": system, **{key: 0 for key in all_features}}
         for system in systems
     ]
     matrix = [
-        {"system": system, **{key: 0 for key in qf.KNOWN_FEATURES}}
+        {"system": system, **{key: 0 for key in all_features}}
         for system in systems
     ]
     for i, system in enumerate(systems):
@@ -471,7 +473,7 @@ def create_coverage_matrix(timestamp, remove_failed, suite, task, variant):
             retriever, timestamp, system, remove_failed, suite, task, variant
         )
         coverage_matrix[timestamp][i].update(feats)
-        for feature in qf.KNOWN_FEATURES:
+        for feature in all_features:
             matrix[i][feature] = len(feats[feature])
 
     return columns, matrix

--- a/tests/utils/features/query_features.py
+++ b/tests/utils/features/query_features.py
@@ -15,9 +15,9 @@ import pymongo.collection
 import sys
 from typing import Any, Iterable, Optional
 
-from features import SystemFeatures, Cmd, Endpoint, Status, Task, Change, Interface
+from features import SystemFeatures, TaskFeatures, Cmd, Endpoint, Status, Task, Change, Interface
 
-KNOWN_FEATURES = ["cmds", "endpoints", "ensures", "tasks", "changes", "interfaces"]
+KNOWN_FEATURES = ["coverages", "cmds", "endpoints", "ensures", "tasks", "changes", "interfaces"]
 
 # file name for the complete list of all features
 ALL_FEATURES_FILE = "all-features.json"
@@ -78,8 +78,9 @@ class Retriever(ABC):
     Retrieves features tags from a data source.
     """
 
-    def __init__(self):
+    def __init__(self, exclude: Optional[list[str]] = None):
         self.cache = {}
+        self.exclude = exclude
 
     @abstractmethod
     def get_sorted_timestamps_and_systems(self) -> list[dict[str, Any]]:
@@ -161,8 +162,8 @@ class MongoRetriever(Retriever):
     json file with host, port, user, and password defined.
     """
 
-    def __init__(self, creds_file):
-        super().__init__()
+    def __init__(self, creds_file, exclude: Optional[list[str]] = None):
+        super().__init__(exclude)
         config = json.load(creds_file)
         self.client = pymongo.MongoClient(
             host=config["host"], port=config["port"], username=config["user"], password=config["password"]
@@ -181,30 +182,51 @@ class MongoRetriever(Retriever):
             dictionary[result["timestamp"].isoformat()].append(result["system"])
         return [{"timestamp": entry[0], "systems": entry[1]} for entry in sorted(dictionary.items(), reverse=True)]
 
+    @staticmethod
+    def _projection_for_system_features(exclude: Optional[list[str]]) -> Optional[dict[str, int]]:
+        if not exclude:
+            return None
+        return {f"tests.{feature}": 0 for feature in exclude}
+
+    @staticmethod
+    def _projection_for_all_features(exclude: Optional[list[str]]) -> Optional[dict[str, int]]:
+        if not exclude:
+            return None
+        return {feature: 0 for feature in exclude}
+
     def _get_systems(self, timestamp: str, systems: list[str] = None) -> Iterable[SystemFeatures]:
+        projection = self._projection_for_system_features(self.exclude)
         if systems:
             for system in systems:
                 system_jsons = self.collection.find(
-                    {"timestamp": datetime.datetime.fromisoformat(timestamp), "system": system}
+                    {"timestamp": datetime.datetime.fromisoformat(timestamp), "system": system},
+                    projection,
                 )
                 for system_json in system_jsons:
                     yield system_json
         else:
-            for result in self.collection.find({"timestamp": datetime.datetime.fromisoformat(timestamp)}):
+            for result in self.collection.find(
+                {"timestamp": datetime.datetime.fromisoformat(timestamp)},
+                projection,
+            ):
                 if "all_features" not in result or not result["all_features"]:
                     yield result
 
     def _get_single_json(self, timestamp: str, system: str) -> SystemFeatures:
+        projection = self._projection_for_system_features(self.exclude)
         json_result = self.collection.find(
-            {"timestamp": datetime.datetime.fromisoformat(timestamp), "system": system}
+            {"timestamp": datetime.datetime.fromisoformat(timestamp), "system": system},
+            projection,
         ).to_list()
         if len(json_result) != 1:
             raise RuntimeError(f"{len(json_result)} entries of system {system} found in collection {timestamp}")
         return json_result[0]
 
     def _get_all_features(self, timestamp) -> dict[str, list[Any]]:
+        projection = self._projection_for_all_features(self.exclude)
         json_result = self.collection.find(
-            {"timestamp": datetime.datetime.fromisoformat(timestamp), "all_features": True}
+            {"timestamp": datetime.datetime.fromisoformat(timestamp), "all_features": True},
+            projection,
         ).to_list()
         if len(json_result) != 1:
             raise RuntimeError(
@@ -228,8 +250,8 @@ class DirRetriever(Retriever):
     Then one can use /write/dir as a data source with this retriever
     """
 
-    def __init__(self, dir: str):
-        super().__init__()
+    def __init__(self, dir: str, exclude: Optional[list[str]] = None):
+        super().__init__(exclude)
         if not os.path.exists(dir):
             raise RuntimeError(f"directory {dir} does not exist")
         self.dir = dir
@@ -264,14 +286,20 @@ class DirRetriever(Retriever):
                 not systems or self.__get_filename_without_last_ext(filename) in systems
             ):
                 with open(os.path.join(timestamp_dir, filename), "r", encoding="utf-8") as f:
-                    yield json.load(f)
+                    system_json = json.load(f)
+                    if self.exclude and "tests" in system_json:
+                        remove_features(system_json["tests"], self.exclude)
+                    yield system_json
 
     def _get_single_json(self, timestamp: str, system: str) -> SystemFeatures:
         sys_path = os.path.join(self.dir, timestamp, system + ".json")
         if not os.path.exists(sys_path):
             raise RuntimeError(f"system file not found {sys_path}")
         with open(sys_path, "r", encoding="utf-8") as f:
-            return json.load(f)
+            system_json = json.load(f)
+            if self.exclude and "tests" in system_json:
+                remove_features(system_json["tests"], self.exclude)
+            return system_json
 
     def _get_all_features(self, timestamp) -> dict[str, list[Any]]:
         sys_path = os.path.join(self.dir, timestamp, ALL_FEATURES_FILE)
@@ -283,6 +311,9 @@ class DirRetriever(Retriever):
                 del all["timestamp"]
             if "all_features" in all:
                 del all["all_features"]
+            if self.exclude:
+                for feature in self.exclude:
+                    all.pop(feature, None)
             return all
 
 
@@ -381,6 +412,15 @@ def subtract_features(first: dict[str, list], second: dict[str, list], match_sna
     if interfaces:
         diff["interfaces"] = interfaces
     return diff
+
+
+def remove_features(tests: list[TaskFeatures], exclude: Optional[list[str]]) -> None:
+    if not exclude:
+        return
+    for test in tests:
+        for feature in exclude:
+            if feature in test.keys():
+                del test[feature]
 
 
 def list_tasks(system_json: SystemFeatures, remove_failed: bool) -> set[TaskIdVariant]:
@@ -594,6 +634,8 @@ def get_feature_name_from_feature(feat: dict) -> str:
         return "interfaces"
     elif "kind" in feat:
         return "changes"
+    elif "coverage" in feat:
+        return "coverage"
     return ""
 
 
@@ -739,13 +781,12 @@ def filter_snap_types(snap_types: list[str]) -> list[str]:
     return [t for t in snap_types if "NOT FOUND" not in t]
 
 
-def clean_dictionary(features: SystemFeatures, exclude: Optional[list[str]]) -> None:
+def clean_dictionary(features: SystemFeatures) -> None:
     """
     Removes all status entries other than Done, Undone, Error.
     Filters out NOT_FOUND snap types.
 
     :param features: features dictionary to clean
-    :param exclude: removes all features of the specified type
     """
 
     def clean_snap_types(lst: list):
@@ -754,9 +795,6 @@ def clean_dictionary(features: SystemFeatures, exclude: Optional[list[str]]) -> 
                 entry["snap_types"] = filter_snap_types(entry["snap_types"])
 
     for test in features["tests"]:
-        if exclude:
-            for exclude_feature in exclude:
-                test.pop(exclude_feature, None)
         clean_snap_types(test.get("tasks", []))
         clean_snap_types(test.get("changes", []))
 
@@ -803,7 +841,6 @@ def minimal_coverage(
     system: Optional[str],
     max_minutes: int,
     force_match_keywords: Optional[list[str]],
-    exclude: Optional[list[str]],
 ) -> dict[str, list[TaskIdVariant]]:
     """
     Given a timestamp and (optional) system, gets the minimal set of tasks that cover the same features as the entire system.
@@ -823,7 +860,7 @@ def minimal_coverage(
     coverage = {}
     for sys_json in sys_jsons:
         time_left = max_minutes if max_minutes > 0 else math.inf
-        clean_dictionary(sys_json, exclude)
+        clean_dictionary(sys_json)
         tasks = sys_json["tests"]
         # All tasks that were successful appear before those that failed
         tasks = sorted(tasks, key=lambda x: (not x["success"], x["runtime"]))
@@ -882,6 +919,7 @@ def add_diff_parser(subparsers: argparse._SubParsersAction) -> str:
     diff.add_argument("-s2", "--system2", help="system of second execution", type=str, required=True)
     diff.add_argument("--remove-failed", help="remove all tasks that failed", action="store_true")
     diff.add_argument("--only-same", help="only compare tasks that were executed on both systems", action="store_true")
+    diff.add_argument("--exclude", help="exclude the list of features", nargs="+")
     return cmd
 
 
@@ -935,6 +973,7 @@ def add_diff_parsers(subparsers: argparse._SubParsersAction) -> tuple[str, str, 
     sys.add_argument("--match-snap-types", help="match the entire feature, including snap types", action="store_true")
     sys.add_argument("--sort-by-test", help="group features by the tests they are found in", action="store_true")
     sys.add_argument("--csv", help="output the diff in csv format rather than json", action="store_true")
+    sys.add_argument("--exclude", help="exclude the list of features", nargs="+")
 
     all = diff_subparsers.add_parser(
         cmd_all,
@@ -946,6 +985,7 @@ def add_diff_parsers(subparsers: argparse._SubParsersAction) -> tuple[str, str, 
     all.add_argument("-t", "--timestamp", help="timestamp of instance to search", required=True, type=str)
     all.add_argument("-s", "--system", help="system whose features should be searched", required=True, type=str)
     all.add_argument("--remove-failed", help="remove all tasks that failed", action="store_true")
+    all.add_argument("--exclude", help="exclude the list of features", nargs="+")
     return cmd, cmd_sys, cmd_all
 
 
@@ -970,6 +1010,7 @@ def add_dup_parser(subparsers: argparse._SubParsersAction) -> str:
     duplicate.add_argument("-t", "--timestamp", help="timestamp of instance to search", required=True, type=str)
     duplicate.add_argument("-s", "--system", help="system whose features should be searched", required=True, type=str)
     duplicate.add_argument("--remove-failed", help="remove all tasks that failed", action="store_true")
+    duplicate.add_argument("--exclude", help="exclude the list of features", nargs="+")
     return cmd
 
 
@@ -986,6 +1027,7 @@ def add_export_parser(subparsers: argparse._SubParsersAction) -> str:
     )
     export.add_argument("-s", "--systems", help="space-separated list of systems", nargs="*")
     export.add_argument("-o", "--output", help="folder to save feature data", required=True, type=str)
+    export.add_argument("--exclude", help="exclude the list of features", nargs="+")
     return cmd
 
 
@@ -1028,6 +1070,7 @@ def add_all_features_parser(subparsers: argparse._SubParsersAction) -> tuple[str
     sys.add_argument("--task", help="if provided, only grab features of this task", default=None, type=str)
     sys.add_argument("--variant", help="if provided, only grab features with this variant", default=None, type=str)
     sys.add_argument("--remove-failed", help="remove all tasks that failed", action="store_true")
+    sys.add_argument("--exclude", help="exclude the list of features", nargs="+")
 
     find = feat_subparsers.add_parser(
         cmd_find,
@@ -1040,6 +1083,7 @@ def add_all_features_parser(subparsers: argparse._SubParsersAction) -> tuple[str
     find.add_argument("--feat", help="feature to search for (json format)", required=True, type=str)
     find.add_argument("--remove-failed", help="remove all tasks that failed", action="store_true")
     find.add_argument("--match-snap-types", help="match the entire feature, including snap types", action="store_true")
+    find.add_argument("--exclude", help="exclude the list of features", nargs="+")
 
     cover = feat_subparsers.add_parser(
         cmd_cover,
@@ -1087,12 +1131,12 @@ def main():
     if args.dir:
 
         def retriever_creator():
-            return DirRetriever(args.dir)
+            return DirRetriever(args.dir, getattr(args, "exclude", None))
 
     elif args.file:
 
         def retriever_creator():
-            return MongoRetriever(args.file)
+            return MongoRetriever(args.file, getattr(args, "exclude", None))
 
     else:
         raise RuntimeError(
@@ -1174,7 +1218,7 @@ def main():
                     raise RuntimeError(f"Error parsing feature {args.feat}: {e}")
             elif args.features_cmd == feat_cover_cmd:
                 result = minimal_coverage(
-                    retriever, args.timestamp, args.system, args.max_minutes, args.force_match_keywords, args.exclude
+                    retriever, args.timestamp, args.system, args.max_minutes, args.force_match_keywords
                 )
                 json.dump(result, sys.stdout, default=lambda x: str(x))
             else:

--- a/tests/utils/features/query_features.py
+++ b/tests/utils/features/query_features.py
@@ -99,7 +99,17 @@ class Retriever(ABC):
             for s in self.cache[timestamp]["systems"]:
                 if s["system"] == system:
                     return s
-        return self._get_single_json(timestamp, system)
+        elif timestamp in self.cache and "sub-systems" in self.cache[timestamp]:
+            for s in self.cache[timestamp]["sub-systems"]:
+                if s["system"] == system:
+                    return s
+        if timestamp not in self.cache:
+            self.cache[timestamp] = {}
+        if "sub-systems" not in self.cache[timestamp]:
+            self.cache[timestamp]["sub-systems"] = []
+        sys_json = self._get_single_json(timestamp, system)
+        self.cache[timestamp]["sub-systems"].append(sys_json)
+        return sys_json
 
     @abstractmethod
     def _get_single_json(self, timestamp: str, system: str) -> SystemFeatures:
@@ -117,15 +127,33 @@ class Retriever(ABC):
             else:
                 return [sys for sys in self.cache[timestamp]["systems"] if sys["system"] in systems]
 
-        if systems:
-            # Do not cache if only a subset of systems is specified
-            # otherwise the cached list won't be complete
-            return self._get_systems(timestamp, systems)
+        if systems and timestamp in self.cache and "sub-systems" in self.cache[timestamp]:
+            sys_list = []
+            retrieve_list = []
+            for system in systems:
+                item = next((subsys for subsys in self.cache[timestamp]["sub-systems"] if subsys["system"] == system), None)
+                if item:
+                    sys_list.append(item)
+                else:
+                    retrieve_list.append(system)
+            if retrieve_list:
+                remaining_systems = self._get_systems(timestamp, retrieve_list)
+                self.cache[timestamp]["sub-systems"].extend(remaining_systems)
+                sys_list.extend(remaining_systems)
+            return sys_list
+        elif systems:
+            if timestamp not in self.cache:
+                self.cache[timestamp] = {}
+            self.cache[timestamp]["sub-systems"] = list(self._get_systems(timestamp, systems))
+            return self.cache[timestamp]["sub-systems"]
         else:
             if timestamp not in self.cache:
                 self.cache[timestamp] = {}
-            self.cache[timestamp]["systems"] = list(self._get_systems(timestamp, systems))
+            self.cache[timestamp]["systems"] = list(self._get_systems(timestamp))
+            if "sub-systems" in self.cache[timestamp]:
+                del self.cache[timestamp]["sub-systems"]
             return self.cache[timestamp]["systems"]
+
 
     @abstractmethod
     def _get_systems(self, timestamp: str, systems: list[str] = None) -> Iterable[SystemFeatures]:

--- a/tests/utils/features/query_features.py
+++ b/tests/utils/features/query_features.py
@@ -618,6 +618,7 @@ def feat_sys(
     suite: str = None,
     task: str = None,
     variant: str = None,
+    consolidate: bool = True,
 ) -> dict:
     """
     Calculates set(system_features), at the indicated timestamp.
@@ -646,7 +647,13 @@ def feat_sys(
     if remove_failed:
         include_tasks = list_tasks(system_json, remove_failed)
 
-    return consolidate_system_features(system_json, include_tasks=include_tasks)
+    if consolidate:
+        return consolidate_system_features(system_json, include_tasks=include_tasks)
+    
+    if include_tasks:
+        system_json["tests"] = [test for test in system_json["tests"] if TaskIdVariant(test["suite"], test["task_name"], test["variant"]) in include_tasks]
+    return system_json
+
 
 
 def get_feature_name_from_feature(feat: dict) -> str:
@@ -1098,6 +1105,7 @@ def add_all_features_parser(subparsers: argparse._SubParsersAction) -> tuple[str
     sys.add_argument("--task", help="if provided, only grab features of this task", default=None, type=str)
     sys.add_argument("--variant", help="if provided, only grab features with this variant", default=None, type=str)
     sys.add_argument("--remove-failed", help="remove all tasks that failed", action="store_true")
+    sys.add_argument("--consolidate", help="consolidate features across all tests into one", action="store_true")
     sys.add_argument("--exclude", help="exclude the list of features", nargs="+")
 
     find = feat_subparsers.add_parser(
@@ -1232,7 +1240,7 @@ def main():
                 json.dump(result, sys.stdout, cls=DateTimeEncoder)
             elif args.features_cmd == feat_sys_cmd:
                 result = feat_sys(
-                    retriever, args.timestamp, args.system, args.remove_failed, args.suite, args.task, args.variant
+                    retriever, args.timestamp, args.system, args.remove_failed, args.suite, args.task, args.variant, args.consolidate,
                 )
                 json.dump(result, sys.stdout, cls=DateTimeEncoder)
             elif args.features_cmd == feat_find_cmd:

--- a/tests/utils/features/query_features.py
+++ b/tests/utils/features/query_features.py
@@ -315,8 +315,7 @@ class DirRetriever(Retriever):
             ):
                 with open(os.path.join(timestamp_dir, filename), "r", encoding="utf-8") as f:
                     system_json = json.load(f)
-                    if self.exclude and "tests" in system_json:
-                        remove_features(system_json["tests"], self.exclude)
+                    remove_features(system_json.get("tests", []), self.exclude)
                     yield system_json
 
     def _get_single_json(self, timestamp: str, system: str) -> SystemFeatures:
@@ -325,8 +324,7 @@ class DirRetriever(Retriever):
             raise RuntimeError(f"system file not found {sys_path}")
         with open(sys_path, "r", encoding="utf-8") as f:
             system_json = json.load(f)
-            if self.exclude and "tests" in system_json:
-                remove_features(system_json["tests"], self.exclude)
+            remove_features(system_json.get("tests", []), self.exclude)
             return system_json
 
     def _get_all_features(self, timestamp) -> dict[str, list[Any]]:
@@ -339,9 +337,8 @@ class DirRetriever(Retriever):
                 del all["timestamp"]
             if "all_features" in all:
                 del all["all_features"]
-            if self.exclude:
-                for feature in self.exclude:
-                    all.pop(feature, None)
+            for feature in self.exclude or []:
+                all.pop(feature, None)
             return all
 
 

--- a/tests/utils/features/test_query_features.py
+++ b/tests/utils/features/test_query_features.py
@@ -602,6 +602,43 @@ class TestQueryFeatures:
                     'changes':[Change(kind="install-snap", snap_types=["app"])]}
         assert expected == cov
 
+    def test_feat_sys_not_consolidated(self):
+        data = {'timestamp1': {'system': {
+            'system': 'system1',
+            'tests': [
+                TaskFeatures(
+                    suite='suite1',
+                    task_name='task1',
+                    success=True,
+                    variant='',
+                    cmds=[Cmd(cmd='snap list')],
+                    endpoints=[Endpoint(method='GET', path='/v2/snaps')],
+                ),
+                TaskFeatures(
+                    suite='suite2',
+                    task_name='task2',
+                    success=False,
+                    variant='v1',
+                    cmds=[Cmd(cmd='snap debug api')],
+                    endpoints=[Endpoint(method='POST', path='/v2/system-info', action='advise-system-key-mismatch')],
+                ),
+            ],
+        }}}
+        retriever = DictRetriever(data)
+
+        # With consolidate=False, feat_sys should return the original system structure.
+        not_consolidated = query_features.feat_sys(retriever, 'timestamp1', 'system', False, consolidate=False)
+        assert 'tests' in not_consolidated
+        assert len(not_consolidated['tests']) == 2
+        assert not_consolidated['tests'][0]['task_name'] == 'task1'
+        assert not_consolidated['tests'][1]['task_name'] == 'task2'
+
+        # remove_failed still applies in non-consolidated mode.
+        not_consolidated_success = query_features.feat_sys(retriever, 'timestamp1', 'system', True, consolidate=False)
+        assert 'tests' in not_consolidated_success
+        assert len(not_consolidated_success['tests']) == 1
+        assert not_consolidated_success['tests'][0]['task_name'] == 'task1'
+
     def test_feat_sys_suite(self):
         data = {'timestamp1': {'system': {
             'system': 'system1',
@@ -1269,6 +1306,7 @@ class TestQueryFeatures:
                 task=None,
                 variant=None,
                 remove_failed=True,
+                consolidate=True,
                 exclude=None,
             )
             query_features.main()
@@ -1376,6 +1414,7 @@ class TestQueryFeatures:
                 task=None,
                 variant=None,
                 remove_failed=False,
+                consolidate=True,
                 exclude=['cmds'],
             )
             query_features.main()

--- a/tests/utils/features/test_query_features.py
+++ b/tests/utils/features/test_query_features.py
@@ -423,7 +423,9 @@ class TestQueryFeatures:
 
 
     def test_dup(self):
-        data = {'timestamp1': {'system1': {'tests': [
+        data = {'timestamp1': {'system1': {
+            'system': 'system1',
+            'tests': [
             TaskFeatures(suite='suite', task_name='task1', success=True, variant='',
                          cmds=[Cmd(cmd="snap list --all"),
                                Cmd(cmd="snap ack file")],
@@ -445,7 +447,9 @@ class TestQueryFeatures:
         assert [] == dup
 
     def test_dup_variants(self):
-        data = {'timestamp1': {'system1': {'tests': [
+        data = {'timestamp1': {'system1': {
+            'system': 'system1',
+            'tests': [
             TaskFeatures(suite='suite', task_name='task1', success=True, variant='a',
                          cmds=[Cmd(cmd="snap list --all"),
                                Cmd(cmd="snap ack file")],
@@ -500,7 +504,9 @@ class TestQueryFeatures:
             check_equal(os.path.join(timestamp2, 'system2.json'), s2_dict)
 
     def test_diff(self):
-        data = {'timestamp1': {'system1': {'tests': [
+        data = {'timestamp1': {'system1': {
+            'system': 'system1',
+            'tests': [
             TaskFeatures(suite='suite', task_name='task1', success=True, variant='',
                          cmds=[Cmd(cmd="snap list --all"),
                                Cmd(cmd="snap ack file")],
@@ -511,15 +517,17 @@ class TestQueryFeatures:
                          cmds=[Cmd(cmd="snap pack file"),
                                Cmd(cmd="snap debug api")],
                          endpoints=[Endpoint(method="POST", path="/v2/snaps/{name}", action="remove")])]},
-            'system2': {'tests': []}},
-            'timestamp2': {'system1': {'tests': [
+            'system2': {'system': 'system2', 'tests': []}},
+            'timestamp2': {'system1': {
+                'system': 'system1',
+                'tests': [
                 TaskFeatures(suite='suite', task_name='task1', success=False, variant='',
                              cmds=[
                                  Cmd(cmd="snap list --all")],
                              endpoints=[Endpoint(
                                  method="GET", path="/v2/changes/{id}"), Endpoint(method="GET", path="/v2/snaps")],
                              changes=[Change(kind="install-snap", snap_types=["app"])])]},
-                           'system2': {'tests': []}}}
+                           'system2': {'system': 'system2', 'tests': []}}}
         retriever = DictRetriever(data)
 
         # When getting difference only between the same tasks in both systems,
@@ -564,7 +572,9 @@ class TestQueryFeatures:
         assert {} == diff
 
     def test_feat_sys(self):
-        data = {'timestamp1': {'system': {'tests': [
+        data = {'timestamp1': {'system': {
+            'system': 'system1',
+            'tests': [
             TaskFeatures(suite='suite1', task_name='task1', success=True, variant='',
                          cmds=[Cmd(cmd="snap list")],
                          endpoints=[
@@ -593,7 +603,9 @@ class TestQueryFeatures:
         assert expected == cov
 
     def test_feat_sys_suite(self):
-        data = {'timestamp1': {'system': {'tests': [
+        data = {'timestamp1': {'system': {
+            'system': 'system1',
+            'tests': [
             TaskFeatures(suite='suite1', task_name='task1', success=True, variant='',
                          cmds=[Cmd(cmd="snap list")],
                          endpoints=[
@@ -629,7 +641,9 @@ class TestQueryFeatures:
         assert {} == cov
 
     def test_feat_sys_task(self):
-        data = {'timestamp1': {'system': {'tests': [
+        data = {'timestamp1': {'system': {
+            'system': 'system1',
+            'tests': [
             TaskFeatures(suite='suite1', task_name='task1', success=True, variant='',
                          cmds=[Cmd(cmd="snap list")],
                          endpoints=[
@@ -661,7 +675,9 @@ class TestQueryFeatures:
         assert {} == cov
 
     def test_feat_sys_variant(self):
-        data = {'timestamp1': {'system': {'tests': [
+        data = {'timestamp1': {'system': {
+            'system': 'system1',
+            'tests': [
             TaskFeatures(suite='suite1', task_name='task1', success=True, variant='',
                          cmds=[Cmd(cmd="snap list")],
                          endpoints=[
@@ -691,7 +707,9 @@ class TestQueryFeatures:
         assert {} == cov
 
     def test_diff_feat_all(self):
-        data = {'timestamp1': {'system': {'tests': [
+        data = {'timestamp1': {'system': {
+            'system': 'system1',
+            'tests': [
             TaskFeatures(suite='suite1', task_name='task1', success=True, variant='',
                          cmds=[Cmd(cmd="snap list")],
                          endpoints=[
@@ -883,41 +901,77 @@ class TestQueryFeatures:
         data = {'timestamp1': {
                 'system1': {'system':'system1', 'tests': [
                     TaskFeatures(suite='suite1', task_name='task1', success=True, variant='',
-                                cmds=[Cmd(cmd="some command")])]},
+                                cmds=[Cmd(cmd="system1")])]},
                 'system2': {'system':'system2', 'tests': [
                     TaskFeatures(suite='suite2', task_name='task2', success=True, variant='',
                                 cmds=[Cmd(cmd="system2")]),]}},}
         retriever = DictRetriever(data)
         retriever.get_single_json('timestamp1', 'system1')
-        assert len(retriever.cache) == 0
-        res = retriever.get_systems('timestamp1', ['system1'])
-        assert res[0]['tests'][0]['cmds'][0]['cmd'] == 'some command'
-
-        # Before data is cached, it's possible to overwrite values
-        retriever.data['timestamp1']['system1']['tests'][0]['cmds'][0]['cmd'] = 'system1'
-        res = retriever.get_systems('timestamp1', ['system1'])
-        assert res[0]['tests'][0]['cmds'][0]['cmd'] == 'system1'
-        assert len(retriever.cache) == 0
-
-        # By calling get_systems without specifying a system list, the base
-        # class will cache the result
-        retriever.get_systems('timestamp1')
         assert len(retriever.cache) == 1
-        assert 'timestamp1' in retriever.cache
-        assert 'systems' in retriever.cache['timestamp1']
-
-        # To prove the cached data is being used, here we change the underlying data
-        retriever.data['timestamp1']['system1']['tests'][0]['cmds'][0]['cmd'] = 'new'
-        res = retriever.get_single_json('timestamp1', 'system1')
-        assert res['tests'][0]['cmds'][0]['cmd'] == 'system1'
-
-        # get_systems and get_single_json all use the cached data
+        assert 'timestamp1' in retriever.cache and 'sub-systems' in retriever.cache['timestamp1']
+        
+        # If I overwrite some data, I will get the cached version
+        retriever.data['timestamp1']['system1']['tests'][0]['cmds'][0]['cmd'] = 'some command'
         res = retriever.get_systems('timestamp1', ['system1'])
         assert res[0]['tests'][0]['cmds'][0]['cmd'] == 'system1'
+
+
+    def test_sys_caching_all_systems(self):
+        data = {'timestamp1': {
+                'system1': {'system':'system1', 'tests': [
+                    TaskFeatures(suite='suite1', task_name='task1', success=True, variant='',
+                                cmds=[Cmd(cmd="system1")])]},
+                'system2': {'system':'system2', 'tests': [
+                    TaskFeatures(suite='suite2', task_name='task2', success=True, variant='',
+                                cmds=[Cmd(cmd="system2")]),]}},}
+        retriever = DictRetriever(data)
         res = retriever.get_systems('timestamp1')
-        assert res[0]['tests'][0]['cmds'][0]['cmd'] == 'system1'
+        assert len(retriever.cache) == 1
+        assert 'timestamp1' in retriever.cache and 'systems' in retriever.cache['timestamp1']
+        
+        # If I overwrite some data, I will get the cached version
+        retriever.data['timestamp1']['system1']['tests'][0]['cmds'][0]['cmd'] = 'some command'
         res = retriever.get_single_json('timestamp1', 'system1')
         assert res['tests'][0]['cmds'][0]['cmd'] == 'system1'
+
+
+    def test_sys_caching_subset_only_returns_requested_systems(self):
+        data = {'timestamp1': {
+                'system1': {'system':'system1', 'tests': [
+                    TaskFeatures(suite='suite1', task_name='task1', success=True, variant='',
+                                cmds=[Cmd(cmd='system1-cmd')])]},
+                'system2': {'system':'system2', 'tests': [
+                    TaskFeatures(suite='suite2', task_name='task2', success=True, variant='',
+                                cmds=[Cmd(cmd='system2-cmd')])]},
+            },
+        }
+        retriever = DictRetriever(data)
+
+        retriever.get_single_json('timestamp1', 'system1')
+        res = retriever.get_systems('timestamp1', ['system2'])
+
+        assert len(res) == 1
+        assert res[0]['system'] == 'system2'
+
+
+    def test_sys_caching_all_systems_clears_partial_cache(self):
+        data = {'timestamp1': {
+                'system1': {'system':'system1', 'tests': [
+                    TaskFeatures(suite='suite1', task_name='task1', success=True, variant='',
+                                cmds=[Cmd(cmd='system1-cmd')])]},
+                'system2': {'system':'system2', 'tests': [
+                    TaskFeatures(suite='suite2', task_name='task2', success=True, variant='',
+                                cmds=[Cmd(cmd='system2-cmd')])]},
+            },
+        }
+        retriever = DictRetriever(data)
+
+        retriever.get_systems('timestamp1', ['system1'])
+        assert 'sub-systems' in retriever.cache['timestamp1']
+
+        retriever.get_systems('timestamp1')
+        assert 'systems' in retriever.cache['timestamp1']
+        assert 'sub-systems' not in retriever.cache['timestamp1']
 
 
     def test_all_features_caching(self):

--- a/tests/utils/features/test_query_features.py
+++ b/tests/utils/features/test_query_features.py
@@ -817,7 +817,6 @@ class TestQueryFeatures:
             system='system1',
             max_minutes=1,
             force_match_keywords=['install'],
-            exclude=[]
         )
 
         assert 'system1' in coverage
@@ -845,7 +844,6 @@ class TestQueryFeatures:
             system='system1',
             max_minutes=4,
             force_match_keywords=['install'],
-            exclude=[]
         )
 
         assert 'system1' in coverage and len(coverage['system1']) == 2
@@ -873,7 +871,6 @@ class TestQueryFeatures:
             system='system1',
             max_minutes=4,
             force_match_keywords=None,
-            exclude=None
         )
 
         assert 'system1' in coverage and len(coverage['system1']) == 2
@@ -1035,7 +1032,8 @@ class TestQueryFeatures:
                 remove_failed=False,
                 only_same=False,
                 match_snap_types=True,
-                sort_by_test=False
+                sort_by_test=False,
+                exclude=None,
             )
             query_features.main()
             expected = {'cmds': [{'cmd': 'b'}], 'endpoints': [{'1': 'a'}]}
@@ -1079,7 +1077,8 @@ class TestQueryFeatures:
                 dir=mocker.get_dir() if mocker_class == "DirMocker" else None,
                 timestamp='2025-05-04',
                 system='system',
-                remove_failed=False
+                remove_failed=False,
+                exclude=None,
             )
             query_features.main()
             expected = {'cmds': [Cmd(cmd='c'),Cmd(cmd='e'),Cmd(cmd='f')],
@@ -1108,6 +1107,7 @@ class TestQueryFeatures:
                 timestamp='2025-05-04',
                 system='system',
                 remove_failed=False,
+                exclude=None,
             )
             query_features.main()
             actual = json.loads(mocker.get_stdout())
@@ -1214,7 +1214,8 @@ class TestQueryFeatures:
                 suite=None,
                 task=None,
                 variant=None,
-                remove_failed=True
+                remove_failed=True,
+                exclude=None,
             )
             query_features.main()
 
@@ -1222,6 +1223,112 @@ class TestQueryFeatures:
             expected = {'cmds':[{'cmd':'a'},{'cmd':'b'},{'cmd':'d'}],
                         'endpoints':[{'1':'a'},{'5':'d'}]}
             assert expected == output
+
+
+    def test_mongoretriever_projection_helpers(self):
+        assert query_features.MongoRetriever._projection_for_system_features(None) is None
+        assert query_features.MongoRetriever._projection_for_all_features(None) is None
+        assert {
+            'tests.cmds': 0,
+            'tests.tasks': 0,
+        } == query_features.MongoRetriever._projection_for_system_features(['cmds', 'tasks'])
+        assert {
+            'cmds': 0,
+            'tasks': 0,
+        } == query_features.MongoRetriever._projection_for_all_features(['cmds', 'tasks'])
+
+
+    def test_dirretriever_exclude_removes_features(self):
+        data = [
+            {
+                'timestamp': '2025-05-04',
+                'system': 'system1',
+                'tests': [
+                    TaskFeatures(
+                        task_name='task1',
+                        suite='suite1',
+                        variant='',
+                        cmds=[{'cmd': 'a'}],
+                        endpoints=[{'path': '/v2/snaps', 'method': 'GET'}],
+                        tasks=[{'kind': 'install-snap', 'last_status': 'Done'}],
+                        success=True,
+                    )
+                ],
+            },
+            {
+                'timestamp': '2025-05-04',
+                'all_features': True,
+                'cmds': [{'cmd': 'a'}, {'cmd': 'b'}],
+                'endpoints': [{'path': '/v2/snaps', 'method': 'GET'}],
+                'tasks': [{'kind': 'install-snap', 'last_status': 'Done'}],
+            },
+        ]
+
+        with DirMocker(data) as dm:
+            retriever = query_features.DirRetriever(dm.get_dir(), exclude=['cmds', 'tasks'])
+
+            single = retriever.get_single_json('2025-05-04', 'system1')
+            assert 'cmds' not in single['tests'][0]
+            assert 'tasks' not in single['tests'][0]
+            assert 'endpoints' in single['tests'][0]
+
+            listed = list(retriever.get_systems('2025-05-04', ['system1']))
+            assert len(listed) == 1
+            assert 'cmds' not in listed[0]['tests'][0]
+            assert 'tasks' not in listed[0]['tests'][0]
+
+            all_features = retriever.get_all_features('2025-05-04')
+            assert 'cmds' not in all_features
+            assert 'tasks' not in all_features
+            assert 'endpoints' in all_features
+
+
+    @patch('argparse.ArgumentParser.parse_args')
+    def test_retriever_feat_sys_with_exclude(self, parse_args_mock: Mock):
+        data = [
+            {
+                'timestamp': '2025-05-04',
+                'system': 'system1',
+                'tests': [
+                    TaskFeatures(
+                        task_name='task1',
+                        suite='suite1',
+                        variant='',
+                        cmds=[{'cmd': 'a'}],
+                        endpoints=[{'1': 'a'}],
+                        success=True,
+                    ),
+                    TaskFeatures(
+                        task_name='task2',
+                        suite='suite1',
+                        variant='',
+                        cmds=[{'cmd': 'd'}],
+                        endpoints=[{'5': 'd'}],
+                        success=True,
+                    ),
+                ],
+            }
+        ]
+
+        with DirMocker(data, do_patch_stdout=True) as dm:
+            parse_args_mock.return_value = argparse.Namespace(
+                command='feat',
+                features_cmd='sys',
+                file=None,
+                dir=dm.get_dir(),
+                timestamp='2025-05-04',
+                system='system1',
+                suite=None,
+                task=None,
+                variant=None,
+                remove_failed=False,
+                exclude=['cmds'],
+            )
+            query_features.main()
+
+            output = json.loads(dm.get_stdout())
+            assert 'cmds' not in output
+            assert output == {'endpoints': [{'1': 'a'}, {'5': 'd'}]}
 
 
     @pytest.mark.parametrize("mocker_class", ["MongoMocker","DirMocker"])


### PR DESCRIPTION
This accounts for an additional feature "coverages" in feature tags. It allows for excluding the field (by allowing the exclusion of any fields), including not retrieving it at all from mongodb. In the non-exclusion case, to better manage the data, this also increasing caching by allowing for partial caches. It privileges the complete cache over the partial cache. This also adds the ability to not consolidate features when querying for all system features to allow for retrieving the set of features for each given test.