### PR TITLE
daemon: read and limit the body once, cache action for reuse (p1)

### DIFF
--- a/daemon/access.go
+++ b/daemon/access.go
@@ -437,7 +437,7 @@ func (ac byActionAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet
 		return BadRequest("unexpected content type: %q", contentType)
 	}
 
-	action, err := parseJSONActionBody(r)
+	action, err := parseRequestAction(r)
 	if err != nil {
 		// Content type is JSON, but it's invalid
 		return BadRequest(err.Error())

--- a/daemon/access.go
+++ b/daemon/access.go
@@ -20,11 +20,8 @@
 package daemon
 
 import (
-	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -410,10 +407,6 @@ func (ac interfaceRootAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucr
 	return checkAccess(d, r, ucred, user, opts)
 }
 
-type actionRequest struct {
-	Action string `json:"action"`
-}
-
 // byActionAccess is an access checker multiplexer. The correct
 // access checker is chosen based on the "action" field in the
 // incoming request.
@@ -428,8 +421,6 @@ type byActionAccess struct {
 	//   - interfaceProviderRootAccess
 	Default accessChecker
 }
-
-const maxBodySize = 4 * 1024 * 1024 // 4MB
 
 func (ac byActionAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
 	switch ac.Default.(type) {
@@ -446,33 +437,13 @@ func (ac byActionAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet
 		return BadRequest("unexpected content type: %q", contentType)
 	}
 
-	req := actionRequest{}
-
-	bufSize := r.ContentLength
-	// The value -1 indicates that the length is unknown.
-	if bufSize > maxBodySize || bufSize == -1 {
-		bufSize = maxBodySize
-	}
-	buf := bytes.NewBuffer(make([]byte, 0, bufSize))
-	tr := io.TeeReader(r.Body, buf)
-	lr := io.LimitedReader{R: tr, N: maxBodySize}
-	decoder := json.NewDecoder(&lr)
-	err := decoder.Decode(&req)
+	action, err := parseJSONActionBody(r)
 	if err != nil {
-		if (errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF)) && lr.N <= 0 {
-			return BadRequest("body size limit exceeded")
-		}
 		// Content type is JSON, but it's invalid
 		return BadRequest(err.Error())
 	}
-	if decoder.More() {
-		return BadRequest("unexpected data after request body")
-	}
 
-	r.Body.Close()
-	r.Body = io.NopCloser(buf)
-
-	checker := ac.ByAction[req.Action]
+	checker := ac.ByAction[action]
 	if checker == nil {
 		return ac.Default.CheckAccess(d, r, ucred, user)
 	}

--- a/daemon/access.go
+++ b/daemon/access.go
@@ -439,7 +439,7 @@ func (ac byActionAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet
 
 	action, err := requestActionFromContext(r.Context())
 	switch {
-	case errors.Is(err, errNoRequestAction):
+	case errors.Is(err, errRequestActionNotCached):
 		return InternalError(err.Error())
 	case err != nil:
 		return BadRequest(err.Error())

--- a/daemon/access.go
+++ b/daemon/access.go
@@ -437,9 +437,9 @@ func (ac byActionAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet
 		return BadRequest("unexpected content type: %q", contentType)
 	}
 
-	action, err := requestActionFromContext(r.Context())
+	action, err := actionResultFromContext(r.Context())
 	switch {
-	case errors.Is(err, errRequestActionNotCached):
+	case errors.Is(err, errActionResultNotCached):
 		return InternalError(err.Error())
 	case err != nil:
 		return BadRequest(err.Error())

--- a/daemon/access.go
+++ b/daemon/access.go
@@ -20,11 +20,8 @@
 package daemon
 
 import (
-	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -410,10 +407,6 @@ func (ac interfaceRootAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucr
 	return checkAccess(d, r, ucred, user, opts)
 }
 
-type actionRequest struct {
-	Action string `json:"action"`
-}
-
 // byActionAccess is an access checker multiplexer. The correct
 // access checker is chosen based on the "action" field in the
 // incoming request.
@@ -428,8 +421,6 @@ type byActionAccess struct {
 	//   - interfaceProviderRootAccess
 	Default accessChecker
 }
-
-const maxBodySize = 4 * 1024 * 1024 // 4MB
 
 func (ac byActionAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
 	switch ac.Default.(type) {
@@ -446,33 +437,15 @@ func (ac byActionAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet
 		return BadRequest("unexpected content type: %q", contentType)
 	}
 
-	req := actionRequest{}
-
-	bufSize := r.ContentLength
-	// The value -1 indicates that the length is unknown.
-	if bufSize > maxBodySize || bufSize == -1 {
-		bufSize = maxBodySize
-	}
-	buf := bytes.NewBuffer(make([]byte, 0, bufSize))
-	tr := io.TeeReader(r.Body, buf)
-	lr := io.LimitedReader{R: tr, N: maxBodySize}
-	decoder := json.NewDecoder(&lr)
-	err := decoder.Decode(&req)
-	if err != nil {
-		if (errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF)) && lr.N <= 0 {
-			return BadRequest("body size limit exceeded")
-		}
-		// Content type is JSON, but it's invalid
+	action, err := requestActionFromContext(r.Context())
+	switch {
+	case errors.Is(err, errNoRequestAction):
+		return InternalError(err.Error())
+	case err != nil:
 		return BadRequest(err.Error())
 	}
-	if decoder.More() {
-		return BadRequest("unexpected data after request body")
-	}
 
-	r.Body.Close()
-	r.Body = io.NopCloser(buf)
-
-	checker := ac.ByAction[req.Action]
+	checker := ac.ByAction[action]
 	if checker == nil {
 		return ac.Default.CheckAccess(d, r, ucred, user)
 	}

--- a/daemon/access_test.go
+++ b/daemon/access_test.go
@@ -20,10 +20,13 @@
 package daemon_test
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"testing/iotest"
 
 	. "gopkg.in/check.v1"
 
@@ -1045,6 +1048,10 @@ func (s *accessSuite) TestByActionAccessDefaultMustBeRoot(c *C) {
 
 }
 
+// TestByActionAccessLargeJSON pins down that byActionAccess still surfaces
+// the body-size-limit error at the access-checker boundary (parsing is
+// delegated to parseJSONActionBody, but the wire-level BadRequest response
+// is byActionAccess's contract).
 func (s *accessSuite) TestByActionAccessLargeJSON(c *C) {
 	body := strings.NewReader(fmt.Sprintf(`{"action": "%s"}`, strings.Repeat("a", 4*1024*1024)))
 	req, err := http.NewRequest("POST", "/v2/system-volumes", body)
@@ -1058,8 +1065,10 @@ func (s *accessSuite) TestByActionAccessLargeJSON(c *C) {
 	c.Assert(err, DeepEquals, daemon.BadRequest("body size limit exceeded"))
 }
 
-func (s *accessSuite) TestByActionAccessDataAfterJOSN(c *C) {
-	body := strings.NewReader(fmt.Sprintf(`{"action": "some-action"} data`))
+// TestByActionAccessDataAfterJSON pins down that byActionAccess still
+// surfaces the trailing-data error at the access-checker boundary.
+func (s *accessSuite) TestByActionAccessDataAfterJSON(c *C) {
+	body := strings.NewReader(`{"action": "some-action"} data`)
 	req, err := http.NewRequest("POST", "/v2/system-volumes", body)
 	c.Assert(err, IsNil)
 	req.Header.Add("Content-Type", "application/json")
@@ -1069,4 +1078,41 @@ func (s *accessSuite) TestByActionAccessDataAfterJOSN(c *C) {
 	ucred := daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapdSocket}
 	err = ac.CheckAccess(nil, req, &ucred, nil)
 	c.Assert(err, DeepEquals, daemon.BadRequest("unexpected data after request body"))
+}
+
+// TestByActionAccessEmptyBody pins down that an empty POST body with a
+// JSON content type is rejected with BadRequest("EOF"), matching
+// pre-refactor wire behavior.
+func (s *accessSuite) TestByActionAccessEmptyBody(c *C) {
+	req, err := http.NewRequest("POST", "/v2/system-volumes", strings.NewReader(""))
+	c.Assert(err, IsNil)
+	req.Header.Add("Content-Type", "application/json")
+
+	ac := daemon.ByActionAccess{Default: daemon.RootAccess{}}
+
+	ucred := daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapdSocket}
+	err = ac.CheckAccess(nil, req, &ucred, nil)
+	c.Assert(err, DeepEquals, daemon.BadRequest("EOF"))
+}
+
+// TestByActionAccessBodyReadError pins down that a non-EOF read error
+// from the request body surfaces as BadRequest carrying the underlying
+// error message.
+func (s *accessSuite) TestByActionAccessBodyReadError(c *C) {
+	simulatedErr := errors.New("simulated transient read error")
+	// Yield a partial JSON prefix, then error on subsequent reads —
+	// stdlib composition of a stream that broke partway through.
+	body := io.NopCloser(io.MultiReader(
+		strings.NewReader(`{"action":"install"`),
+		iotest.ErrReader(simulatedErr),
+	))
+	req, err := http.NewRequest("POST", "/v2/system-volumes", body)
+	c.Assert(err, IsNil)
+	req.Header.Add("Content-Type", "application/json")
+
+	ac := daemon.ByActionAccess{Default: daemon.RootAccess{}}
+
+	ucred := daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapdSocket}
+	err = ac.CheckAccess(nil, req, &ucred, nil)
+	c.Assert(err, DeepEquals, daemon.BadRequest(simulatedErr.Error()))
 }

--- a/daemon/access_test.go
+++ b/daemon/access_test.go
@@ -1050,7 +1050,7 @@ func (s *accessSuite) TestByActionAccessDefaultMustBeRoot(c *C) {
 
 // TestByActionAccessLargeJSON pins down that byActionAccess still surfaces
 // the body-size-limit error at the access-checker boundary (parsing is
-// delegated to parseJSONActionBody, but the wire-level BadRequest response
+// delegated to parseRequestAction, but the wire-level BadRequest response
 // is byActionAccess's contract).
 func (s *accessSuite) TestByActionAccessLargeJSON(c *C) {
 	body := strings.NewReader(fmt.Sprintf(`{"action": "%s"}`, strings.Repeat("a", 4*1024*1024)))

--- a/daemon/access_test.go
+++ b/daemon/access_test.go
@@ -887,7 +887,7 @@ func reqWithAction(c *C, action string, isJSON, malformed bool) *http.Request {
 // withCachedAction reads the body once and caches the action on the request
 // context, matching Command.ServeHTTP before CheckAccess.
 func withCachedAction(c *C, req *http.Request) *http.Request {
-	action, err := daemon.ReadRequestBody(req)
+	action, err := daemon.ExtractRequestAction(req)
 	// ServeHTTP answers 400 first, so an unusable body never reaches a checker.
 	c.Assert(daemon.IsBodyUnusable(err), Equals, false)
 	return req.WithContext(daemon.WithRequestAction(req.Context(), action, err))
@@ -1091,5 +1091,5 @@ func (s *accessSuite) TestByActionAccessMissingContext(c *C) {
 
 	ucred := daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapdSocket}
 	err = ac.CheckAccess(nil, req, &ucred, nil)
-	c.Assert(err, DeepEquals, daemon.InternalError("internal error: request action not in context"))
+	c.Assert(err, DeepEquals, daemon.InternalError("internal error: request action not cached"))
 }

--- a/daemon/access_test.go
+++ b/daemon/access_test.go
@@ -890,7 +890,7 @@ func withCachedAction(c *C, req *http.Request) *http.Request {
 	action, err := daemon.ExtractRequestAction(req)
 	// ServeHTTP answers 400 first, so an unusable body never reaches a checker.
 	c.Assert(daemon.IsBodyUnusable(err), Equals, false)
-	return req.WithContext(daemon.WithRequestAction(req.Context(), action, err))
+	return req.WithContext(daemon.WithActionResult(req.Context(), action, err))
 }
 
 func (s *accessSuite) TestByActionAccess(c *C) {

--- a/daemon/access_test.go
+++ b/daemon/access_test.go
@@ -1056,6 +1056,8 @@ func (s *accessSuite) TestByActionAccessDefaultMustBeRoot(c *C) {
 }
 
 func (s *accessSuite) TestByActionAccessDataAfterJSON(c *C) {
+	// Trailing data is refused by ServeHTTP; the checker still 400s if reached
+	// with a cached parse error, even though the action was decoded.
 	body := strings.NewReader(`{"action": "some-action"} data`)
 	req, err := http.NewRequest("POST", "/v2/system-volumes", body)
 	c.Assert(err, IsNil)

--- a/daemon/access_test.go
+++ b/daemon/access_test.go
@@ -881,7 +881,16 @@ func reqWithAction(c *C, action string, isJSON, malformed bool) *http.Request {
 	if isJSON {
 		req.Header.Add("Content-Type", "application/json")
 	}
-	return req
+	return withCachedAction(c, req)
+}
+
+// withCachedAction reads the body once and caches the action on the request
+// context, matching Command.ServeHTTP before CheckAccess.
+func withCachedAction(c *C, req *http.Request) *http.Request {
+	action, err := daemon.ReadRequestBody(req)
+	// ServeHTTP answers 400 first, so an unusable body never reaches a checker.
+	c.Assert(daemon.IsBodyUnusable(err), Equals, false)
+	return req.WithContext(daemon.WithRequestAction(req.Context(), action, err))
 }
 
 func (s *accessSuite) TestByActionAccess(c *C) {
@@ -1031,6 +1040,7 @@ func (s *accessSuite) TestByActionAccessDefaultMustBeRoot(c *C) {
 		req, err := http.NewRequest("POST", "/v2/system-volumes", body)
 		c.Assert(err, IsNil)
 		req.Header.Add("Content-Type", "application/json")
+		req = withCachedAction(c, req)
 
 		ac := daemon.ByActionAccess{Default: tc.ac}
 
@@ -1045,28 +1055,41 @@ func (s *accessSuite) TestByActionAccessDefaultMustBeRoot(c *C) {
 
 }
 
-func (s *accessSuite) TestByActionAccessLargeJSON(c *C) {
-	body := strings.NewReader(fmt.Sprintf(`{"action": "%s"}`, strings.Repeat("a", 4*1024*1024)))
+func (s *accessSuite) TestByActionAccessDataAfterJSON(c *C) {
+	body := strings.NewReader(`{"action": "some-action"} data`)
 	req, err := http.NewRequest("POST", "/v2/system-volumes", body)
 	c.Assert(err, IsNil)
 	req.Header.Add("Content-Type", "application/json")
-
-	ac := daemon.ByActionAccess{Default: daemon.RootAccess{}}
-
-	ucred := daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapdSocket}
-	err = ac.CheckAccess(nil, req, &ucred, nil)
-	c.Assert(err, DeepEquals, daemon.BadRequest("body size limit exceeded"))
-}
-
-func (s *accessSuite) TestByActionAccessDataAfterJOSN(c *C) {
-	body := strings.NewReader(fmt.Sprintf(`{"action": "some-action"} data`))
-	req, err := http.NewRequest("POST", "/v2/system-volumes", body)
-	c.Assert(err, IsNil)
-	req.Header.Add("Content-Type", "application/json")
+	req = withCachedAction(c, req)
 
 	ac := daemon.ByActionAccess{Default: daemon.RootAccess{}}
 
 	ucred := daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapdSocket}
 	err = ac.CheckAccess(nil, req, &ucred, nil)
 	c.Assert(err, DeepEquals, daemon.BadRequest("unexpected data after request body"))
+}
+
+func (s *accessSuite) TestByActionAccessEmptyBody(c *C) {
+	req, err := http.NewRequest("POST", "/v2/system-volumes", strings.NewReader(""))
+	c.Assert(err, IsNil)
+	req.Header.Add("Content-Type", "application/json")
+	req = withCachedAction(c, req)
+
+	ac := daemon.ByActionAccess{Default: daemon.RootAccess{}}
+
+	ucred := daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapdSocket}
+	err = ac.CheckAccess(nil, req, &ucred, nil)
+	c.Assert(err, DeepEquals, daemon.BadRequest("empty request body"))
+}
+
+func (s *accessSuite) TestByActionAccessMissingContext(c *C) {
+	req, err := http.NewRequest("POST", "/v2/system-volumes", strings.NewReader(`{"action":"some-action"}`))
+	c.Assert(err, IsNil)
+	req.Header.Add("Content-Type", "application/json")
+
+	ac := daemon.ByActionAccess{Default: daemon.RootAccess{}}
+
+	ucred := daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapdSocket}
+	err = ac.CheckAccess(nil, req, &ucred, nil)
+	c.Assert(err, DeepEquals, daemon.InternalError("internal error: request action not in context"))
 }

--- a/daemon/api_base_test.go
+++ b/daemon/api_base_test.go
@@ -800,6 +800,29 @@ const (
 	actionIsExpected   actionExpectedBool = true
 )
 
+// recordAction records req's action for TestMain coverage, using the same
+// selection and decoding as Command.ServeHTTP. The body is restored so the
+// request can still be served.
+func recordAction(c *check.C, cmd *daemon.Command, req *http.Request) {
+	if req.Body == nil || !daemon.RequestDecodesAction(req) {
+		return
+	}
+
+	body, err := io.ReadAll(req.Body)
+	c.Assert(err, check.IsNil)
+	req.Body = io.NopCloser(bytes.NewReader(body))
+
+	action, err := daemon.DecodeAction(body)
+	if err != nil || action == "" {
+		return
+	}
+
+	actionsMap.AddAction(cmd, action)
+	if !strutil.ListContains(cmd.Actions, action) {
+		c.Errorf("The action, %s, is not registered in the list of Actions of the corresponding command %s", action, cmd.Path)
+	}
+}
+
 func (s *apiBaseSuite) req(c *check.C, req *http.Request, u *auth.UserState, actionExpected actionExpectedBool) daemon.Response {
 	if s.d == nil {
 		panic("call s.daemon(c) etc in your test first")
@@ -821,21 +844,8 @@ func (s *apiBaseSuite) req(c *check.C, req *http.Request, u *auth.UserState, act
 		acc = cmd.WriteAccess
 		expAcc = s.expectedWriteAccess
 		whichAcc = "WriteAccess"
-		if actionExpected && req.Body != nil && (req.Header.Get("Content-Type") == "application/json" || req.Header.Get("Content-Type") == "") {
-			bodyBytes, err := io.ReadAll(req.Body)
-			c.Assert(err, check.IsNil)
-			var data struct {
-				Action string `json:"action"`
-			}
-			if err := json.Unmarshal(bodyBytes, &data); err == nil {
-				if data.Action != "" {
-					actionsMap.AddAction(cmd, data.Action)
-					if !strutil.ListContains(cmd.Actions, data.Action) {
-						c.Errorf("The action, %s, is not registered in the list of Actions of the corresponding command %s", data.Action, cmd.Path)
-					}
-				}
-			}
-			req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+		if actionExpected {
+			recordAction(c, cmd, req)
 		}
 	case "PUT":
 		f = cmd.PUT
@@ -884,22 +894,7 @@ func (s *apiBaseSuite) serveHTTP(c *check.C, w http.ResponseWriter, req *http.Re
 
 	cmd, vars := handlerCommand(c, s.d, req)
 	s.vars = vars
-	if req.Method == "POST" && req.Body != nil && (req.Header.Get("Content-Type") == "application/json" || req.Header.Get("Content-Type") == "") {
-		bodyBytes, err := io.ReadAll(req.Body)
-		c.Assert(err, check.IsNil)
-		var data struct {
-			Action string `json:"action"`
-		}
-		if err := json.Unmarshal(bodyBytes, &data); err == nil {
-			if data.Action != "" {
-				actionsMap.AddAction(cmd, data.Action)
-				if !strutil.ListContains(cmd.Actions, data.Action) {
-					c.Errorf("The action, %s, is not registered in the list of Actions of the corresponding command %s", data.Action, cmd.Path)
-				}
-			}
-		}
-		req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
-	}
+	recordAction(c, cmd, req)
 
 	cmd.ServeHTTP(w, req)
 }

--- a/daemon/api_base_test.go
+++ b/daemon/api_base_test.go
@@ -802,7 +802,8 @@ const (
 
 // recordAction records req's action for TestMain coverage, using the same
 // selection and decoding as Command.ServeHTTP. The body is restored so the
-// request can still be served.
+// request can still be served. Trailing data still yields an action and is
+// recorded; the Actions-list check applies only to a clean decode.
 func recordAction(c *check.C, cmd *daemon.Command, req *http.Request) {
 	if req.Body == nil || !daemon.RequestDecodesAction(req) {
 		return
@@ -813,11 +814,14 @@ func recordAction(c *check.C, cmd *daemon.Command, req *http.Request) {
 	req.Body = io.NopCloser(bytes.NewReader(body))
 
 	action, err := daemon.DecodeAction(body)
-	if err != nil || action == "" {
+	if action == "" {
 		return
 	}
 
 	actionsMap.AddAction(cmd, action)
+	if err != nil {
+		return
+	}
 	if !strutil.ListContains(cmd.Actions, action) {
 		c.Errorf("The action, %s, is not registered in the list of Actions of the corresponding command %s", action, cmd.Path)
 	}

--- a/daemon/api_cohort_test.go
+++ b/daemon/api_cohort_test.go
@@ -59,7 +59,7 @@ func (s *cohortSuite) TestCreateCohort(c *check.C) {
 		"bar": "cohort for bar",
 	}
 
-	req, err := http.NewRequest("POST", "/v2/cohorts", strings.NewReader(`{"action": "create", "snaps": ["foo","bar"]}]`))
+	req, err := http.NewRequest("POST", "/v2/cohorts", strings.NewReader(`{"action": "create", "snaps": ["foo","bar"]}`))
 	c.Assert(err, check.IsNil)
 
 	rsp := s.syncReq(c, req, nil, actionIsExpected)
@@ -68,7 +68,7 @@ func (s *cohortSuite) TestCreateCohort(c *check.C) {
 }
 
 func (s *cohortSuite) TestCreateCohortNoSnaps(c *check.C) {
-	req, err := http.NewRequest("POST", "/v2/cohorts", strings.NewReader(`{"action": "create"}]`))
+	req, err := http.NewRequest("POST", "/v2/cohorts", strings.NewReader(`{"action": "create"}`))
 	c.Assert(err, check.IsNil)
 
 	rsp := s.syncReq(c, req, nil, actionIsExpected)
@@ -77,10 +77,10 @@ func (s *cohortSuite) TestCreateCohortNoSnaps(c *check.C) {
 }
 
 func (s *cohortSuite) TestCreateCohortBadAction(c *check.C) {
-	req, err := http.NewRequest("POST", "/v2/cohorts", strings.NewReader(`{"action": "pupate", "snaps": ["foo","bar"]}]`))
+	req, err := http.NewRequest("POST", "/v2/cohorts", strings.NewReader(`{"action": "pupate", "snaps": ["foo","bar"]}`))
 	c.Assert(err, check.IsNil)
 
-	rspe := s.errorReq(c, req, nil, actionIsExpected)
+	rspe := s.errorReq(c, req, nil, actionIsUnexpected)
 	c.Check(rspe.Status, check.Equals, 400)
 	c.Check(rspe.Message, check.Equals, `unknown cohort action "pupate"`)
 }
@@ -88,7 +88,7 @@ func (s *cohortSuite) TestCreateCohortBadAction(c *check.C) {
 func (s *cohortSuite) TestCreateCohortError(c *check.C) {
 	s.err = errors.New("something went wrong")
 
-	req, err := http.NewRequest("POST", "/v2/cohorts", strings.NewReader(`{"action": "create", "snaps": ["foo","bar"]}]`))
+	req, err := http.NewRequest("POST", "/v2/cohorts", strings.NewReader(`{"action": "create", "snaps": ["foo","bar"]}`))
 	c.Assert(err, check.IsNil)
 
 	rspe := s.errorReq(c, req, nil, actionIsExpected)

--- a/daemon/api_system_recovery_keys_test.go
+++ b/daemon/api_system_recovery_keys_test.go
@@ -124,8 +124,7 @@ func (s *recoveryKeysSuite) TestPostSystemRecoveryKeysAsUserErrors(c *C) {
 	s.daemon(c)
 	mockSystemRecoveryKeys(c)
 
-	req, err := http.NewRequest("POST", "/v2/system-recovery-keys", nil)
-	c.Assert(err, IsNil)
+	req := httptest.NewRequest("POST", "/v2/system-recovery-keys", nil)
 
 	// being properly authorized as user is not enough, needs root
 	s.asUserAuth(c, req)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -164,7 +164,7 @@ func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	traceSnapdAPI(c, w, r)
+	traceSnapdAPI(c, r)
 
 	rsp := rspf(c, r, user)
 
@@ -186,30 +186,123 @@ func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	rsp.ServeHTTP(w, r)
 }
 
-func traceSnapdAPI(c *Command, w http.ResponseWriter, r *http.Request) {
-	if osutil.GetenvBool("SNAPD_TRACE") {
-		loggedWithAction := false
-		if r.Method == "POST" && (r.Header.Get("Content-Type") == "application/json" || r.Header.Get("Content-Type") == "") {
-			r.Body = http.MaxBytesReader(w, r.Body, 3*1024*1024) // 3 MB limit
-			bodyBytes, err := io.ReadAll(r.Body)
-			if err != nil {
-				logger.Trace("endpoint-error", "body-read", err)
-			}
-			var data struct {
-				Action string `json:"action"`
-			}
-			if err := json.Unmarshal(bodyBytes, &data); err == nil {
-				if data.Action != "" {
-					loggedWithAction = true
-					logger.Trace("endpoint", "method", r.Method, "path", c.Path, "action", data.Action)
-				}
-			}
-			r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+const maxBodySize = 4 * 1024 * 1024 // 4MiB
+
+type actionRequest struct {
+	Action string `json:"action"`
+}
+
+// jsonActionBody wraps a buffered request body with the result of a prior
+// parseJSONActionBody call. The stored parseErr is returned on later calls without
+// re-reading or re-decoding the body.
+type jsonActionBody struct {
+	io.ReadCloser
+	action   string
+	parseErr error
+}
+
+// chainedReadCloser presents several readers as one stream and closes orig.
+type chainedReadCloser struct {
+	io.Reader
+	orig io.Closer
+}
+
+func (c *chainedReadCloser) Close() error {
+	return c.orig.Close()
+}
+
+// parseJSONActionBody decodes the top-level "action" field from a POST
+// request's JSON body and replaces r.Body with a buffered copy so
+// downstream handlers can still consume the request body after the
+// action has been extracted. Safe to call more than once per request;
+// later calls return the cached action and error from jsonActionBody.
+//
+// The returned error reports why the action could not be extracted.
+//
+// Limitations:
+//   - PUT is not supported (no snapd API uses action on PUT today).
+//   - multipart/form-data is not supported.
+//   - Only requests with Content-Type application/json, or with no
+//     Content-Type (assumed to be JSON), are parsed; callers needing a
+//     strict application/json check must enforce that before calling.
+func parseJSONActionBody(r *http.Request) (string, error) {
+	if ab, ok := r.Body.(*jsonActionBody); ok {
+		return ab.action, ab.parseErr
+	}
+	ct := r.Header.Get("Content-Type")
+	if r.Method != "POST" || r.Body == nil || (ct != "" && ct != "application/json") {
+		return "", nil
+	}
+
+	orig := r.Body
+	prefix, readErr := io.ReadAll(io.LimitReader(orig, maxBodySize+1))
+
+	// chainAndCache wraps r.Body so downstream handlers still see the
+	// buffered prefix followed by whatever the original stream yields
+	// next.
+	chainAndCache := func(err error) (string, error) {
+		r.Body = &jsonActionBody{
+			ReadCloser: &chainedReadCloser{
+				Reader: io.MultiReader(bytes.NewReader(prefix), orig),
+				orig:   orig,
+			},
+			parseErr: err,
 		}
-		if !loggedWithAction {
-			logger.Trace("endpoint", "method", r.Method, "path", c.Path)
+		return "", err
+	}
+
+	var action string
+	var parseErr error
+
+	switch {
+	case len(prefix) > maxBodySize:
+		return chainAndCache(errors.New("body size limit exceeded"))
+
+	case readErr != nil:
+		return chainAndCache(readErr)
+
+	case len(prefix) == 0:
+		parseErr = io.EOF
+
+	default:
+		var req actionRequest
+		dec := json.NewDecoder(bytes.NewReader(prefix))
+		if err := dec.Decode(&req); err != nil {
+			parseErr = err
+		} else {
+			// Ensure the body contains exactly one JSON value (no trailing data).
+			var extra any
+			if err := dec.Decode(&extra); err != io.EOF {
+				parseErr = errors.New("unexpected data after request body")
+			} else {
+				action = req.Action
+			}
 		}
 	}
+
+	// Success / decode failure / empty body: prefix contains the entire
+	// body.
+	_ = orig.Close()
+	r.Body = &jsonActionBody{
+		ReadCloser: io.NopCloser(bytes.NewReader(prefix)),
+		action:     action,
+		parseErr:   parseErr,
+	}
+	return action, parseErr
+}
+
+func traceSnapdAPI(c *Command, r *http.Request) {
+	if !osutil.GetenvBool("SNAPD_TRACE") {
+		return
+	}
+	action, err := parseJSONActionBody(r)
+	if err != nil && !errors.Is(err, io.EOF) {
+		logger.Trace("endpoint-error", "body-read", err)
+	} else if action != "" {
+		logger.Trace("endpoint", "method", r.Method, "path", c.Path, "action", action)
+		return
+	}
+	logger.Trace("endpoint", "method", r.Method, "path", c.Path)
 }
 
 type wrappedWriter struct {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -192,11 +192,12 @@ type actionRequest struct {
 	Action string `json:"action"`
 }
 
-// jsonActionBody wraps a buffered request body with the result of a prior
-// parseJSONActionBody call. The stored parseErr is returned on later calls without
-// re-reading or re-decoding the body.
-type jsonActionBody struct {
-	io.ReadCloser
+// actionContextKey is the context key for a cached actionResult.
+type actionContextKey struct{}
+
+// actionResult holds the cached outcome of a parseRequestAction call.
+
+type actionResult struct {
 	action   string
 	parseErr error
 }
@@ -211,11 +212,11 @@ func (c *chainedReadCloser) Close() error {
 	return c.orig.Close()
 }
 
-// parseJSONActionBody decodes the top-level "action" field from a POST
+// parseRequestAction decodes the top-level "action" field from a POST
 // request's JSON body and replaces r.Body with a buffered copy so
 // downstream handlers can still consume the request body after the
 // action has been extracted. Safe to call more than once per request;
-// later calls return the cached action and error from jsonActionBody.
+// later calls return the result cached in r's context.
 //
 // The returned error reports why the action could not be extracted.
 //
@@ -225,9 +226,9 @@ func (c *chainedReadCloser) Close() error {
 //   - Only requests with Content-Type application/json, or with no
 //     Content-Type (assumed to be JSON), are parsed; callers needing a
 //     strict application/json check must enforce that before calling.
-func parseJSONActionBody(r *http.Request) (string, error) {
-	if ab, ok := r.Body.(*jsonActionBody); ok {
-		return ab.action, ab.parseErr
+func parseRequestAction(r *http.Request) (string, error) {
+	if cached, ok := r.Context().Value(actionContextKey{}).(actionResult); ok {
+		return cached.action, cached.parseErr
 	}
 	ct := r.Header.Get("Content-Type")
 	if r.Method != "POST" || r.Body == nil || (ct != "" && ct != "application/json") {
@@ -237,17 +238,11 @@ func parseJSONActionBody(r *http.Request) (string, error) {
 	orig := r.Body
 	prefix, readErr := io.ReadAll(io.LimitReader(orig, maxBodySize+1))
 
-	// chainAndCache wraps r.Body so downstream handlers still see the
-	// buffered prefix followed by whatever the original stream yields
-	// next.
+	// chainAndCache is used when the body cannot be fully buffered: it chains
+	// the already-read prefix back to the original stream and caches the error.
 	chainAndCache := func(err error) (string, error) {
-		r.Body = &jsonActionBody{
-			ReadCloser: &chainedReadCloser{
-				Reader: io.MultiReader(bytes.NewReader(prefix), orig),
-				orig:   orig,
-			},
-			parseErr: err,
-		}
+		*r = *r.WithContext(context.WithValue(r.Context(), actionContextKey{}, actionResult{parseErr: err}))
+		r.Body = &chainedReadCloser{Reader: io.MultiReader(bytes.NewReader(prefix), orig), orig: orig}
 		return "", err
 	}
 
@@ -257,13 +252,10 @@ func parseJSONActionBody(r *http.Request) (string, error) {
 	switch {
 	case len(prefix) > maxBodySize:
 		return chainAndCache(errors.New("body size limit exceeded"))
-
 	case readErr != nil:
 		return chainAndCache(readErr)
-
 	case len(prefix) == 0:
 		parseErr = io.EOF
-
 	default:
 		var req actionRequest
 		dec := json.NewDecoder(bytes.NewReader(prefix))
@@ -280,14 +272,10 @@ func parseJSONActionBody(r *http.Request) (string, error) {
 		}
 	}
 
-	// Success / decode failure / empty body: prefix contains the entire
-	// body.
+	// Success / decode failure / empty body: prefix contains the entire body.
 	_ = orig.Close()
-	r.Body = &jsonActionBody{
-		ReadCloser: io.NopCloser(bytes.NewReader(prefix)),
-		action:     action,
-		parseErr:   parseErr,
-	}
+	*r = *r.WithContext(context.WithValue(r.Context(), actionContextKey{}, actionResult{action: action, parseErr: parseErr}))
+	r.Body = io.NopCloser(bytes.NewReader(prefix))
 	return action, parseErr
 }
 
@@ -295,7 +283,7 @@ func traceSnapdAPI(c *Command, r *http.Request) {
 	if !osutil.GetenvBool("SNAPD_TRACE") {
 		return
 	}
-	action, err := parseJSONActionBody(r)
+	action, err := parseRequestAction(r)
 	if err != nil && !errors.Is(err, io.EOF) {
 		logger.Trace("endpoint-error", "body-read", err)
 	} else if action != "" {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime"
 	"net"
 	"net/http"
 	"os"
@@ -212,6 +213,16 @@ func (c *chainedReadCloser) Close() error {
 	return c.orig.Close()
 }
 
+// isJSONContentType reports whether ct is acceptable for a JSON request body.
+// An empty ct is accepted as assumed JSON; any parameters are ignored.
+func isJSONContentType(ct string) bool {
+	if ct == "" {
+		return true
+	}
+	mediaType, _, err := mime.ParseMediaType(ct)
+	return err == nil && mediaType == "application/json"
+}
+
 // parseRequestAction decodes the top-level "action" field from a POST
 // request's JSON body and replaces r.Body with a buffered copy so
 // downstream handlers can still consume the request body after the
@@ -230,8 +241,7 @@ func parseRequestAction(r *http.Request) (string, error) {
 	if cached, ok := r.Context().Value(actionContextKey{}).(actionResult); ok {
 		return cached.action, cached.parseErr
 	}
-	ct := r.Header.Get("Content-Type")
-	if r.Method != "POST" || r.Body == nil || (ct != "" && ct != "application/json") {
+	if r.Method != "POST" || r.Body == nil || !isJSONContentType(r.Header.Get("Content-Type")) {
 		return "", nil
 	}
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -170,6 +170,10 @@ func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	r = r.WithContext(withActionResult(r.Context(), action, err))
+	if errors.Is(err, errUnexpectedDataAfterBody) {
+		BadRequest(err.Error()).ServeHTTP(w, r)
+		return
+	}
 
 	if rspe := access.CheckAccess(c.d, r, ucred, user); rspe != nil {
 		rspe.ServeHTTP(w, r)
@@ -316,7 +320,9 @@ func extractRequestAction(r *http.Request) (string, error) {
 	return decodeActionFromBody(body)
 }
 
-// decodeActionFromBody returns the top-level "action", empty when the body has no such field.
+// decodeActionFromBody returns the top-level "action", empty when the body has
+// no such field. Trailing data after the JSON value is an error and does not
+// discard a decoded action.
 func decodeActionFromBody(body []byte) (string, error) {
 	if len(body) == 0 {
 		return "", errEmptyBody
@@ -330,7 +336,7 @@ func decodeActionFromBody(body []byte) (string, error) {
 	// Decode again rather than Decoder.More(), which misses trailing } and ].
 	var extra any
 	if err := dec.Decode(&extra); err != io.EOF {
-		return "", errUnexpectedDataAfterBody
+		return req.Action, errUnexpectedDataAfterBody
 	}
 	return req.Action, nil
 }
@@ -342,7 +348,8 @@ func traceSnapdAPI(c *Command, r *http.Request) {
 	action, err := actionResultFromContext(r.Context())
 	if err != nil && !errors.Is(err, errEmptyBody) {
 		logger.Trace("endpoint-error", "body-read", err)
-	} else if action != "" {
+	}
+	if action != "" {
 		logger.Trace("endpoint", "method", r.Method, "path", c.Path, "action", action)
 		return
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -164,7 +164,7 @@ func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// One read, so later stages look the action up from context instead of
 	// touching the body again.
-	action, err := readRequestBody(r)
+	action, err := extractRequestAction(r)
 	if isBodyUnusable(err) {
 		BadRequest(err.Error()).ServeHTTP(w, r)
 		return
@@ -205,7 +205,7 @@ var (
 	errBodyUnreadable          = errors.New("cannot read request body")
 	errEmptyBody               = errors.New("empty request body")
 	errUnexpectedDataAfterBody = errors.New("unexpected data after request body")
-	errNoRequestAction         = errors.New("internal error: request action not in context")
+	errRequestActionNotCached  = errors.New("internal error: request action not cached")
 )
 
 // isBodyUnusable reports a body later stages cannot be served from (oversize
@@ -230,28 +230,28 @@ func withRequestAction(ctx context.Context, action string, err error) context.Co
 }
 
 // requestActionFromContext returns the action cached by withRequestAction.
-// A miss is errNoRequestAction: ServeHTTP always caches first, so a miss
+// A miss is errRequestActionNotCached: ServeHTTP always caches first, so a miss
 // means the caller skipped that step rather than that the request had no action.
 func requestActionFromContext(ctx context.Context) (string, error) {
 	cached, ok := ctx.Value(actionContextKey{}).(requestAction)
 	if !ok {
-		return "", errNoRequestAction
+		return "", errRequestActionNotCached
 	}
 	return cached.action, cached.parseErr
 }
 
-// requestBodyPolicy reports whether the body is read into memory (and
+// requestBodyPolicy reports whether the body is buffered in memory (and
 // rejected if larger than maxBodySize) and whether it is decoded for "action".
 // Selection is loose so tracing can still see an action; callers apply
 // stricter rules themselves.
-func requestBodyPolicy(r *http.Request) (read, wantAction bool) {
+func requestBodyPolicy(r *http.Request) (bufferBody, decodeAction bool) {
 	switch r.Method {
 	case "POST", "PUT":
 	default:
 		return false, false
 	}
 	// No PUT endpoint defines an action.
-	canDecode := r.Method == "POST"
+	decodeAction = r.Method == "POST"
 
 	ct := r.Header.Get("Content-Type")
 	if ct == "" {
@@ -261,7 +261,7 @@ func requestBodyPolicy(r *http.Request) (read, wantAction bool) {
 		if strings.TrimSuffix(r.URL.Path, "/") == "/v2/assertions" {
 			return false, false
 		}
-		return true, canDecode
+		return true, decodeAction
 	}
 
 	mediaType, _, _ := mime.ParseMediaType(ct)
@@ -278,14 +278,17 @@ func requestBodyPolicy(r *http.Request) (read, wantAction bool) {
 		return false, false
 	}
 
-	return true, canDecode && mediaType == "application/json"
+	return true, decodeAction && mediaType == "application/json"
 }
 
-// readRequestBody reads the request body once, rejecting it if oversize
+// extractRequestAction buffers the request body once, rejecting it if oversize
 // and extracting the action.
-func readRequestBody(r *http.Request) (string, error) {
-	read, wantAction := requestBodyPolicy(r)
-	if !read {
+func extractRequestAction(r *http.Request) (string, error) {
+	bufferBody, decodeAction := requestBodyPolicy(r)
+	if !bufferBody {
+		if decodeAction {
+			return "", errors.New("internal error: cannot decode action without buffering the body")
+		}
 		return "", nil
 	}
 
@@ -293,10 +296,10 @@ func readRequestBody(r *http.Request) (string, error) {
 		return "", errBodyTooLarge
 	}
 
-	body, readErr := io.ReadAll(io.LimitReader(r.Body, maxBodySize+1))
-	if readErr != nil {
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxBodySize+1))
+	if err != nil {
 		// Partial bytes are not the whole body, and the rest was never limited.
-		return "", fmt.Errorf("%w: %v", errBodyUnreadable, readErr)
+		return "", fmt.Errorf("%w: %v", errBodyUnreadable, err)
 	}
 	if len(body) > maxBodySize {
 		return "", errBodyTooLarge
@@ -306,14 +309,14 @@ func readRequestBody(r *http.Request) (string, error) {
 	// whatever r.Body holds later, so this does not leak the original.
 	r.Body = io.NopCloser(bytes.NewReader(body))
 
-	if !wantAction {
+	if !decodeAction {
 		return "", nil
 	}
-	return decodeAction(body)
+	return decodeActionFromBody(body)
 }
 
-// decodeAction returns the top-level "action", empty when the body has no such field.
-func decodeAction(body []byte) (string, error) {
+// decodeActionFromBody returns the top-level "action", empty when the body has no such field.
+func decodeActionFromBody(body []byte) (string, error) {
 	if len(body) == 0 {
 		return "", errEmptyBody
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -169,7 +169,7 @@ func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		BadRequest(err.Error()).ServeHTTP(w, r)
 		return
 	}
-	r = r.WithContext(withRequestAction(r.Context(), action, err))
+	r = r.WithContext(withActionResult(r.Context(), action, err))
 
 	if rspe := access.CheckAccess(c.d, r, ucred, user); rspe != nil {
 		rspe.ServeHTTP(w, r)
@@ -205,7 +205,7 @@ var (
 	errBodyUnreadable          = errors.New("cannot read request body")
 	errEmptyBody               = errors.New("empty request body")
 	errUnexpectedDataAfterBody = errors.New("unexpected data after request body")
-	errRequestActionNotCached  = errors.New("internal error: request action not cached")
+	errActionResultNotCached   = errors.New("internal error: request action not cached")
 )
 
 // isBodyUnusable reports a body later stages cannot be served from (oversize
@@ -214,28 +214,31 @@ func isBodyUnusable(err error) bool {
 	return errors.Is(err, errBodyTooLarge) || errors.Is(err, errBodyUnreadable)
 }
 
-type actionRequest struct {
+// actionInRequest is the JSON shape used to pick the top-level "action" out of a body.
+type actionInRequest struct {
 	Action string `json:"action"`
 }
 
 type actionContextKey struct{}
 
-type requestAction struct {
+// actionResult is the cached outcome of extractRequestAction: the action, if
+// any, and the parse error, if any. A decode error does not clear the action.
+type actionResult struct {
 	action   string
 	parseErr error
 }
 
-func withRequestAction(ctx context.Context, action string, err error) context.Context {
-	return context.WithValue(ctx, actionContextKey{}, requestAction{action: action, parseErr: err})
+func withActionResult(ctx context.Context, action string, err error) context.Context {
+	return context.WithValue(ctx, actionContextKey{}, actionResult{action: action, parseErr: err})
 }
 
-// requestActionFromContext returns the action cached by withRequestAction.
-// A miss is errRequestActionNotCached: ServeHTTP always caches first, so a miss
+// actionResultFromContext returns the action cached by withActionResult.
+// A miss is errActionResultNotCached: ServeHTTP always caches first, so a miss
 // means the caller skipped that step rather than that the request had no action.
-func requestActionFromContext(ctx context.Context) (string, error) {
-	cached, ok := ctx.Value(actionContextKey{}).(requestAction)
+func actionResultFromContext(ctx context.Context) (string, error) {
+	cached, ok := ctx.Value(actionContextKey{}).(actionResult)
 	if !ok {
-		return "", errRequestActionNotCached
+		return "", errActionResultNotCached
 	}
 	return cached.action, cached.parseErr
 }
@@ -319,7 +322,7 @@ func decodeActionFromBody(body []byte) (string, error) {
 		return "", errEmptyBody
 	}
 
-	var req actionRequest
+	var req actionInRequest
 	dec := json.NewDecoder(bytes.NewReader(body))
 	if err := dec.Decode(&req); err != nil {
 		return "", err
@@ -336,7 +339,7 @@ func traceSnapdAPI(c *Command, r *http.Request) {
 	if !osutil.GetenvBool("SNAPD_TRACE") {
 		return
 	}
-	action, err := requestActionFromContext(r.Context())
+	action, err := actionResultFromContext(r.Context())
 	if err != nil && !errors.Is(err, errEmptyBody) {
 		logger.Trace("endpoint-error", "body-read", err)
 	} else if action != "" {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime"
 	"net"
 	"net/http"
 	"os"
@@ -37,7 +38,9 @@ import (
 	"github.com/gorilla/mux"
 	"gopkg.in/tomb.v2"
 
+	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
+	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/netutil"
@@ -159,12 +162,21 @@ func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// One read, so later stages look the action up from context instead of
+	// touching the body again.
+	action, err := readRequestBody(r)
+	if isBodyUnusable(err) {
+		BadRequest(err.Error()).ServeHTTP(w, r)
+		return
+	}
+	r = r.WithContext(withRequestAction(r.Context(), action, err))
+
 	if rspe := access.CheckAccess(c.d, r, ucred, user); rspe != nil {
 		rspe.ServeHTTP(w, r)
 		return
 	}
 
-	traceSnapdAPI(c, w, r)
+	traceSnapdAPI(c, r)
 
 	rsp := rspf(c, r, user)
 
@@ -186,30 +198,151 @@ func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	rsp.ServeHTTP(w, r)
 }
 
-func traceSnapdAPI(c *Command, w http.ResponseWriter, r *http.Request) {
-	if osutil.GetenvBool("SNAPD_TRACE") {
-		loggedWithAction := false
-		if r.Method == "POST" && (r.Header.Get("Content-Type") == "application/json" || r.Header.Get("Content-Type") == "") {
-			r.Body = http.MaxBytesReader(w, r.Body, 3*1024*1024) // 3 MB limit
-			bodyBytes, err := io.ReadAll(r.Body)
-			if err != nil {
-				logger.Trace("endpoint-error", "body-read", err)
-			}
-			var data struct {
-				Action string `json:"action"`
-			}
-			if err := json.Unmarshal(bodyBytes, &data); err == nil {
-				if data.Action != "" {
-					loggedWithAction = true
-					logger.Trace("endpoint", "method", r.Method, "path", c.Path, "action", data.Action)
-				}
-			}
-			r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
-		}
-		if !loggedWithAction {
-			logger.Trace("endpoint", "method", r.Method, "path", c.Path)
-		}
+const maxBodySize = 4 * 1024 * 1024
+
+var (
+	errBodyTooLarge            = errors.New("body size limit exceeded")
+	errBodyUnreadable          = errors.New("cannot read request body")
+	errEmptyBody               = errors.New("empty request body")
+	errUnexpectedDataAfterBody = errors.New("unexpected data after request body")
+	errNoRequestAction         = errors.New("internal error: request action not in context")
+)
+
+// isBodyUnusable reports a body later stages cannot be served from (oversize
+// or a broken stream). A decode failure is not unusable.
+func isBodyUnusable(err error) bool {
+	return errors.Is(err, errBodyTooLarge) || errors.Is(err, errBodyUnreadable)
+}
+
+type actionRequest struct {
+	Action string `json:"action"`
+}
+
+type actionContextKey struct{}
+
+type requestAction struct {
+	action   string
+	parseErr error
+}
+
+func withRequestAction(ctx context.Context, action string, err error) context.Context {
+	return context.WithValue(ctx, actionContextKey{}, requestAction{action: action, parseErr: err})
+}
+
+// requestActionFromContext returns the action cached by withRequestAction.
+// A miss is errNoRequestAction: ServeHTTP always caches first, so a miss
+// means the caller skipped that step rather than that the request had no action.
+func requestActionFromContext(ctx context.Context) (string, error) {
+	cached, ok := ctx.Value(actionContextKey{}).(requestAction)
+	if !ok {
+		return "", errNoRequestAction
 	}
+	return cached.action, cached.parseErr
+}
+
+// requestBodyPolicy reports whether the body is read into memory (and
+// rejected if larger than maxBodySize) and whether it is decoded for "action".
+// Selection is loose so tracing can still see an action; callers apply
+// stricter rules themselves.
+func requestBodyPolicy(r *http.Request) (read, wantAction bool) {
+	switch r.Method {
+	case "POST", "PUT":
+	default:
+		return false, false
+	}
+	// No PUT endpoint defines an action.
+	canDecode := r.Method == "POST"
+
+	ct := r.Header.Get("Content-Type")
+	if ct == "" {
+		// The snap client often omits Content-Type on JSON. snap ack is
+		// the exception: it streams assertions to POST /v2/assertions
+		// with no Content-Type at all.
+		if strings.TrimSuffix(r.URL.Path, "/") == "/v2/assertions" {
+			return false, false
+		}
+		return true, canDecode
+	}
+
+	mediaType, _, _ := mime.ParseMediaType(ct)
+	if mediaType == "" {
+		// Unrecognised type is not a stream exemption.
+		return true, false
+	}
+
+	// snap try shares POST /v2/snaps and multipart/form-data with sideload;
+	// telling them apart means buffering the form, so both are left unread.
+	if strings.HasPrefix(mediaType, "multipart/") ||
+		mediaType == client.SnapshotExportMediaType ||
+		mediaType == asserts.MediaType {
+		return false, false
+	}
+
+	return true, canDecode && mediaType == "application/json"
+}
+
+// readRequestBody reads the request body once, rejecting it if oversize
+// and extracting the action.
+func readRequestBody(r *http.Request) (string, error) {
+	read, wantAction := requestBodyPolicy(r)
+	if !read {
+		return "", nil
+	}
+
+	if r.ContentLength > maxBodySize {
+		return "", errBodyTooLarge
+	}
+
+	body, readErr := io.ReadAll(io.LimitReader(r.Body, maxBodySize+1))
+	if readErr != nil {
+		// Partial bytes are not the whole body, and the rest was never limited.
+		return "", fmt.Errorf("%w: %v", errBodyUnreadable, readErr)
+	}
+	if len(body) > maxBodySize {
+		return "", errBodyTooLarge
+	}
+
+	// net/http closes the body it captured when the request was read, not
+	// whatever r.Body holds later, so this does not leak the original.
+	r.Body = io.NopCloser(bytes.NewReader(body))
+
+	if !wantAction {
+		return "", nil
+	}
+	return decodeAction(body)
+}
+
+// decodeAction returns the top-level "action", empty when the body has no such field.
+func decodeAction(body []byte) (string, error) {
+	if len(body) == 0 {
+		return "", errEmptyBody
+	}
+
+	var req actionRequest
+	dec := json.NewDecoder(bytes.NewReader(body))
+	if err := dec.Decode(&req); err != nil {
+		return "", err
+	}
+	// Decode again rather than Decoder.More(), which misses trailing } and ].
+	var extra any
+	if err := dec.Decode(&extra); err != io.EOF {
+		return "", errUnexpectedDataAfterBody
+	}
+	return req.Action, nil
+}
+
+func traceSnapdAPI(c *Command, r *http.Request) {
+	if !osutil.GetenvBool("SNAPD_TRACE") {
+		return
+	}
+	action, err := requestActionFromContext(r.Context())
+	if err != nil && !errors.Is(err, errEmptyBody) {
+		logger.Trace("endpoint-error", "body-read", err)
+	} else if action != "" {
+		logger.Trace("endpoint", "method", r.Method, "path", c.Path, "action", action)
+		return
+	}
+	logger.Trace("endpoint", "method", r.Method, "path", c.Path)
 }
 
 type wrappedWriter struct {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -245,13 +245,10 @@ func requestActionFromContext(ctx context.Context) (string, error) {
 // Selection is loose so tracing can still see an action; callers apply
 // stricter rules themselves.
 func requestBodyPolicy(r *http.Request) (bufferBody, decodeAction bool) {
-	switch r.Method {
-	case "POST", "PUT":
-	default:
+	// TODO: buffer PUT once size limits for snap conf and confdb are established
+	if r.Method != "POST" {
 		return false, false
 	}
-	// No PUT endpoint defines an action.
-	decodeAction = r.Method == "POST"
 
 	ct := r.Header.Get("Content-Type")
 	if ct == "" {
@@ -261,7 +258,7 @@ func requestBodyPolicy(r *http.Request) (bufferBody, decodeAction bool) {
 		if strings.TrimSuffix(r.URL.Path, "/") == "/v2/assertions" {
 			return false, false
 		}
-		return true, decodeAction
+		return true, true
 	}
 
 	mediaType, _, _ := mime.ParseMediaType(ct)
@@ -278,11 +275,12 @@ func requestBodyPolicy(r *http.Request) (bufferBody, decodeAction bool) {
 		return false, false
 	}
 
-	return true, decodeAction && mediaType == "application/json"
+	return true, mediaType == "application/json"
 }
 
 // extractRequestAction buffers the request body once, rejecting it if oversize
-// and extracting the action.
+// and extracting the action. Bodies that requestBodyPolicy leaves unread
+// (recognised streams, PUT, non-POST) are not touched.
 func extractRequestAction(r *http.Request) (string, error) {
 	bufferBody, decodeAction := requestBodyPolicy(r)
 	if !bufferBody {

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -1558,6 +1558,27 @@ func (s *daemonSuite) TestNoticesRequestCanceledOnStop(c *check.C) {
 		"type": "error"})
 }
 
+func (s *daemonSuite) TestIsJSONContentType(c *check.C) {
+	for _, tc := range []struct {
+		ct   string
+		want bool
+	}{
+		{"", true},
+		{"application/json", true},
+		{"APPLICATION/JSON", true},
+		{"Application/Json", true},
+		{"application/json; charset=utf-8", true},
+		{"application/json; charset=windows-1252", true},
+		{"application/json; boundary=foo", true},
+		{"text/plain", false},
+		{"multipart/form-data", false},
+		{"application/json-patch+json", false},
+		{"notvalid", false},
+	} {
+		c.Check(isJSONContentType(tc.ct), check.Equals, tc.want, check.Commentf("ct: %q", tc.ct))
+	}
+}
+
 func (s *daemonSuite) TestParseRequestAction(c *check.C) {
 	type testCase struct {
 		name          string

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -1558,7 +1558,7 @@ func (s *daemonSuite) TestNoticesRequestCanceledOnStop(c *check.C) {
 		"type": "error"})
 }
 
-func (s *daemonSuite) TestParseJSONActionBody(c *check.C) {
+func (s *daemonSuite) TestParseRequestAction(c *check.C) {
 	type testCase struct {
 		name          string
 		method        string
@@ -1666,7 +1666,7 @@ func (s *daemonSuite) TestParseJSONActionBody(c *check.C) {
 			req.ContentLength = tc.contentLength
 		}
 
-		got, err := parseJSONActionBody(req)
+		got, err := parseRequestAction(req)
 		cmt := check.Commentf("case: %s", tc.name)
 		if tc.wantErr != "" {
 			c.Assert(err, check.ErrorMatches, tc.wantErr+".*", cmt)
@@ -1685,24 +1685,24 @@ func (s *daemonSuite) TestParseJSONActionBody(c *check.C) {
 
 	for _, method := range []string{"GET", "PUT", "DELETE", "PATCH"} {
 		req := httptest.NewRequest(method, "/", strings.NewReader(`{"action":"install"}`))
-		got, err := parseJSONActionBody(req)
+		got, err := parseRequestAction(req)
 		c.Assert(err, check.IsNil, check.Commentf("method: %s", method))
 		c.Check(got, check.Equals, "", check.Commentf("method: %s", method))
 	}
 }
 
-func (s *daemonSuite) TestParseJSONActionBodyIdempotent(c *check.C) {
+func (s *daemonSuite) TestParseRequestActionIdempotent(c *check.C) {
 	body := `{"action":"install","snaps":["x"]}`
 	req := httptest.NewRequest("POST", "/", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 
-	action, err := parseJSONActionBody(req)
+	action, err := parseRequestAction(req)
 	c.Assert(err, check.IsNil)
 	c.Check(action, check.Equals, "install")
-	_, ok := req.Body.(*jsonActionBody)
+	_, ok := req.Context().Value(actionContextKey{}).(actionResult)
 	c.Assert(ok, check.Equals, true)
 
-	action, err = parseJSONActionBody(req)
+	action, err = parseRequestAction(req)
 	c.Assert(err, check.IsNil)
 	c.Check(action, check.Equals, "install")
 
@@ -1711,12 +1711,12 @@ func (s *daemonSuite) TestParseJSONActionBodyIdempotent(c *check.C) {
 	c.Check(string(gotBody), check.Equals, body)
 }
 
-// TestParseJSONActionBodyReadErrorPreservesBody pins the readErr branch of
-// parseJSONActionBody: when the request body Read fails partway through,
+// TestParseRequestActionReadErrorPreservesBody pins the readErr branch of
+// parseRequestAction: when the request body Read fails partway through,
 // the successfully-buffered prefix is chained back to the underlying
 // stream so downstream handlers still get an honest opportunity to read
 // what was received.
-func (s *daemonSuite) TestParseJSONActionBodyReadErrorPreservesBody(c *check.C) {
+func (s *daemonSuite) TestParseRequestActionReadErrorPreservesBody(c *check.C) {
 	prefix := []byte(`{"action":"install"`)
 	simulatedErr := errors.New("simulated transient read error")
 	// Compose a body that yields the prefix once then errors on every
@@ -1729,7 +1729,7 @@ func (s *daemonSuite) TestParseJSONActionBodyReadErrorPreservesBody(c *check.C) 
 	))
 	req.Header.Set("Content-Type", "application/json")
 
-	action, err := parseJSONActionBody(req)
+	action, err := parseRequestAction(req)
 	c.Check(action, check.Equals, "")
 	c.Assert(err, check.NotNil)
 	c.Check(err, check.Equals, simulatedErr)

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -20,8 +20,10 @@
 package daemon
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -29,9 +31,11 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"syscall"
 	"testing"
+	"testing/iotest"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -1552,4 +1556,283 @@ func (s *daemonSuite) TestNoticesRequestCanceledOnStop(c *check.C) {
 			"message": "request canceled",
 		},
 		"type": "error"})
+}
+
+func (s *daemonSuite) TestParseJSONActionBody(c *check.C) {
+	type testCase struct {
+		name          string
+		method        string
+		body          string
+		contentType   string // "" sets application/json; "none" omits the header
+		contentLength int64
+		nilBody       bool
+		wantAction    string
+		wantErr       string
+	}
+
+	for _, tc := range []testCase{
+		{
+			name:       "extracts action",
+			body:       `{"snaps":["x"],"action":"refresh"}`,
+			wantAction: "refresh",
+		},
+		{
+			name:       "action absent",
+			body:       `{"snaps":["x"]}`,
+			wantAction: "",
+		},
+		{
+			name:       "empty action",
+			body:       `{"action":""}`,
+			wantAction: "",
+		},
+		{
+			name:          "content length ignored",
+			body:          `{"action":"install","snaps":["x"]}`,
+			contentLength: 5,
+			wantAction:    "install",
+		},
+		{
+			name:          "content length unknown",
+			body:          `{"action":"install","snaps":["x"]}`,
+			contentLength: -1,
+			wantAction:    "install",
+		},
+		{
+			name:    "non-object top-level",
+			body:    `[{"action":"install"}]`,
+			wantErr: "json: cannot unmarshal array",
+		},
+		{
+			name:    "malformed json",
+			body:    `{not json`,
+			wantErr: "invalid character",
+		},
+		{
+			name:    "data after json",
+			body:    `{"action":"install"} trailing`,
+			wantErr: "unexpected data after request body",
+		},
+		{
+			name:    "data after json starting with brace",
+			body:    `{"action":"install"} }morestuff`,
+			wantErr: "unexpected data after request body",
+		},
+		{
+			name:    "data after json starting with bracket",
+			body:    `{"action":"install"} ]morestuff`,
+			wantErr: "unexpected data after request body",
+		},
+		{
+			name:    "body size limit exceeded",
+			body:    strings.Repeat("x", maxBodySize+1),
+			wantErr: "body size limit exceeded",
+		},
+		{
+			name:    "nil body",
+			method:  "POST",
+			nilBody: true,
+		},
+		{
+			name:    "empty body EOF",
+			body:    "",
+			wantErr: "EOF",
+		},
+		{
+			name:        "multipart skipped",
+			body:        `{"action":"install"}`,
+			contentType: "multipart/form-data",
+		},
+	} {
+		method := tc.method
+		if method == "" {
+			method = "POST"
+		}
+		var req *http.Request
+		if tc.nilBody {
+			req = httptest.NewRequest(method, "/", nil)
+			req.Body = nil
+		} else {
+			req = httptest.NewRequest(method, "/", strings.NewReader(tc.body))
+		}
+		switch tc.contentType {
+		case "none":
+		case "":
+			req.Header.Set("Content-Type", "application/json")
+		default:
+			req.Header.Set("Content-Type", tc.contentType)
+		}
+		if tc.contentLength != 0 {
+			req.ContentLength = tc.contentLength
+		}
+
+		got, err := parseJSONActionBody(req)
+		cmt := check.Commentf("case: %s", tc.name)
+		if tc.wantErr != "" {
+			c.Assert(err, check.ErrorMatches, tc.wantErr+".*", cmt)
+		} else {
+			c.Assert(err, check.IsNil, cmt)
+			c.Check(got, check.Equals, tc.wantAction, cmt)
+		}
+
+		if tc.nilBody {
+			continue
+		}
+		gotBody, readErr := io.ReadAll(req.Body)
+		c.Assert(readErr, check.IsNil, cmt)
+		c.Check(string(gotBody), check.Equals, tc.body, cmt)
+	}
+
+	for _, method := range []string{"GET", "PUT", "DELETE", "PATCH"} {
+		req := httptest.NewRequest(method, "/", strings.NewReader(`{"action":"install"}`))
+		got, err := parseJSONActionBody(req)
+		c.Assert(err, check.IsNil, check.Commentf("method: %s", method))
+		c.Check(got, check.Equals, "", check.Commentf("method: %s", method))
+	}
+}
+
+func (s *daemonSuite) TestParseJSONActionBodyIdempotent(c *check.C) {
+	body := `{"action":"install","snaps":["x"]}`
+	req := httptest.NewRequest("POST", "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	action, err := parseJSONActionBody(req)
+	c.Assert(err, check.IsNil)
+	c.Check(action, check.Equals, "install")
+	_, ok := req.Body.(*jsonActionBody)
+	c.Assert(ok, check.Equals, true)
+
+	action, err = parseJSONActionBody(req)
+	c.Assert(err, check.IsNil)
+	c.Check(action, check.Equals, "install")
+
+	gotBody, readErr := io.ReadAll(req.Body)
+	c.Assert(readErr, check.IsNil)
+	c.Check(string(gotBody), check.Equals, body)
+}
+
+// TestParseJSONActionBodyReadErrorPreservesBody pins the readErr branch of
+// parseJSONActionBody: when the request body Read fails partway through,
+// the successfully-buffered prefix is chained back to the underlying
+// stream so downstream handlers still get an honest opportunity to read
+// what was received.
+func (s *daemonSuite) TestParseJSONActionBodyReadErrorPreservesBody(c *check.C) {
+	prefix := []byte(`{"action":"install"`)
+	simulatedErr := errors.New("simulated transient read error")
+	// Compose a body that yields the prefix once then errors on every
+	// subsequent Read — a stdlib-only equivalent of a stream that
+	// broke partway through (client disconnect, TLS error, reset).
+	req := httptest.NewRequest("POST", "/", http.NoBody)
+	req.Body = io.NopCloser(io.MultiReader(
+		bytes.NewReader(prefix),
+		iotest.ErrReader(simulatedErr),
+	))
+	req.Header.Set("Content-Type", "application/json")
+
+	action, err := parseJSONActionBody(req)
+	c.Check(action, check.Equals, "")
+	c.Assert(err, check.NotNil)
+	c.Check(err, check.Equals, simulatedErr)
+
+	// The prefix that was successfully consumed before the error must
+	// still be readable via r.Body.
+	buf := make([]byte, len(prefix))
+	n, readErr := io.ReadFull(req.Body, buf)
+	c.Check(n, check.Equals, len(prefix))
+	c.Check(readErr, check.IsNil)
+	c.Check(buf, check.DeepEquals, prefix)
+
+	// A subsequent read must surface the original error — the point of
+	// chaining is to let downstream try, not to hide the truncation
+	// behind a silent EOF from an in-memory buffer.
+	_, nextErr := req.Body.Read(make([]byte, 1))
+	c.Check(nextErr, check.Equals, simulatedErr)
+}
+
+func (s *daemonSuite) TestServeHTTPTraceExtractsActionPreservesBody(c *check.C) {
+	os.Setenv("SNAPD_TRACE", "1")
+	defer os.Unsetenv("SNAPD_TRACE")
+
+	d := s.newTestDaemon(c)
+	body := `{"action":"install","snaps":["x"]}`
+
+	var gotBody string
+	cmd := &Command{d: d, Path: "/v2/test"}
+	cmd.POST = func(_ *Command, r *http.Request, _ *auth.UserState) Response {
+		b, err := io.ReadAll(r.Body)
+		c.Assert(err, check.IsNil)
+		gotBody = string(b)
+		return SyncResponse(nil)
+	}
+	cmd.WriteAccess = openAccess{}
+
+	req := httptest.NewRequest("POST", "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = fmt.Sprintf("pid=100;uid=0;socket=%s;", dirs.SnapdSocket)
+	rec := httptest.NewRecorder()
+	cmd.ServeHTTP(rec, req)
+
+	c.Check(rec.Code, check.Equals, 200)
+	c.Check(gotBody, check.Equals, body)
+}
+
+// TestServeHTTPTraceOversizeBodyStillServed verifies that when SNAPD_TRACE
+// is enabled and the request body exceeds maxBodySize, the tracer records
+// the parse failure but the downstream handler still receives the full,
+// untruncated body via the chained reader.
+func (s *daemonSuite) TestServeHTTPTraceOversizeBodyStillServed(c *check.C) {
+	os.Setenv("SNAPD_TRACE", "1")
+	defer os.Unsetenv("SNAPD_TRACE")
+
+	d := s.newTestDaemon(c)
+	body := strings.Repeat("x", maxBodySize+128)
+
+	var gotLen int
+	cmd := &Command{d: d, Path: "/v2/test"}
+	cmd.POST = func(_ *Command, r *http.Request, _ *auth.UserState) Response {
+		b, err := io.ReadAll(r.Body)
+		c.Assert(err, check.IsNil)
+		gotLen = len(b)
+		return SyncResponse(nil)
+	}
+	cmd.WriteAccess = openAccess{}
+
+	req := httptest.NewRequest("POST", "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = fmt.Sprintf("pid=100;uid=0;socket=%s;", dirs.SnapdSocket)
+	rec := httptest.NewRecorder()
+	cmd.ServeHTTP(rec, req)
+
+	c.Check(rec.Code, check.Equals, 200)
+	c.Check(gotLen, check.Equals, len(body))
+}
+
+// TestServeHTTPTraceInvalidJSONStillServed verifies that a parse failure in
+// the tracer (invalid JSON body) does not cause the request to be rejected
+// and that the handler still sees the original body.
+func (s *daemonSuite) TestServeHTTPTraceInvalidJSONStillServed(c *check.C) {
+	os.Setenv("SNAPD_TRACE", "1")
+	defer os.Unsetenv("SNAPD_TRACE")
+
+	d := s.newTestDaemon(c)
+	body := `{not json`
+
+	var gotBody string
+	cmd := &Command{d: d, Path: "/v2/test"}
+	cmd.POST = func(_ *Command, r *http.Request, _ *auth.UserState) Response {
+		b, err := io.ReadAll(r.Body)
+		c.Assert(err, check.IsNil)
+		gotBody = string(b)
+		return SyncResponse(nil)
+	}
+	cmd.WriteAccess = openAccess{}
+
+	req := httptest.NewRequest("POST", "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = fmt.Sprintf("pid=100;uid=0;socket=%s;", dirs.SnapdSocket)
+	rec := httptest.NewRecorder()
+	cmd.ServeHTTP(rec, req)
+
+	c.Check(rec.Code, check.Equals, 200)
+	c.Check(gotBody, check.Equals, body)
 }

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -1558,32 +1558,32 @@ func (s *daemonSuite) TestNoticesRequestCanceledOnStop(c *check.C) {
 
 func (s *daemonSuite) TestRequestBodyPolicy(c *check.C) {
 	for _, tc := range []struct {
-		method, path, ct     string
-		wantRead, wantAction bool
+		method, path, ct                 string
+		wantBufferBody, wantDecodeAction bool
 	}{
-		{ct: "", wantRead: true, wantAction: true},
-		{ct: "application/json", wantRead: true, wantAction: true},
-		{ct: "APPLICATION/JSON", wantRead: true, wantAction: true},
-		{ct: "Application/Json", wantRead: true, wantAction: true},
-		{ct: "application/json; charset=utf-8", wantRead: true, wantAction: true},
-		{ct: "application/json; charset=windows-1252", wantRead: true, wantAction: true},
-		{ct: "application/json; boundary=foo", wantRead: true, wantAction: true},
-		{ct: "text/plain; charset", wantRead: true},
-		// Unparseable types are read (and rejected if oversize), not streamed.
-		{ct: "application/json; charset=utf-8; charset=utf-16", wantRead: true},
-		{ct: "application/json extra", wantRead: true},
-		{ct: "application/", wantRead: true},
-		{ct: "application", wantRead: true},
-		{ct: "; charset=utf-8", wantRead: true},
-		{ct: "text/plain", wantRead: true},
-		{ct: "application/json-patch+json", wantRead: true},
-		{ct: "notvalid", wantRead: true},
+		{ct: "", wantBufferBody: true, wantDecodeAction: true},
+		{ct: "application/json", wantBufferBody: true, wantDecodeAction: true},
+		{ct: "APPLICATION/JSON", wantBufferBody: true, wantDecodeAction: true},
+		{ct: "Application/Json", wantBufferBody: true, wantDecodeAction: true},
+		{ct: "application/json; charset=utf-8", wantBufferBody: true, wantDecodeAction: true},
+		{ct: "application/json; charset=windows-1252", wantBufferBody: true, wantDecodeAction: true},
+		{ct: "application/json; boundary=foo", wantBufferBody: true, wantDecodeAction: true},
+		{ct: "text/plain; charset", wantBufferBody: true},
+		// Unparseable types are buffered (and rejected if oversize), not streamed.
+		{ct: "application/json; charset=utf-8; charset=utf-16", wantBufferBody: true},
+		{ct: "application/json extra", wantBufferBody: true},
+		{ct: "application/", wantBufferBody: true},
+		{ct: "application", wantBufferBody: true},
+		{ct: "; charset=utf-8", wantBufferBody: true},
+		{ct: "text/plain", wantBufferBody: true},
+		{ct: "application/json-patch+json", wantBufferBody: true},
+		{ct: "notvalid", wantBufferBody: true},
 		{ct: "multipart/form-data"},
 		{ct: "multipart/mixed"},
 		{ct: client.SnapshotExportMediaType},
 		{ct: asserts.MediaType},
-		{method: "PUT", ct: "application/json", wantRead: true},
-		{method: "PUT", ct: "", wantRead: true},
+		{method: "PUT", ct: "application/json", wantBufferBody: true},
+		{method: "PUT", ct: "", wantBufferBody: true},
 		{method: "PUT", path: "/v2/assertions"},
 		{method: "GET", ct: "application/json"},
 		{method: "DELETE", ct: "application/json"},
@@ -1591,7 +1591,7 @@ func (s *daemonSuite) TestRequestBodyPolicy(c *check.C) {
 		{path: "/v2/assertions"},
 		{path: "/v2/assertions/"},
 		// The path exception is only for an absent Content-Type.
-		{path: "/v2/assertions", ct: "application/json", wantRead: true, wantAction: true},
+		{path: "/v2/assertions", ct: "application/json", wantBufferBody: true, wantDecodeAction: true},
 	} {
 		method := tc.method
 		if method == "" {
@@ -1605,14 +1605,14 @@ func (s *daemonSuite) TestRequestBodyPolicy(c *check.C) {
 		if tc.ct != "" {
 			req.Header.Set("Content-Type", tc.ct)
 		}
-		read, wantAction := requestBodyPolicy(req)
+		bufferBody, decodeAction := requestBodyPolicy(req)
 		cmt := check.Commentf("method=%s path=%s ct=%q", method, path, tc.ct)
-		c.Check(read, check.Equals, tc.wantRead, cmt)
-		c.Check(wantAction, check.Equals, tc.wantAction, cmt)
+		c.Check(bufferBody, check.Equals, tc.wantBufferBody, cmt)
+		c.Check(decodeAction, check.Equals, tc.wantDecodeAction, cmt)
 	}
 }
 
-func (s *daemonSuite) TestReadRequestBody(c *check.C) {
+func (s *daemonSuite) TestExtractRequestAction(c *check.C) {
 	type testCase struct {
 		name          string
 		method        string
@@ -1834,7 +1834,7 @@ func (s *daemonSuite) TestReadRequestBody(c *check.C) {
 			req.ContentLength = tc.contentLength
 		}
 
-		got, err := readRequestBody(req)
+		got, err := extractRequestAction(req)
 		cmt := check.Commentf("case: %s", tc.name)
 		if tc.wantErr != "" {
 			c.Assert(err, check.ErrorMatches, tc.wantErr+".*", cmt)
@@ -1857,13 +1857,13 @@ func (s *daemonSuite) TestReadRequestBody(c *check.C) {
 	for _, method := range []string{"GET", "DELETE", "PATCH"} {
 		cmt := check.Commentf("method: %s", method)
 		req := httptest.NewRequest(method, "/", strings.NewReader(`{"action":"install"}`))
-		got, err := readRequestBody(req)
+		got, err := extractRequestAction(req)
 		c.Assert(err, check.IsNil, cmt)
 		c.Check(got, check.Equals, "", cmt)
 	}
 }
 
-func (s *daemonSuite) TestReadRequestBodyReadError(c *check.C) {
+func (s *daemonSuite) TestExtractRequestActionReadError(c *check.C) {
 	prefix := []byte(`{"action":"install"`)
 	simulatedErr := errors.New("simulated transient read error")
 	// Prefix then a persistent read error, as when the client disconnects.
@@ -1874,7 +1874,7 @@ func (s *daemonSuite) TestReadRequestBodyReadError(c *check.C) {
 	))
 	req.Header.Set("Content-Type", "application/json")
 
-	action, err := readRequestBody(req)
+	action, err := extractRequestAction(req)
 	c.Check(action, check.Equals, "")
 	c.Assert(err, check.NotNil)
 	c.Check(err, check.ErrorMatches, "cannot read request body: "+simulatedErr.Error())
@@ -1905,8 +1905,8 @@ func (s *daemonSuite) TestRequestActionContext(c *check.C) {
 func (s *daemonSuite) TestRequestActionFromContextMissing(c *check.C) {
 	action, err := requestActionFromContext(context.Background())
 	c.Check(action, check.Equals, "")
-	c.Check(err, check.Equals, errNoRequestAction)
-	c.Check(err, check.ErrorMatches, "internal error: request action not in context")
+	c.Check(err, check.Equals, errRequestActionNotCached)
+	c.Check(err, check.ErrorMatches, "internal error: request action not cached")
 }
 
 // recordingTraceLogger records logger.Trace calls. Log.Trace is a no-op
@@ -2164,7 +2164,7 @@ func (s *daemonSuite) TestTraceSnapdAPI(c *check.C) {
 		} else {
 			// traceSnapdAPI reads the cached action, so skip ServeHTTP
 			// only after the body has been read and cached.
-			action, err := readRequestBody(req)
+			action, err := extractRequestAction(req)
 			c.Assert(isBodyUnusable(err), check.Equals, false, cmt)
 			req = req.WithContext(withRequestAction(req.Context(), action, err))
 			traceSnapdAPI(cmd, req)

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -20,8 +20,10 @@
 package daemon
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -29,17 +31,21 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"syscall"
 	"testing"
+	"testing/iotest"
 	"time"
 
 	"github.com/gorilla/mux"
 	"gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/boot"
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord"
 	"github.com/snapcore/snapd/overlord/auth"
@@ -157,9 +163,8 @@ func (s *daemonSuite) TestCommandMethodDispatch(c *check.C) {
 	cmd.WriteAccess = authenticatedAccess{}
 
 	for _, method := range []string{"GET", "POST", "PUT"} {
-		req, err := http.NewRequest(method, "", nil)
+		req := httptest.NewRequest(method, "/", nil)
 		req.Header.Add("User-Agent", fakeUserAgent)
-		c.Assert(err, check.IsNil)
 
 		rec := httptest.NewRecorder()
 		req.RemoteAddr = fmt.Sprintf("pid=100;uid=1001;socket=%s;", dirs.SnapdSocket)
@@ -174,8 +179,7 @@ func (s *daemonSuite) TestCommandMethodDispatch(c *check.C) {
 		c.Check(rec.Code, check.Equals, 200)
 	}
 
-	req, err := http.NewRequest("POTATO", "", nil)
-	c.Assert(err, check.IsNil)
+	req := httptest.NewRequest("POTATO", "/", nil)
 	req.RemoteAddr = fmt.Sprintf("pid=100;uid=1001;socket=%s;", dirs.SnapdSocket)
 	req.Header.Set("Authorization", fmt.Sprintf(`Macaroon root="%s"`, authUser.Macaroon))
 	rec := httptest.NewRecorder()
@@ -200,12 +204,12 @@ func (s *daemonSuite) TestCommandMethodDispatchRoot(c *check.C) {
 	cmd.WriteAccess = authenticatedAccess{}
 
 	for _, method := range []string{"GET", "POST", "PUT"} {
-		req, err := http.NewRequest(method, "", nil)
+		req := httptest.NewRequest(method, "/", nil)
 		req.Header.Add("User-Agent", fakeUserAgent)
-		c.Assert(err, check.IsNil)
 
 		rec := httptest.NewRecorder()
 		// no ucred => forbidden
+		req.RemoteAddr = ""
 		cmd.ServeHTTP(rec, req)
 		c.Check(rec.Code, check.Equals, 403, check.Commentf(method))
 
@@ -217,8 +221,7 @@ func (s *daemonSuite) TestCommandMethodDispatchRoot(c *check.C) {
 		c.Check(rec.Code, check.Equals, 200)
 	}
 
-	req, err := http.NewRequest("POTATO", "", nil)
-	c.Assert(err, check.IsNil)
+	req := httptest.NewRequest("POTATO", "/", nil)
 	req.RemoteAddr = fmt.Sprintf("pid=100;uid=0;socket=%s;", dirs.SnapdSocket)
 
 	rec := httptest.NewRecorder()
@@ -1439,8 +1442,7 @@ func (s *daemonSuite) TestConnTrackerCanShutdown(c *check.C) {
 }
 
 func doTestReq(c *check.C, cmd *Command, mth string) *httptest.ResponseRecorder {
-	req, err := http.NewRequest(mth, "", nil)
-	c.Assert(err, check.IsNil)
+	req := httptest.NewRequest(mth, "/", nil)
 	req.RemoteAddr = fmt.Sprintf("pid=100;uid=0;socket=%s;", dirs.SnapdSocket)
 	rec := httptest.NewRecorder()
 	cmd.ServeHTTP(rec, req)
@@ -1552,4 +1554,790 @@ func (s *daemonSuite) TestNoticesRequestCanceledOnStop(c *check.C) {
 			"message": "request canceled",
 		},
 		"type": "error"})
+}
+
+func (s *daemonSuite) TestRequestBodyPolicy(c *check.C) {
+	for _, tc := range []struct {
+		method, path, ct     string
+		wantRead, wantAction bool
+	}{
+		{ct: "", wantRead: true, wantAction: true},
+		{ct: "application/json", wantRead: true, wantAction: true},
+		{ct: "APPLICATION/JSON", wantRead: true, wantAction: true},
+		{ct: "Application/Json", wantRead: true, wantAction: true},
+		{ct: "application/json; charset=utf-8", wantRead: true, wantAction: true},
+		{ct: "application/json; charset=windows-1252", wantRead: true, wantAction: true},
+		{ct: "application/json; boundary=foo", wantRead: true, wantAction: true},
+		{ct: "text/plain; charset", wantRead: true},
+		// Unparseable types are read (and rejected if oversize), not streamed.
+		{ct: "application/json; charset=utf-8; charset=utf-16", wantRead: true},
+		{ct: "application/json extra", wantRead: true},
+		{ct: "application/", wantRead: true},
+		{ct: "application", wantRead: true},
+		{ct: "; charset=utf-8", wantRead: true},
+		{ct: "text/plain", wantRead: true},
+		{ct: "application/json-patch+json", wantRead: true},
+		{ct: "notvalid", wantRead: true},
+		{ct: "multipart/form-data"},
+		{ct: "multipart/mixed"},
+		{ct: client.SnapshotExportMediaType},
+		{ct: asserts.MediaType},
+		{method: "PUT", ct: "application/json", wantRead: true},
+		{method: "PUT", ct: "", wantRead: true},
+		{method: "PUT", path: "/v2/assertions"},
+		{method: "GET", ct: "application/json"},
+		{method: "DELETE", ct: "application/json"},
+		{method: "PATCH", ct: "application/json"},
+		{path: "/v2/assertions"},
+		{path: "/v2/assertions/"},
+		// The path exception is only for an absent Content-Type.
+		{path: "/v2/assertions", ct: "application/json", wantRead: true, wantAction: true},
+	} {
+		method := tc.method
+		if method == "" {
+			method = "POST"
+		}
+		path := tc.path
+		if path == "" {
+			path = "/"
+		}
+		req := httptest.NewRequest(method, path, strings.NewReader(`{}`))
+		if tc.ct != "" {
+			req.Header.Set("Content-Type", tc.ct)
+		}
+		read, wantAction := requestBodyPolicy(req)
+		cmt := check.Commentf("method=%s path=%s ct=%q", method, path, tc.ct)
+		c.Check(read, check.Equals, tc.wantRead, cmt)
+		c.Check(wantAction, check.Equals, tc.wantAction, cmt)
+	}
+}
+
+func (s *daemonSuite) TestReadRequestBody(c *check.C) {
+	type testCase struct {
+		name          string
+		method        string
+		path          string
+		body          string
+		contentType   string // "" sets application/json; "none" omits the header
+		contentLength int64
+		wantAction    string
+		wantErr       string
+		wantSentinel  error
+	}
+
+	head := `{"action":"ok","pad":"`
+	tail := `"}`
+	atLimit := head + strings.Repeat("x", maxBodySize-len(head)-len(tail)) + tail
+	c.Assert(len(atLimit), check.Equals, maxBodySize)
+
+	for _, tc := range []testCase{
+		{
+			name:       "extracts action",
+			body:       `{"snaps":["x"],"action":"refresh"}`,
+			wantAction: "refresh",
+		},
+		{
+			name:       "action absent",
+			body:       `{"snaps":["x"]}`,
+			wantAction: "",
+		},
+		{
+			name:       "empty action",
+			body:       `{"action":""}`,
+			wantAction: "",
+		},
+		{
+			name:          "content length ignored",
+			body:          `{"action":"install","snaps":["x"]}`,
+			contentLength: 5,
+			wantAction:    "install",
+		},
+		{
+			name:          "content length unknown",
+			body:          `{"action":"install","snaps":["x"]}`,
+			contentLength: -1,
+			wantAction:    "install",
+		},
+		{
+			name:    "non-object top-level",
+			body:    `[{"action":"install"}]`,
+			wantErr: "json: cannot unmarshal array",
+		},
+		{
+			name:    "malformed json",
+			body:    `{not json`,
+			wantErr: "invalid character",
+		},
+		{
+			name:         "data after json",
+			body:         `{"action":"install"} trailing`,
+			wantErr:      "unexpected data after request body",
+			wantSentinel: errUnexpectedDataAfterBody,
+		},
+		{
+			name:         "data after json starting with brace",
+			body:         `{"action":"install"} }morestuff`,
+			wantErr:      "unexpected data after request body",
+			wantSentinel: errUnexpectedDataAfterBody,
+		},
+		{
+			name:         "data after json starting with bracket",
+			body:         `{"action":"install"} ]morestuff`,
+			wantErr:      "unexpected data after request body",
+			wantSentinel: errUnexpectedDataAfterBody,
+		},
+		{
+			name:          "declared content-length oversize",
+			body:          `{"action":"install"}`,
+			contentLength: maxBodySize + 1,
+			wantErr:       "body size limit exceeded",
+			wantSentinel:  errBodyTooLarge,
+		},
+		{
+			name:         "body size limit exceeded",
+			body:         strings.Repeat("x", maxBodySize+1),
+			wantErr:      "body size limit exceeded",
+			wantSentinel: errBodyTooLarge,
+		},
+		{
+			name:          "oversize with unknown content-length",
+			body:          strings.Repeat("x", maxBodySize+1),
+			contentLength: -1,
+			wantErr:       "body size limit exceeded",
+			wantSentinel:  errBodyTooLarge,
+		},
+		{
+			name:       "body at size limit still parsed",
+			body:       atLimit,
+			wantAction: "ok",
+		},
+		{
+			name:         "empty body",
+			body:         "",
+			wantErr:      "empty request body",
+			wantSentinel: errEmptyBody,
+		},
+		{
+			name:         "whitespace-only body",
+			body:         " \n\t",
+			wantErr:      "EOF",
+			wantSentinel: io.EOF,
+		},
+		{
+			name:        "multipart skipped",
+			body:        `{"action":"install"}`,
+			contentType: "multipart/form-data",
+		},
+		{
+			name:         "malformed parameter still size limited",
+			body:         strings.Repeat("x", maxBodySize+1),
+			contentType:  "application/json; charset",
+			wantErr:      "body size limit exceeded",
+			wantSentinel: errBodyTooLarge,
+		},
+		{
+			name:        "text body read but not parsed",
+			body:        `{"action":"install"}`,
+			contentType: "text/plain",
+			wantAction:  "",
+		},
+		{
+			name:         "text body size limited",
+			body:         strings.Repeat("x", maxBodySize+1),
+			contentType:  "text/plain",
+			wantErr:      "body size limit exceeded",
+			wantSentinel: errBodyTooLarge,
+		},
+		{
+			name:         "unknown media type size limited",
+			body:         strings.Repeat("x", maxBodySize+1),
+			contentType:  "application/octet-stream",
+			wantErr:      "body size limit exceeded",
+			wantSentinel: errBodyTooLarge,
+		},
+		{
+			// An unidentifiable Content-Type must not buy an exemption.
+			name:         "unparseable media type size limited",
+			body:         strings.Repeat("x", maxBodySize+1),
+			contentType:  "application/",
+			wantErr:      "body size limit exceeded",
+			wantSentinel: errBodyTooLarge,
+		},
+		{
+			name:        "labelled assertions skipped",
+			path:        "/v2/assertions",
+			body:        strings.Repeat("x", maxBodySize+1),
+			contentType: asserts.MediaType,
+		},
+		{
+			name:        "snapshot archive skipped",
+			path:        "/v2/snapshots",
+			body:        strings.Repeat("x", maxBodySize+1),
+			contentType: client.SnapshotExportMediaType,
+		},
+		{
+			name:       "put not parsed",
+			method:     "PUT",
+			body:       `{"action":"delegate"}`,
+			wantAction: "",
+		},
+		{
+			name:         "put still size limited",
+			method:       "PUT",
+			body:         strings.Repeat("x", maxBodySize+1),
+			wantErr:      "body size limit exceeded",
+			wantSentinel: errBodyTooLarge,
+		},
+		{
+			name:       "put malformed json not parsed",
+			method:     "PUT",
+			body:       `{not json`,
+			wantAction: "",
+		},
+		{
+			name:        "empty content-type still json",
+			path:        "/v2/warnings",
+			body:        `{"action":"okay"}`,
+			contentType: "none",
+			wantAction:  "okay",
+		},
+		{
+			name:        "assertions empty content-type skipped",
+			path:        "/v2/assertions",
+			body:        strings.Repeat("x", maxBodySize+1),
+			contentType: "none",
+		},
+		{
+			name:        "assertions trailing slash empty content-type skipped",
+			path:        "/v2/assertions/",
+			body:        "type: account\n",
+			contentType: "none",
+		},
+	} {
+		method := tc.method
+		if method == "" {
+			method = "POST"
+		}
+		path := tc.path
+		if path == "" {
+			path = "/"
+		}
+		req := httptest.NewRequest(method, path, strings.NewReader(tc.body))
+		switch tc.contentType {
+		case "none":
+		case "":
+			req.Header.Set("Content-Type", "application/json")
+		default:
+			req.Header.Set("Content-Type", tc.contentType)
+		}
+		if tc.contentLength != 0 {
+			req.ContentLength = tc.contentLength
+		}
+
+		got, err := readRequestBody(req)
+		cmt := check.Commentf("case: %s", tc.name)
+		if tc.wantErr != "" {
+			c.Assert(err, check.ErrorMatches, tc.wantErr+".*", cmt)
+		} else {
+			c.Assert(err, check.IsNil, cmt)
+			c.Check(got, check.Equals, tc.wantAction, cmt)
+		}
+
+		if tc.wantSentinel != errBodyTooLarge || tc.contentLength > maxBodySize {
+			gotBody, readErr := io.ReadAll(req.Body)
+			c.Assert(readErr, check.IsNil, cmt)
+			c.Check(string(gotBody), check.Equals, tc.body, cmt)
+		}
+		if tc.wantSentinel != nil {
+			c.Check(err, check.Equals, tc.wantSentinel, cmt)
+		}
+
+	}
+
+	for _, method := range []string{"GET", "DELETE", "PATCH"} {
+		cmt := check.Commentf("method: %s", method)
+		req := httptest.NewRequest(method, "/", strings.NewReader(`{"action":"install"}`))
+		got, err := readRequestBody(req)
+		c.Assert(err, check.IsNil, cmt)
+		c.Check(got, check.Equals, "", cmt)
+	}
+}
+
+func (s *daemonSuite) TestReadRequestBodyReadError(c *check.C) {
+	prefix := []byte(`{"action":"install"`)
+	simulatedErr := errors.New("simulated transient read error")
+	// Prefix then a persistent read error, as when the client disconnects.
+	req := httptest.NewRequest("POST", "/", http.NoBody)
+	req.Body = io.NopCloser(io.MultiReader(
+		bytes.NewReader(prefix),
+		iotest.ErrReader(simulatedErr),
+	))
+	req.Header.Set("Content-Type", "application/json")
+
+	action, err := readRequestBody(req)
+	c.Check(action, check.Equals, "")
+	c.Assert(err, check.NotNil)
+	c.Check(err, check.ErrorMatches, "cannot read request body: "+simulatedErr.Error())
+	c.Check(errors.Is(err, errBodyUnreadable), check.Equals, true)
+	c.Check(isBodyUnusable(err), check.Equals, true)
+}
+
+func (s *daemonSuite) TestRequestActionContext(c *check.C) {
+	for _, tc := range []struct {
+		name   string
+		action string
+		err    error
+	}{
+		{name: "action", action: "install"},
+		{name: "no action field", action: ""},
+		{name: "empty body", err: errEmptyBody},
+		{name: "oversize", err: errBodyTooLarge},
+		{name: "decode failure", err: errUnexpectedDataAfterBody},
+	} {
+		cmt := check.Commentf("case: %s", tc.name)
+		ctx := withRequestAction(context.Background(), tc.action, tc.err)
+		action, err := requestActionFromContext(ctx)
+		c.Check(action, check.Equals, tc.action, cmt)
+		c.Check(err, check.Equals, tc.err, cmt)
+	}
+}
+
+func (s *daemonSuite) TestRequestActionFromContextMissing(c *check.C) {
+	action, err := requestActionFromContext(context.Background())
+	c.Check(action, check.Equals, "")
+	c.Check(err, check.Equals, errNoRequestAction)
+	c.Check(err, check.ErrorMatches, "internal error: request action not in context")
+}
+
+// recordingTraceLogger records logger.Trace calls. Log.Trace is a no-op
+// unless structured JSON logging is enabled, so tests that care about
+// SNAPD_TRACE output install this instead of logger.MockLogger.
+type recordingTraceLogger struct {
+	logger.Logger
+	calls []traceCall
+}
+
+type traceCall struct {
+	msg   string
+	attrs []any
+}
+
+func (l *recordingTraceLogger) Trace(msg string, attrs ...any) {
+	l.calls = append(l.calls, traceCall{msg: msg, attrs: append([]any(nil), attrs...)})
+}
+
+// withLogger installs l as the global logger. MockLogger is used only to
+// restore the previous logger when the returned function is called.
+func withLogger(l logger.Logger) (restore func()) {
+	_, restore = logger.MockLogger()
+	logger.SetLogger(l)
+	return restore
+}
+
+func (s *daemonSuite) TestTraceSnapdAPI(c *check.C) {
+	rec := &recordingTraceLogger{Logger: logger.NullLogger}
+	defer withLogger(rec)()
+
+	cmd := &Command{Path: "/v2/test"}
+	simulatedErr := errors.New("simulated transient read error")
+
+	// ServeHTTP cases share one daemon: a second times out on the state file lock.
+	d := s.newTestDaemon(c)
+
+	for _, tc := range []struct {
+		name         string
+		trace        bool
+		method       string
+		path         string
+		contentType  string // "" sets application/json; "none" omits the header
+		body         string
+		customBody   io.ReadCloser
+		serveHTTP    bool
+		wantMsgs     []string
+		wantAction   string
+		wantBodyRead string
+		wantStatus   int
+	}{
+		{
+			name:     "trace disabled",
+			method:   "POST",
+			body:     `{"action":"install"}`,
+			wantMsgs: nil,
+		},
+		{
+			name:     "get skipped",
+			trace:    true,
+			method:   "GET",
+			body:     `{"action":"install"}`,
+			wantMsgs: []string{"endpoint"},
+		},
+		{
+			name:     "delete skipped",
+			trace:    true,
+			method:   "DELETE",
+			body:     `{"action":"install"}`,
+			wantMsgs: []string{"endpoint"},
+		},
+		{
+			name:     "patch skipped",
+			trace:    true,
+			method:   "PATCH",
+			body:     `{"action":"install"}`,
+			wantMsgs: []string{"endpoint"},
+		},
+		{
+			name:        "multipart skipped",
+			trace:       true,
+			method:      "POST",
+			contentType: "multipart/form-data",
+			body:        `{"action":"install"}`,
+			wantMsgs:    []string{"endpoint"},
+		},
+		{
+			name:        "snapshot skipped",
+			trace:       true,
+			method:      "POST",
+			contentType: client.SnapshotExportMediaType,
+			body:        `{"action":"install"}`,
+			wantMsgs:    []string{"endpoint"},
+		},
+		{
+			name:        "assertions unlabeled skipped",
+			trace:       true,
+			method:      "POST",
+			path:        "/v2/assertions",
+			contentType: "none",
+			body:        "type: account\n",
+			wantMsgs:    []string{"endpoint"},
+		},
+		{
+			name:       "post extracts action",
+			trace:      true,
+			method:     "POST",
+			body:       `{"action":"install"}`,
+			wantMsgs:   []string{"endpoint"},
+			wantAction: "install",
+		},
+		{
+			name:     "put action not traced",
+			trace:    true,
+			method:   "PUT",
+			body:     `{"action":"delegate"}`,
+			wantMsgs: []string{"endpoint"},
+		},
+		{
+			name:        "charset json extracts action",
+			trace:       true,
+			method:      "POST",
+			contentType: "application/json; charset=utf-8",
+			body:        `{"action":"okay"}`,
+			wantMsgs:    []string{"endpoint"},
+			wantAction:  "okay",
+		},
+		{
+			name:        "empty content-type extracts action",
+			trace:       true,
+			method:      "POST",
+			path:        "/v2/warnings",
+			contentType: "none",
+			body:        `{"action":"okay"}`,
+			wantMsgs:    []string{"endpoint"},
+			wantAction:  "okay",
+		},
+		{
+			name:     "action absent",
+			trace:    true,
+			method:   "POST",
+			body:     `{"snaps":["x"]}`,
+			wantMsgs: []string{"endpoint"},
+		},
+		{
+			name:     "empty action",
+			trace:    true,
+			method:   "POST",
+			body:     `{"action":""}`,
+			wantMsgs: []string{"endpoint"},
+		},
+		{
+			name:     "empty body",
+			trace:    true,
+			method:   "POST",
+			body:     "",
+			wantMsgs: []string{"endpoint"},
+		},
+		{
+			name:         "whitespace-only",
+			trace:        true,
+			method:       "POST",
+			body:         " \n\t",
+			wantMsgs:     []string{"endpoint-error", "endpoint"},
+			wantBodyRead: "EOF",
+		},
+		{
+			name:         "malformed json",
+			trace:        true,
+			method:       "POST",
+			body:         `{not json`,
+			wantMsgs:     []string{"endpoint-error", "endpoint"},
+			wantBodyRead: "invalid character",
+		},
+		{
+			name:         "non-object json",
+			trace:        true,
+			method:       "POST",
+			body:         `[{"action":"install"}]`,
+			wantMsgs:     []string{"endpoint-error", "endpoint"},
+			wantBodyRead: "cannot unmarshal",
+		},
+		{
+			name:         "trailing data",
+			trace:        true,
+			method:       "POST",
+			body:         `{"action":"install"} trailing`,
+			wantMsgs:     []string{"endpoint-error", "endpoint"},
+			wantBodyRead: "unexpected data after request body",
+		},
+		{
+			name:   "read error rejected before trace",
+			trace:  true,
+			method: "POST",
+			customBody: io.NopCloser(io.MultiReader(
+				bytes.NewReader([]byte(`{"action":"install"`)),
+				iotest.ErrReader(simulatedErr),
+			)),
+			serveHTTP:  true,
+			wantMsgs:   nil,
+			wantStatus: 400,
+		},
+		{
+			name:       "oversize rejected before trace",
+			trace:      true,
+			method:     "POST",
+			body:       strings.Repeat("x", maxBodySize+1),
+			serveHTTP:  true,
+			wantMsgs:   nil,
+			wantStatus: 400,
+		},
+	} {
+		rec.calls = nil
+		if tc.trace {
+			os.Setenv("SNAPD_TRACE", "1")
+		} else {
+			os.Unsetenv("SNAPD_TRACE")
+		}
+
+		method := tc.method
+		if method == "" {
+			method = "POST"
+		}
+		path := tc.path
+		if path == "" {
+			path = "/"
+		}
+		var req *http.Request
+		if tc.customBody != nil {
+			req = httptest.NewRequest(method, path, http.NoBody)
+			req.Body = tc.customBody
+		} else {
+			req = httptest.NewRequest(method, path, strings.NewReader(tc.body))
+		}
+		switch tc.contentType {
+		case "none":
+		case "":
+			req.Header.Set("Content-Type", "application/json")
+		default:
+			req.Header.Set("Content-Type", tc.contentType)
+		}
+
+		cmt := check.Commentf("case: %s", tc.name)
+		if tc.serveHTTP {
+			cmdHTTP := &Command{d: d, Path: path}
+			cmdHTTP.POST = func(*Command, *http.Request, *auth.UserState) Response {
+				c.Fatalf("handler must not run for %s", tc.name)
+				return SyncResponse(nil)
+			}
+			cmdHTTP.WriteAccess = openAccess{}
+			req.RemoteAddr = fmt.Sprintf("pid=100;uid=0;socket=%s;", dirs.SnapdSocket)
+			httprec := httptest.NewRecorder()
+			cmdHTTP.ServeHTTP(httprec, req)
+			c.Check(httprec.Code, check.Equals, tc.wantStatus, cmt)
+		} else {
+			// traceSnapdAPI reads the cached action, so skip ServeHTTP
+			// only after the body has been read and cached.
+			action, err := readRequestBody(req)
+			c.Assert(isBodyUnusable(err), check.Equals, false, cmt)
+			req = req.WithContext(withRequestAction(req.Context(), action, err))
+			traceSnapdAPI(cmd, req)
+		}
+
+		var gotMsgs []string
+		var gotAction string
+		var gotBodyRead string
+		for _, call := range rec.calls {
+			gotMsgs = append(gotMsgs, call.msg)
+			for i := 0; i+1 < len(call.attrs); i += 2 {
+				key, _ := call.attrs[i].(string)
+				switch key {
+				case "action":
+					gotAction, _ = call.attrs[i+1].(string)
+				case "body-read":
+					gotBodyRead = fmt.Sprint(call.attrs[i+1])
+				}
+			}
+		}
+		c.Check(gotMsgs, check.DeepEquals, tc.wantMsgs, cmt)
+		c.Check(gotAction, check.Equals, tc.wantAction, cmt)
+		if tc.wantBodyRead != "" {
+			c.Check(gotBodyRead, testutil.Contains, tc.wantBodyRead, cmt)
+		} else {
+			c.Check(gotBodyRead, check.Equals, "", cmt)
+		}
+	}
+	os.Unsetenv("SNAPD_TRACE")
+}
+
+func (s *daemonSuite) TestServeHTTPTraceExtractsActionPreservesBody(c *check.C) {
+	os.Setenv("SNAPD_TRACE", "1")
+	defer os.Unsetenv("SNAPD_TRACE")
+
+	d := s.newTestDaemon(c)
+	body := `{"action":"install","snaps":["x"]}`
+
+	var gotBody string
+	cmd := &Command{d: d, Path: "/v2/test"}
+	cmd.POST = func(_ *Command, r *http.Request, _ *auth.UserState) Response {
+		b, err := io.ReadAll(r.Body)
+		c.Assert(err, check.IsNil)
+		gotBody = string(b)
+		return SyncResponse(nil)
+	}
+	cmd.WriteAccess = openAccess{}
+
+	req := httptest.NewRequest("POST", "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = fmt.Sprintf("pid=100;uid=0;socket=%s;", dirs.SnapdSocket)
+	rec := httptest.NewRecorder()
+	cmd.ServeHTTP(rec, req)
+
+	c.Check(rec.Code, check.Equals, 200)
+	c.Check(gotBody, check.Equals, body)
+}
+
+func (s *daemonSuite) TestServeHTTPOversizeBodyRejected(c *check.C) {
+	d := s.newTestDaemon(c)
+	defer os.Unsetenv("SNAPD_TRACE")
+	for _, trace := range []bool{false, true} {
+		if trace {
+			os.Setenv("SNAPD_TRACE", "1")
+		} else {
+			os.Unsetenv("SNAPD_TRACE")
+		}
+
+		body := strings.Repeat("x", maxBodySize+128)
+		handlerCalled := false
+		cmd := &Command{d: d, Path: "/v2/test"}
+		cmd.POST = func(_ *Command, r *http.Request, _ *auth.UserState) Response {
+			handlerCalled = true
+			return SyncResponse(nil)
+		}
+		cmd.WriteAccess = openAccess{}
+
+		req := httptest.NewRequest("POST", "/", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.RemoteAddr = fmt.Sprintf("pid=100;uid=0;socket=%s;", dirs.SnapdSocket)
+		rec := httptest.NewRecorder()
+		cmd.ServeHTTP(rec, req)
+
+		c.Check(rec.Code, check.Equals, 400, check.Commentf("trace=%v", trace))
+		c.Check(handlerCalled, check.Equals, false, check.Commentf("trace=%v", trace))
+		c.Check(rec.Body.String(), check.Matches, `(?s).*body size limit exceeded.*`, check.Commentf("trace=%v", trace))
+	}
+}
+
+func (s *daemonSuite) TestServeHTTPUnreadableBodyRejected(c *check.C) {
+	d := s.newTestDaemon(c)
+	simulatedErr := errors.New("simulated transient read error")
+
+	handlerCalled := false
+	cmd := &Command{d: d, Path: "/v2/test"}
+	cmd.POST = func(_ *Command, r *http.Request, _ *auth.UserState) Response {
+		handlerCalled = true
+		return SyncResponse(nil)
+	}
+	cmd.WriteAccess = openAccess{}
+
+	req := httptest.NewRequest("POST", "/", http.NoBody)
+	req.Body = io.NopCloser(io.MultiReader(
+		strings.NewReader(`{"action":"install"`),
+		iotest.ErrReader(simulatedErr),
+	))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = fmt.Sprintf("pid=100;uid=0;socket=%s;", dirs.SnapdSocket)
+	rec := httptest.NewRecorder()
+	cmd.ServeHTTP(rec, req)
+
+	c.Check(rec.Code, check.Equals, 400)
+	c.Check(handlerCalled, check.Equals, false)
+	c.Check(rec.Body.String(), check.Matches, `(?s).*cannot read request body: `+simulatedErr.Error()+`.*`)
+}
+
+func (s *daemonSuite) TestServeHTTPSkippedOversizeBodyStillServed(c *check.C) {
+	d := s.newTestDaemon(c)
+	body := strings.Repeat("x", maxBodySize+128)
+	for _, tc := range []struct {
+		path        string
+		contentType string
+	}{
+		{"/v2/assertions", ""},
+		{"/v2/snaps", "multipart/form-data; boundary=x"},
+		{"/v2/snapshots", client.SnapshotExportMediaType},
+	} {
+		var gotLen int
+		cmd := &Command{d: d, Path: tc.path}
+		cmd.POST = func(_ *Command, r *http.Request, _ *auth.UserState) Response {
+			b, err := io.ReadAll(r.Body)
+			c.Assert(err, check.IsNil)
+			gotLen = len(b)
+			return SyncResponse(nil)
+		}
+		cmd.WriteAccess = openAccess{}
+
+		req := httptest.NewRequest("POST", tc.path, strings.NewReader(body))
+		if tc.contentType != "" {
+			req.Header.Set("Content-Type", tc.contentType)
+		}
+		req.RemoteAddr = fmt.Sprintf("pid=100;uid=0;socket=%s;", dirs.SnapdSocket)
+		rec := httptest.NewRecorder()
+		cmd.ServeHTTP(rec, req)
+
+		c.Check(rec.Code, check.Equals, 200, check.Commentf("%s %s", tc.path, tc.contentType))
+		c.Check(gotLen, check.Equals, len(body), check.Commentf("%s %s", tc.path, tc.contentType))
+	}
+}
+
+func (s *daemonSuite) TestServeHTTPTraceInvalidJSONStillServed(c *check.C) {
+	os.Setenv("SNAPD_TRACE", "1")
+	defer os.Unsetenv("SNAPD_TRACE")
+
+	d := s.newTestDaemon(c)
+	body := `{not json`
+
+	var gotBody string
+	cmd := &Command{d: d, Path: "/v2/test"}
+	cmd.POST = func(_ *Command, r *http.Request, _ *auth.UserState) Response {
+		b, err := io.ReadAll(r.Body)
+		c.Assert(err, check.IsNil)
+		gotBody = string(b)
+		return SyncResponse(nil)
+	}
+	cmd.WriteAccess = openAccess{}
+
+	req := httptest.NewRequest("POST", "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = fmt.Sprintf("pid=100;uid=0;socket=%s;", dirs.SnapdSocket)
+	rec := httptest.NewRecorder()
+	cmd.ServeHTTP(rec, req)
+
+	c.Check(rec.Code, check.Equals, 200)
+	c.Check(gotBody, check.Equals, body)
 }

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -1582,8 +1582,9 @@ func (s *daemonSuite) TestRequestBodyPolicy(c *check.C) {
 		{ct: "multipart/mixed"},
 		{ct: client.SnapshotExportMediaType},
 		{ct: asserts.MediaType},
-		{method: "PUT", ct: "application/json", wantBufferBody: true},
-		{method: "PUT", ct: "", wantBufferBody: true},
+		// PUT is not buffered until confdb / snap-conf size limits exist.
+		{method: "PUT", ct: "application/json"},
+		{method: "PUT", ct: ""},
 		{method: "PUT", path: "/v2/assertions"},
 		{method: "GET", ct: "application/json"},
 		{method: "DELETE", ct: "application/json"},
@@ -1782,11 +1783,9 @@ func (s *daemonSuite) TestExtractRequestAction(c *check.C) {
 			wantAction: "",
 		},
 		{
-			name:         "put still size limited",
-			method:       "PUT",
-			body:         strings.Repeat("x", maxBodySize+1),
-			wantErr:      "body size limit exceeded",
-			wantSentinel: errBodyTooLarge,
+			name:   "put not size limited",
+			method: "PUT",
+			body:   strings.Repeat("x", maxBodySize+1),
 		},
 		{
 			name:       "put malformed json not parsed",
@@ -1854,7 +1853,7 @@ func (s *daemonSuite) TestExtractRequestAction(c *check.C) {
 
 	}
 
-	for _, method := range []string{"GET", "DELETE", "PATCH"} {
+	for _, method := range []string{"GET", "PUT", "DELETE", "PATCH"} {
 		cmt := check.Commentf("method: %s", method)
 		req := httptest.NewRequest(method, "/", strings.NewReader(`{"action":"install"}`))
 		got, err := extractRequestAction(req)

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -1881,7 +1881,7 @@ func (s *daemonSuite) TestExtractRequestActionReadError(c *check.C) {
 	c.Check(isBodyUnusable(err), check.Equals, true)
 }
 
-func (s *daemonSuite) TestRequestActionContext(c *check.C) {
+func (s *daemonSuite) TestActionResultContext(c *check.C) {
 	for _, tc := range []struct {
 		name   string
 		action string
@@ -1894,17 +1894,17 @@ func (s *daemonSuite) TestRequestActionContext(c *check.C) {
 		{name: "decode failure", err: errUnexpectedDataAfterBody},
 	} {
 		cmt := check.Commentf("case: %s", tc.name)
-		ctx := withRequestAction(context.Background(), tc.action, tc.err)
-		action, err := requestActionFromContext(ctx)
+		ctx := withActionResult(context.Background(), tc.action, tc.err)
+		action, err := actionResultFromContext(ctx)
 		c.Check(action, check.Equals, tc.action, cmt)
 		c.Check(err, check.Equals, tc.err, cmt)
 	}
 }
 
-func (s *daemonSuite) TestRequestActionFromContextMissing(c *check.C) {
-	action, err := requestActionFromContext(context.Background())
+func (s *daemonSuite) TestActionResultFromContextMissing(c *check.C) {
+	action, err := actionResultFromContext(context.Background())
 	c.Check(action, check.Equals, "")
-	c.Check(err, check.Equals, errRequestActionNotCached)
+	c.Check(err, check.Equals, errActionResultNotCached)
 	c.Check(err, check.ErrorMatches, "internal error: request action not cached")
 }
 
@@ -2165,7 +2165,7 @@ func (s *daemonSuite) TestTraceSnapdAPI(c *check.C) {
 			// only after the body has been read and cached.
 			action, err := extractRequestAction(req)
 			c.Assert(isBodyUnusable(err), check.Equals, false, cmt)
-			req = req.WithContext(withRequestAction(req.Context(), action, err))
+			req = req.WithContext(withActionResult(req.Context(), action, err))
 			traceSnapdAPI(cmd, req)
 		}
 

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -1672,18 +1672,21 @@ func (s *daemonSuite) TestExtractRequestAction(c *check.C) {
 		{
 			name:         "data after json",
 			body:         `{"action":"install"} trailing`,
+			wantAction:   "install",
 			wantErr:      "unexpected data after request body",
 			wantSentinel: errUnexpectedDataAfterBody,
 		},
 		{
 			name:         "data after json starting with brace",
 			body:         `{"action":"install"} }morestuff`,
+			wantAction:   "install",
 			wantErr:      "unexpected data after request body",
 			wantSentinel: errUnexpectedDataAfterBody,
 		},
 		{
 			name:         "data after json starting with bracket",
 			body:         `{"action":"install"} ]morestuff`,
+			wantAction:   "install",
 			wantErr:      "unexpected data after request body",
 			wantSentinel: errUnexpectedDataAfterBody,
 		},
@@ -1839,8 +1842,8 @@ func (s *daemonSuite) TestExtractRequestAction(c *check.C) {
 			c.Assert(err, check.ErrorMatches, tc.wantErr+".*", cmt)
 		} else {
 			c.Assert(err, check.IsNil, cmt)
-			c.Check(got, check.Equals, tc.wantAction, cmt)
 		}
+		c.Check(got, check.Equals, tc.wantAction, cmt)
 
 		if tc.wantSentinel != errBodyTooLarge || tc.contentLength > maxBodySize {
 			gotBody, readErr := io.ReadAll(req.Body)
@@ -1891,7 +1894,7 @@ func (s *daemonSuite) TestActionResultContext(c *check.C) {
 		{name: "no action field", action: ""},
 		{name: "empty body", err: errEmptyBody},
 		{name: "oversize", err: errBodyTooLarge},
-		{name: "decode failure", err: errUnexpectedDataAfterBody},
+		{name: "trailing data keeps action", action: "install", err: errUnexpectedDataAfterBody},
 	} {
 		cmt := check.Commentf("case: %s", tc.name)
 		ctx := withActionResult(context.Background(), tc.action, tc.err)
@@ -2089,12 +2092,13 @@ func (s *daemonSuite) TestTraceSnapdAPI(c *check.C) {
 			wantBodyRead: "cannot unmarshal",
 		},
 		{
-			name:         "trailing data",
-			trace:        true,
-			method:       "POST",
-			body:         `{"action":"install"} trailing`,
-			wantMsgs:     []string{"endpoint-error", "endpoint"},
-			wantBodyRead: "unexpected data after request body",
+			name:       "trailing data rejected before trace",
+			trace:      true,
+			method:     "POST",
+			body:       `{"action":"install"} trailing`,
+			serveHTTP:  true,
+			wantMsgs:   nil,
+			wantStatus: 400,
 		},
 		{
 			name:   "read error rejected before trace",
@@ -2278,6 +2282,33 @@ func (s *daemonSuite) TestServeHTTPUnreadableBodyRejected(c *check.C) {
 	c.Check(rec.Code, check.Equals, 400)
 	c.Check(handlerCalled, check.Equals, false)
 	c.Check(rec.Body.String(), check.Matches, `(?s).*cannot read request body: `+simulatedErr.Error()+`.*`)
+}
+
+func (s *daemonSuite) TestServeHTTPTrailingDataRejected(c *check.C) {
+	d := s.newTestDaemon(c)
+	for _, body := range []string{
+		`{"action":"install"} trailing`,
+		`{"action":"install"} }morestuff`,
+		`{"action":"install"} ]morestuff`,
+	} {
+		handlerCalled := false
+		cmd := &Command{d: d, Path: "/v2/test"}
+		cmd.POST = func(_ *Command, r *http.Request, _ *auth.UserState) Response {
+			handlerCalled = true
+			return SyncResponse(nil)
+		}
+		cmd.WriteAccess = openAccess{}
+
+		req := httptest.NewRequest("POST", "/", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.RemoteAddr = fmt.Sprintf("pid=100;uid=0;socket=%s;", dirs.SnapdSocket)
+		rec := httptest.NewRecorder()
+		cmd.ServeHTTP(rec, req)
+
+		c.Check(rec.Code, check.Equals, 400, check.Commentf("%q", body))
+		c.Check(handlerCalled, check.Equals, false, check.Commentf("%q", body))
+		c.Check(rec.Body.String(), check.Matches, `(?s).*unexpected data after request body.*`, check.Commentf("%q", body))
+	}
 }
 
 func (s *daemonSuite) TestServeHTTPSkippedOversizeBodyStillServed(c *check.C) {

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -400,7 +400,22 @@ var (
 	MaxReadBuflen = maxReadBuflen
 
 	IsRequestFromSnapCmd = isRequestFromSnapCmd
+
+	// Together these reproduce what Command.ServeHTTP does to a request
+	// before access checking.
+	ReadRequestBody   = readRequestBody
+	WithRequestAction = withRequestAction
+	IsBodyUnusable    = isBodyUnusable
+
+	// The rules Command.ServeHTTP uses to find a request's action, shared
+	// with the action coverage check in api_base_test.go.
+	DecodeAction = decodeAction
 )
+
+func RequestDecodesAction(r *http.Request) bool {
+	_, wantAction := requestBodyPolicy(r)
+	return wantAction
+}
 
 func MockRebootNoticeWait(d time.Duration) (restore func()) {
 	restore = testutil.Backup(&rebootNoticeWait)

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -404,7 +404,7 @@ var (
 	// Together these reproduce what Command.ServeHTTP does to a request
 	// before access checking.
 	ExtractRequestAction = extractRequestAction
-	WithRequestAction    = withRequestAction
+	WithActionResult     = withActionResult
 	IsBodyUnusable       = isBodyUnusable
 
 	// The rules Command.ServeHTTP uses to find a request's action, shared

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -403,18 +403,18 @@ var (
 
 	// Together these reproduce what Command.ServeHTTP does to a request
 	// before access checking.
-	ReadRequestBody   = readRequestBody
-	WithRequestAction = withRequestAction
-	IsBodyUnusable    = isBodyUnusable
+	ExtractRequestAction = extractRequestAction
+	WithRequestAction    = withRequestAction
+	IsBodyUnusable       = isBodyUnusable
 
 	// The rules Command.ServeHTTP uses to find a request's action, shared
 	// with the action coverage check in api_base_test.go.
-	DecodeAction = decodeAction
+	DecodeAction = decodeActionFromBody
 )
 
 func RequestDecodesAction(r *http.Request) bool {
-	_, wantAction := requestBodyPolicy(r)
-	return wantAction
+	_, decodeAction := requestBodyPolicy(r)
+	return decodeAction
 }
 
 func MockRebootNoticeWait(d time.Duration) (restore func()) {


### PR DESCRIPTION
`Command.ServeHTTP` now reads each request body exactly once under a single 4 MiB limit, replacing two independent reads with mismatched 3 MiB and 4 MiB caps that could each hand a truncated body to the handler; bodies recognized as legitimately large — sideloads, snapshot imports and assertion streams — are never read and keep streaming to their handler. The extracted `action` is cached on the request context so the access checker and the tracer share one result, which is what lets a later security-logging step record the action of a request before the access check denies it.

Oversize is rejected from a declared `Content-Length` when that is already above 4 MiB, so a client cannot force the daemon to buffer the limit before being denied. Otherwise size is measured on the whole body after a `LimitReader` read.

<details>
<summary>Design decisions</summary>

- **One read, in one place.** `Command.ServeHTTP` calls `extractRequestAction` once, after the method dispatch and before `access.CheckAccess`. It has to precede the access decision because security logging must be able to record the action of a request that is *denied*.
- **The result travels on the request context.** `withActionResult` caches the action and any decode error; `byActionAccess` and `traceSnapdAPI` only look it up through `actionResultFromContext` and never touch the body again. A cache miss is reported as an internal error rather than being mistaken for a request that carried no action.
- **Relaxed at the top, strict below.** The shared read selects by parsed media type and never rejects on a caller's behalf: a body that failed to decode still reaches the caller, with the error attached. `byActionAccess` keeps its own stricter rule (exactly `application/json`) and is what turns that error into a 400.
- **Reading is broader than decoding.** `requestBodyPolicy` parses the media type once and returns both decisions: every POST body is read except recognised streams; PUT is left unread until confdb and snap-conf size limits exist. Only JSON POST bodies are decoded. A decoded body that is not exactly one JSON value still yields the `action` if the first value decoded; `ServeHTTP` caches it, then answers 400. That is why `decodeActionFromBody` calls `json.Decoder` a second time instead of using `json.Unmarshal`.
- **Only an unusable body is fatal.** A single 4 MiB limit replaces the previous pair (4 MiB in `byActionAccess`, 3 MiB in `traceSnapdAPI`). Oversize is detected from a declared `Content-Length` when that is already above the limit, otherwise by reading under `LimitReader` and measuring the whole body — not whatever the decoder happened to consume. A body that exceeds it, a stream that broke partway through, or JSON with trailing data after the first value, is refused: `ServeHTTP` answers 400 and stops. Trailing data still caches the decoded `action` first. Every other decode failure carries on.
- **Handlers always see the whole body.** Whenever the body is read it is handed back in full, so the outcome of the decode can never truncate what the handler receives. An unusable body is the sole exception, and it is discarded along with the rejected request.
- **Large payloads are never read, rather than exempted after the fact.** They are recognised by media type (`multipart/*`, `client.SnapshotExportMediaType`, `asserts.MediaType`) plus unlabelled `POST /v2/assertions`, which is `snap ack`. A Content-Type that cannot be recognised is read, not exempted: the exception is earned by identifying the payload, so failing to identify one must not grant it.

</details>

<details>
<summary>Design summary</summary>

```mermaid
flowchart TD
  req["incoming request"] --> disp{"handler for this method?"}
  disp -- no --> notAllowed["405 method not allowed"]
  disp -- yes --> sel

  subgraph readBody [extractRequestAction: the single body read]
    sel{"requestBodyPolicy: read and/or decode?"}
    sel -- "neither: recognised stream, PUT, or a method that is never read" --> skip["body left untouched"]
    sel -- read --> cl{"Content-Length already over 4 MiB?"}
    cl -- yes --> reject
    cl -- no --> read["read under LimitReader, restore the body, decode the action if wanted"]
  end

  skip --> cache
  read --> usable{"isBodyUnusable?"}
  usable -- "yes: oversize or broken stream" --> reject["400, request ends, body discarded"]
  usable -- "no, even if the decode failed" --> cache["cache action and parseErr on the request context"]
  cache --> trailing{"trailing data after the JSON value?"}
  trailing -- yes --> trailingReject["400, request ends; decoded action already cached"]
  trailing -- no --> check["access.CheckAccess"]
  check --> allowed{"allowed?"}
  allowed -- no --> denied["401 or 403 from the checker, 400 from byActionAccess on content type or a decode error; not traced"]
  allowed -- yes --> trace["traceSnapdAPI, only when SNAPD_TRACE=1"]
  trace --> handler["handler reads the body in full"]

  ctx[("request context")]
  cache -. writes .-> ctx
  ctx -. "read by byActionAccess" .-> check
  ctx -. "read by the tracer" .-> trace
```
</details>

<details>
<summary>Body Size Limit Exceptions</summary>

The 4 MiB limit applies only to POST bodies that `requestBodyPolicy` chooses to buffer. Two different mechanisms skip that read.
- **Method.** PUT is never buffered. The only PUT endpoints today are snap conf and confdb, whose size limits are not yet established. A PUT body is left unread and is not decoded for `action`. TODO: buffer PUT once those size limits exist.
- **Recognised streams.** Selected POST payloads are identified by media type (and, for `snap ack`, by an absent Content-Type on `POST /v2/assertions`). An exempt body is never read, so these endpoints keep streaming rather than being buffered and then waved through.
Stream recognition is by media type and so is path independent, except for that one path-scoped rule. PUT is not a row in the table: it is skipped by method, not by Content-Type.
| Content-Type | Endpoints today | Payload | Expected size | Carries a JSON action? |
| --- | --- | --- | --- | --- |
| `multipart/*` | `POST /v2/snaps` | sideloaded snap files, or `snap try` | hundreds of MB for sideload, tiny for try | No. `snap try` does send `action=try`, but as a form field |
| `multipart/form-data` | `POST /v2/systems`, `POST /v2/systems/{label}` | offline system create bundle | hundreds of MB | No. `create` arrives as a form field |
| `multipart/form-data` | `POST /v2/model` | offline remodel bundle | hundreds of MB | No. The operation is implied by the endpoint |
| `application/x.snapd.snapshot` (`client.SnapshotExportMediaType`) | `POST /v2/snapshots` | snapshot import stream | effectively unbounded | No. Import is implied by the media type |
| `application/x.ubuntu.assertion` (`asserts.MediaType`) | `POST /v2/assertions` | labelled assertion stream | unbounded in principle | No |
| absent | `POST /v2/assertions` only | `snap ack` assertion stream; `client.Ack` sends no headers | unbounded in principle | No |
A Content-Type that cannot be parsed into a media type is read rather than exempted: the exemption is earned by recognising a payload that must not be held in memory, so failing to recognise one cannot grant it. A malformed *parameter* is not such a failure, since `mime.ParseMediaType` returns the media type alongside `ErrInvalidMediaParameter` — otherwise a single junk parameter would buy an exemption.

</details>

<details>
<summary> byActionAccess AccessChecker behavior Before VS After</summary>

The checker no longer reads the body; it looks up what `ServeHTTP` cached. Trailing data after the JSON value is refused by `ServeHTTP` after that cache step, so the checker is not reached. Other decode errors still reach the checker and become 400 there. Observable behavior is otherwise unchanged except where noted.

| Case | master | this PR | Note |
| --- | --- | --- | --- |
| Non-JSON or absent Content-Type | 400 `unexpected content type: %q` | same | Still an exact string comparison, so `application/json; charset=utf-8` is rejected here even though the shared reader accepts it |
| Valid JSON with a known `action` | routes to that action's checker | same | |
| Valid JSON with an unknown or absent `action` | falls through to `Default` (root-level) | same | |
| Malformed JSON | 400 `invalid character …` | same | Decoder error text unchanged; still from the checker |
| Non-object top level | 400 `json: cannot unmarshal array …` | same | Still from the checker |
| Whitespace-only body | 400 `EOF` | same | The decoder's `io.EOF`, now distinct from a zero-length body; still from the checker |
| Ordinary trailing data (`` `{"action":"x"} trailing` ``) | 400 `unexpected data after request body` from the checker | same message, from `ServeHTTP` after caching the action and before the checker | Checker and tracer are not reached. The decoded `action` is already on the request context |
| Zero-length body | 400 `EOF` | 400 `empty request body` | **Improved.** `EOF` leaked a stdlib internal and could not be told apart from a whitespace-only body |
| Trailing data starting with `}` or `]` | accepted; the action was extracted and the handler could see a truncated body | 400 `unexpected data after request body` from `ServeHTTP` | **Improved.** `json.Decoder.More()` returns false on `}` and `]`; the second `Decode` catches it. Same cache-then-400 path as ordinary trailing data |
| A single JSON value larger than 4 MiB | 400 `body size limit exceeded` from the checker | same message, from `ServeHTTP` before the checker runs | Indistinguishable to a client; the checker is simply never reached. Not cached: the body is unusable |
| Declared `Content-Length` over 4 MiB, small actual body | read until the decoder or the 4 MiB cap | 400 `body size limit exceeded` from `ServeHTTP`, body not read | **Improved.** The declared length is enough |
| A small JSON value followed by more than 4 MiB of data | 400 `unexpected data after request body` | 400 `body size limit exceeded` | **Improved.** Size is measured on the whole body, not on what the decoder happened to consume |
| Mid-stream read error | 400 with the underlying error text, from the checker | 400 `cannot read request body: …`, from `ServeHTTP` | **Changed.** Same status, prefixed message, checker not reached. Not cached: the body is unusable |
| Non-JSON Content-Type *and* an oversize body | 400 `unexpected content type` — the body was never read | 400 `body size limit exceeded` | **Changed.** The limit is applied ahead of the checker, so the precedence of the two errors is reversed. Neither `byActionAccess` endpoint (`POST /v2/system-volumes`, `POST /v2/interfaces/requests`) accepts anything but JSON, so this is theoretical today |
| A request that never went through `Command.ServeHTTP` | the checker parsed the body itself | 500 `internal error: request action not cached` | **New.** The checker now depends on `ServeHTTP` having read the body, and a cache miss is reported rather than being read as "no action" |
| Body handed to the handler | only what the decoder happened to buffer, so a large body could be truncated | the full body | **Improved** |
| Allocation | preallocated `min(Content-Length, 4 MiB)`, so a 1-byte body declaring `Content-Length: 4194304`, or any body of unknown length, allocated 4 MiB | grows with the actual body when it is read; a declared `Content-Length` over 4 MiB is rejected without allocating | **Improved** |

</details>

<details>
<summary> traceSnapdAPI behavior Before VS After</summary>

The tracer no longer reads the body; it looks up what `ServeHTTP` cached. It still runs only after `CheckAccess` succeeds, so a request refused earlier — oversize, a broken stream, or trailing data after the JSON value — is not traced.

| Case | master | this PR | Note |
| --- | --- | --- | --- |
| `SNAPD_TRACE` unset | nothing logged | same | |
| Denied or rejected request | not traced | same | The tracer still runs after `CheckAccess` |
| POST JSON with an `action` | `endpoint` with `action` | same | |
| `action` absent or empty | `endpoint` without `action` | same | |
| Zero-length body | `endpoint` only | same | `errEmptyBody` is filtered, matching master's silently failed `Unmarshal` of an empty slice |
| GET, DELETE, PATCH | `endpoint` without `action` | same | Body not read |
| PUT with a JSON `action` | `endpoint` without `action` | same | PUT is not buffered until confdb / snap-conf size limits exist |
| Multipart, snapshot export, labelled assertions | `endpoint` without `action` | same | Skipped by media type |
| `application/json; charset=utf-8` | `endpoint` without `action` | `endpoint` with `action` | **Changed.** RFC-compliant parameters are accepted now that selection goes through `mime.ParseMediaType` |
| Unlabelled `POST /v2/assertions` | read under the 3 MiB cap, which could truncate the handler's body | not read; `endpoint` without `action` | **Changed.** `snap ack` sends no Content-Type, and its stream is no longer touched |
| Body between 3 and 4 MiB | `endpoint-error` (`http: request body too large`), and the handler saw a truncated body | decoded normally; `endpoint` with `action` if present | **Changed.** One shared 4 MiB limit; the `MaxBytesReader` side effect is gone |
| Whitespace-only body | `endpoint` only, the decode failure swallowed | `endpoint-error` (`EOF`) then `endpoint` | **Changed / noisier.** Required for the security-logging seam |
| Malformed JSON | `endpoint` only | `endpoint-error` (`invalid character …`) then `endpoint` | **Changed / noisier.** Same reason |
| Non-object top level | `endpoint` only | `endpoint-error` then `endpoint` | **Changed / noisier.** Same reason |
| Trailing data after the JSON value | `endpoint` only, the `Unmarshal` error swallowed | not traced; `ServeHTTP` answers 400 first | **Changed.** Hard failure after the action is cached and before `CheckAccess`; the tracer is not reached |
| Body over 4 MiB | `endpoint-error`, then the request was served with a truncated body | not traced; `ServeHTTP` answers 400 first | **Changed.** Hard failure ahead of the tracer. Body unusable, so not cached |
| Mid-stream read error | `endpoint-error` then `endpoint`, request served with a truncated body | not traced; `ServeHTTP` answers 400 first | **Changed.** Same reason as the oversize case |
| `endpoint-error` attribute key | `body-read`, always a genuine read failure | `body-read`, now also decode failures | **Changed.** The key no longer separates a failed read from a failed decode |

Nothing consumes `endpoint-error`: `EndpointFeature` in `tests/utils/features/featextractor.py` matches `msg == "endpoint"` and reads only `method`, `path` and `action`. The last three rows are therefore open questions about what the line is for rather than about anything that breaks — whether the tracer should run for a request refused before the access check, and whether one key should cover both failure kinds.

</details>

Jira: https://warthogs.atlassian.net/browse/SNAPDENG-37105


