### PR TITLE
seclog: adjust auth logging api (p2)

### DIFF
--- a/seclog/eventdata.go
+++ b/seclog/eventdata.go
@@ -87,19 +87,39 @@ type SnapdUser struct {
 	Expiration     time.Time `json:"expiration"`
 }
 
-// Peer describes the Unix-domain peer of an API request (Socket, UID, PID).
+// Peer describes the Unix-domain peer of an API request.
+//
+// Socket, UID, and PID come from peer credentials and are expected to be
+// set when emitting AUTHZ events (the access gate is not reached without
+// them). The remaining fields are best-effort enrichment and should use
+// "<unknown>" when unavailable.
 //
 // Callers may signal "unknown" by setting UID to [peerNobody] and/or PID to
-// [peerNoProcess]. These mirror the daemon ucrednetNobody and ucrednetNoProcess
-// sentinels (see daemon/ucrednet.go).
+// [peerNoProcess] for display via [Peer.String]; these mirror the daemon
+// `ucrednetNobody` and `ucrednetNoProcess` sentinels (see daemon/ucrednet.go).
 type Peer struct {
 	Socket string `json:"socket"`
 	UID    uint32 `json:"uid"`
 	PID    int32  `json:"pid"`
+	// Exe is the executable path of the peer process, read from
+	// /proc/<pid>/exe. "<unknown>" when not available.
+	Exe string `json:"exe"`
+	// SecurityLabel is the AppArmor or SELinux LSM label of the peer
+	// process. "<unknown>" when not available.
+	SecurityLabel string `json:"security_label"`
+	// CgroupLabel is the snap cgroup label of the peer process (e.g.
+	// snap.<instance>.<app>). "<unknown>" when not available.
+	CgroupLabel string `json:"cgroup_label"`
+	// Snap is the snap instance name of the peer process, derived from
+	// [Peer.SecurityLabel]. "<unknown>" when not available.
+	Snap string `json:"snap"`
+	// App is the snap application or service name of the peer process,
+	// derived from [Peer.SecurityLabel]. "<unknown>" when not available.
+	App string `json:"app"`
 }
 
