### PR TITLE
many: support accessing validation-sets through confdb [WIP] 

### DIFF
--- a/daemon/api_confdb_test.go
+++ b/daemon/api_confdb_test.go
@@ -397,17 +397,6 @@ func (s *confdbSuite) TestUnsetView(c *C) {
 	})
 	defer restore()
 
-	s.st.Lock()
-	tx, err := confdbstate.NewTransaction(s.st, "system", "network")
-	s.st.Unlock()
-	c.Assert(err, IsNil)
-
-	path, err := confdb.ParsePathIntoAccessors("wifi.ssid", confdb.ParseOptions{})
-	c.Assert(err, IsNil)
-
-	err = tx.Set(path, "foo")
-	c.Assert(err, IsNil)
-
 	var called bool
 	restore = daemon.MockConfdbstateWriteConfdb(func(_ context.Context, _ *state.State, view *confdb.View, values map[string]any) (string, error) {
 		called = true

--- a/interfaces/builtin/confdb.go
+++ b/interfaces/builtin/confdb.go
@@ -76,6 +76,10 @@ func (iface *confdbInterface) BeforePreparePlug(plug *snap.PlugInfo) error {
 		return fmt.Errorf(`optional confdb plug "role" attribute must be "custodian"`)
 	}
 
+	if role == "custodian" && account == "system" {
+		return fmt.Errorf(`snaps cannot be custodians of "system" confdb schemas`)
+	}
+
 	return nil
 }
 

--- a/overlord/assertstate/assertstate.go
+++ b/overlord/assertstate/assertstate.go
@@ -33,6 +33,7 @@ import (
 	"github.com/snapcore/snapd/confdb"
 	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/overlord/confdbstate"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
@@ -402,6 +403,11 @@ func delayedCrossMgrInit() {
 	snapstate.EnforceLocalValidationSets = ApplyLocalEnforcedValidationSets
 	// hook helper for getting validated integrity data
 	snapstate.ValidatedIntegrityData = ValidatedIntegrityData
+	// wire confdbstate helpers that look up confdb-schema assertions
+	confdbstate.AssertstateFetchConfdbSchemaAssertion = FetchConfdbSchemaAssertion
+	confdbstate.AssertstateConfdbSchema = ConfdbSchema
+	// register the system custodian for the "validation-sets" confdb-schema
+	confdbstate.RegisterConfdbHandler(&valsetsConfdbHandler{})
 }
 
 // AutoRefreshAssertions tries to refresh all assertions

--- a/overlord/assertstate/confdb_handler.go
+++ b/overlord/assertstate/confdb_handler.go
@@ -48,22 +48,22 @@ func (c *valsetsConfdbHandler) SchemaName() string {
 	return "validation-sets"
 }
 
-func (c *valsetsConfdbHandler) Commit(st *state.State, tx *confdbstate.Transaction) error {
+func (c *valsetsConfdbHandler) Commit(st *state.State, tx *confdbstate.Transaction) ([]*state.TaskSet, error) {
 	view, err := confdbstate.GetView(st, "system", "validation-sets", "admin")
 	if err != nil {
-		return fmt.Errorf("internal error: unexpected confdb-schema in validation-sets handler: %v", err)
+		return nil, fmt.Errorf("internal error: unexpected confdb-schema in validation-sets handler: %v", err)
 	}
 
 	type vsKey struct{ account, name string }
 	valsets := make(map[vsKey][][]confdb.Accessor)
 	for _, path := range tx.AlteredPaths() {
 		if len(path) < 3 {
-			return fmt.Errorf("internal error: unexpected storage path: %v", confdb.JoinAccessors(path))
+			return nil, fmt.Errorf("internal error: unexpected storage path: %v", confdb.JoinAccessors(path))
 		}
 
 		// if we ever change the storage schema, we need to adjust this code so fail hard here
 		if path[0].Name() != "v1" {
-			return fmt.Errorf("internal error: cannot write to system/validation-sets: unsupported storage version %q", path[0].Name())
+			return nil, fmt.Errorf("internal error: cannot write to system/validation-sets: unsupported storage version %q", path[0].Name())
 		}
 
 		k := vsKey{account: path[1].Name(), name: path[2].Name()}
@@ -76,38 +76,38 @@ func (c *valsetsConfdbHandler) Commit(st *state.State, tx *confdbstate.Transacti
 		if err != nil {
 			if errors.Is(err, &confdb.NoDataError{}) {
 				if err := ForgetValidationSet(st, k.account, k.name, ForgetValidationSetOpts{}); err != nil {
-					return fmt.Errorf("cannot forget validation set %s/%s: %v", k.account, k.name, err)
+					return nil, fmt.Errorf("cannot forget validation set %s/%s: %v", k.account, k.name, err)
 				}
 				continue
 			}
-			return fmt.Errorf("cannot read validation set %s/%s from confdb: %v", k.account, k.name, err)
+			return nil, fmt.Errorf("cannot read validation set %s/%s from confdb: %v", k.account, k.name, err)
 		}
 
 		// TODO: GetViaView returns value wrapped in map keyed by request. Maybe
 		// just use the confdb method directly? We don't really need this here
 		resultMap, ok := result.(map[string]any)
 		if !ok {
-			return fmt.Errorf("internal error: unexpected result type %T for validation set %s/%s", result, k.account, k.name)
+			return nil, fmt.Errorf("internal error: unexpected result type %T for validation set %s/%s", result, k.account, k.name)
 		}
 		val := resultMap[request]
 
 		tr := &ValidationSetTracking{}
 		err = GetValidationSet(st, k.account, k.name, tr)
 		if err != nil && !errors.Is(err, state.ErrNoState) {
-			return err
+			return nil, err
 		}
 		tr.AccountID = k.account
 		tr.Name = k.name
 
 		err = updateValSetTracking(k.account, k.name, tr, val)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		UpdateValidationSet(st, tr)
 	}
 
-	return nil
+	return nil, nil
 }
 
 // updateValSetTracking uses the values set through confdb to update the

--- a/overlord/assertstate/confdb_handler.go
+++ b/overlord/assertstate/confdb_handler.go
@@ -1,0 +1,268 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package assertstate
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/confdb"
+	"github.com/snapcore/snapd/overlord/confdbstate"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/release"
+)
+
+// valsetsConfdbHandler implements confdbstate.SystemConfdbCustodian
+// for the "validation-sets" system confdb-schema. On commit it translates the
+// altered storage paths back into (accountID, setName) pairs, reads the data
+// from the committed transaction via the admin view, and updates (or forgets)
+// the corresponding ValidationSetTracking in the snapd state.
+type valsetsConfdbHandler struct{}
+
+// NewValsetsConfdbHandler returns the system confdb handler for validation-sets.
+func NewValsetsConfdbHandler() confdbstate.SystemConfdbHandler {
+	return &valsetsConfdbHandler{}
+}
+
+func (c *valsetsConfdbHandler) SchemaName() string {
+	return "validation-sets"
+}
+
+func (c *valsetsConfdbHandler) Commit(st *state.State, tx *confdbstate.Transaction) error {
+	view, err := confdbstate.GetView(st, "system", "validation-sets", "admin")
+	if err != nil {
+		return fmt.Errorf("internal error: unexpected confdb-schema in validation-sets handler: %v", err)
+	}
+
+	type vsKey struct{ account, name string }
+	valsets := make(map[vsKey][][]confdb.Accessor)
+	for _, path := range tx.AlteredPaths() {
+		if len(path) < 3 {
+			return fmt.Errorf("internal error: unexpected storage path: %v", confdb.JoinAccessors(path))
+		}
+
+		// if we ever change the storage schema, we need to adjust this code so fail hard here
+		if path[0].Name() != "v1" {
+			return fmt.Errorf("internal error: cannot write to system/validation-sets: unsupported storage version %q", path[0].Name())
+		}
+
+		k := vsKey{account: path[1].Name(), name: path[2].Name()}
+		valsets[k] = append(valsets[k], path)
+	}
+
+	for k := range valsets {
+		request := k.account + "." + k.name
+		result, err := confdbstate.GetViaView(tx, view, []string{request}, nil, confdb.AdminAccess)
+		if err != nil {
+			if errors.Is(err, &confdb.NoDataError{}) {
+				if err := ForgetValidationSet(st, k.account, k.name, ForgetValidationSetOpts{}); err != nil {
+					return fmt.Errorf("cannot forget validation set %s/%s: %v", k.account, k.name, err)
+				}
+				continue
+			}
+			return fmt.Errorf("cannot read validation set %s/%s from confdb: %v", k.account, k.name, err)
+		}
+
+		// TODO: GetViaView returns value wrapped in map keyed by request. Maybe
+		// just use the confdb method directly? We don't really need this here
+		resultMap, ok := result.(map[string]any)
+		if !ok {
+			return fmt.Errorf("internal error: unexpected result type %T for validation set %s/%s", result, k.account, k.name)
+		}
+		val := resultMap[request]
+
+		tr := &ValidationSetTracking{}
+		err = GetValidationSet(st, k.account, k.name, tr)
+		if err != nil && !errors.Is(err, state.ErrNoState) {
+			return err
+		}
+		tr.AccountID = k.account
+		tr.Name = k.name
+
+		err = updateValSetTracking(k.account, k.name, tr, val)
+		if err != nil {
+			return err
+		}
+
+		UpdateValidationSet(st, tr)
+	}
+
+	return nil
+}
+
+// updateValSetTracking uses the values set through confdb to update the
+// ValidationSetTracking.
+func updateValSetTracking(accountID, name string, tr *ValidationSetTracking, val any) error {
+	valset, ok := val.(map[string]any)
+	if !ok {
+		return fmt.Errorf("internal error: unexpected type %T for validation set %s/%s", val, accountID, name)
+	}
+
+	if rawMode, ok := valset["mode"]; ok {
+		mode, ok := rawMode.(string)
+		if !ok {
+			return fmt.Errorf(`validation set %s/%s "mode" should be a string: %v`, accountID, name, rawMode)
+		}
+
+		// per the storage schema these are the only choices and it can't be unset
+		switch mode {
+		case "monitor":
+			tr.Mode = Monitor
+		case "enforce":
+			tr.Mode = Enforce
+		}
+	}
+
+	if rawSeq, ok := valset["pinned-sequence"]; ok {
+		v, ok := rawSeq.(float64)
+		if !ok {
+			return fmt.Errorf(`validation set %s/%s "pinned-sequence" should be an int: %v`, accountID, name, rawSeq)
+		}
+
+		tr.PinnedAt = int(v)
+	} else {
+		tr.PinnedAt = 0
+	}
+
+	return nil
+}
+
+// Databag reads all validation set tracking from the state and returns a
+// confdb.JSONDatabag with data in the nested storage structure expected by the
+// system/validation-sets confdb-schema (v1.<account>.<set-name>).
+func (c *valsetsConfdbHandler) Databag(st *state.State) (confdb.JSONDatabag, error) {
+	sets, err := ValidationSets(st)
+	if err != nil {
+		return nil, err
+	}
+
+	bag := confdb.NewJSONDatabag()
+	if len(sets) == 0 {
+		return bag, nil
+	}
+
+	db := DB(st)
+	accounts := make(map[string]json.RawMessage)
+	for _, tr := range sets {
+		entry := map[string]any{
+			"sequence": tr.Current,
+		}
+		switch tr.Mode {
+		case Monitor:
+			entry["mode"] = "monitor"
+		case Enforce:
+			entry["mode"] = "enforce"
+		}
+
+		if tr.PinnedAt != 0 {
+			entry["pinned-sequence"] = tr.PinnedAt
+		}
+
+		// fetch the validation-set assertion to get snap constraints (for reading
+		// purposes only)
+		a, err := db.Find(asserts.ValidationSetType, map[string]string{
+			"series":     release.Series,
+			"account-id": tr.AccountID,
+			"name":       tr.Name,
+			"sequence":   strconv.Itoa(tr.Current),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("cannot find validation-set %s/%s: %v", tr.AccountID, tr.Name, err)
+		}
+
+		vs := a.(*asserts.ValidationSet)
+		entry["revision"] = vs.Revision()
+		snaps := buildSnapsEntry(vs.Snaps())
+		if len(snaps) > 0 {
+			entry["snaps"] = snaps
+		}
+		// TODO: add test coverage for this
+
+		entryJSON, err := json.Marshal(entry)
+		if err != nil {
+			return nil, fmt.Errorf("internal error: cannot marshal validation set %s/%s: %v", tr.AccountID, tr.Name, err)
+		}
+
+		// get or create the account-level map
+		var accountMap map[string]json.RawMessage
+		if raw, ok := accounts[tr.AccountID]; ok {
+			if err := json.Unmarshal(raw, &accountMap); err != nil {
+				return nil, fmt.Errorf("internal error: cannot unmarshal account map: %v", err)
+			}
+		} else {
+			accountMap = make(map[string]json.RawMessage)
+		}
+		accountMap[tr.Name] = json.RawMessage(entryJSON)
+
+		accountJSON, err := json.Marshal(accountMap)
+		if err != nil {
+			return nil, fmt.Errorf("internal error: cannot marshal account map: %v", err)
+		}
+		accounts[tr.AccountID] = json.RawMessage(accountJSON)
+	}
+
+	v1JSON, err := json.Marshal(accounts)
+	if err != nil {
+		return nil, fmt.Errorf("internal error: cannot marshal v1 map: %v", err)
+	}
+
+	bag["v1"] = json.RawMessage(v1JSON)
+	return bag, nil
+}
+
+// buildSnapsEntry converts validation-set snap constraints into the storage
+// format expected by the confdb schema: an array of maps with name, id,
+// presence, revision, and components.
+func buildSnapsEntry(snaps []*asserts.ValidationSetSnap) []map[string]any {
+	result := make([]map[string]any, 0, len(snaps))
+	for _, sn := range snaps {
+		snapEntry := map[string]any{
+			"name": sn.Name,
+			"id":   sn.SnapID,
+		}
+
+		if sn.Presence != "" {
+			snapEntry["presence"] = string(sn.Presence)
+		}
+		if sn.Revision > 0 {
+			snapEntry["revision"] = sn.Revision
+		}
+
+		if len(sn.Components) > 0 {
+			components := make(map[string]any, len(sn.Components))
+			for compName, comp := range sn.Components {
+				compEntry := make(map[string]any)
+				if comp.Presence != "" {
+					compEntry["presence"] = string(comp.Presence)
+				}
+				if comp.Revision > 0 {
+					compEntry["revision"] = comp.Revision
+				}
+				components[compName] = compEntry
+			}
+			snapEntry["components"] = components
+		}
+		result = append(result, snapEntry)
+	}
+	return result
+}

--- a/overlord/assertstate/confdb_handler_test.go
+++ b/overlord/assertstate/confdb_handler_test.go
@@ -161,7 +161,7 @@ func (s *confdbHandlerSuite) TestUpdateEntireValidationSet(c *C) {
 	c.Assert(err, IsNil)
 
 	handler := &assertstate.ValsetsConfdbHandler{}
-	err = handler.Commit(s.st, tx)
+	_, err = handler.Commit(s.st, tx)
 	c.Assert(err, IsNil)
 
 	var tr assertstate.ValidationSetTracking
@@ -191,7 +191,7 @@ func (s *confdbHandlerSuite) TestCommitUpdatesOnlyMode(c *C) {
 	c.Assert(err, IsNil)
 
 	handler := &assertstate.ValsetsConfdbHandler{}
-	err = handler.Commit(s.st, tx)
+	_, err = handler.Commit(s.st, tx)
 	c.Assert(err, IsNil)
 
 	var tr assertstate.ValidationSetTracking
@@ -221,7 +221,7 @@ func (s *confdbHandlerSuite) TestCommitUnsetsPinnedSequence(c *C) {
 	c.Assert(err, IsNil)
 
 	handler := &assertstate.ValsetsConfdbHandler{}
-	err = handler.Commit(s.st, tx)
+	_, err = handler.Commit(s.st, tx)
 	c.Assert(err, IsNil)
 
 	var tr assertstate.ValidationSetTracking
@@ -268,7 +268,7 @@ func (s *confdbHandlerSuite) TestCommitForgetsDeletedValidationSet(c *C) {
 	c.Assert(err, IsNil)
 
 	handler := &assertstate.ValsetsConfdbHandler{}
-	err = handler.Commit(s.st, tx)
+	_, err = handler.Commit(s.st, tx)
 	c.Assert(err, IsNil)
 
 	// check it was deleted from state
@@ -299,7 +299,7 @@ func (s *confdbHandlerSuite) TestCommitRejectsUnsupportedStorageVersion(c *C) {
 	c.Assert(err, IsNil)
 
 	handler := &assertstate.ValsetsConfdbHandler{}
-	err = handler.Commit(s.st, tx)
+	_, err = handler.Commit(s.st, tx)
 	c.Assert(err, ErrorMatches, `internal error: cannot write to system/validation-sets: unsupported storage version "v2"`)
 }
 
@@ -318,7 +318,7 @@ func (s *confdbHandlerSuite) TestCommitRejectsShortPath(c *C) {
 	c.Assert(err, IsNil)
 
 	handler := &assertstate.ValsetsConfdbHandler{}
-	err = handler.Commit(s.st, tx)
+	_, err = handler.Commit(s.st, tx)
 	c.Assert(err, ErrorMatches, `internal error: unexpected storage path: v1.my-account`)
 }
 
@@ -359,7 +359,7 @@ func (s *confdbHandlerSuite) TestCommitDifferentAccounts(c *C) {
 	c.Assert(err, IsNil)
 
 	handler := &assertstate.ValsetsConfdbHandler{}
-	err = handler.Commit(s.st, tx)
+	_, err = handler.Commit(s.st, tx)
 	c.Assert(err, IsNil)
 
 	var tr1 assertstate.ValidationSetTracking
@@ -411,7 +411,7 @@ func (s *confdbHandlerSuite) TestCommitMultipleSetsUnderSameAccount(c *C) {
 	c.Assert(err, IsNil)
 
 	handler := &assertstate.ValsetsConfdbHandler{}
-	err = handler.Commit(s.st, tx)
+	_, err = handler.Commit(s.st, tx)
 	c.Assert(err, IsNil)
 
 	for i, n := range []string{"first-set", "second-set", "third-set"} {

--- a/overlord/assertstate/confdb_handler_test.go
+++ b/overlord/assertstate/confdb_handler_test.go
@@ -1,0 +1,424 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package assertstate_test
+
+import (
+	"fmt"
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/assertstest"
+	"github.com/snapcore/snapd/confdb"
+	"github.com/snapcore/snapd/overlord/assertstate"
+	"github.com/snapcore/snapd/overlord/confdbstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type confdbHandlerSuite struct {
+	testutil.BaseTest
+	st           *state.State
+	storeSigning *assertstest.StoreStack
+	devSignings  map[string]*assertstest.SigningDB
+	view         *confdb.View
+	confdbSchema *asserts.ConfdbSchema
+}
+
+var _ = Suite(&confdbHandlerSuite{})
+
+func (s *confdbHandlerSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	s.st = state.New(nil)
+
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	s.storeSigning = assertstest.NewStoreStack("canonical", nil)
+	s.devSignings = make(map[string]*assertstest.SigningDB)
+
+	var builtinConfdb asserts.Assertion
+	for _, as := range asserts.Builtin() {
+		if as.Type() == asserts.ConfdbSchemaType && as.HeaderString("name") == "validation-sets" {
+			builtinConfdb = as
+			break
+		}
+	}
+	c.Assert(builtinConfdb, NotNil)
+	s.confdbSchema = builtinConfdb.(*asserts.ConfdbSchema)
+
+	db, err := asserts.OpenDatabase(&asserts.DatabaseConfig{
+		Backstore:       asserts.NewMemoryBackstore(),
+		Trusted:         s.storeSigning.Trusted,
+		OtherPredefined: []asserts.Assertion{builtinConfdb},
+	})
+	c.Assert(err, IsNil)
+	c.Assert(db.Add(s.storeSigning.StoreAccountKey("")), IsNil)
+
+	assertstate.ReplaceDB(s.st, db)
+	assertstate.DelayedCrossMgrInit()
+
+	// mock a model so ForgetValidationSet doesn't panic
+	a := assertstest.FakeAssertion(map[string]any{
+		"type":         "model",
+		"authority-id": "canonical",
+		"series":       "16",
+		"brand-id":     "canonical",
+		"model":        "pc",
+		"architecture": "amd64",
+		"gadget":       "pc",
+		"kernel":       "pc-kernel",
+	})
+	deviceCtx := &snapstatetest.TrivialDeviceContext{
+		DeviceModel: a.(*asserts.Model),
+	}
+	s.AddCleanup(snapstatetest.MockDeviceContext(deviceCtx))
+	s.st.Set("seeded", true)
+
+	// add a validation-set assertion for my-account/my-set with mock snap data
+	s.addValidationSetAssert(c, "my-account", "my-set", 1, []any{
+		map[string]any{
+			"id":       "mysnapididididididididididididid",
+			"name":     "my-snap",
+			"presence": "required",
+			"revision": "1",
+		},
+	})
+
+	s.view, err = confdbstate.GetView(s.st, "system", "validation-sets", "admin")
+	c.Assert(err, IsNil)
+}
+
+// addValidationSetAssert signs and adds a validation-set assertion to the DB.
+// Developer accounts and signing keys are created on first use per account.
+func (s *confdbHandlerSuite) addValidationSetAssert(c *C, accountID, name string, sequence int, snaps []any) {
+	if _, ok := s.devSignings[accountID]; !ok {
+		privKey, _ := assertstest.GenerateKey(752)
+		acct := assertstest.NewAccount(s.storeSigning, accountID, map[string]any{
+			"account-id": accountID,
+		}, "")
+		c.Assert(assertstate.Add(s.st, acct), IsNil)
+		acctKey := assertstest.NewAccountKey(s.storeSigning, acct, nil, privKey.PublicKey(), "")
+		c.Assert(assertstate.Add(s.st, acctKey), IsNil)
+		s.devSignings[accountID] = assertstest.NewSigningDB(accountID, privKey)
+	}
+
+	if snaps == nil {
+		snaps = []any{}
+	}
+
+	headers := map[string]any{
+		"series":       "16",
+		"account-id":   accountID,
+		"authority-id": accountID,
+		"publisher-id": accountID,
+		"name":         name,
+		"sequence":     fmt.Sprintf("%d", sequence),
+		"snaps":        snaps,
+		"timestamp":    time.Now().Format(time.RFC3339),
+		"revision":     "1",
+	}
+	a, err := s.devSignings[accountID].Sign(asserts.ValidationSetType, headers, nil, "")
+	c.Assert(err, IsNil)
+	c.Assert(assertstate.Add(s.st, a), IsNil)
+}
+
+func (s *confdbHandlerSuite) TestUpdateEntireValidationSet(c *C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	assertstate.UpdateValidationSet(s.st, &assertstate.ValidationSetTracking{
+		AccountID: "my-account",
+		Name:      "my-set",
+		Mode:      assertstate.Monitor,
+		Current:   1,
+	})
+
+	tx, err := confdbstate.NewTransaction(s.st, "system", "validation-sets")
+	c.Assert(err, IsNil)
+
+	// set the entire validation set map
+	err = s.view.Set(tx, "my-account.my-set", map[string]any{"mode": "enforce", "pinned-sequence": 5})
+	c.Assert(err, IsNil)
+
+	handler := &assertstate.ValsetsConfdbHandler{}
+	err = handler.Commit(s.st, tx)
+	c.Assert(err, IsNil)
+
+	var tr assertstate.ValidationSetTracking
+	err = assertstate.GetValidationSet(s.st, "my-account", "my-set", &tr)
+	c.Assert(err, IsNil)
+	c.Check(tr.Mode, Equals, assertstate.Enforce)
+	c.Check(tr.PinnedAt, Equals, 5)
+}
+
+func (s *confdbHandlerSuite) TestCommitUpdatesOnlyMode(c *C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	assertstate.UpdateValidationSet(s.st, &assertstate.ValidationSetTracking{
+		AccountID: "my-account",
+		Name:      "my-set",
+		Mode:      assertstate.Enforce,
+		PinnedAt:  3,
+		Current:   1,
+	})
+
+	tx, err := confdbstate.NewTransaction(s.st, "system", "validation-sets")
+	c.Assert(err, IsNil)
+
+	// set specific path
+	err = s.view.Set(tx, "my-account.my-set.mode", "monitor")
+	c.Assert(err, IsNil)
+
+	handler := &assertstate.ValsetsConfdbHandler{}
+	err = handler.Commit(s.st, tx)
+	c.Assert(err, IsNil)
+
+	var tr assertstate.ValidationSetTracking
+	err = assertstate.GetValidationSet(s.st, "my-account", "my-set", &tr)
+	c.Assert(err, IsNil)
+	c.Check(tr.Mode, Equals, assertstate.Monitor)
+	c.Check(tr.PinnedAt, Equals, 3)
+}
+
+func (s *confdbHandlerSuite) TestCommitUnsetsPinnedSequence(c *C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	assertstate.UpdateValidationSet(s.st, &assertstate.ValidationSetTracking{
+		AccountID: "my-account",
+		Name:      "my-set",
+		Mode:      assertstate.Enforce,
+		PinnedAt:  7,
+		Current:   1,
+	})
+
+	tx, err := confdbstate.NewTransaction(s.st, "system", "validation-sets")
+	c.Assert(err, IsNil)
+
+	// unset part of the data
+	err = s.view.Unset(tx, "my-account.my-set.pinned-sequence")
+	c.Assert(err, IsNil)
+
+	handler := &assertstate.ValsetsConfdbHandler{}
+	err = handler.Commit(s.st, tx)
+	c.Assert(err, IsNil)
+
+	var tr assertstate.ValidationSetTracking
+	err = assertstate.GetValidationSet(s.st, "my-account", "my-set", &tr)
+	c.Assert(err, IsNil)
+	c.Check(tr.Mode, Equals, assertstate.Enforce)
+	c.Check(tr.PinnedAt, Equals, 0)
+}
+
+func (s *confdbHandlerSuite) TestCannotUnsetMode(c *C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	tx, err := confdbstate.NewTransaction(s.st, "system", "validation-sets")
+	c.Assert(err, IsNil)
+
+	err = s.view.Set(tx, "my-account.my-set", map[string]any{
+		"mode":            "enforce",
+		"pinned-sequence": 5,
+	})
+	c.Assert(err, IsNil)
+
+	// unsetting mode fails because the storage schema marks it as required
+	err = s.view.Unset(tx, "my-account.my-set.mode")
+	c.Assert(err, ErrorMatches, `.*cannot find required combinations of keys`)
+}
+
+func (s *confdbHandlerSuite) TestCommitForgetsDeletedValidationSet(c *C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	assertstate.UpdateValidationSet(s.st, &assertstate.ValidationSetTracking{
+		AccountID: "my-account",
+		Name:      "my-set",
+		Mode:      assertstate.Monitor,
+		Current:   1,
+	})
+
+	tx, err := confdbstate.NewTransaction(s.st, "system", "validation-sets")
+	c.Assert(err, IsNil)
+
+	// unset through confdb
+	err = s.view.Unset(tx, "my-account.my-set")
+	c.Assert(err, IsNil)
+
+	handler := &assertstate.ValsetsConfdbHandler{}
+	err = handler.Commit(s.st, tx)
+	c.Assert(err, IsNil)
+
+	// check it was deleted from state
+	var tr assertstate.ValidationSetTracking
+	err = assertstate.GetValidationSet(s.st, "my-account", "my-set", &tr)
+	c.Assert(err, testutil.ErrorIs, state.ErrNoState)
+}
+
+func (s *confdbHandlerSuite) TestCommitRejectsUnsupportedStorageVersion(c *C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	// Seed existing validation set tracking
+	assertstate.UpdateValidationSet(s.st, &assertstate.ValidationSetTracking{
+		AccountID: "my-account",
+		Name:      "my-set",
+		Mode:      assertstate.Monitor,
+		Current:   1,
+	})
+
+	tx, err := confdbstate.NewTransaction(s.st, "system", "validation-sets")
+	c.Assert(err, IsNil)
+
+	// Inject a non-v1 path delta directly into the transaction
+	path, err := confdb.ParsePathIntoAccessors("v2.my-account.my-set.mode", confdb.ParseOptions{})
+	c.Assert(err, IsNil)
+	err = tx.Set(path, "enforce")
+	c.Assert(err, IsNil)
+
+	handler := &assertstate.ValsetsConfdbHandler{}
+	err = handler.Commit(s.st, tx)
+	c.Assert(err, ErrorMatches, `internal error: cannot write to system/validation-sets: unsupported storage version "v2"`)
+}
+
+// TODO: remove?
+func (s *confdbHandlerSuite) TestCommitRejectsShortPath(c *C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	tx, err := confdbstate.NewTransaction(s.st, "system", "validation-sets")
+	c.Assert(err, IsNil)
+
+	// Inject a path with fewer than 3 elements
+	path, err := confdb.ParsePathIntoAccessors("v1.my-account", confdb.ParseOptions{})
+	c.Assert(err, IsNil)
+	err = tx.Set(path, "something")
+	c.Assert(err, IsNil)
+
+	handler := &assertstate.ValsetsConfdbHandler{}
+	err = handler.Commit(s.st, tx)
+	c.Assert(err, ErrorMatches, `internal error: unexpected storage path: v1.my-account`)
+}
+
+func (s *confdbHandlerSuite) TestCommitDifferentAccounts(c *C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	// Seed two validation sets
+	s.addValidationSetAssert(c, "acct1", "set-a", 1, nil)
+	assertstate.UpdateValidationSet(s.st, &assertstate.ValidationSetTracking{
+		AccountID: "acct1",
+		Name:      "set-a",
+		Mode:      assertstate.Monitor,
+		Current:   1,
+	})
+	s.addValidationSetAssert(c, "acct2", "set-b", 1, nil)
+	assertstate.UpdateValidationSet(s.st, &assertstate.ValidationSetTracking{
+		AccountID: "acct2",
+		Name:      "set-b",
+		Mode:      assertstate.Enforce,
+		PinnedAt:  1,
+		Current:   1,
+	})
+
+	tx, err := confdbstate.NewTransaction(s.st, "system", "validation-sets")
+	c.Assert(err, IsNil)
+
+	// Modify both
+	err = s.view.Set(tx, "acct1.set-a", map[string]any{
+		"mode":            "enforce",
+		"pinned-sequence": 10,
+	})
+	c.Assert(err, IsNil)
+	err = s.view.Set(tx, "acct2.set-b", map[string]any{
+		"mode":            "monitor",
+		"pinned-sequence": 1,
+	})
+	c.Assert(err, IsNil)
+
+	handler := &assertstate.ValsetsConfdbHandler{}
+	err = handler.Commit(s.st, tx)
+	c.Assert(err, IsNil)
+
+	var tr1 assertstate.ValidationSetTracking
+	err = assertstate.GetValidationSet(s.st, "acct1", "set-a", &tr1)
+	c.Assert(err, IsNil)
+	c.Check(tr1.Mode, Equals, assertstate.Enforce)
+	c.Check(tr1.PinnedAt, Equals, 10)
+
+	var tr2 assertstate.ValidationSetTracking
+	err = assertstate.GetValidationSet(s.st, "acct2", "set-b", &tr2)
+	c.Assert(err, IsNil)
+	c.Check(tr2.Mode, Equals, assertstate.Monitor)
+	// PinnedAt is preserved since it's in the confdb
+	c.Check(tr2.PinnedAt, Equals, 1)
+}
+
+func (s *confdbHandlerSuite) TestCommitMultipleSetsUnderSameAccount(c *C) {
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	s.addValidationSetAssert(c, "my-account", "first-set", 1, nil)
+	assertstate.UpdateValidationSet(s.st, &assertstate.ValidationSetTracking{
+		AccountID: "my-account",
+		Name:      "first-set",
+		Mode:      assertstate.Enforce,
+		PinnedAt:  1,
+		Current:   1,
+	})
+	s.addValidationSetAssert(c, "my-account", "second-set", 1, nil)
+	assertstate.UpdateValidationSet(s.st, &assertstate.ValidationSetTracking{
+		AccountID: "my-account",
+		Name:      "second-set",
+		Mode:      assertstate.Monitor,
+		Current:   1,
+	})
+
+	tx, err := confdbstate.NewTransaction(s.st, "system", "validation-sets")
+	c.Assert(err, IsNil)
+
+	err = s.view.Set(tx, "my-account.second-set", map[string]any{
+		"mode":            "enforce",
+		"pinned-sequence": 2,
+	})
+	c.Assert(err, IsNil)
+	err = s.view.Set(tx, "my-account.third-set", map[string]any{
+		"mode":            "enforce",
+		"pinned-sequence": 3,
+	})
+	c.Assert(err, IsNil)
+
+	handler := &assertstate.ValsetsConfdbHandler{}
+	err = handler.Commit(s.st, tx)
+	c.Assert(err, IsNil)
+
+	for i, n := range []string{"first-set", "second-set", "third-set"} {
+		var tr assertstate.ValidationSetTracking
+		err = assertstate.GetValidationSet(s.st, "my-account", n, &tr)
+		c.Assert(err, IsNil)
+		c.Check(tr.Mode, Equals, assertstate.Enforce)
+		c.Check(tr.PinnedAt, Equals, i+1)
+	}
+}

--- a/overlord/assertstate/export_test.go
+++ b/overlord/assertstate/export_test.go
@@ -26,7 +26,10 @@ var (
 	ValidationSetAssertionForMonitor          = validationSetAssertionForMonitor
 	AddCurrentTrackingToValidationSetsHistory = addCurrentTrackingToValidationSetsHistory
 	ValidationSetsHistoryTop                  = validationSetsHistoryTop
+	DelayedCrossMgrInit                       = delayedCrossMgrInit
 )
+
+type ValsetsConfdbHandler = valsetsConfdbHandler
 
 func MockMaxGroups(n int) (restore func()) {
 	oldMaxGroups := maxGroups

--- a/overlord/confdbstate/confdbmgr.go
+++ b/overlord/confdbstate/confdbmgr.go
@@ -45,16 +45,29 @@ const (
 	schedulingCachePrefix = "scheduling-confdb-"
 )
 
-func setupConfdbHook(st *state.State, snapName, hookName string, ignoreError bool) *state.Task {
-	hookSup := &hookstate.HookSetup{
-		Snap:        snapName,
-		Hook:        hookName,
-		Optional:    true,
-		IgnoreError: ignoreError,
-	}
-	summary := fmt.Sprintf(i18n.G("Run hook %s of snap %q"), hookName, snapName)
-	task := hookstate.HookTask(st, summary, hookSup, nil)
-	return task
+// SystemConfdbHandler is implemented by specific handlers that process confdb
+// request for "system" confdb-schema related to a particular subsystem
+// (e.g., validation-sets).
+type SystemConfdbHandler interface {
+	// SchemaName returns the name of the confdb-schema this handler
+	// manages (e.g. "validation-sets").
+	SchemaName() string
+
+	// Commit takes a transaction holding the modified confdb data and makes those
+	// changes effective within the subsystem.
+	Commit(st *state.State, tx *Transaction) error
+
+	// Databag returns a JSONDatabag holding a confdb-acceptable representation
+	// of the data this handler is responsible for.
+	Databag(st *state.State) (confdb.JSONDatabag, error)
+}
+
+// systemHandlers holds handlers for "system" confdb-schemas.
+var systemHandlers = map[string]SystemConfdbHandler{}
+
+// RegisterConfdbHandler registers a handler for a "system" confdb-schema.
+func RegisterConfdbHandler(c SystemConfdbHandler) {
+	systemHandlers[c.SchemaName()] = c
 }
 
 type ConfdbManager struct{}
@@ -104,11 +117,21 @@ func (m *ConfdbManager) doCommitTransaction(t *state.Task, _ *tomb.Tomb) (err er
 		return err
 	}
 
-	confdbAssert, err := assertstateConfdbSchema(st, tx.ConfdbAccount, tx.ConfdbName)
+	confdbAssert, err := AssertstateConfdbSchema(st, tx.ConfdbAccount, tx.ConfdbName)
 	if err != nil {
 		return err
 	}
 	schema := confdbAssert.Schema().DatabagSchema
+
+	// changes to "system" confdbs are made effective by subsystem handlers
+	if tx.ConfdbAccount == "system" {
+		handler, ok := systemHandlers[tx.ConfdbName]
+		if !ok {
+			// shouldn't happen; we check for this early
+			return fmt.Errorf("internal error: no system handler registered for confdb-schema %q", tx.ConfdbName)
+		}
+		return handler.Commit(st, tx)
+	}
 
 	hasSaveViewHook := false
 	for _, task := range t.Change().Tasks() {
@@ -139,7 +162,7 @@ func (m *ConfdbManager) doCommitTransaction(t *state.Task, _ *tomb.Tomb) (err er
 		}
 
 		view := confdbAssert.Schema().View(viewName)
-		paths := tx.alteredPaths()
+		paths := tx.AlteredPaths()
 		mightAffectEph, err := view.WriteAffectsEphemeral(paths)
 		if err != nil {
 			return fmt.Errorf("cannot commit transaction: cannot check for ephemeral paths: %v", err)
@@ -180,6 +203,8 @@ func (m *ConfdbManager) doLoadDataIntoChange(t *state.Task, _ *tomb.Tomb) error 
 	if err != nil {
 		return err
 	}
+
+	// TODO: also needs to handle reads of "system" confdb-schemas
 
 	var viewName string
 	err = t.Get("view-name", &viewName)
@@ -570,6 +595,18 @@ func (h *saveViewHandler) Error(origErr error) (ignoreErr bool, err error) {
 
 	// ignore error for now so we run again to try to undo any committed data
 	return true, nil
+}
+
+func setupConfdbHook(st *state.State, snapName, hookName string, ignoreError bool) *state.Task {
+	hookSup := &hookstate.HookSetup{
+		Snap:        snapName,
+		Hook:        hookName,
+		Optional:    true,
+		IgnoreError: ignoreError,
+	}
+	summary := fmt.Sprintf(i18n.G("Run hook %s of snap %q"), hookName, snapName)
+	task := hookstate.HookTask(st, summary, hookSup, nil)
+	return task
 }
 
 func (h *saveViewHandler) Done() error {

--- a/overlord/confdbstate/confdbmgr.go
+++ b/overlord/confdbstate/confdbmgr.go
@@ -54,8 +54,10 @@ type SystemConfdbHandler interface {
 	SchemaName() string
 
 	// Commit takes a transaction holding the modified confdb data and makes those
-	// changes effective within the subsystem.
-	Commit(st *state.State, tx *Transaction) error
+	// changes effective within the subsystem. It may return task sets that need
+	// to be completed before the commit can be considered done. If no async work
+	// is needed, it returns nil task sets.
+	Commit(st *state.State, tx *Transaction) ([]*state.TaskSet, error)
 
 	// Databag returns a JSONDatabag holding a confdb-acceptable representation
 	// of the data this handler is responsible for.
@@ -130,7 +132,44 @@ func (m *ConfdbManager) doCommitTransaction(t *state.Task, _ *tomb.Tomb) (err er
 			// shouldn't happen; we check for this early
 			return fmt.Errorf("internal error: no system handler registered for confdb-schema %q", tx.ConfdbName)
 		}
-		return handler.Commit(st, tx)
+
+		var committed bool
+		if err := t.Get("scheduled-tasks", &committed); err != nil && !errors.Is(err, state.ErrNoState) {
+			return err
+		}
+
+		if committed {
+			// we've already scheduled commit tasks and, since this handler is running
+			// again, they've finished. There's nothing else to do
+			return nil
+		}
+
+		taskSets, err := handler.Commit(st, tx)
+		if err != nil {
+			return err
+		}
+
+		if len(taskSets) == 0 {
+			// synchronous commit, we're done
+			return nil
+		}
+
+		// this confdb handler needs to run tasks, so the commit task will wait for
+		// those and run when they're done
+		chg := t.Change()
+		for _, ts := range taskSets {
+			chg.AddAll(ts)
+			// NOTE: ideally we would just wait for the last one but can we be sure
+			// that the tasks in the taskset are a neat sequence of waiting tasks?
+			t.WaitAll(ts)
+		}
+		t.Set("scheduled-tasks", true)
+		t.SetStatus(state.DoStatus)
+
+		// ensure the new tasks are picked up by the task runner
+		st.EnsureBefore(0)
+
+		return &state.Retry{}
 	}
 
 	hasSaveViewHook := false

--- a/overlord/confdbstate/confdbstate.go
+++ b/overlord/confdbstate/confdbstate.go
@@ -31,7 +31,6 @@ import (
 	"github.com/snapcore/snapd/confdb"
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/logger"
-	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/ifacestate/ifacerepo"
 	"github.com/snapcore/snapd/overlord/state"
@@ -43,8 +42,9 @@ import (
 )
 
 var (
-	assertstateConfdbSchema               = assertstate.ConfdbSchema
-	assertstateFetchConfdbSchemaAssertion = assertstate.FetchConfdbSchemaAssertion
+	// assertstate implements SystemConfdbHandler so this avoids a circular import
+	AssertstateConfdbSchema               func(st *state.State, account, schemaName string) (*asserts.ConfdbSchema, error)
+	AssertstateFetchConfdbSchemaAssertion func(st *state.State, userID int, account, name string) error
 
 	setConfdbChangeKind = swfeats.RegisterChangeKind("set-confdb")
 	getConfdbChangeKind = swfeats.RegisterChangeKind("get-confdb")
@@ -100,7 +100,7 @@ func (e *NoViewError) Error() string {
 // name. Returns asserts.NotFoundError if no confdb-schema assertion can be
 // fetched and NoViewError if the known confdb-schema has no such view.
 func GetView(st *state.State, account, schemaName, viewName string) (*confdb.View, error) {
-	confdbSchemaAs, err := assertstateConfdbSchema(st, account, schemaName)
+	confdbSchemaAs, err := AssertstateConfdbSchema(st, account, schemaName)
 	if err != nil {
 		if !errors.Is(err, &asserts.NotFoundError{}) {
 			return nil, err
@@ -108,7 +108,7 @@ func GetView(st *state.State, account, schemaName, viewName string) (*confdb.Vie
 		logger.Noticef("confdb-schema %s/%s not found locally, fetching from store", account, schemaName)
 
 		userID := 0
-		fetchErr := assertstateFetchConfdbSchemaAssertion(st, userID, account, schemaName)
+		fetchErr := AssertstateFetchConfdbSchemaAssertion(st, userID, account, schemaName)
 		if fetchErr != nil {
 			if errors.Is(fetchErr, store.ErrStoreOffline) {
 				logger.Noticef(fetchErr.Error())
@@ -117,7 +117,7 @@ func GetView(st *state.State, account, schemaName, viewName string) (*confdb.Vie
 			return nil, fetchErr
 		}
 
-		confdbSchemaAs, err = assertstateConfdbSchema(st, account, schemaName)
+		confdbSchemaAs, err = AssertstateConfdbSchema(st, account, schemaName)
 		if err != nil {
 			return nil, err
 		}
@@ -174,7 +174,16 @@ func GetViaView(bag confdb.Databag, view *confdb.View, requests []string, constr
 	return results, nil
 }
 
-var readDatabag = func(st *state.State, account, dbSchemaName string) (confdb.JSONDatabag, error) {
+var readDatabag = func(st *state.State, account, schema string) (confdb.JSONDatabag, error) {
+	if account == "system" {
+		handler, ok := systemHandlers[schema]
+		if !ok {
+			return nil, fmt.Errorf("cannot read databag for system/%s: no internal handler", schema)
+		}
+
+		return handler.Databag(st)
+	}
+
 	var databags map[string]map[string]confdb.JSONDatabag
 	if err := st.Get("confdb-databags", &databags); err != nil {
 		if errors.Is(err, &state.NoStateError{}) {
@@ -183,14 +192,19 @@ var readDatabag = func(st *state.State, account, dbSchemaName string) (confdb.JS
 		return nil, err
 	}
 
-	if databags[account] == nil || databags[account][dbSchemaName] == nil {
+	if databags[account] == nil || databags[account][schema] == nil {
 		return confdb.NewJSONDatabag(), nil
 	}
 
-	return databags[account][dbSchemaName], nil
+	return databags[account][schema], nil
 }
 
 var writeDatabag = func(st *state.State, databag confdb.JSONDatabag, account, dbSchemaName string) error {
+	if account == "system" {
+		// should never happen but let's be defensive
+		return fmt.Errorf("internal error: \"system\" confdbs do not store databags")
+	}
+
 	var databags map[string]map[string]confdb.JSONDatabag
 	err := st.Get("confdb-databags", &databags)
 	if err != nil && !errors.Is(err, state.ErrNoState) {
@@ -464,16 +478,26 @@ func WriteConfdbFromSnap(hookCtx *hookstate.Context, view *confdb.View, values m
 }
 
 func createChangeConfdbTasks(st *state.State, tx *Transaction, view *confdb.View, callingSnap string) (ts *state.TaskSet, commitTask, clearTxTask *state.Task, err error) {
-	custodians, custodianPlugs, err := getCustodianPlugsForView(st, view)
-	if err != nil {
-		return nil, nil, nil, err
+	isSystem := view.Schema().Account == "system"
+
+	var custodians []string
+	var custodianPlugs map[string]*snap.PlugInfo
+	if !isSystem {
+		custodians, custodianPlugs, err = getCustodianPlugsForView(st, view)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
+		if len(custodianPlugs) == 0 {
+			return nil, nil, nil, fmt.Errorf("cannot write confdb view %s: no custodian snap connected", view.ID())
+		}
+	} else {
+		if _, ok := systemHandlers[tx.ConfdbName]; !ok {
+			return nil, nil, nil, fmt.Errorf("cannot write confdb system/%s: no internal handler", view.Schema().Name)
+		}
 	}
 
-	if len(custodianPlugs) == 0 {
-		return nil, nil, nil, fmt.Errorf("cannot write confdb view %s: no custodian snap connected", view.ID())
-	}
-
-	paths := tx.alteredPaths()
+	paths := tx.AlteredPaths()
 	mightAffectEph, err := view.WriteAffectsEphemeral(paths)
 	if err != nil {
 		return nil, nil, nil, err
@@ -510,7 +534,7 @@ func createChangeConfdbTasks(st *state.State, tx *Transaction, view *confdb.View
 			linkTask(chgViewTask)
 		}
 
-		if hookPrefix == "save-view-" && mightAffectEph && !saveViewHookPresent {
+		if hookPrefix == "save-view-" && mightAffectEph && !saveViewHookPresent && !isSystem {
 			return nil, nil, nil, fmt.Errorf("cannot write confdb view %s: write might change ephemeral data but no custodians has a save-view hook", view.ID())
 		}
 	}
@@ -935,13 +959,24 @@ func ReadConfdb(ctx context.Context, st *state.State, view *confdb.View, request
 // load-view or query-view hooks, nil is returned. If there are hooks to run,
 // a clear-confdb-tx task is also scheduled to remove the ongoing transaction at the end.
 func createLoadConfdbTasks(st *state.State, tx *Transaction, view *confdb.View, requests []string, constraints map[string]any) (*state.TaskSet, *state.Task, error) {
-	custodians, custodianPlugs, err := getCustodianPlugsForView(st, view)
-	if err != nil {
-		return nil, nil, err
-	}
+	isSystem := view.Schema().Account == "system"
 
-	if len(custodians) == 0 {
-		return nil, nil, fmt.Errorf("cannot read confdb view %s: no custodian snap connected", view.ID())
+	var custodians []string
+	var custodianPlugs map[string]*snap.PlugInfo
+	if !isSystem {
+		var err error
+		custodians, custodianPlugs, err = getCustodianPlugsForView(st, view)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if len(custodians) == 0 {
+			return nil, nil, fmt.Errorf("cannot read confdb view %s: no custodian snap connected", view.ID())
+		}
+	} else {
+		if _, ok := systemHandlers[tx.ConfdbName]; !ok {
+			return nil, nil, fmt.Errorf("cannot read confdb system/%s: no internal handler", view.Schema().Name)
+		}
 	}
 
 	ts := state.NewTaskSet()
@@ -978,7 +1013,7 @@ func createLoadConfdbTasks(st *state.State, tx *Transaction, view *confdb.View, 
 		}
 
 		// there must be least one load-view hook if we're accessing ephemeral data
-		if hookPrefix == "load-view-" && mightAffectEph && !loadViewHookPresent {
+		if hookPrefix == "load-view-" && mightAffectEph && !loadViewHookPresent && !isSystem {
 			return nil, nil, fmt.Errorf("cannot schedule tasks to read view %s: read might cover ephemeral data but no custodian has a load-view hook", view.ID())
 		}
 	}

--- a/overlord/confdbstate/confdbstate_test.go
+++ b/overlord/confdbstate/confdbstate_test.go
@@ -3462,3 +3462,152 @@ func (s *confdbTestSuite) setupSystemConfdbValidationSets(c *C) {
 		Current:   3,
 	})
 }
+
+type mockConfdbHandler struct {
+	c *C
+
+	commitFunc func(st *state.State, tx *confdbstate.Transaction) ([]*state.TaskSet, error)
+}
+
+func (h *mockConfdbHandler) SchemaName() string {
+	return "validation-sets"
+}
+
+func (h *mockConfdbHandler) Commit(st *state.State, tx *confdbstate.Transaction) ([]*state.TaskSet, error) {
+	if h.commitFunc != nil {
+		return h.commitFunc(st, tx)
+	}
+	return nil, nil
+}
+
+func (h *mockConfdbHandler) Databag(st *state.State) (confdb.JSONDatabag, error) {
+	bag := confdb.NewJSONDatabag()
+	bag.Set(parsePath(h.c, "v1.my-account.my-set.mode"), "enforce")
+	bag.Set(parsePath(h.c, "v1.my-account.my-set.sequence"), 3)
+	return bag, nil
+}
+
+func (s *confdbTestSuite) TestSystemConfdbAsyncCommit(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.setupSystemConfdbValidationSets(c)
+	ifacerepo.Replace(s.state, interfaces.NewRepository())
+
+	var asyncTaskRan bool
+	s.o.TaskRunner().AddHandler("mock-async-work", func(t *state.Task, _ *tomb.Tomb) error {
+		asyncTaskRan = true
+		return nil
+	}, nil)
+
+	handler := &mockConfdbHandler{
+		c: c,
+		commitFunc: func(st *state.State, tx *confdbstate.Transaction) ([]*state.TaskSet, error) {
+			asyncTask := st.NewTask("mock-async-work", "async work from commit handler")
+			return []*state.TaskSet{state.NewTaskSet(asyncTask)}, nil
+		},
+	}
+
+	// overwrite validation-sets handler so we can "use" the validation-sets
+	//confdb-schema and not have to mock another one
+	confdbstate.RegisterConfdbHandler(handler)
+
+	view, err := confdbstate.GetView(s.state, "system", "validation-sets", "admin")
+	c.Assert(err, IsNil)
+
+	chgID, err := confdbstate.WriteConfdb(nil, s.state, view, map[string]any{"my-account.my-set.pinned-sequence": 10})
+	c.Assert(err, IsNil)
+
+	s.state.Unlock()
+	err = s.o.Settle(5 * time.Second)
+	s.state.Lock()
+	c.Assert(err, IsNil)
+
+	chg := s.state.Change(chgID)
+	c.Assert(chg, NotNil)
+
+	// check commit scheduled the async tasks
+	c.Check(asyncTaskRan, Equals, true)
+	c.Check(chg.Status(), Equals, state.DoneStatus)
+}
+
+func (s *confdbTestSuite) TestSystemConfdbAsyncCommitTaskError(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.setupSystemConfdbValidationSets(c)
+	ifacerepo.Replace(s.state, interfaces.NewRepository())
+
+	s.o.TaskRunner().AddHandler("mock-async-fail", func(t *state.Task, _ *tomb.Tomb) error {
+		return fmt.Errorf("async task failed")
+	}, nil)
+
+	handler := &mockConfdbHandler{
+		c: c,
+		commitFunc: func(st *state.State, tx *confdbstate.Transaction) ([]*state.TaskSet, error) {
+			asyncTask := st.NewTask("mock-async-fail", "async work that fails")
+			return []*state.TaskSet{state.NewTaskSet(asyncTask)}, nil
+		},
+	}
+	confdbstate.RegisterConfdbHandler(handler)
+
+	view, err := confdbstate.GetView(s.state, "system", "validation-sets", "admin")
+	c.Assert(err, IsNil)
+
+	chgID, err := confdbstate.WriteConfdb(nil, s.state, view, map[string]any{"my-account.my-set.pinned-sequence": 10})
+	c.Assert(err, IsNil)
+
+	s.state.Unlock()
+	err = s.o.Settle(5 * time.Second)
+	s.state.Lock()
+	c.Assert(err, IsNil)
+
+	chg := s.state.Change(chgID)
+	c.Assert(chg, NotNil)
+
+	c.Check(chg.Status(), Equals, state.ErrorStatus)
+	var commitTask *state.Task
+	for _, t := range chg.Tasks() {
+		if t.Kind() == "commit-confdb-tx" {
+			commitTask = t
+			break
+		}
+	}
+	c.Assert(commitTask, NotNil)
+	c.Assert(commitTask.Status(), Equals, state.HoldStatus)
+}
+
+func (s *confdbTestSuite) TestSystemConfdbSyncCommit(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.setupSystemConfdbValidationSets(c)
+	ifacerepo.Replace(s.state, interfaces.NewRepository())
+
+	var commitCalled bool
+	handler := &mockConfdbHandler{
+		c: c,
+		commitFunc: func(*state.State, *confdbstate.Transaction) ([]*state.TaskSet, error) {
+			commitCalled = true
+			return nil, nil
+		},
+	}
+	confdbstate.RegisterConfdbHandler(handler)
+
+	view, err := confdbstate.GetView(s.state, "system", "validation-sets", "admin")
+	c.Assert(err, IsNil)
+
+	chgID, err := confdbstate.WriteConfdb(nil, s.state, view, map[string]any{"my-account.my-set.pinned-sequence": 10})
+	c.Assert(err, IsNil)
+
+	s.state.Unlock()
+	err = s.o.Settle(5 * time.Second)
+	s.state.Lock()
+	c.Assert(err, IsNil)
+
+	chg := s.state.Change(chgID)
+	c.Assert(chg, NotNil)
+
+	c.Check(commitCalled, Equals, true)
+	c.Check(chg.Status(), Equals, state.DoneStatus)
+}

--- a/overlord/confdbstate/confdbstate_test.go
+++ b/overlord/confdbstate/confdbstate_test.go
@@ -83,6 +83,11 @@ func (s *confdbTestSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 	s.o.AddManager(hookMgr)
 
+	// wire assertstate helpers into confdbstate (normally done by assertstate.Manager
+	// via delayedCrossMgrInit, but assertstate is not initialised in this suite)
+	confdbstate.AssertstateConfdbSchema = assertstate.ConfdbSchema
+	confdbstate.AssertstateFetchConfdbSchemaAssertion = assertstate.FetchConfdbSchemaAssertion
+
 	// to test the confdbManager
 	mgr := confdbstate.Manager(s.state, hookMgr, runner)
 	s.o.AddManager(mgr)
@@ -3224,4 +3229,236 @@ func (s *confdbTestSuite) TestAPIBlockingAccessTimedOutRacesWithUnblock(c *C) {
 	case <-time.After(testutil.HostScaledTimeout(2 * time.Second)):
 		c.Fatal("expected access to block but timed out")
 	}
+}
+
+func (s *confdbTestSuite) TestReadSystemConfdbValidationSets(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.setupSystemConfdbValidationSets(c)
+
+	view, err := confdbstate.GetView(s.state, "system", "validation-sets", "state")
+	c.Assert(err, IsNil)
+
+	chgID, err := confdbstate.ReadConfdb(context.Background(), s.state, view, []string{"my-account.my-set"}, nil, confdb.AdminAccess)
+	c.Assert(err, IsNil)
+
+	chg := s.state.Change(chgID)
+	c.Assert(chg, NotNil)
+	c.Assert(chg.Status(), Equals, state.DoneStatus)
+	c.Assert(chg.Tasks(), HasLen, 0)
+
+	var apiData map[string]any
+	err = chg.Get("api-data", &apiData)
+	c.Assert(err, IsNil)
+
+	vals, ok := apiData["values"]
+	c.Assert(ok, Equals, true)
+	c.Assert(vals, DeepEquals, map[string]any{
+		"my-account.my-set": map[string]any{
+			"mode":            "enforce",
+			"pinned-sequence": float64(5),
+			"sequence":        float64(3),
+			"revision":        float64(1),
+			"snaps": []any{
+				map[string]any{
+					"name":     "my-snap",
+					"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzx",
+					"presence": "required",
+				},
+				map[string]any{
+					"name":     "other-snap",
+					"id":       "zOqKhntON3vR7kwEbVPsILm7bUViPDzy",
+					"presence": "optional",
+					"revision": float64(7),
+				},
+			},
+		},
+	})
+}
+
+func (s *confdbTestSuite) TestWriteSystemConfdbValidationSetsWithObserveViewHook(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.setupSystemConfdbValidationSets(c)
+
+	// set up a snap connected to system/validation-sets/state with an observe-view hook
+	repo := interfaces.NewRepository()
+	ifacerepo.Replace(s.state, repo)
+
+	confdbIface := &ifacetest.TestInterface{InterfaceName: "confdb"}
+	err := repo.AddInterface(confdbIface)
+	c.Assert(err, IsNil)
+
+	const coreYaml = `name: core
+version: 1
+type: os
+slots:
+  confdb-slot:
+    interface: confdb
+`
+	coreInfo := mockInstalledSnap(c, s.state, coreYaml, nil)
+	coreSet, err := interfaces.NewSnapAppSet(coreInfo, nil)
+	c.Assert(err, IsNil)
+	err = repo.AddAppSet(coreSet)
+	c.Assert(err, IsNil)
+
+	const observerYaml = `name: observer-snap
+version: 1
+type: app
+plugs:
+  state:
+    interface: confdb
+    account: system
+    view: validation-sets/state
+`
+	hooks := []string{"observe-view-state"}
+	observerInfo := mockInstalledSnap(c, s.state, observerYaml, hooks)
+	observerInfo.Hooks["observe-view-state"] = &snap.HookInfo{
+		Name: "observe-view-state",
+		Snap: observerInfo,
+	}
+
+	observerSet, err := interfaces.NewSnapAppSet(observerInfo, nil)
+	c.Assert(err, IsNil)
+	err = repo.AddAppSet(observerSet)
+	c.Assert(err, IsNil)
+
+	_, err = repo.Connect(&interfaces.ConnRef{
+		PlugRef: interfaces.PlugRef{Snap: "observer-snap", Name: "state"},
+		SlotRef: interfaces.SlotRef{Snap: "core", Name: "confdb-slot"},
+	}, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+
+	view, err := confdbstate.GetView(s.state, "system", "validation-sets", "admin")
+	c.Assert(err, IsNil)
+
+	// make sure the hook observes the right thing
+	var observeViewCalled bool
+	restore := hookstate.MockRunHook(func(ctx *hookstate.Context, _ *tomb.Tomb) ([]byte, error) {
+		if ctx.HookName() != "observe-view-state" {
+			return nil, nil
+		}
+
+		ctx.State().Lock()
+		defer ctx.State().Unlock()
+
+		req := []string{"my-account.my-set"}
+		tx, err := confdbstate.ReadConfdbFromSnap(ctx, view, req, nil, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		res, err := confdbstate.GetViaView(tx, view, req, nil, confdb.AdminAccess)
+		if err != nil {
+			return nil, err
+		}
+		c.Check(res, DeepEquals, map[string]any{
+			"my-account.my-set": map[string]any{
+				"mode":            "enforce",
+				"pinned-sequence": float64(10),
+				"sequence":        float64(3),
+				"revision":        float64(1),
+				"snaps": []any{
+					map[string]any{
+						"name":     "my-snap",
+						"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzx",
+						"presence": "required",
+					},
+					map[string]any{
+						"name":     "other-snap",
+						"id":       "zOqKhntON3vR7kwEbVPsILm7bUViPDzy",
+						"presence": "optional",
+						"revision": float64(7),
+					},
+				},
+			},
+		})
+
+		observeViewCalled = true
+		return nil, nil
+	})
+	defer restore()
+
+	chgID, err := confdbstate.WriteConfdb(nil, s.state, view, map[string]any{"my-account.my-set.pinned-sequence": 10})
+	c.Assert(err, IsNil)
+
+	s.state.Unlock()
+	err = s.o.Settle(5 * time.Second)
+	s.state.Lock()
+	c.Assert(err, IsNil)
+
+	chg := s.state.Change(chgID)
+	c.Assert(chg.Status(), Equals, state.DoneStatus)
+
+	// change propagated to val set state
+	var tr assertstate.ValidationSetTracking
+	err = assertstate.GetValidationSet(s.state, "my-account", "my-set", &tr)
+	c.Assert(err, IsNil)
+	c.Check(tr.PinnedAt, Equals, 10)
+	c.Check(tr.Mode, Equals, assertstate.Enforce)
+
+	// make sure the hook was called and its assertions ran
+	c.Assert(observeViewCalled, Equals, true)
+}
+
+// setup an assertion DB with the builtin system/validation-sets confdb-schema
+// and a my-account/my-set validation set. Also sets up the val sets confdb
+// handler and seeds some initial data.
+func (s *confdbTestSuite) setupSystemConfdbValidationSets(c *C) {
+	storeSigning := assertstest.NewStoreStack("canonical", nil)
+	db, err := asserts.OpenDatabase(&asserts.DatabaseConfig{
+		Backstore:       asserts.NewMemoryBackstore(),
+		Trusted:         storeSigning.Trusted,
+		OtherPredefined: asserts.Builtin(),
+	})
+	c.Assert(err, IsNil)
+	c.Assert(db.Add(storeSigning.StoreAccountKey("")), IsNil)
+
+	devAcc := assertstest.NewAccount(storeSigning, "my-account-user", map[string]any{
+		"account-id": "my-account",
+	}, "")
+	c.Assert(db.Add(devAcc), IsNil)
+
+	devPrivKey, _ := assertstest.GenerateKey(752)
+	devAccKey := assertstest.NewAccountKey(storeSigning, devAcc, nil, devPrivKey.PublicKey(), "")
+	c.Assert(db.Add(devAccKey), IsNil)
+
+	devSigning := assertstest.NewSigningDB("my-account", devPrivKey)
+	vs, err := devSigning.Sign(asserts.ValidationSetType, map[string]any{
+		"series":       "16",
+		"account-id":   "my-account",
+		"authority-id": "my-account",
+		"name":         "my-set",
+		"sequence":     "3",
+		"revision":     "1",
+		"timestamp":    "2030-11-06T09:16:26Z",
+		"snaps": []any{
+			map[string]any{
+				"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzx",
+				"name":     "my-snap",
+				"presence": "required",
+			},
+			map[string]any{
+				"id":       "zOqKhntON3vR7kwEbVPsILm7bUViPDzy",
+				"name":     "other-snap",
+				"presence": "optional",
+				"revision": "7",
+			},
+		},
+	}, nil, "")
+	c.Assert(err, IsNil)
+	c.Assert(db.Add(vs), IsNil)
+	assertstate.ReplaceDB(s.state, db)
+
+	confdbstate.RegisterConfdbHandler(assertstate.NewValsetsConfdbHandler())
+
+	assertstate.UpdateValidationSet(s.state, &assertstate.ValidationSetTracking{
+		AccountID: "my-account",
+		Name:      "my-set",
+		Mode:      assertstate.Enforce,
+		PinnedAt:  5,
+		Current:   3,
+	})
 }

--- a/overlord/confdbstate/export_test.go
+++ b/overlord/confdbstate/export_test.go
@@ -92,5 +92,5 @@ func GetOngoingTxs(st *state.State, account, schemaName string) (ongoingTxs *con
 }
 
 func MockFetchConfdbSchemaAssertion(f func(*state.State, int, string, string) error) func() {
-	return testutil.Mock(&assertstateFetchConfdbSchemaAssertion, f)
+	return testutil.Mock(&AssertstateFetchConfdbSchemaAssertion, f)
 }

--- a/overlord/confdbstate/transaction.go
+++ b/overlord/confdbstate/transaction.go
@@ -250,7 +250,7 @@ func (t *Transaction) Clear(st *state.State) error {
 	return nil
 }
 
-func (t *Transaction) alteredPaths() [][]confdb.Accessor {
+func (t *Transaction) AlteredPaths() [][]confdb.Accessor {
 	// TODO: maybe we can extend this to recurse into delta's value and figure out
 	// the most specific key possible
 	paths := make([][]confdb.Accessor, 0, len(t.deltas))

--- a/overlord/hookstate/ctlcmd/get_test.go
+++ b/overlord/hookstate/ctlcmd/get_test.go
@@ -628,6 +628,8 @@ slots:
 	}
 
 	s.setConfdbFlag(true, c)
+
+	confdbstate.AssertstateConfdbSchema = assertstate.ConfdbSchema
 }
 
 func (s *confdbSuite) setConfdbFlag(val bool, c *C) {

--- a/overlord/hookstate/ctlcmd/set.go
+++ b/overlord/hookstate/ctlcmd/set.go
@@ -266,6 +266,10 @@ func setConfdbValues(ctx *hookstate.Context, plugName string, values map[string]
 	ctx.Lock()
 	defer ctx.Unlock()
 
+	if confdbstate.IsConfdbHookCtx(ctx) && !confdbstate.CanHookSetConfdb(ctx) {
+		return fmt.Errorf("cannot modify confdb in %q hook", ctx.HookName())
+	}
+
 	plug, err := checkConfdbPlugConnection(ctx, plugName)
 	if err != nil {
 		return err
@@ -279,10 +283,6 @@ func setConfdbValues(ctx *hookstate.Context, plugName string, values map[string]
 	view, err := confdbstateGetView(ctx.State(), account, dbSchemaName, viewName)
 	if err != nil {
 		return err
-	}
-
-	if confdbstate.IsConfdbHookCtx(ctx) && !confdbstate.CanHookSetConfdb(ctx) {
-		return fmt.Errorf("cannot modify confdb in %q hook", ctx.HookName())
 	}
 
 	return confdbstateWriteConfdb(ctx, view, values, opts)


### PR DESCRIPTION
Adds support for accessing validation-sets. This required less system-specific hacks than I thought it would which I suppose is a good sign. Most of the heavy lifting it done in `overlord/assertstate/confdb_handler.go`. Note that the interface assumes that the confdb->other-state translation can be done synchronously, which is true for validation sets and AFAICT should hold for most use cases.

~Based on https://github.com/canonical/snapd/pull/17255 which fixes a bug in reading lists that surfaced when adding these tests~