-// [peerNobody] and [peerNoProcess] mirror the daemon ucrednetNobody and
-// ucrednetNoProcess sentinels. They are duplicated here to keep seclog
+// [peerNobody] and [peerNoProcess] mirror the daemon `ucrednetNobody` and
+// `ucrednetNoProcess` sentinels. They are duplicated here to keep seclog
 // free of snapd package imports.
 const (
 	peerNobody    = ^uint32(0)
@@ -132,11 +152,9 @@ func (p Peer) String() string {
 
 // Endpoint describes an API endpoint involved in an authorization event.
 type Endpoint struct {
-	Method        string `json:"method"`
-	Path          string `json:"path"`
-	Action        string `json:"action"`
-	AccessChecker string `json:"access_checker"`
-	AccessLevel   string `json:"access_level"`
+	Method string `json:"method"`
+	Path   string `json:"path"`
+	Action string `json:"action"`
 }
 
 // String returns a colon-separated representation in the form
@@ -160,6 +178,21 @@ func (e Endpoint) String() string {
 
 	return method + ":" + path + ":" + action
 }
+
+// ReasonGranted values identify the mechanism that granted access for
+// authz_admin events. They are passed to [LogAdminActivity] as the
+// reasonGranted argument and emitted as reason_granted.
+//
+// When access was granted via a snap interface connection, the value is
+// expanded by appending the interface name and plug or slot side, in the
+// form " <interface>+<plug|slot>" (e.g. "root-auth desktop-launch+plug").
+// The same postfix may apply to any of the base values when an interface
+// also contributed to the grant.
+const (
+	ReasonGrantedUserAuth   = "user-auth"
+	ReasonGrantedRootAuth   = "root-auth"
+	ReasonGrantedPolkitAuth = "polkit-auth"
+)
 
 // AuthzCheck represents the outcome of a single authorization check.
 type AuthzCheck string

--- a/seclog/eventdata.go
+++ b/seclog/eventdata.go
@@ -87,12 +87,24 @@ type SnapdUser struct {
 	Expiration     time.Time `json:"expiration"`
 }
 
+// LSM security label keys for [Peer.SecurityLabels].
+const (
+	PeerSecurityLabelAppArmor = "AppArmor"
+	PeerSecurityLabelSELinux  = "SELinux"
+)
+
 // Peer describes the Unix-domain peer of an API request.
 //
 // Socket, UID, and PID come from peer credentials and are expected to be
 // set when emitting AUTHZ events (the access gate is not reached without
-// them). The remaining fields are best-effort enrichment and should use
-// "<unknown>" when unavailable.
+// them). Exe, CgroupLabel, Snap, and App are best-effort enrichment fields.
+// When unavailable, leave them empty or set them to [unknown]; [Peer.LogValue]
+// logs empty values as [unknown].
+//
+// [Peer.SecurityLabels] is also best-effort enrichment: include only the LSM
+// keys that were obtained. Do not use [unknown] as a map value; omit unavailable
+// keys instead. An empty or nil map is logged as an empty JSON object. Keys are
+// emitted in alphabetical order.
 //
 // Callers may signal "unknown" by setting UID to [peerNobody] and/or PID to
 // [peerNoProcess] for display via [Peer.String]; these mirror the daemon
@@ -102,19 +114,20 @@ type Peer struct {
 	UID    uint32 `json:"uid"`
 	PID    int32  `json:"pid"`
 	// Exe is the executable path of the peer process, read from
-	// /proc/<pid>/exe. "<unknown>" when not available.
+	// /proc/<pid>/exe. [unknown] when unavailable.
 	Exe string `json:"exe"`
-	// SecurityLabel is the AppArmor or SELinux LSM label of the peer
-	// process. "<unknown>" when not available.
-	SecurityLabel string `json:"security_label"`
+	// SecurityLabels holds LSM security labels keyed by [PeerSecurityLabelAppArmor]
+	// and [PeerSecurityLabelSELinux]. Omit unavailable keys.
+	SecurityLabels map[string]string `json:"security_labels"`
 	// CgroupLabel is the snap cgroup label of the peer process (e.g.
-	// snap.<instance>.<app>). "<unknown>" when not available.
+	// snap.<instance>.<app>). [unknown] when unavailable.
 	CgroupLabel string `json:"cgroup_label"`
-	// Snap is the snap instance name of the peer process, derived from
-	// [Peer.SecurityLabel]. "<unknown>" when not available.
+	// Snap is the snap instance name of the peer process, typically derived
+	// from the AppArmor entry in [Peer.SecurityLabels]. [unknown] when unavailable.
 	Snap string `json:"snap"`
 	// App is the snap application or service name of the peer process,
-	// derived from [Peer.SecurityLabel]. "<unknown>" when not available.
+	// typically derived from the AppArmor entry in [Peer.SecurityLabels].
+	// [unknown] when unavailable.
 	App string `json:"app"`
 }
 
@@ -151,6 +164,9 @@ func (p Peer) String() string {
 }
 
 // Endpoint describes an API endpoint involved in an authorization event.
+// When unavailable, leave Method and Path empty or set them to [unknown], and
+// leave Action empty or set it to [none]; [Endpoint.LogValue] logs empty
+// method and path as [unknown] and an empty action as [none].
 type Endpoint struct {
 	Method string `json:"method"`
 	Path   string `json:"path"`

--- a/seclog/eventdata.go
+++ b/seclog/eventdata.go
@@ -194,45 +194,18 @@ const (
 	ReasonGrantedPolkitAuth = "polkit-auth"
 )
 
-// AuthzCheck represents the outcome of a single authorization check.
-type AuthzCheck string
-
-// AuthzCheck outcome values for a single authorization stage.
-// The default for a new [AuthzChecks] is [AuthzNotApplicable].
+// ReasonDenied values identify why access was denied for authz_fail events.
+// They are passed to [LogUnauthorizedAccess] as the reasonDenied argument
+// and emitted as reason_denied.
 const (
-	AuthzNotApplicable AuthzCheck = "not-applicable" // stage not used for this request
-	AuthzNotReached    AuthzCheck = "not-reached"    // applicable but not evaluated yet
-	AuthzFail          AuthzCheck = "fail"
-	AuthzPass          AuthzCheck = "pass"
+	ReasonDeniedNoPeerCredentials    = "no-peer-credentials"
+	ReasonDeniedSocketNotPermitted   = "socket-not-permitted"
+	ReasonDeniedMissingInterfacePlug = "missing-interface-plug"
+	ReasonDeniedMissingInterfaceSlot = "missing-interface-slot"
+	ReasonDeniedUserAuthDenied       = "user-auth-denied"
+	ReasonDeniedRootAuthDenied       = "root-auth-denied"
+	ReasonDeniedPolkitAuthDenied     = "polkit-auth-denied"
 )
-
-// AuthzChecks captures the outcome of each authorization stage evaluated
-// during an access check. Each field records whether that stage passed,
-// failed, or was not applicable to the request.
-type AuthzChecks struct {
-	AccessOptions AuthzCheck `json:"access_options"`
-	PeerCreds     AuthzCheck `json:"peer_credentials"`
-	Socket        AuthzCheck `json:"socket"`
-	Interface     AuthzCheck `json:"interface_requirements"`
-	OpenAccess    AuthzCheck `json:"open_access"`
-	UserAuth      AuthzCheck `json:"user_authentication"`
-	Root          AuthzCheck `json:"root"`
-	Polkit        AuthzCheck `json:"polkit"`
-}
-
-// NewAuthzChecks returns an [AuthzChecks] with all fields set to [AuthzNotApplicable].
-func NewAuthzChecks() AuthzChecks {
-	return AuthzChecks{
-		AccessOptions: AuthzNotApplicable,
-		PeerCreds:     AuthzNotApplicable,
-		Socket:        AuthzNotApplicable,
-		Interface:     AuthzNotApplicable,
-		OpenAccess:    AuthzNotApplicable,
-		UserAuth:      AuthzNotApplicable,
-		Root:          AuthzNotApplicable,
-		Polkit:        AuthzNotApplicable,
-	}
-}
 
 // String returns a colon-separated description of the user in the form
 // "<ID>:<StoreUserEmail>:<StoreUserName>". Fields that are unset use

--- a/seclog/eventdata.go
+++ b/seclog/eventdata.go
@@ -195,32 +195,36 @@ func (e Endpoint) String() string {
 	return method + ":" + path + ":" + action
 }
 
-// ReasonGranted values identify the mechanism that granted access for
-// authz_admin events. They are passed to [LogAdminActivity] as the
-// reasonGranted argument and emitted as reason_granted.
+// GrantReason identifies why access was granted for authz_admin events.
+// It is passed to [LogAdminActivity] as grantReason and emitted as
+// reason_granted.
 //
 // When access was granted via a snap interface connection, the value is
 // expanded by appending the interface name and plug or slot side, in the
 // form " <interface>+<plug|slot>" (e.g. "root-auth desktop-launch+plug").
 // The same postfix may apply to any of the base values when an interface
 // also contributed to the grant.
+type GrantReason string
+
 const (
-	ReasonGrantedUserAuth   = "user-auth"
-	ReasonGrantedRootAuth   = "root-auth"
-	ReasonGrantedPolkitAuth = "polkit-auth"
+	GrantUserAuth   GrantReason = "user-auth"
+	GrantRootAuth   GrantReason = "root-auth"
+	GrantPolkitAuth GrantReason = "polkit-auth"
 )
 
-// ReasonDenied values identify why access was denied for authz_fail events.
-// They are passed to [LogUnauthorizedAccess] as the reasonDenied argument
-// and emitted as reason_denied.
+// DenialReason identifies why access was denied for authz_fail events.
+// It is passed to [LogUnauthorizedAccess] as denialReason and emitted as
+// reason_denied.
+type DenialReason string
+
 const (
-	ReasonDeniedNoPeerCredentials    = "no-peer-credentials"
-	ReasonDeniedSocketNotPermitted   = "socket-not-permitted"
-	ReasonDeniedMissingInterfacePlug = "missing-interface-plug"
-	ReasonDeniedMissingInterfaceSlot = "missing-interface-slot"
-	ReasonDeniedUserAuthDenied       = "user-auth-denied"
-	ReasonDeniedRootAuthDenied       = "root-auth-denied"
-	ReasonDeniedPolkitAuthDenied     = "polkit-auth-denied"
+	DenialNoPeerCredentials    DenialReason = "no-peer-credentials"
+	DenialSocketNotPermitted   DenialReason = "socket-not-permitted"
+	DenialMissingInterfacePlug DenialReason = "missing-interface-plug"
+	DenialMissingInterfaceSlot DenialReason = "missing-interface-slot"
+	DenialUserAuth             DenialReason = "user-auth-denied"
+	DenialRootAuth             DenialReason = "root-auth-denied"
+	DenialPolkitAuth           DenialReason = "polkit-auth-denied"
 )
 
 // String returns a colon-separated description of the user in the form

--- a/seclog/eventdata.go
+++ b/seclog/eventdata.go
@@ -199,11 +199,9 @@ func (e Endpoint) String() string {
 // It is passed to [LogAdminActivity] as grantReason and emitted as
 // reason_granted.
 //
-// When access was granted via a snap interface connection, the value is
-// expanded by appending the interface name and plug or slot side, in the
-// form " <interface>+<plug|slot>" (e.g. "root-auth desktop-launch+plug").
-// The same postfix may apply to any of the base values when an interface
-// also contributed to the grant.
+// The base values are [GrantUserAuth], [GrantRootAuth], and
+// [GrantPolkitAuth]. When an interface connection also contributed to
+// the grant, use [GrantReason.WithInterface].
 type GrantReason string
 
 const (
@@ -211,6 +209,28 @@ const (
 	GrantRootAuth   GrantReason = "root-auth"
 	GrantPolkitAuth GrantReason = "polkit-auth"
 )
+
+// WithInterface returns a [GrantReason] that includes a snap interface
+// connection as part of why access was granted.
+//
+// The result has the form "<reason> <interface> <plug|slot>", for
+// example "root-auth desktop-launch plug".
+//
+// If iface is empty, WithInterface returns g unchanged so it can be
+// called unconditionally.
+//
+// onPlugSide is true when the requesting snap was on the plug side of
+// the connection, false for the slot side.
+func (g GrantReason) WithInterface(iface string, onPlugSide bool) GrantReason {
+	if iface == "" {
+		return g
+	}
+	side := "slot"
+	if onPlugSide {
+		side = "plug"
+	}
+	return GrantReason(string(g) + " " + iface + " " + side)
+}
 
 // DenialReason identifies why access was denied for authz_fail events.
 // It is passed to [LogUnauthorizedAccess] as denialReason and emitted as

--- a/seclog/eventdata_test.go
+++ b/seclog/eventdata_test.go
@@ -85,15 +85,3 @@ func (s *SecLogSuite) TestPeerString(c *C) {
 
 	c.Check(seclog.Peer{UID: ^uint32(0)}.String(), Equals, "<unknown>:<unknown>:<unknown>")
 }
-
-func (s *SecLogSuite) TestNewAuthzChecks(c *C) {
-	checks := seclog.NewAuthzChecks()
-	c.Check(checks.AccessOptions, Equals, seclog.AuthzNotApplicable)
-	c.Check(checks.PeerCreds, Equals, seclog.AuthzNotApplicable)
-	c.Check(checks.Socket, Equals, seclog.AuthzNotApplicable)
-	c.Check(checks.Interface, Equals, seclog.AuthzNotApplicable)
-	c.Check(checks.OpenAccess, Equals, seclog.AuthzNotApplicable)
-	c.Check(checks.UserAuth, Equals, seclog.AuthzNotApplicable)
-	c.Check(checks.Root, Equals, seclog.AuthzNotApplicable)
-	c.Check(checks.Polkit, Equals, seclog.AuthzNotApplicable)
-}

--- a/seclog/eventdata_test.go
+++ b/seclog/eventdata_test.go
@@ -85,3 +85,16 @@ func (s *SecLogSuite) TestPeerString(c *C) {
 
 	c.Check(seclog.Peer{UID: ^uint32(0)}.String(), Equals, "<unknown>:<unknown>:<unknown>")
 }
+
+func (s *SecLogSuite) TestGrantReasonWithInterface(c *C) {
+	c.Check(seclog.GrantRootAuth.WithInterface("desktop-launch", true),
+		Equals, seclog.GrantReason("root-auth desktop-launch plug"))
+	c.Check(seclog.GrantUserAuth.WithInterface("snap-themes-control", false),
+		Equals, seclog.GrantReason("user-auth snap-themes-control slot"))
+	c.Check(seclog.GrantPolkitAuth.WithInterface("snap-fde-control", true),
+		Equals, seclog.GrantReason("polkit-auth snap-fde-control plug"))
+
+	// Empty iface means no interface contributed; the base reason is unchanged.
+	c.Check(seclog.GrantRootAuth.WithInterface("", true), Equals, seclog.GrantRootAuth)
+	c.Check(seclog.GrantRootAuth.WithInterface("", false), Equals, seclog.GrantRootAuth)
+}

--- a/seclog/seclog.go
+++ b/seclog/seclog.go
@@ -193,17 +193,22 @@ func LogUserRemoved(user SnapdUser) {
 // LogAdminActivity logs an administrative API access event using the
 // global security logger. It is emitted when authorization succeeds (the
 // access gate passed), not when the API operation or handler succeeds.
-func LogAdminActivity(user SnapdUser, peer Peer, endpoint Endpoint, checks AuthzChecks) {
+//
+// reasonGranted identifies why access was granted; see [ReasonGrantedUserAuth],
+// [ReasonGrantedRootAuth], and [ReasonGrantedPolkitAuth], optionally expanded
+// with an interface plug/slot postfix when applicable.
+func LogAdminActivity(user SnapdUser, peer Peer, endpoint Endpoint, reasonGranted string) {
 	lock.Lock()
 	defer lock.Unlock()
 
 	globalLogger.LogEvent(
 		Event{Category: "AUTHZ", Name: "authz_admin", Level: LevelInfo},
-		fmt.Sprintf("User %s from %s accessed %s", user.String(), peer.String(), endpoint.String()),
+		fmt.Sprintf("User %s from %s granted access to %s (%s)",
+			user.String(), peer.String(), endpoint.String(), reasonGranted),
 		Attr{Key: "user", Value: user},
 		Attr{Key: "peer", Value: peer},
 		Attr{Key: "endpoint", Value: endpoint},
-		Attr{Key: "authz_checks", Value: checks},
+		Attr{Key: "reason_granted", Value: reasonGranted},
 	)
 }
 

--- a/seclog/seclog.go
+++ b/seclog/seclog.go
@@ -216,18 +216,22 @@ func LogAdminActivity(user SnapdUser, peer Peer, endpoint Endpoint, reasonGrante
 // global security logger. It is emitted when authorization fails (the
 // access gate denied the request), not when the API operation or handler
 // fails after access was granted.
-func LogUnauthorizedAccess(user SnapdUser, peer Peer, endpoint Endpoint, checks AuthzChecks, reason Reason) {
+//
+// reasonDenied identifies why access was denied; see [ReasonDeniedNoPeerCredentials],
+// [ReasonDeniedSocketNotPermitted], [ReasonDeniedMissingInterfacePlug],
+// [ReasonDeniedMissingInterfaceSlot], [ReasonDeniedUserAuthDenied],
+// [ReasonDeniedRootAuthDenied], and [ReasonDeniedPolkitAuthDenied].
+func LogUnauthorizedAccess(user SnapdUser, peer Peer, endpoint Endpoint, reasonDenied string) {
 	lock.Lock()
 	defer lock.Unlock()
 
 	globalLogger.LogEvent(
 		Event{Category: "AUTHZ", Name: "authz_fail", Level: LevelCritical},
-		fmt.Sprintf("User %s from %s attempted to access %s without authorization: %s",
-			user.String(), peer.String(), endpoint.String(), reason.String()),
+		fmt.Sprintf("User %s from %s denied access to %s (%s)",
+			user.String(), peer.String(), endpoint.String(), reasonDenied),
 		Attr{Key: "user", Value: user},
 		Attr{Key: "peer", Value: peer},
 		Attr{Key: "endpoint", Value: endpoint},
-		Attr{Key: "authz_checks", Value: checks},
-		Attr{Key: "error", Value: reason},
+		Attr{Key: "reason_denied", Value: reasonDenied},
 	)
 }

--- a/seclog/seclog.go
+++ b/seclog/seclog.go
@@ -194,21 +194,20 @@ func LogUserRemoved(user SnapdUser) {
 // global security logger. It is emitted when authorization succeeds (the
 // access gate passed), not when the API operation or handler succeeds.
 //
-// reasonGranted identifies why access was granted; see [ReasonGrantedUserAuth],
-// [ReasonGrantedRootAuth], and [ReasonGrantedPolkitAuth], optionally expanded
-// with an interface plug/slot postfix when applicable.
-func LogAdminActivity(user SnapdUser, peer Peer, endpoint Endpoint, reasonGranted string) {
+// grantReason identifies why access was granted; see [GrantReason],
+// optionally expanded with an interface plug/slot postfix when applicable.
+func LogAdminActivity(user SnapdUser, peer Peer, endpoint Endpoint, grantReason GrantReason) {
 	lock.Lock()
 	defer lock.Unlock()
 
 	globalLogger.LogEvent(
 		Event{Category: "AUTHZ", Name: "authz_admin", Level: LevelInfo},
 		fmt.Sprintf("User %s from %s granted access to %s (%s)",
-			user.String(), peer.String(), endpoint.String(), reasonGranted),
+			user.String(), peer.String(), endpoint.String(), grantReason),
 		Attr{Key: "user", Value: user},
 		Attr{Key: "peer", Value: peer},
 		Attr{Key: "endpoint", Value: endpoint},
-		Attr{Key: "reason_granted", Value: reasonGranted},
+		Attr{Key: "reason_granted", Value: grantReason},
 	)
 }
 
@@ -217,21 +216,18 @@ func LogAdminActivity(user SnapdUser, peer Peer, endpoint Endpoint, reasonGrante
 // access gate denied the request), not when the API operation or handler
 // fails after access was granted.
 //
-// reasonDenied identifies why access was denied; see [ReasonDeniedNoPeerCredentials],
-// [ReasonDeniedSocketNotPermitted], [ReasonDeniedMissingInterfacePlug],
-// [ReasonDeniedMissingInterfaceSlot], [ReasonDeniedUserAuthDenied],
-// [ReasonDeniedRootAuthDenied], and [ReasonDeniedPolkitAuthDenied].
-func LogUnauthorizedAccess(user SnapdUser, peer Peer, endpoint Endpoint, reasonDenied string) {
+// denialReason identifies why access was denied; see [DenialReason].
+func LogUnauthorizedAccess(user SnapdUser, peer Peer, endpoint Endpoint, denialReason DenialReason) {
 	lock.Lock()
 	defer lock.Unlock()
 
 	globalLogger.LogEvent(
 		Event{Category: "AUTHZ", Name: "authz_fail", Level: LevelCritical},
 		fmt.Sprintf("User %s from %s denied access to %s (%s)",
-			user.String(), peer.String(), endpoint.String(), reasonDenied),
+			user.String(), peer.String(), endpoint.String(), denialReason),
 		Attr{Key: "user", Value: user},
 		Attr{Key: "peer", Value: peer},
 		Attr{Key: "endpoint", Value: endpoint},
-		Attr{Key: "reason_denied", Value: reasonDenied},
+		Attr{Key: "reason_denied", Value: denialReason},
 	)
 }

--- a/seclog/seclog.go
+++ b/seclog/seclog.go
@@ -194,8 +194,9 @@ func LogUserRemoved(user SnapdUser) {
 // global security logger. It is emitted when authorization succeeds (the
 // access gate passed), not when the API operation or handler succeeds.
 //
-// grantReason identifies why access was granted; see [GrantReason],
-// optionally expanded with an interface plug/slot postfix when applicable.
+// grantReason identifies why access was granted; see [GrantReason].
+// When an interface connection also contributed, pass the result of
+// [GrantReason.WithInterface].
 func LogAdminActivity(user SnapdUser, peer Peer, endpoint Endpoint, grantReason GrantReason) {
 	lock.Lock()
 	defer lock.Unlock()

--- a/seclog/seclog_test.go
+++ b/seclog/seclog_test.go
@@ -242,23 +242,22 @@ func (s *SecLogSuite) TestLogAdminActivity(c *C) {
 	c.Check(s.buf.String(), testutil.Contains, "[user=")
 }
 
-// TestLogUnauthorizedAccess verifies that LogUnauthorizedAccess emits the expected event, peer, and reason.
+// TestLogUnauthorizedAccess verifies that LogUnauthorizedAccess emits the expected event and attributes.
 func (s *SecLogSuite) TestLogUnauthorizedAccess(c *C) {
 	user := seclog.SnapdUser{ID: 1, StoreUserEmail: "hacker@example.com", StoreUserName: "hacker"}
 	peer := seclog.Peer{Socket: "/run/snapd.socket", UID: 1000, PID: 12345}
 	endpoint := seclog.Endpoint{Method: "DELETE", Path: "/v2/snaps/core"}
-	checks := seclog.NewAuthzChecks()
-	reason := seclog.Reason{Code: 401, Kind: "invalid-credentials", Message: "no permission"}
 
-	seclog.LogUnauthorizedAccess(user, peer, endpoint, checks, reason)
+	seclog.LogUnauthorizedAccess(user, peer, endpoint, seclog.ReasonDeniedUserAuthDenied)
 
 	c.Check(s.buf.String(), testutil.Contains, "authz_fail")
 	c.Check(s.buf.String(), testutil.Contains, "from /run/snapd.socket")
-	c.Check(s.buf.String(), testutil.Contains, "without authorization:")
-	c.Check(s.buf.String(), testutil.Contains, "without authorization: 401:no permission")
+	c.Check(s.buf.String(), testutil.Contains, "denied access to DELETE:/v2/snaps/core:<none> (user-auth-denied)")
 	c.Check(s.buf.String(), testutil.Contains, "hacker@example.com")
-	c.Check(s.buf.String(), testutil.Contains, "DELETE:/v2/snaps/core:<none>")
+	c.Check(s.buf.String(), testutil.Contains, "/run/snapd.socket")
 	c.Check(s.buf.String(), testutil.Contains, "12345")
-	c.Check(s.buf.String(), testutil.Contains, "[error=")
+	c.Check(s.buf.String(), testutil.Contains, "[peer=")
+	c.Check(s.buf.String(), testutil.Contains, "[endpoint=")
+	c.Check(s.buf.String(), testutil.Contains, "[reason_denied=\"user-auth-denied\"]")
 	c.Check(s.buf.String(), testutil.Contains, "[user=")
 }

--- a/seclog/seclog_test.go
+++ b/seclog/seclog_test.go
@@ -224,25 +224,21 @@ func (s *SecLogSuite) TestLogAdminActivity(c *C) {
 	user := seclog.SnapdUser{ID: 1, StoreUserEmail: "admin@example.com", StoreUserName: "admin"}
 	peer := seclog.Peer{Socket: "/run/snapd.socket", UID: 0, PID: 4242}
 	endpoint := seclog.Endpoint{
-		Method:        "POST",
-		Path:          "/v2/snaps",
-		Action:        "install",
-		AccessChecker: "authenticated",
-		AccessLevel:   "authenticated",
+		Method: "POST",
+		Path:   "/v2/snaps",
+		Action: "install",
 	}
-	checks := seclog.NewAuthzChecks()
-
-	seclog.LogAdminActivity(user, peer, endpoint, checks)
+	seclog.LogAdminActivity(user, peer, endpoint, seclog.ReasonGrantedRootAuth)
 
 	c.Check(s.buf.String(), testutil.Contains, "authz_admin")
 	c.Check(s.buf.String(), testutil.Contains, "from /run/snapd.socket")
-	c.Check(s.buf.String(), testutil.Contains, "accessed POST:/v2/snaps:install")
+	c.Check(s.buf.String(), testutil.Contains, "granted access to POST:/v2/snaps:install (root-auth)")
 	c.Check(s.buf.String(), testutil.Contains, "admin@example.com")
 	c.Check(s.buf.String(), testutil.Contains, "/run/snapd.socket")
 	c.Check(s.buf.String(), testutil.Contains, "4242")
 	c.Check(s.buf.String(), testutil.Contains, "[peer=")
 	c.Check(s.buf.String(), testutil.Contains, "[endpoint=")
-	c.Check(s.buf.String(), testutil.Contains, "[authz_checks=")
+	c.Check(s.buf.String(), testutil.Contains, "[reason_granted=\"root-auth\"]")
 	c.Check(s.buf.String(), testutil.Contains, "[user=")
 }
 

--- a/seclog/seclog_test.go
+++ b/seclog/seclog_test.go
@@ -242,6 +242,17 @@ func (s *SecLogSuite) TestLogAdminActivity(c *C) {
 	c.Check(s.buf.String(), testutil.Contains, "[user=")
 }
 
+func (s *SecLogSuite) TestLogAdminActivityWithInterface(c *C) {
+	user := seclog.SnapdUser{ID: 1, StoreUserEmail: "admin@example.com", StoreUserName: "admin"}
+	peer := seclog.Peer{Socket: "/run/snapd-snap.socket", UID: 0, PID: 4242}
+	endpoint := seclog.Endpoint{Method: "GET", Path: "/v2/snaps"}
+	reason := seclog.GrantRootAuth.WithInterface("desktop-launch", true)
+	seclog.LogAdminActivity(user, peer, endpoint, reason)
+
+	c.Check(s.buf.String(), testutil.Contains, "granted access to GET:/v2/snaps:<none> (root-auth desktop-launch plug)")
+	c.Check(s.buf.String(), testutil.Contains, "[reason_granted=\"root-auth desktop-launch plug\"]")
+}
+
 // TestLogUnauthorizedAccess verifies that LogUnauthorizedAccess emits the expected event and attributes.
 func (s *SecLogSuite) TestLogUnauthorizedAccess(c *C) {
 	user := seclog.SnapdUser{ID: 1, StoreUserEmail: "hacker@example.com", StoreUserName: "hacker"}

--- a/seclog/seclog_test.go
+++ b/seclog/seclog_test.go
@@ -228,7 +228,7 @@ func (s *SecLogSuite) TestLogAdminActivity(c *C) {
 		Path:   "/v2/snaps",
 		Action: "install",
 	}
-	seclog.LogAdminActivity(user, peer, endpoint, seclog.ReasonGrantedRootAuth)
+	seclog.LogAdminActivity(user, peer, endpoint, seclog.GrantRootAuth)
 
 	c.Check(s.buf.String(), testutil.Contains, "authz_admin")
 	c.Check(s.buf.String(), testutil.Contains, "from /run/snapd.socket")
@@ -248,7 +248,7 @@ func (s *SecLogSuite) TestLogUnauthorizedAccess(c *C) {
 	peer := seclog.Peer{Socket: "/run/snapd.socket", UID: 1000, PID: 12345}
 	endpoint := seclog.Endpoint{Method: "DELETE", Path: "/v2/snaps/core"}
 
-	seclog.LogUnauthorizedAccess(user, peer, endpoint, seclog.ReasonDeniedUserAuthDenied)
+	seclog.LogUnauthorizedAccess(user, peer, endpoint, seclog.DenialUserAuth)
 
 	c.Check(s.buf.String(), testutil.Contains, "authz_fail")
 	c.Check(s.buf.String(), testutil.Contains, "from /run/snapd.socket")

--- a/seclog/slog.go
+++ b/seclog/slog.go
@@ -212,18 +212,3 @@ func (p Peer) LogValue() slog.Value {
 		slog.String("app", p.App),
 	)
 }
-
-// LogValue implements [slog.LogValuer], allowing [AuthzChecks] to be
-// used directly as a structured log attribute value.
-func (a AuthzChecks) LogValue() slog.Value {
-	return slog.GroupValue(
-		slog.String("access_options", string(a.AccessOptions)),
-		slog.String("peer_credentials", string(a.PeerCreds)),
-		slog.String("socket", string(a.Socket)),
-		slog.String("interface_requirements", string(a.Interface)),
-		slog.String("open_access", string(a.OpenAccess)),
-		slog.String("user_authentication", string(a.UserAuth)),
-		slog.String("root", string(a.Root)),
-		slog.String("polkit", string(a.Polkit)),
-	)
-}

--- a/seclog/slog.go
+++ b/seclog/slog.go
@@ -195,8 +195,6 @@ func (e Endpoint) LogValue() slog.Value {
 		slog.String("method", e.Method),
 		slog.String("path", e.Path),
 		slog.String("action", e.Action),
-		slog.String("access_checker", e.AccessChecker),
-		slog.String("access_level", e.AccessLevel),
 	)
 }
 
@@ -207,6 +205,11 @@ func (p Peer) LogValue() slog.Value {
 		slog.String("socket", p.Socket),
 		slog.Int64("uid", int64(p.UID)),
 		slog.Int64("pid", int64(p.PID)),
+		slog.String("exe", p.Exe),
+		slog.String("security_label", p.SecurityLabel),
+		slog.String("cgroup_label", p.CgroupLabel),
+		slog.String("snap", p.Snap),
+		slog.String("app", p.App),
 	)
 }
 

--- a/seclog/slog.go
+++ b/seclog/slog.go
@@ -28,6 +28,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"sort"
 	"sync/atomic"
 	"time"
 
@@ -192,9 +193,9 @@ func (u SnapdUser) LogValue() slog.Value {
 // used directly as a structured log attribute value.
 func (e Endpoint) LogValue() slog.Value {
 	return slog.GroupValue(
-		slog.String("method", e.Method),
-		slog.String("path", e.Path),
-		slog.String("action", e.Action),
+		slog.String("method", fieldOrUnknown(e.Method)),
+		slog.String("path", fieldOrUnknown(e.Path)),
+		slog.String("action", fieldOrNone(e.Action)),
 	)
 }
 
@@ -205,10 +206,44 @@ func (p Peer) LogValue() slog.Value {
 		slog.String("socket", p.Socket),
 		slog.Int64("uid", int64(p.UID)),
 		slog.Int64("pid", int64(p.PID)),
-		slog.String("exe", p.Exe),
-		slog.String("security_label", p.SecurityLabel),
-		slog.String("cgroup_label", p.CgroupLabel),
-		slog.String("snap", p.Snap),
-		slog.String("app", p.App),
+		slog.String("exe", fieldOrUnknown(p.Exe)),
+		peerSecurityLabelsAttr(p.SecurityLabels),
+		slog.String("cgroup_label", fieldOrUnknown(p.CgroupLabel)),
+		slog.String("snap", fieldOrUnknown(p.Snap)),
+		slog.String("app", fieldOrUnknown(p.App)),
 	)
+}
+
+// fieldOrUnknown returns [unknown] when value is empty.
+func fieldOrUnknown(value string) string {
+	if value == "" {
+		return unknown
+	}
+	return value
+}
+
+// fieldOrNone returns [none] when value is empty.
+func fieldOrNone(value string) string {
+	if value == "" {
+		return none
+	}
+	return value
+}
+
+// peerSecurityLabelsAttr renders security_labels as an empty JSON object when
+// no LSM labels were obtained, or as a key-sorted group otherwise.
+func peerSecurityLabelsAttr(labels map[string]string) slog.Attr {
+	if len(labels) == 0 {
+		return slog.Any("security_labels", map[string]string{})
+	}
+	keys := make([]string, 0, len(labels))
+	for key := range labels {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	attrs := make([]slog.Attr, 0, len(keys))
+	for _, key := range keys {
+		attrs = append(attrs, slog.String(key, labels[key]))
+	}
+	return slog.Attr{Key: "security_labels", Value: slog.GroupValue(attrs...)}
 }

--- a/seclog/slog.go
+++ b/seclog/slog.go
@@ -174,6 +174,18 @@ func (r Reason) LogValue() slog.Value {
 	)
 }
 
+// LogValue implements [slog.LogValuer], allowing [GrantReason] to be
+// used directly as a structured log attribute value.
+func (r GrantReason) LogValue() slog.Value {
+	return slog.StringValue(string(r))
+}
+
+// LogValue implements [slog.LogValuer], allowing [DenialReason] to be
+// used directly as a structured log attribute value.
+func (r DenialReason) LogValue() slog.Value {
+	return slog.StringValue(string(r))
+}
+
 // LogValue implements [slog.LogValuer], allowing [SnapdUser] to be
 // used directly as a structured log attribute value.
 func (u SnapdUser) LogValue() slog.Value {

--- a/seclog/slog_test.go
+++ b/seclog/slog_test.go
@@ -25,7 +25,9 @@
 //   Write failure handling              → TestWriteFailure*
 //   SnapdUser.LogValue                  → TestSnapdUserLogValue
 //   Reason.LogValue                     → TestReasonLogValue
-//   Peer.LogValue                       → TestPeerLogValue
+//   Peer.LogValue                       → TestPeerLogValue,
+//                                         TestPeerLogValueSecurityLabelsKeyOrder,
+//                                         TestPeerLogValueEmptySecurityLabels
 //   Endpoint.LogValue                   → TestEndpointLogValue
 
 package seclog_test
@@ -313,14 +315,14 @@ func (s *SlogSuite) TestReasonLogValue(c *C) {
 func (s *SlogSuite) TestPeerLogValue(c *C) {
 	type peerRecord struct {
 		Peer struct {
-			Socket        string `json:"socket"`
-			UID           int64  `json:"uid"`
-			PID           int64  `json:"pid"`
-			Exe           string `json:"exe"`
-			SecurityLabel string `json:"security_label"`
-			CgroupLabel   string `json:"cgroup_label"`
-			Snap          string `json:"snap"`
-			App           string `json:"app"`
+			Socket         string            `json:"socket"`
+			UID            int64             `json:"uid"`
+			PID            int64             `json:"pid"`
+			Exe            string            `json:"exe"`
+			SecurityLabels map[string]string `json:"security_labels"`
+			CgroupLabel    string            `json:"cgroup_label"`
+			Snap           string            `json:"snap"`
+			App            string            `json:"app"`
 		} `json:"peer"`
 	}
 
@@ -331,7 +333,10 @@ func (s *SlogSuite) TestPeerLogValue(c *C) {
 		seclog.Attr{Key: "peer", Value: seclog.Peer{
 			Socket: "/run/snapd.socket", UID: 0, PID: 4242,
 			Exe: "/usr/bin/snap", Snap: "<unknown>", App: "<unknown>",
-			SecurityLabel: "unconfined", CgroupLabel: "<unknown>",
+			SecurityLabels: map[string]string{
+				seclog.PeerSecurityLabelAppArmor: "unconfined",
+			},
+			CgroupLabel: "<unknown>",
 		}},
 	)
 
@@ -344,8 +349,49 @@ func (s *SlogSuite) TestPeerLogValue(c *C) {
 	c.Check(obtained.Peer.Exe, Equals, "/usr/bin/snap")
 	c.Check(obtained.Peer.Snap, Equals, "<unknown>")
 	c.Check(obtained.Peer.App, Equals, "<unknown>")
-	c.Check(obtained.Peer.SecurityLabel, Equals, "unconfined")
+	c.Check(obtained.Peer.SecurityLabels, DeepEquals, map[string]string{
+		seclog.PeerSecurityLabelAppArmor: "unconfined",
+	})
 	c.Check(obtained.Peer.CgroupLabel, Equals, "<unknown>")
+}
+
+func (s *SlogSuite) TestPeerLogValueSecurityLabelsKeyOrder(c *C) {
+	logger := s.newLogger(c)
+	logger.LogEvent(
+		seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo},
+		"test",
+		seclog.Attr{Key: "peer", Value: seclog.Peer{
+			Socket: "/run/snapd.socket", UID: 1000, PID: 4242,
+			SecurityLabels: map[string]string{
+				seclog.PeerSecurityLabelSELinux:  "system_u:system_r:snappy_t:s0",
+				seclog.PeerSecurityLabelAppArmor: "snap.snapd.snapd",
+			},
+		}},
+	)
+
+	// Keys are emitted in alphabetical order: AppArmor before SELinux.
+	c.Check(s.buf.String(), testutil.Contains, `"security_labels":{"AppArmor":"snap.snapd.snapd","SELinux":"system_u:system_r:snappy_t:s0"}`)
+	c.Check(s.buf.String(), testutil.Contains, `"exe":"<unknown>"`)
+	c.Check(s.buf.String(), testutil.Contains, `"cgroup_label":"<unknown>"`)
+	c.Check(s.buf.String(), testutil.Contains, `"snap":"<unknown>"`)
+	c.Check(s.buf.String(), testutil.Contains, `"app":"<unknown>"`)
+}
+
+func (s *SlogSuite) TestPeerLogValueEmptySecurityLabels(c *C) {
+	logger := s.newLogger(c)
+	logger.LogEvent(
+		seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo},
+		"test",
+		seclog.Attr{Key: "peer", Value: seclog.Peer{
+			Socket: "/run/snapd.socket", UID: 1000, PID: 4242,
+		}},
+	)
+
+	c.Check(s.buf.String(), testutil.Contains, `"security_labels":{}`)
+	c.Check(s.buf.String(), testutil.Contains, `"exe":"<unknown>"`)
+	c.Check(s.buf.String(), testutil.Contains, `"cgroup_label":"<unknown>"`)
+	c.Check(s.buf.String(), testutil.Contains, `"snap":"<unknown>"`)
+	c.Check(s.buf.String(), testutil.Contains, `"app":"<unknown>"`)
 }
 
 func (s *SlogSuite) TestEndpointLogValue(c *C) {
@@ -357,23 +403,49 @@ func (s *SlogSuite) TestEndpointLogValue(c *C) {
 		} `json:"endpoint"`
 	}
 
-	logger := s.newLogger(c)
-	logger.LogEvent(
-		seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo},
-		"test",
-		seclog.Attr{Key: "endpoint", Value: seclog.Endpoint{
-			Method: "POST",
-			Path:   "/v2/snaps",
-			Action: "install",
-		}},
-	)
+	cases := []struct {
+		endpoint   seclog.Endpoint
+		wantMethod string
+		wantPath   string
+		wantAction string
+	}{
+		{
+			endpoint: seclog.Endpoint{
+				Method: "POST",
+				Path:   "/v2/snaps",
+				Action: "install",
+			},
+			wantMethod: "POST",
+			wantPath:   "/v2/snaps",
+			wantAction: "install",
+		},
+		{
+			endpoint: seclog.Endpoint{
+				Method: "DELETE",
+				Path:   "/v2/snaps/core",
+			},
+			wantMethod: "DELETE",
+			wantPath:   "/v2/snaps/core",
+			wantAction: "<none>",
+		},
+	}
 
-	var obtained endpointRecord
-	err := json.Unmarshal(s.buf.Bytes(), &obtained)
-	c.Assert(err, IsNil)
-	c.Check(obtained.Endpoint.Method, Equals, "POST")
-	c.Check(obtained.Endpoint.Path, Equals, "/v2/snaps")
-	c.Check(obtained.Endpoint.Action, Equals, "install")
+	for _, tc := range cases {
+		s.buf.Reset()
+		logger := s.newLogger(c)
+		logger.LogEvent(
+			seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo},
+			"test",
+			seclog.Attr{Key: "endpoint", Value: tc.endpoint},
+		)
+
+		var obtained endpointRecord
+		err := json.Unmarshal(s.buf.Bytes(), &obtained)
+		c.Assert(err, IsNil)
+		c.Check(obtained.Endpoint.Method, Equals, tc.wantMethod)
+		c.Check(obtained.Endpoint.Path, Equals, tc.wantPath)
+		c.Check(obtained.Endpoint.Action, Equals, tc.wantAction)
+	}
 }
 
 func (s *SlogSuite) TestLevelFiltering(c *C) {

--- a/seclog/slog_test.go
+++ b/seclog/slog_test.go
@@ -303,9 +303,14 @@ func (s *SlogSuite) TestReasonLogValue(c *C) {
 func (s *SlogSuite) TestPeerLogValue(c *C) {
 	type peerRecord struct {
 		Peer struct {
-			Socket string `json:"socket"`
-			UID    int64  `json:"uid"`
-			PID    int64  `json:"pid"`
+			Socket        string `json:"socket"`
+			UID           int64  `json:"uid"`
+			PID           int64  `json:"pid"`
+			Exe           string `json:"exe"`
+			SecurityLabel string `json:"security_label"`
+			CgroupLabel   string `json:"cgroup_label"`
+			Snap          string `json:"snap"`
+			App           string `json:"app"`
 		} `json:"peer"`
 	}
 
@@ -315,6 +320,8 @@ func (s *SlogSuite) TestPeerLogValue(c *C) {
 		"test",
 		seclog.Attr{Key: "peer", Value: seclog.Peer{
 			Socket: "/run/snapd.socket", UID: 0, PID: 4242,
+			Exe: "/usr/bin/snap", Snap: "<unknown>", App: "<unknown>",
+			SecurityLabel: "unconfined", CgroupLabel: "<unknown>",
 		}},
 	)
 
@@ -324,16 +331,19 @@ func (s *SlogSuite) TestPeerLogValue(c *C) {
 	c.Check(obtained.Peer.Socket, Equals, "/run/snapd.socket")
 	c.Check(obtained.Peer.UID, Equals, int64(0))
 	c.Check(obtained.Peer.PID, Equals, int64(4242))
+	c.Check(obtained.Peer.Exe, Equals, "/usr/bin/snap")
+	c.Check(obtained.Peer.Snap, Equals, "<unknown>")
+	c.Check(obtained.Peer.App, Equals, "<unknown>")
+	c.Check(obtained.Peer.SecurityLabel, Equals, "unconfined")
+	c.Check(obtained.Peer.CgroupLabel, Equals, "<unknown>")
 }
 
 func (s *SlogSuite) TestEndpointLogValue(c *C) {
 	type endpointRecord struct {
 		Endpoint struct {
-			Method        string `json:"method"`
-			Path          string `json:"path"`
-			Action        string `json:"action"`
-			AccessChecker string `json:"access_checker"`
-			AccessLevel   string `json:"access_level"`
+			Method string `json:"method"`
+			Path   string `json:"path"`
+			Action string `json:"action"`
 		} `json:"endpoint"`
 	}
 
@@ -342,11 +352,9 @@ func (s *SlogSuite) TestEndpointLogValue(c *C) {
 		seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo},
 		"test",
 		seclog.Attr{Key: "endpoint", Value: seclog.Endpoint{
-			Method:        "POST",
-			Path:          "/v2/snaps",
-			Action:        "install",
-			AccessChecker: "authenticated",
-			AccessLevel:   "authenticated",
+			Method: "POST",
+			Path:   "/v2/snaps",
+			Action: "install",
 		}},
 	)
 
@@ -356,8 +364,6 @@ func (s *SlogSuite) TestEndpointLogValue(c *C) {
 	c.Check(obtained.Endpoint.Method, Equals, "POST")
 	c.Check(obtained.Endpoint.Path, Equals, "/v2/snaps")
 	c.Check(obtained.Endpoint.Action, Equals, "install")
-	c.Check(obtained.Endpoint.AccessChecker, Equals, "authenticated")
-	c.Check(obtained.Endpoint.AccessLevel, Equals, "authenticated")
 }
 
 func (s *SlogSuite) TestAuthzChecksLogValue(c *C) {

--- a/seclog/slog_test.go
+++ b/seclog/slog_test.go
@@ -27,7 +27,6 @@
 //   Reason.LogValue                     → TestReasonLogValue
 //   Peer.LogValue                       → TestPeerLogValue
 //   Endpoint.LogValue                   → TestEndpointLogValue
-//   AuthzChecks.LogValue                → TestAuthzChecksLogValue
 
 package seclog_test
 
@@ -173,11 +172,22 @@ func (s *SlogSuite) TestLogEventKeyOrder(c *C) {
 			attrs: []seclog.Attr{
 				{Key: "peer", Value: seclog.Peer{Socket: "/run/snapd.socket"}},
 				{Key: "endpoint", Value: seclog.Endpoint{Method: "GET", Path: "/v2/snaps"}},
-				{Key: "authz_checks", Value: seclog.NewAuthzChecks()},
+				{Key: "reason_granted", Value: seclog.ReasonGrantedRootAuth},
 			},
 			wantKeys: []string{
 				"datetime", "level", "description",
-				"app_id", "type", "category", "event", "peer", "endpoint", "authz_checks",
+				"app_id", "type", "category", "event", "peer", "endpoint", "reason_granted",
+			},
+		},
+		{
+			attrs: []seclog.Attr{
+				{Key: "peer", Value: seclog.Peer{Socket: "/run/snapd.socket"}},
+				{Key: "endpoint", Value: seclog.Endpoint{Method: "GET", Path: "/v2/snaps"}},
+				{Key: "reason_denied", Value: seclog.ReasonDeniedUserAuthDenied},
+			},
+			wantKeys: []string{
+				"datetime", "level", "description",
+				"app_id", "type", "category", "event", "peer", "endpoint", "reason_denied",
 			},
 		},
 	}
@@ -364,43 +374,6 @@ func (s *SlogSuite) TestEndpointLogValue(c *C) {
 	c.Check(obtained.Endpoint.Method, Equals, "POST")
 	c.Check(obtained.Endpoint.Path, Equals, "/v2/snaps")
 	c.Check(obtained.Endpoint.Action, Equals, "install")
-}
-
-func (s *SlogSuite) TestAuthzChecksLogValue(c *C) {
-	type authzChecksRecord struct {
-		AuthzChecks struct {
-			AccessOptions string `json:"access_options"`
-			PeerCreds     string `json:"peer_credentials"`
-			Socket        string `json:"socket"`
-			Interface     string `json:"interface_requirements"`
-			OpenAccess    string `json:"open_access"`
-			UserAuth      string `json:"user_authentication"`
-			Root          string `json:"root"`
-			Polkit        string `json:"polkit"`
-		} `json:"authz_checks"`
-	}
-
-	checks := seclog.NewAuthzChecks()
-	checks.PeerCreds = seclog.AuthzPass
-
-	logger := s.newLogger(c)
-	logger.LogEvent(
-		seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo},
-		"test",
-		seclog.Attr{Key: "authz_checks", Value: checks},
-	)
-
-	var obtained authzChecksRecord
-	err := json.Unmarshal(s.buf.Bytes(), &obtained)
-	c.Assert(err, IsNil)
-	c.Check(obtained.AuthzChecks.AccessOptions, Equals, string(seclog.AuthzNotApplicable))
-	c.Check(obtained.AuthzChecks.PeerCreds, Equals, string(seclog.AuthzPass))
-	c.Check(obtained.AuthzChecks.Socket, Equals, string(seclog.AuthzNotApplicable))
-	c.Check(obtained.AuthzChecks.Interface, Equals, string(seclog.AuthzNotApplicable))
-	c.Check(obtained.AuthzChecks.OpenAccess, Equals, string(seclog.AuthzNotApplicable))
-	c.Check(obtained.AuthzChecks.UserAuth, Equals, string(seclog.AuthzNotApplicable))
-	c.Check(obtained.AuthzChecks.Root, Equals, string(seclog.AuthzNotApplicable))
-	c.Check(obtained.AuthzChecks.Polkit, Equals, string(seclog.AuthzNotApplicable))
 }
 
 func (s *SlogSuite) TestLevelFiltering(c *C) {

--- a/seclog/slog_test.go
+++ b/seclog/slog_test.go
@@ -254,6 +254,24 @@ func (s *SlogSuite) TestSnapdUserLogValue(c *C) {
 	}
 }
 
+func (s *SlogSuite) TestGrantReasonLogValue(c *C) {
+	type record struct {
+		ReasonGranted string `json:"reason_granted"`
+	}
+
+	logger := s.newLogger(c)
+	logger.LogEvent(
+		seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo},
+		"test",
+		seclog.Attr{Key: "reason_granted", Value: seclog.GrantRootAuth.WithInterface("desktop-launch", true)},
+	)
+
+	var obtained record
+	err := json.Unmarshal(s.buf.Bytes(), &obtained)
+	c.Assert(err, IsNil)
+	c.Check(obtained.ReasonGranted, Equals, "root-auth desktop-launch plug")
+}
+
 func (s *SlogSuite) TestReasonLogValue(c *C) {
 	type errorRecord struct {
 		Error struct {

--- a/seclog/slog_test.go
+++ b/seclog/slog_test.go
@@ -18,18 +18,6 @@
  *
  */
 
-// slog.go coverage (all tests in this file):
-//   NewSlogLogger, LogEvent envelope  → TestNewSlogLogger, TestLogEventEnvelope
-//   Key order                           → TestLogEventKeyOrder
-//   Level filtering                     → TestLevelFiltering
-//   Write failure handling              → TestWriteFailure*
-//   SnapdUser.LogValue                  → TestSnapdUserLogValue
-//   Reason.LogValue                     → TestReasonLogValue
-//   Peer.LogValue                       → TestPeerLogValue,
-//                                         TestPeerLogValueSecurityLabelsKeyOrder,
-//                                         TestPeerLogValueEmptySecurityLabels
-//   Endpoint.LogValue                   → TestEndpointLogValue
-
 package seclog_test
 
 import (

--- a/seclog/slog_test.go
+++ b/seclog/slog_test.go
@@ -174,7 +174,7 @@ func (s *SlogSuite) TestLogEventKeyOrder(c *C) {
 			attrs: []seclog.Attr{
 				{Key: "peer", Value: seclog.Peer{Socket: "/run/snapd.socket"}},
 				{Key: "endpoint", Value: seclog.Endpoint{Method: "GET", Path: "/v2/snaps"}},
-				{Key: "reason_granted", Value: seclog.ReasonGrantedRootAuth},
+				{Key: "reason_granted", Value: seclog.GrantRootAuth},
 			},
 			wantKeys: []string{
 				"datetime", "level", "description",
@@ -185,7 +185,7 @@ func (s *SlogSuite) TestLogEventKeyOrder(c *C) {
 			attrs: []seclog.Attr{
 				{Key: "peer", Value: seclog.Peer{Socket: "/run/snapd.socket"}},
 				{Key: "endpoint", Value: seclog.Endpoint{Method: "GET", Path: "/v2/snaps"}},
-				{Key: "reason_denied", Value: seclog.ReasonDeniedUserAuthDenied},
+				{Key: "reason_denied", Value: seclog.DenialUserAuth},
 			},
 			wantKeys: []string{
 				"datetime", "level", "description",


### PR DESCRIPTION
Change the `LogAdminActivity` and `LogUnauthorizedAccess` api and structs to focus on Who, What and Why/-Not:

Who:          `SnapdUser` + `Peer`
What:         `Endpoint`
Why/-Not: `ReasonGranted` / `ReasonDenied`

Spec: [SD236- Security Event Logging - Admin actions allowed/denied](https://docs.google.com/document/d/1fl7Gy3GJVu8VwUtT1_LWwZ7DEAW9sUMAzF3XGrcZ_d4/edit?tab=t.0#heading=h.etzql0edger)
Jira: https://warthogs.atlassian.net/browse/SNAPDENG-37105 