### PR TITLE
daemon: add auth recorder (p4)

### DIFF
--- a/daemon/access.go
+++ b/daemon/access.go
@@ -38,6 +38,7 @@ import (
 	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/polkit"
 	"github.com/snapcore/snapd/sandbox/cgroup"
+	"github.com/snapcore/snapd/seclog"
 	"github.com/snapcore/snapd/strutil"
 )
 
@@ -81,13 +82,42 @@ type accessChecker interface {
 	CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState, rec AuthzRecorder) *apiError
 }
 
+func isAuditedAccessLevel(level accessLevel) bool {
+	return level == accessLevelAuthenticated || level == accessLevelRoot
+}
+
+func recordDeniedIfAudited(rec AuthzRecorder, level accessLevel, reason string) {
+	if isAuditedAccessLevel(level) {
+		rec.RecordDenied(reason)
+	}
+}
+
+func recordGrantedIfAudited(rec AuthzRecorder, level accessLevel, reason, iface string, plug bool) {
+	if isAuditedAccessLevel(level) {
+		rec.RecordGranted(reason, iface, plug)
+	}
+}
+
+func recordDeniedMissingInterfaceIfAudited(rec AuthzRecorder, level accessLevel, plug bool) {
+	if !isAuditedAccessLevel(level) {
+		return
+	}
+	if plug {
+		rec.RecordDenied(seclog.ReasonDeniedMissingInterfacePlug)
+	} else {
+		rec.RecordDenied(seclog.ReasonDeniedMissingInterfaceSlot)
+	}
+}
+
 // requireSockets ensures the request was received via one of the specified sockets.
-func requireSockets(ucred *ucrednet, sockets []string) *apiError {
+func requireSockets(ucred *ucrednet, sockets []string, rec AuthzRecorder, level accessLevel) *apiError {
 	if ucred == nil {
+		recordDeniedIfAudited(rec, level, seclog.ReasonDeniedNoPeerCredentials)
 		return Forbidden("access denied")
 	}
 
 	if !strutil.ListContains(sockets, ucred.Socket) {
+		recordDeniedIfAudited(rec, level, seclog.ReasonDeniedSocketNotPermitted)
 		return Forbidden("access denied")
 	}
 
@@ -130,19 +160,21 @@ func (o accessOptions) validate() error {
 	return nil
 }
 
-func checkAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState, opts accessOptions, _ AuthzRecorder) *apiError {
+func checkAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState, opts accessOptions, rec AuthzRecorder) *apiError {
 	if err := opts.validate(); err != nil {
 		return InternalError(err.Error())
 	}
 
-	if rspe := requireSockets(ucred, opts.Sockets); rspe != nil {
+	if rspe := requireSockets(ucred, opts.Sockets, rec, opts.AccessLevel); rspe != nil {
 		return rspe
 	}
 
+	var ifaceOutcome interfaceAccessOutcome
 	if opts.InterfaceAccess != nil {
 		// No interface checks are made if request is coming from snapd.socket
 		// to account for the snapd-control interface.
-		rspe := requireInterfaceApiAccess(d, r, ucred, *opts.InterfaceAccess)
+		var rspe *apiError
+		ifaceOutcome, rspe = requireInterfaceApiAccess(d, r, ucred, *opts.InterfaceAccess, rec, opts.AccessLevel)
 		if rspe != nil {
 			return rspe
 		}
@@ -152,12 +184,17 @@ func checkAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserSta
 		return nil
 	}
 
+	iface := ifaceOutcome.MatchedIface
+	plug := ifaceOutcome.Plug
+
 	if opts.AccessLevel == accessLevelAuthenticated && user != nil {
 		// user != nil means we have an authenticated user
+		recordGrantedIfAudited(rec, opts.AccessLevel, seclog.ReasonGrantedUserAuth, iface, plug)
 		return nil
 	}
 
 	if ucred.Uid == 0 {
+		recordGrantedIfAudited(rec, opts.AccessLevel, seclog.ReasonGrantedRootAuth, iface, plug)
 		return nil
 	}
 
@@ -165,13 +202,21 @@ func checkAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserSta
 	// being prompted for authorisation. This should be avoided if
 	// access is otherwise granted.
 	if opts.PolkitAction != "" {
-		return checkPolkitAction(r, ucred, opts.PolkitAction)
+		rspe := checkPolkitAction(r, ucred, opts.PolkitAction)
+		if rspe == nil {
+			recordGrantedIfAudited(rec, opts.AccessLevel, seclog.ReasonGrantedPolkitAuth, iface, plug)
+		} else {
+			recordDeniedIfAudited(rec, opts.AccessLevel, seclog.ReasonDeniedPolkitAuthDenied)
+		}
+		return rspe
 	}
 
 	// XXX: when to 403 vs 401?
 	if opts.AccessLevel == accessLevelAuthenticated || opts.InterfaceAccess != nil {
+		recordDeniedIfAudited(rec, opts.AccessLevel, seclog.ReasonDeniedUserAuthDenied)
 		return Unauthorized("access denied")
 	}
+	recordDeniedIfAudited(rec, opts.AccessLevel, seclog.ReasonDeniedRootAuthDenied)
 	return Forbidden("access denied")
 }
 
@@ -250,39 +295,47 @@ type interfaceAccessReqs struct {
 	Plug bool
 }
 
+// interfaceAccessOutcome carries a matched interface connection for grant postfix.
+type interfaceAccessOutcome struct {
+	MatchedIface string
+	Plug         bool
+}
+
 func requireInterfaceApiAccessImpl(d *Daemon, r *http.Request,
-	ucred *ucrednet, req interfaceAccessReqs,
-) *apiError {
+	ucred *ucrednet, req interfaceAccessReqs, rec AuthzRecorder, level accessLevel,
+) (interfaceAccessOutcome, *apiError) {
 	if !req.Slot && !req.Plug {
-		return InternalError("required connection side is unspecified")
+		return interfaceAccessOutcome{}, InternalError("required connection side is unspecified")
 	}
 	if req.Slot && req.Plug {
-		return InternalError("snap cannot be specified on both sides of the connection")
+		return interfaceAccessOutcome{}, InternalError("snap cannot be specified on both sides of the connection")
 	}
 
 	if len(req.Interfaces) == 0 {
-		return InternalError("interfaces access check, but interfaces list is empty")
+		return interfaceAccessOutcome{}, InternalError("interfaces access check, but interfaces list is empty")
 	}
 
 	if ucred == nil {
-		return Forbidden("access denied")
+		recordDeniedIfAudited(rec, level, seclog.ReasonDeniedNoPeerCredentials)
+		return interfaceAccessOutcome{}, Forbidden("access denied")
 	}
 
 	switch ucred.Socket {
 	case dirs.SnapdSocket:
-		// Allow access on main snapd.socket
-		return nil
+		return interfaceAccessOutcome{}, nil
 
 	case dirs.SnapSocket:
 		// Handled below
 	default:
-		return Forbidden("access denied")
+		recordDeniedIfAudited(rec, level, seclog.ReasonDeniedSocketNotPermitted)
+		return interfaceAccessOutcome{}, Forbidden("access denied")
 	}
 
 	// Access on snapd-snap.socket requires a connected plug.
 	snapName, err := cgroupSnapNameFromPid(int(ucred.Pid))
 	if err != nil {
-		return Forbidden("could not determine snap name for pid: %s", err)
+		recordDeniedMissingInterfaceIfAudited(rec, level, req.Plug)
+		return interfaceAccessOutcome{}, Forbidden("could not determine snap name for pid: %s", err)
 	}
 
 	st := d.state
@@ -290,16 +343,16 @@ func requireInterfaceApiAccessImpl(d *Daemon, r *http.Request,
 	defer st.Unlock()
 	conns, err := ifacestate.ConnectionStates(st)
 	if err != nil {
-		return Forbidden("internal error: cannot get connections: %s", err)
+		return interfaceAccessOutcome{}, Forbidden("internal error: cannot get connections: %s", err)
 	}
-	foundMatchingInterface := false
+	var outcome interfaceAccessOutcome
 	for refStr, connState := range conns {
 		if !connState.Active() || !strutil.ListContains(req.Interfaces, connState.Interface) {
 			continue
 		}
 		connRef, err := interfaces.ParseConnRef(refStr)
 		if err != nil {
-			return Forbidden("internal error: %s", err)
+			return interfaceAccessOutcome{}, Forbidden("internal error: %s", err)
 		}
 		matchOnSlot := req.Slot && connRef.SlotRef.Snap == snapName
 		matchOnPlug := req.Plug && connRef.PlugRef.Snap == snapName
@@ -308,13 +361,17 @@ func requireInterfaceApiAccessImpl(d *Daemon, r *http.Request,
 			// Do not return here, but keep processing connections for the side
 			// effect of attaching all connected interfaces we asked for to the
 			// remote address.
-			foundMatchingInterface = true
+			if outcome.MatchedIface == "" {
+				outcome.MatchedIface = connState.Interface
+				outcome.Plug = req.Plug
+			}
 		}
 	}
-	if foundMatchingInterface {
-		return nil
+	if outcome.MatchedIface != "" {
+		return outcome, nil
 	}
-	return Forbidden("access denied")
+	recordDeniedMissingInterfaceIfAudited(rec, level, req.Plug)
+	return interfaceAccessOutcome{}, Forbidden("access denied")
 }
 
 // interfaceOpenAccess behaves like openAccess, but allows requests from
@@ -463,7 +520,6 @@ func (ac byActionAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet
 		if (errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF)) && lr.N <= 0 {
 			return BadRequest("body size limit exceeded")
 		}
-		// Content type is JSON, but it's invalid
 		return BadRequest(err.Error())
 	}
 	if decoder.More() {

--- a/daemon/access.go
+++ b/daemon/access.go
@@ -78,7 +78,7 @@ func checkPolkitActionImpl(r *http.Request, ucred *ucrednet, action string) *api
 // accessUnknown, which indicates the decision should be delegated to
 // the next access checker.
 type accessChecker interface {
-	CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError
+	CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState, rec AuthzRecorder) *apiError
 }
 
 // requireSockets ensures the request was received via one of the specified sockets.
@@ -130,7 +130,7 @@ func (o accessOptions) validate() error {
 	return nil
 }
 
-func checkAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState, opts accessOptions) *apiError {
+func checkAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState, opts accessOptions, _ AuthzRecorder) *apiError {
 	if err := opts.validate(); err != nil {
 		return InternalError(err.Error())
 	}
@@ -179,12 +179,12 @@ func checkAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserSta
 // have peer credentials and were not received on snapd-snap.socket
 type openAccess struct{}
 
-func (ac openAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
+func (ac openAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState, rec AuthzRecorder) *apiError {
 	opts := accessOptions{
 		AccessLevel: accessLevelOpen,
 		Sockets:     []string{dirs.SnapdSocket},
 	}
-	return checkAccess(d, r, ucred, user, opts)
+	return checkAccess(d, r, ucred, user, opts, rec)
 }
 
 // authenticatedAccess allows requests from authenticated users,
@@ -202,36 +202,36 @@ type authenticatedAccess struct {
 	Polkit string
 }
 
-func (ac authenticatedAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
+func (ac authenticatedAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState, rec AuthzRecorder) *apiError {
 	opts := accessOptions{
 		AccessLevel:  accessLevelAuthenticated,
 		Sockets:      []string{dirs.SnapdSocket},
 		PolkitAction: ac.Polkit,
 	}
-	return checkAccess(d, r, ucred, user, opts)
+	return checkAccess(d, r, ucred, user, opts, rec)
 }
 
 // rootAccess allows requests from the root uid, provided they
 // were not received on snapd-snap.socket
 type rootAccess struct{}
 
-func (ac rootAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
+func (ac rootAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState, rec AuthzRecorder) *apiError {
 	opts := accessOptions{
 		AccessLevel: accessLevelRoot,
 		Sockets:     []string{dirs.SnapdSocket},
 	}
-	return checkAccess(d, r, ucred, user, opts)
+	return checkAccess(d, r, ucred, user, opts, rec)
 }
 
 // snapAccess allows requests from the snapd-snap.socket only.
 type snapAccess struct{}
 
-func (ac snapAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
+func (ac snapAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState, rec AuthzRecorder) *apiError {
 	opts := accessOptions{
 		AccessLevel: accessLevelOpen,
 		Sockets:     []string{dirs.SnapSocket},
 	}
-	return checkAccess(d, r, ucred, user, opts)
+	return checkAccess(d, r, ucred, user, opts, rec)
 }
 
 var (
@@ -323,7 +323,7 @@ type interfaceOpenAccess struct {
 	Interfaces []string
 }
 
-func (ac interfaceOpenAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
+func (ac interfaceOpenAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState, rec AuthzRecorder) *apiError {
 	opts := accessOptions{
 		AccessLevel: accessLevelOpen,
 		Sockets:     []string{dirs.SnapdSocket, dirs.SnapSocket},
@@ -332,7 +332,7 @@ func (ac interfaceOpenAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucr
 			Plug:       true,
 		},
 	}
-	return checkAccess(d, r, ucred, user, opts)
+	return checkAccess(d, r, ucred, user, opts, rec)
 }
 
 // interfaceAuthenticatedAccess behaves like authenticatedAccess, but also
@@ -348,7 +348,7 @@ type interfaceAuthenticatedAccess struct {
 	Polkit string
 }
 
-func (ac interfaceAuthenticatedAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
+func (ac interfaceAuthenticatedAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState, rec AuthzRecorder) *apiError {
 	opts := accessOptions{
 		AccessLevel: accessLevelAuthenticated,
 		Sockets:     []string{dirs.SnapdSocket, dirs.SnapSocket},
@@ -358,7 +358,7 @@ func (ac interfaceAuthenticatedAccess) CheckAccess(d *Daemon, r *http.Request, u
 		},
 		PolkitAction: ac.Polkit,
 	}
-	return checkAccess(d, r, ucred, user, opts)
+	return checkAccess(d, r, ucred, user, opts, rec)
 }
 
 // interfaceProviderRootAccess behaves like rootAccess, but also allows requests
@@ -368,7 +368,7 @@ type interfaceProviderRootAccess struct {
 	Interfaces []string
 }
 
-func (ac interfaceProviderRootAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
+func (ac interfaceProviderRootAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState, rec AuthzRecorder) *apiError {
 	opts := accessOptions{
 		AccessLevel: accessLevelRoot,
 		Sockets:     []string{dirs.SnapdSocket, dirs.SnapSocket},
@@ -377,7 +377,7 @@ func (ac interfaceProviderRootAccess) CheckAccess(d *Daemon, r *http.Request, uc
 			Slot:       true,
 		},
 	}
-	return checkAccess(d, r, ucred, user, opts)
+	return checkAccess(d, r, ucred, user, opts, rec)
 }
 
 // interfaceRootAccess behaves like rootAccess, but also allows requests
@@ -398,7 +398,7 @@ type interfaceRootAccess struct {
 	Polkit string
 }
 
-func (ac interfaceRootAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
+func (ac interfaceRootAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState, rec AuthzRecorder) *apiError {
 	opts := accessOptions{
 		AccessLevel: accessLevelRoot,
 		Sockets:     []string{dirs.SnapdSocket, dirs.SnapSocket},
@@ -408,7 +408,7 @@ func (ac interfaceRootAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucr
 		},
 		PolkitAction: ac.Polkit,
 	}
-	return checkAccess(d, r, ucred, user, opts)
+	return checkAccess(d, r, ucred, user, opts, rec)
 }
 
 type actionRequest struct {
@@ -432,7 +432,7 @@ type byActionAccess struct {
 
 const maxBodySize = 4 * 1024 * 1024 // 4MB
 
-func (ac byActionAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
+func (ac byActionAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState, rec AuthzRecorder) *apiError {
 	switch ac.Default.(type) {
 	// TODO: If less strict interfaces are needed as defaults then
 	// we might need to introduce access checker sorting so that the
@@ -475,10 +475,10 @@ func (ac byActionAccess) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet
 
 	checker := ac.ByAction[req.Action]
 	if checker == nil {
-		return ac.Default.CheckAccess(d, r, ucred, user)
+		return ac.Default.CheckAccess(d, r, ucred, user, rec)
 	}
 
-	return checker.CheckAccess(d, r, ucred, user)
+	return checker.CheckAccess(d, r, ucred, user, rec)
 }
 
 // isRequestFromSnapCmd checks that the request is coming from snap command.

--- a/daemon/access_test.go
+++ b/daemon/access_test.go
@@ -49,16 +49,16 @@ var (
 
 func (s *accessSuite) TestAccessOptionsValidation(c *C) {
 	opts := daemon.AccessOptions{}
-	c.Check(daemon.CheckAccess(nil, nil, nil, nil, opts), ErrorMatches, `unexpected access level "" \(api 500\)`)
+	c.Check(daemon.CheckAccess(nil, nil, nil, nil, opts, daemon.NewNopAuthzRecorder()), ErrorMatches, `unexpected access level "" \(api 500\)`)
 
 	opts = daemon.AccessOptions{AccessLevel: "some-level"}
-	c.Check(daemon.CheckAccess(nil, nil, nil, nil, opts), ErrorMatches, `unexpected access level "some-level" \(api 500\)`)
+	c.Check(daemon.CheckAccess(nil, nil, nil, nil, opts, daemon.NewNopAuthzRecorder()), ErrorMatches, `unexpected access level "some-level" \(api 500\)`)
 
 	opts = daemon.AccessOptions{AccessLevel: "root"}
-	c.Check(daemon.CheckAccess(nil, nil, nil, nil, opts), ErrorMatches, `no sockets specified \(api 500\)`)
+	c.Check(daemon.CheckAccess(nil, nil, nil, nil, opts, daemon.NewNopAuthzRecorder()), ErrorMatches, `no sockets specified \(api 500\)`)
 
 	opts = daemon.AccessOptions{AccessLevel: "root", Sockets: []string{"some-socket"}}
-	c.Check(daemon.CheckAccess(nil, nil, nil, nil, opts), ErrorMatches, `unexpected socket "some-socket" \(api 500\)`)
+	c.Check(daemon.CheckAccess(nil, nil, nil, nil, opts, daemon.NewNopAuthzRecorder()), ErrorMatches, `unexpected socket "some-socket" \(api 500\)`)
 }
 
 func (s *accessSuite) TestOpenAccess(c *C) {
@@ -66,15 +66,15 @@ func (s *accessSuite) TestOpenAccess(c *C) {
 
 	// openAccess denies access from snapd-snap.socket
 	ucred := &daemon.Ucrednet{Uid: 42, Pid: 100, Socket: dirs.SnapSocket}
-	c.Check(ac.CheckAccess(nil, nil, ucred, nil), DeepEquals, errForbidden)
+	c.Check(ac.CheckAccess(nil, nil, ucred, nil, daemon.NewNopAuthzRecorder()), DeepEquals, errForbidden)
 
 	// Access allowed from snapd.socket
 	ucred.Socket = dirs.SnapdSocket
-	c.Check(ac.CheckAccess(nil, nil, ucred, nil), IsNil)
+	c.Check(ac.CheckAccess(nil, nil, ucred, nil, daemon.NewNopAuthzRecorder()), IsNil)
 
 	// Access forbidden without peer credentials.  This will need
 	// to be revisited if the API is ever exposed over TCP.
-	c.Check(ac.CheckAccess(nil, nil, nil, nil), DeepEquals, errForbidden)
+	c.Check(ac.CheckAccess(nil, nil, nil, nil, daemon.NewNopAuthzRecorder()), DeepEquals, errForbidden)
 }
 
 func (s *accessSuite) TestAuthenticatedAccess(c *C) {
@@ -92,26 +92,26 @@ func (s *accessSuite) TestAuthenticatedAccess(c *C) {
 
 	// authenticatedAccess denies access from snapd-snap.socket
 	ucred := &daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapSocket}
-	c.Check(ac.CheckAccess(nil, req, ucred, nil), DeepEquals, errForbidden)
-	c.Check(ac.CheckAccess(nil, req, ucred, user), DeepEquals, errForbidden)
+	c.Check(ac.CheckAccess(nil, req, ucred, nil, daemon.NewNopAuthzRecorder()), DeepEquals, errForbidden)
+	c.Check(ac.CheckAccess(nil, req, ucred, user, daemon.NewNopAuthzRecorder()), DeepEquals, errForbidden)
 
 	// the same for unknown sockets
 	ucred = &daemon.Ucrednet{Uid: 0, Pid: 100, Socket: "unexpected.socket"}
-	c.Check(ac.CheckAccess(nil, req, ucred, nil), DeepEquals, errForbidden)
+	c.Check(ac.CheckAccess(nil, req, ucred, nil, daemon.NewNopAuthzRecorder()), DeepEquals, errForbidden)
 
 	// With macaroon auth, a normal user is granted access
 	ucred = &daemon.Ucrednet{Uid: 42, Pid: 100, Socket: dirs.SnapdSocket}
-	c.Check(ac.CheckAccess(nil, req, ucred, user), IsNil)
+	c.Check(ac.CheckAccess(nil, req, ucred, user, daemon.NewNopAuthzRecorder()), IsNil)
 
 	// Macaroon access requires peer credentials
-	c.Check(ac.CheckAccess(nil, req, nil, user), DeepEquals, errForbidden)
+	c.Check(ac.CheckAccess(nil, req, nil, user, daemon.NewNopAuthzRecorder()), DeepEquals, errForbidden)
 
 	// Without macaroon auth, normal users are unauthorized
-	c.Check(ac.CheckAccess(nil, req, ucred, nil), DeepEquals, errUnauthorized)
+	c.Check(ac.CheckAccess(nil, req, ucred, nil, daemon.NewNopAuthzRecorder()), DeepEquals, errUnauthorized)
 
 	// The root user is granted access without a macaroon
 	ucred = &daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapdSocket}
-	c.Check(ac.CheckAccess(nil, req, ucred, nil), IsNil)
+	c.Check(ac.CheckAccess(nil, req, ucred, nil, daemon.NewNopAuthzRecorder()), IsNil)
 }
 
 func (s *accessSuite) TestAuthenticatedAccessPolkit(c *C) {
@@ -130,9 +130,9 @@ func (s *accessSuite) TestAuthenticatedAccessPolkit(c *C) {
 		return daemon.Forbidden("access denied")
 	})
 	defer restore()
-	c.Check(ac.CheckAccess(nil, req, nil, nil), DeepEquals, errForbidden)
-	c.Check(ac.CheckAccess(nil, req, nil, user), DeepEquals, errForbidden)
-	c.Check(ac.CheckAccess(nil, req, ucred, nil), IsNil)
+	c.Check(ac.CheckAccess(nil, req, nil, nil, daemon.NewNopAuthzRecorder()), DeepEquals, errForbidden)
+	c.Check(ac.CheckAccess(nil, req, nil, user, daemon.NewNopAuthzRecorder()), DeepEquals, errForbidden)
+	c.Check(ac.CheckAccess(nil, req, ucred, nil, daemon.NewNopAuthzRecorder()), IsNil)
 
 	// polkit is checked for regular users without macaroon auth
 	restore = daemon.MockCheckPolkitAction(func(r *http.Request, u *daemon.Ucrednet, action string) *daemon.APIError {
@@ -143,7 +143,7 @@ func (s *accessSuite) TestAuthenticatedAccessPolkit(c *C) {
 	})
 	defer restore()
 	ucred = &daemon.Ucrednet{Uid: 42, Pid: 100, Socket: dirs.SnapdSocket}
-	c.Check(ac.CheckAccess(nil, req, ucred, nil), IsNil)
+	c.Check(ac.CheckAccess(nil, req, ucred, nil, daemon.NewNopAuthzRecorder()), IsNil)
 }
 
 func (s *accessSuite) TestCheckPolkitActionImpl(c *C) {
@@ -211,22 +211,22 @@ func (s *accessSuite) TestRootAccess(c *C) {
 	user := &auth.UserState{}
 
 	// rootAccess denies access without ucred
-	c.Check(ac.CheckAccess(nil, nil, nil, nil), DeepEquals, errForbidden)
-	c.Check(ac.CheckAccess(nil, nil, nil, user), DeepEquals, errForbidden)
+	c.Check(ac.CheckAccess(nil, nil, nil, nil, daemon.NewNopAuthzRecorder()), DeepEquals, errForbidden)
+	c.Check(ac.CheckAccess(nil, nil, nil, user, daemon.NewNopAuthzRecorder()), DeepEquals, errForbidden)
 
 	// rootAccess denies access from snapd-snap.socket
 	ucred := &daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapSocket}
-	c.Check(ac.CheckAccess(nil, nil, ucred, nil), DeepEquals, errForbidden)
-	c.Check(ac.CheckAccess(nil, nil, ucred, user), DeepEquals, errForbidden)
+	c.Check(ac.CheckAccess(nil, nil, ucred, nil, daemon.NewNopAuthzRecorder()), DeepEquals, errForbidden)
+	c.Check(ac.CheckAccess(nil, nil, ucred, user, daemon.NewNopAuthzRecorder()), DeepEquals, errForbidden)
 
 	// Non-root users are forbidden, even with macaroon auth
 	ucred = &daemon.Ucrednet{Uid: 42, Pid: 100, Socket: dirs.SnapdSocket}
-	c.Check(ac.CheckAccess(nil, nil, ucred, nil), DeepEquals, errForbidden)
-	c.Check(ac.CheckAccess(nil, nil, ucred, user), DeepEquals, errForbidden)
+	c.Check(ac.CheckAccess(nil, nil, ucred, nil, daemon.NewNopAuthzRecorder()), DeepEquals, errForbidden)
+	c.Check(ac.CheckAccess(nil, nil, ucred, user, daemon.NewNopAuthzRecorder()), DeepEquals, errForbidden)
 
 	// Root is granted access
 	ucred = &daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapdSocket}
-	c.Check(ac.CheckAccess(nil, nil, ucred, nil), IsNil)
+	c.Check(ac.CheckAccess(nil, nil, ucred, nil, daemon.NewNopAuthzRecorder()), IsNil)
 }
 
 func (s *accessSuite) TestSnapAccess(c *C) {
@@ -234,12 +234,12 @@ func (s *accessSuite) TestSnapAccess(c *C) {
 
 	// snapAccess allows access from snapd-snap.socket
 	ucred := &daemon.Ucrednet{Uid: 42, Pid: 100, Socket: dirs.SnapSocket}
-	c.Check(ac.CheckAccess(nil, nil, ucred, nil), IsNil)
+	c.Check(ac.CheckAccess(nil, nil, ucred, nil, daemon.NewNopAuthzRecorder()), IsNil)
 
 	// access is forbidden on the main socket or without peer creds
 	ucred.Socket = dirs.SnapdSocket
-	c.Check(ac.CheckAccess(nil, nil, ucred, nil), DeepEquals, errForbidden)
-	c.Check(ac.CheckAccess(nil, nil, nil, nil), DeepEquals, errForbidden)
+	c.Check(ac.CheckAccess(nil, nil, ucred, nil, daemon.NewNopAuthzRecorder()), DeepEquals, errForbidden)
+	c.Check(ac.CheckAccess(nil, nil, nil, nil, daemon.NewNopAuthzRecorder()), DeepEquals, errForbidden)
 }
 
 func (s *accessSuite) TestRequireInterfaceApiAccessImpl(c *C) {
@@ -271,26 +271,26 @@ plugs:
 	var ac daemon.AccessChecker = daemon.InterfaceOpenAccess{Interfaces: []string{"snap-themes-control", "snap-refresh-control"}}
 
 	// Access with no ucred data is forbidden
-	c.Check(ac.CheckAccess(d, nil, nil, nil), DeepEquals, errForbidden)
+	c.Check(ac.CheckAccess(d, nil, nil, nil, daemon.NewNopAuthzRecorder()), DeepEquals, errForbidden)
 
 	// Access from snapd.socket is allowed
 	ucred := &daemon.Ucrednet{Uid: 1000, Pid: 1001, Socket: dirs.SnapdSocket}
 	req := http.Request{RemoteAddr: ucred.String()}
-	c.Check(ac.CheckAccess(d, nil, ucred, nil), IsNil)
+	c.Check(ac.CheckAccess(d, nil, ucred, nil, daemon.NewNopAuthzRecorder()), IsNil)
 	c.Check(req.RemoteAddr, Equals, ucred.String())
 
 	// Access from unknown sockets is forbidden
 	ucred = &daemon.Ucrednet{Uid: 1000, Pid: 1001, Socket: "unknown.socket"}
-	c.Check(ac.CheckAccess(d, nil, ucred, nil), DeepEquals, errForbidden)
+	c.Check(ac.CheckAccess(d, nil, ucred, nil, daemon.NewNopAuthzRecorder()), DeepEquals, errForbidden)
 
 	// Access from pids that cannot be mapped to a snap on
 	// snapd-snap.socket are rejected
 	ucred = &daemon.Ucrednet{Uid: 1000, Pid: 1001, Socket: dirs.SnapSocket}
-	c.Check(ac.CheckAccess(d, nil, ucred, nil), DeepEquals, daemon.Forbidden("could not determine snap name for pid: not a snap"))
+	c.Check(ac.CheckAccess(d, nil, ucred, nil, daemon.NewNopAuthzRecorder()), DeepEquals, daemon.Forbidden("could not determine snap name for pid: not a snap"))
 
 	// Access from snapd-snap.socket is rejected by default
 	ucred = &daemon.Ucrednet{Uid: 1000, Pid: 42, Socket: dirs.SnapSocket}
-	c.Check(ac.CheckAccess(d, nil, ucred, nil), DeepEquals, errForbidden)
+	c.Check(ac.CheckAccess(d, nil, ucred, nil, daemon.NewNopAuthzRecorder()), DeepEquals, errForbidden)
 
 	// Now connect the marker interface
 	st := d.Overlord().State()
@@ -304,7 +304,7 @@ plugs:
 
 	// Access is allowed now that the snap has the plug connected
 	req = http.Request{RemoteAddr: ucred.String()}
-	c.Check(ac.CheckAccess(s.d, &req, ucred, nil), IsNil)
+	c.Check(ac.CheckAccess(s.d, &req, ucred, nil, daemon.NewNopAuthzRecorder()), IsNil)
 	// Interface is attached to RemoteAddr
 	c.Check(req.RemoteAddr, Equals, fmt.Sprintf("%siface=snap-themes-control;", ucred))
 
@@ -320,7 +320,7 @@ plugs:
 	})
 	st.Unlock()
 	req = http.Request{RemoteAddr: ucred.String()}
-	c.Check(ac.CheckAccess(s.d, &req, ucred, nil), IsNil)
+	c.Check(ac.CheckAccess(s.d, &req, ucred, nil, daemon.NewNopAuthzRecorder()), IsNil)
 	// Check that both interfaces are attached to RemoteAddr.
 	// Since conns is a map, order is not guaranteed.
 	c.Check(req.RemoteAddr, Matches, fmt.Sprintf("^%siface=(snap-themes-control&snap-refresh-control|snap-refresh-control&snap-themes-control);$", ucred))
@@ -335,7 +335,7 @@ plugs:
 	})
 	st.Unlock()
 	req = http.Request{RemoteAddr: ucred.String()}
-	c.Check(ac.CheckAccess(d, nil, ucred, nil), DeepEquals, errForbidden)
+	c.Check(ac.CheckAccess(d, nil, ucred, nil, daemon.NewNopAuthzRecorder()), DeepEquals, errForbidden)
 	c.Check(req.RemoteAddr, Equals, ucred.String())
 }
 
@@ -357,7 +357,7 @@ func (s *accessSuite) TestInterfaceOpenAccess(c *C) {
 		return nil
 	})
 	defer restore()
-	c.Check(ac.CheckAccess(s.d, nil, ucred, nil), IsNil)
+	c.Check(ac.CheckAccess(s.d, nil, ucred, nil, daemon.NewNopAuthzRecorder()), IsNil)
 
 	// Access is forbidden if requireInterfaceApiAccess() fails
 	restore = daemon.MockRequireInterfaceApiAccess(func(
@@ -366,7 +366,7 @@ func (s *accessSuite) TestInterfaceOpenAccess(c *C) {
 		return errForbidden
 	})
 	defer restore()
-	c.Check(ac.CheckAccess(s.d, nil, ucred, nil), DeepEquals, errForbidden)
+	c.Check(ac.CheckAccess(s.d, nil, ucred, nil, daemon.NewNopAuthzRecorder()), DeepEquals, errForbidden)
 }
 
 func (s *accessSuite) TestInterfaceAuthenticatedAccess(c *C) {
@@ -396,8 +396,8 @@ func (s *accessSuite) TestInterfaceAuthenticatedAccess(c *C) {
 		return errForbidden
 	})
 	defer restore()
-	c.Check(ac.CheckAccess(s.d, req, ucred, nil), DeepEquals, errForbidden)
-	c.Check(ac.CheckAccess(s.d, req, ucred, user), DeepEquals, errForbidden)
+	c.Check(ac.CheckAccess(s.d, req, ucred, nil, daemon.NewNopAuthzRecorder()), DeepEquals, errForbidden)
+	c.Check(ac.CheckAccess(s.d, req, ucred, user, daemon.NewNopAuthzRecorder()), DeepEquals, errForbidden)
 
 	// If requireInterfaceApiAccess succeeds, root is granted access
 	restore = daemon.MockRequireInterfaceApiAccess(func(
@@ -406,14 +406,14 @@ func (s *accessSuite) TestInterfaceAuthenticatedAccess(c *C) {
 		return nil
 	})
 	defer restore()
-	c.Check(ac.CheckAccess(s.d, req, ucred, nil), IsNil)
+	c.Check(ac.CheckAccess(s.d, req, ucred, nil, daemon.NewNopAuthzRecorder()), IsNil)
 
 	// Macaroon auth will grant a normal user access too
 	ucred = &daemon.Ucrednet{Uid: 42, Pid: 100, Socket: dirs.SnapSocket}
-	c.Check(ac.CheckAccess(s.d, req, ucred, user), IsNil)
+	c.Check(ac.CheckAccess(s.d, req, ucred, user, daemon.NewNopAuthzRecorder()), IsNil)
 
 	// Without macaroon auth, normal users are unauthorized
-	c.Check(ac.CheckAccess(s.d, req, ucred, nil), DeepEquals, errUnauthorized)
+	c.Check(ac.CheckAccess(s.d, req, ucred, nil, daemon.NewNopAuthzRecorder()), DeepEquals, errUnauthorized)
 }
 
 func (s *accessSuite) TestInterfaceAuthenticatedAccessPolkit(c *C) {
@@ -444,9 +444,9 @@ func (s *accessSuite) TestInterfaceAuthenticatedAccessPolkit(c *C) {
 		return errForbidden
 	})
 	defer restore()
-	c.Check(ac.CheckAccess(s.d, req, ucred, nil), IsNil)
+	c.Check(ac.CheckAccess(s.d, req, ucred, nil, daemon.NewNopAuthzRecorder()), IsNil)
 	ucred = &daemon.Ucrednet{Uid: 42, Pid: 100, Socket: dirs.SnapdSocket}
-	c.Check(ac.CheckAccess(s.d, req, ucred, user), IsNil)
+	c.Check(ac.CheckAccess(s.d, req, ucred, user, daemon.NewNopAuthzRecorder()), IsNil)
 
 	// polkit is checked for regular users without macaroon auth
 	restore = daemon.MockCheckPolkitAction(func(r *http.Request, u *daemon.Ucrednet, action string) *daemon.APIError {
@@ -456,7 +456,7 @@ func (s *accessSuite) TestInterfaceAuthenticatedAccessPolkit(c *C) {
 		return nil
 	})
 	defer restore()
-	c.Check(ac.CheckAccess(s.d, req, ucred, nil), IsNil)
+	c.Check(ac.CheckAccess(s.d, req, ucred, nil, daemon.NewNopAuthzRecorder()), IsNil)
 }
 
 func (s *accessSuite) TestInterfaceProviderRootAccessCallsWithCorrectArgs(c *C) {
@@ -491,7 +491,7 @@ func (s *accessSuite) TestInterfaceProviderRootAccessCallsWithCorrectArgs(c *C) 
 		return errForbidden
 	})
 	defer restore()
-	c.Check(ac.CheckAccess(s.d, req, ucred, nil), DeepEquals, errForbidden)
+	c.Check(ac.CheckAccess(s.d, req, ucred, nil, daemon.NewNopAuthzRecorder()), DeepEquals, errForbidden)
 	c.Assert(called, Equals, 1)
 }
 
@@ -555,7 +555,7 @@ plugs:
 	req := &http.Request{
 		RemoteAddr: ucred.String(),
 	}
-	c.Check(ac.CheckAccess(s.d, req, ucred, nil), DeepEquals, errForbidden)
+	c.Check(ac.CheckAccess(s.d, req, ucred, nil, daemon.NewNopAuthzRecorder()), DeepEquals, errForbidden)
 
 	// Now connect both interfaces
 	st := d.Overlord().State()
@@ -575,45 +575,45 @@ plugs:
 	req = &http.Request{
 		RemoteAddr: ucred.String(),
 	}
-	c.Check(ac.CheckAccess(s.d, req, ucred, user), IsNil)
+	c.Check(ac.CheckAccess(s.d, req, ucred, user, daemon.NewNopAuthzRecorder()), IsNil)
 
 	// connected-fwupd-caller, but on the plug side
 	ucred = &daemon.Ucrednet{Uid: 0, Pid: 1042, Socket: dirs.SnapSocket}
 	req = &http.Request{
 		RemoteAddr: ucred.String(),
 	}
-	c.Check(ac.CheckAccess(s.d, req, ucred, user), DeepEquals, errForbidden)
+	c.Check(ac.CheckAccess(s.d, req, ucred, user, daemon.NewNopAuthzRecorder()), DeepEquals, errForbidden)
 
 	// disconnected-fwupd-caller
 	ucred = &daemon.Ucrednet{Uid: 0, Pid: 10042, Socket: dirs.SnapSocket}
 	req = &http.Request{
 		RemoteAddr: ucred.String(),
 	}
-	c.Check(ac.CheckAccess(s.d, req, ucred, user), DeepEquals, errForbidden)
+	c.Check(ac.CheckAccess(s.d, req, ucred, user, daemon.NewNopAuthzRecorder()), DeepEquals, errForbidden)
 
 	// normal user has no access even with a Macaroon auth
 	ucred = &daemon.Ucrednet{Uid: 42, Pid: 42, Socket: dirs.SnapSocket}
 	req = &http.Request{
 		RemoteAddr: ucred.String(),
 	}
-	c.Check(ac.CheckAccess(s.d, req, ucred, user), DeepEquals, errUnauthorized)
+	c.Check(ac.CheckAccess(s.d, req, ucred, user, daemon.NewNopAuthzRecorder()), DeepEquals, errUnauthorized)
 
 	// Without macaroon auth, normal users are unauthorized
-	c.Check(ac.CheckAccess(s.d, req, ucred, nil), DeepEquals, errUnauthorized)
+	c.Check(ac.CheckAccess(s.d, req, ucred, nil, daemon.NewNopAuthzRecorder()), DeepEquals, errUnauthorized)
 
 	// on snapd socket, non-root is unauthorized
 	ucred = &daemon.Ucrednet{Uid: 42, Pid: 123, Socket: dirs.SnapdSocket}
 	req = &http.Request{
 		RemoteAddr: ucred.String(),
 	}
-	c.Check(ac.CheckAccess(s.d, req, ucred, nil), DeepEquals, errUnauthorized)
+	c.Check(ac.CheckAccess(s.d, req, ucred, nil, daemon.NewNopAuthzRecorder()), DeepEquals, errUnauthorized)
 
 	// but root is
 	ucred = &daemon.Ucrednet{Uid: 0, Pid: 123, Socket: dirs.SnapdSocket}
 	req = &http.Request{
 		RemoteAddr: ucred.String(),
 	}
-	c.Check(ac.CheckAccess(s.d, req, ucred, nil), IsNil)
+	c.Check(ac.CheckAccess(s.d, req, ucred, nil, daemon.NewNopAuthzRecorder()), IsNil)
 }
 
 func (s *accessSuite) TestInterfaceRootAccessCallsWithCorrectArgs(c *C) {
@@ -648,7 +648,7 @@ func (s *accessSuite) TestInterfaceRootAccessCallsWithCorrectArgs(c *C) {
 		return errForbidden
 	})
 	defer restore()
-	c.Check(ac.CheckAccess(s.d, req, ucred, nil), DeepEquals, errForbidden)
+	c.Check(ac.CheckAccess(s.d, req, ucred, nil, daemon.NewNopAuthzRecorder()), DeepEquals, errForbidden)
 	c.Assert(called, Equals, 1)
 }
 
@@ -700,7 +700,7 @@ plugs:
 	req := &http.Request{
 		RemoteAddr: ucred.String(),
 	}
-	c.Check(ac.CheckAccess(s.d, req, ucred, nil), DeepEquals, errForbidden)
+	c.Check(ac.CheckAccess(s.d, req, ucred, nil, daemon.NewNopAuthzRecorder()), DeepEquals, errForbidden)
 
 	// Now connect connected-fwupd-caller (plug) to fwupd-app (slot)
 	st := d.Overlord().State()
@@ -717,38 +717,38 @@ plugs:
 	req = &http.Request{
 		RemoteAddr: ucred.String(),
 	}
-	c.Check(ac.CheckAccess(s.d, req, ucred, user), IsNil)
+	c.Check(ac.CheckAccess(s.d, req, ucred, user, daemon.NewNopAuthzRecorder()), IsNil)
 
 	// fwupd-app, connected on the slot side
 	ucred = &daemon.Ucrednet{Uid: 0, Pid: 42, Socket: dirs.SnapSocket}
 	req = &http.Request{
 		RemoteAddr: ucred.String(),
 	}
-	c.Check(ac.CheckAccess(s.d, req, ucred, user), DeepEquals, errForbidden)
+	c.Check(ac.CheckAccess(s.d, req, ucred, user, daemon.NewNopAuthzRecorder()), DeepEquals, errForbidden)
 
 	// normal user has no access even with a Macaroon auth
 	ucred = &daemon.Ucrednet{Uid: 42, Pid: 1042, Socket: dirs.SnapSocket}
 	req = &http.Request{
 		RemoteAddr: ucred.String(),
 	}
-	c.Check(ac.CheckAccess(s.d, req, ucred, user), DeepEquals, errUnauthorized)
+	c.Check(ac.CheckAccess(s.d, req, ucred, user, daemon.NewNopAuthzRecorder()), DeepEquals, errUnauthorized)
 
 	// Without macaroon auth, normal users are unauthorized
-	c.Check(ac.CheckAccess(s.d, req, ucred, nil), DeepEquals, errUnauthorized)
+	c.Check(ac.CheckAccess(s.d, req, ucred, nil, daemon.NewNopAuthzRecorder()), DeepEquals, errUnauthorized)
 
 	// on snapd socket, non-root is unauthorized
 	ucred = &daemon.Ucrednet{Uid: 42, Pid: 123, Socket: dirs.SnapdSocket}
 	req = &http.Request{
 		RemoteAddr: ucred.String(),
 	}
-	c.Check(ac.CheckAccess(s.d, req, ucred, nil), DeepEquals, errUnauthorized)
+	c.Check(ac.CheckAccess(s.d, req, ucred, nil, daemon.NewNopAuthzRecorder()), DeepEquals, errUnauthorized)
 
 	// but root is
 	ucred = &daemon.Ucrednet{Uid: 0, Pid: 123, Socket: dirs.SnapdSocket}
 	req = &http.Request{
 		RemoteAddr: ucred.String(),
 	}
-	c.Check(ac.CheckAccess(s.d, req, ucred, nil), IsNil)
+	c.Check(ac.CheckAccess(s.d, req, ucred, nil, daemon.NewNopAuthzRecorder()), IsNil)
 }
 
 func (s *accessSuite) TestInterfaceRootAccessPolkit(c *C) {
@@ -809,13 +809,13 @@ plugs:
 	})
 	defer restore()
 	// ucred is missing
-	c.Check(ac.CheckAccess(nil, req, nil, nil), DeepEquals, errForbidden)
+	c.Check(ac.CheckAccess(nil, req, nil, nil, daemon.NewNopAuthzRecorder()), DeepEquals, errForbidden)
 	// user is root (on snapd.socket)
-	c.Check(ac.CheckAccess(nil, req, &daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapdSocket}, nil), IsNil)
+	c.Check(ac.CheckAccess(nil, req, &daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapdSocket}, nil, daemon.NewNopAuthzRecorder()), IsNil)
 	// snap request (as root) with relevant connected plug (on snapd-snap.socket)
-	c.Check(ac.CheckAccess(s.d, req, &daemon.Ucrednet{Uid: 0, Pid: 1042, Socket: dirs.SnapSocket}, nil), IsNil)
+	c.Check(ac.CheckAccess(s.d, req, &daemon.Ucrednet{Uid: 0, Pid: 1042, Socket: dirs.SnapSocket}, nil, daemon.NewNopAuthzRecorder()), IsNil)
 	// snap request without relevant connected plug (on snapd-snap.socket)
-	c.Check(ac.CheckAccess(s.d, req, &daemon.Ucrednet{Uid: 0, Pid: 42, Socket: dirs.SnapSocket}, user), DeepEquals, errForbidden)
+	c.Check(ac.CheckAccess(s.d, req, &daemon.Ucrednet{Uid: 0, Pid: 42, Socket: dirs.SnapSocket}, user, daemon.NewNopAuthzRecorder()), DeepEquals, errForbidden)
 
 	// polkit is checked for snaps with connected plug
 	called := 0
@@ -827,11 +827,11 @@ plugs:
 	})
 	defer restore()
 	// regular user (on snapd.socket)
-	c.Check(ac.CheckAccess(nil, req, &daemon.Ucrednet{Uid: 1001, Pid: 100, Socket: dirs.SnapdSocket}, nil), IsNil)
+	c.Check(ac.CheckAccess(nil, req, &daemon.Ucrednet{Uid: 1001, Pid: 100, Socket: dirs.SnapdSocket}, nil, daemon.NewNopAuthzRecorder()), IsNil)
 	// snap request (with macaroon) with relevant connected plug (on snapd-snap.socket)
-	c.Check(ac.CheckAccess(s.d, req, &daemon.Ucrednet{Uid: 1001, Pid: 1042, Socket: dirs.SnapSocket}, user), IsNil)
+	c.Check(ac.CheckAccess(s.d, req, &daemon.Ucrednet{Uid: 1001, Pid: 1042, Socket: dirs.SnapSocket}, user, daemon.NewNopAuthzRecorder()), IsNil)
 	// snap request (without macaroon) with relevant connected plug (on snapd-snap.socket)
-	c.Check(ac.CheckAccess(s.d, req, &daemon.Ucrednet{Uid: 1001, Pid: 1042, Socket: dirs.SnapSocket}, nil), IsNil)
+	c.Check(ac.CheckAccess(s.d, req, &daemon.Ucrednet{Uid: 1001, Pid: 1042, Socket: dirs.SnapSocket}, nil, daemon.NewNopAuthzRecorder()), IsNil)
 	c.Check(called, Equals, 3)
 }
 
@@ -989,7 +989,7 @@ func (s *accessSuite) TestByActionAccess(c *C) {
 
 		for action := range byAction {
 			cmt := Commentf("sub-test tcs[%d] failed for action %q", idx, action)
-			err := ac.CheckAccess(nil, reqWithAction(c, action, !tc.notJSON, tc.malformed), &tc.ucred, user)
+			err := ac.CheckAccess(nil, reqWithAction(c, action, !tc.notJSON, tc.malformed), &tc.ucred, user, daemon.NewNopAuthzRecorder())
 			if expectedErr := tc.expectedErr[action]; err != nil {
 				c.Check(err, DeepEquals, expectedErr, cmt)
 			} else {
@@ -998,7 +998,7 @@ func (s *accessSuite) TestByActionAccess(c *C) {
 		}
 
 		cmt := Commentf("sub-test tcs[%d] failed for default action", idx)
-		err := ac.CheckAccess(nil, reqWithAction(c, "default", !tc.notJSON, tc.malformed), &tc.ucred, user)
+		err := ac.CheckAccess(nil, reqWithAction(c, "default", !tc.notJSON, tc.malformed), &tc.ucred, user, daemon.NewNopAuthzRecorder())
 		if expectedErr := tc.expectedErr["default"]; err != nil {
 			c.Check(err, DeepEquals, expectedErr, cmt)
 		} else {
@@ -1035,7 +1035,7 @@ func (s *accessSuite) TestByActionAccessDefaultMustBeRoot(c *C) {
 		ac := daemon.ByActionAccess{Default: tc.ac}
 
 		ucred := daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapdSocket}
-		err = ac.CheckAccess(nil, req, &ucred, nil)
+		err = ac.CheckAccess(nil, req, &ucred, nil, daemon.NewNopAuthzRecorder())
 		if tc.canBeDefault {
 			c.Assert(err, IsNil)
 		} else {
@@ -1054,7 +1054,7 @@ func (s *accessSuite) TestByActionAccessLargeJSON(c *C) {
 	ac := daemon.ByActionAccess{Default: daemon.RootAccess{}}
 
 	ucred := daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapdSocket}
-	err = ac.CheckAccess(nil, req, &ucred, nil)
+	err = ac.CheckAccess(nil, req, &ucred, nil, daemon.NewNopAuthzRecorder())
 	c.Assert(err, DeepEquals, daemon.BadRequest("body size limit exceeded"))
 }
 
@@ -1067,6 +1067,6 @@ func (s *accessSuite) TestByActionAccessDataAfterJOSN(c *C) {
 	ac := daemon.ByActionAccess{Default: daemon.RootAccess{}}
 
 	ucred := daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapdSocket}
-	err = ac.CheckAccess(nil, req, &ucred, nil)
+	err = ac.CheckAccess(nil, req, &ucred, nil, daemon.NewNopAuthzRecorder())
 	c.Assert(err, DeepEquals, daemon.BadRequest("unexpected data after request body"))
 }

--- a/daemon/access_test.go
+++ b/daemon/access_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/polkit"
+	"github.com/snapcore/snapd/seclog"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -346,24 +347,24 @@ func (s *accessSuite) TestInterfaceOpenAccess(c *C) {
 	// interfaceOpenAccess allows access if requireInterfaceApiAccess() succeeds
 	ucred := &daemon.Ucrednet{Uid: 42, Pid: 100, Socket: dirs.SnapSocket}
 	restore := daemon.MockRequireInterfaceApiAccess(func(
-		d *daemon.Daemon, r *http.Request, u *daemon.Ucrednet, reqs daemon.InterfaceAccessReqs,
-	) *daemon.APIError {
+		d *daemon.Daemon, r *http.Request, u *daemon.Ucrednet, reqs daemon.InterfaceAccessReqs, _ daemon.AuthzRecorder, _ daemon.AccessLevel,
+	) (daemon.InterfaceAccessOutcome, *daemon.APIError) {
 		c.Check(d, Equals, s.d)
 		c.Check(u, Equals, ucred)
 		c.Check(reqs, DeepEquals, daemon.InterfaceAccessReqs{
 			Interfaces: []string{"snap-themes-control", "snap-interfaces-requests-control"},
 			Plug:       true,
 		})
-		return nil
+		return daemon.InterfaceAccessOutcome{}, nil
 	})
 	defer restore()
 	c.Check(ac.CheckAccess(s.d, nil, ucred, nil, daemon.NewNopAuthzRecorder()), IsNil)
 
 	// Access is forbidden if requireInterfaceApiAccess() fails
 	restore = daemon.MockRequireInterfaceApiAccess(func(
-		d *daemon.Daemon, r *http.Request, u *daemon.Ucrednet, req daemon.InterfaceAccessReqs,
-	) *daemon.APIError {
-		return errForbidden
+		d *daemon.Daemon, r *http.Request, u *daemon.Ucrednet, req daemon.InterfaceAccessReqs, _ daemon.AuthzRecorder, _ daemon.AccessLevel,
+	) (daemon.InterfaceAccessOutcome, *daemon.APIError) {
+		return daemon.InterfaceAccessOutcome{}, errForbidden
 	})
 	defer restore()
 	c.Check(ac.CheckAccess(s.d, nil, ucred, nil, daemon.NewNopAuthzRecorder()), DeepEquals, errForbidden)
@@ -386,14 +387,14 @@ func (s *accessSuite) TestInterfaceAuthenticatedAccess(c *C) {
 	// interfaceAuthenticatedAccess denies access if requireInterfaceApiAccess fails
 	ucred := &daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapSocket}
 	restore = daemon.MockRequireInterfaceApiAccess(func(
-		d *daemon.Daemon, r *http.Request, u *daemon.Ucrednet, reqs daemon.InterfaceAccessReqs,
-	) *daemon.APIError {
+		d *daemon.Daemon, r *http.Request, u *daemon.Ucrednet, reqs daemon.InterfaceAccessReqs, _ daemon.AuthzRecorder, _ daemon.AccessLevel,
+	) (daemon.InterfaceAccessOutcome, *daemon.APIError) {
 		c.Check(d, Equals, s.d)
 		c.Check(u, Equals, ucred)
 		c.Check(reqs, DeepEquals, daemon.InterfaceAccessReqs{
 			Plug: true,
 		})
-		return errForbidden
+		return daemon.InterfaceAccessOutcome{}, errForbidden
 	})
 	defer restore()
 	c.Check(ac.CheckAccess(s.d, req, ucred, nil, daemon.NewNopAuthzRecorder()), DeepEquals, errForbidden)
@@ -401,9 +402,9 @@ func (s *accessSuite) TestInterfaceAuthenticatedAccess(c *C) {
 
 	// If requireInterfaceApiAccess succeeds, root is granted access
 	restore = daemon.MockRequireInterfaceApiAccess(func(
-		d *daemon.Daemon, r *http.Request, u *daemon.Ucrednet, reqs daemon.InterfaceAccessReqs,
-	) *daemon.APIError {
-		return nil
+		d *daemon.Daemon, r *http.Request, u *daemon.Ucrednet, reqs daemon.InterfaceAccessReqs, _ daemon.AuthzRecorder, _ daemon.AccessLevel,
+	) (daemon.InterfaceAccessOutcome, *daemon.APIError) {
+		return daemon.InterfaceAccessOutcome{}, nil
 	})
 	defer restore()
 	c.Check(ac.CheckAccess(s.d, req, ucred, nil, daemon.NewNopAuthzRecorder()), IsNil)
@@ -425,14 +426,14 @@ func (s *accessSuite) TestInterfaceAuthenticatedAccessPolkit(c *C) {
 
 	s.daemon(c)
 	restore := daemon.MockRequireInterfaceApiAccess(func(
-		d *daemon.Daemon, r *http.Request, u *daemon.Ucrednet, reqs daemon.InterfaceAccessReqs,
-	) *daemon.APIError {
+		d *daemon.Daemon, r *http.Request, u *daemon.Ucrednet, reqs daemon.InterfaceAccessReqs, _ daemon.AuthzRecorder, _ daemon.AccessLevel,
+	) (daemon.InterfaceAccessOutcome, *daemon.APIError) {
 		c.Check(d, Equals, s.d)
 		c.Check(u, Equals, ucred)
 		c.Check(reqs, DeepEquals, daemon.InterfaceAccessReqs{
 			Plug: true,
 		})
-		return nil
+		return daemon.InterfaceAccessOutcome{}, nil
 	})
 	defer restore()
 
@@ -479,8 +480,8 @@ func (s *accessSuite) TestInterfaceProviderRootAccessCallsWithCorrectArgs(c *C) 
 	// mock and check whether correct arguments are passed
 	called := 0
 	restore = daemon.MockRequireInterfaceApiAccess(func(
-		d *daemon.Daemon, r *http.Request, u *daemon.Ucrednet, reqs daemon.InterfaceAccessReqs,
-	) *daemon.APIError {
+		d *daemon.Daemon, r *http.Request, u *daemon.Ucrednet, reqs daemon.InterfaceAccessReqs, _ daemon.AuthzRecorder, _ daemon.AccessLevel,
+	) (daemon.InterfaceAccessOutcome, *daemon.APIError) {
 		c.Check(d, Equals, s.d)
 		c.Check(u, Equals, ucred)
 		c.Check(reqs, DeepEquals, daemon.InterfaceAccessReqs{
@@ -488,7 +489,7 @@ func (s *accessSuite) TestInterfaceProviderRootAccessCallsWithCorrectArgs(c *C) 
 			Slot:       true,
 		})
 		called++
-		return errForbidden
+		return daemon.InterfaceAccessOutcome{}, errForbidden
 	})
 	defer restore()
 	c.Check(ac.CheckAccess(s.d, req, ucred, nil, daemon.NewNopAuthzRecorder()), DeepEquals, errForbidden)
@@ -636,8 +637,8 @@ func (s *accessSuite) TestInterfaceRootAccessCallsWithCorrectArgs(c *C) {
 	// mock and check whether correct arguments are passed
 	called := 0
 	restore = daemon.MockRequireInterfaceApiAccess(func(
-		d *daemon.Daemon, r *http.Request, u *daemon.Ucrednet, reqs daemon.InterfaceAccessReqs,
-	) *daemon.APIError {
+		d *daemon.Daemon, r *http.Request, u *daemon.Ucrednet, reqs daemon.InterfaceAccessReqs, _ daemon.AuthzRecorder, _ daemon.AccessLevel,
+	) (daemon.InterfaceAccessOutcome, *daemon.APIError) {
 		c.Check(d, Equals, s.d)
 		c.Check(u, Equals, ucred)
 		c.Check(reqs, DeepEquals, daemon.InterfaceAccessReqs{
@@ -645,7 +646,7 @@ func (s *accessSuite) TestInterfaceRootAccessCallsWithCorrectArgs(c *C) {
 			Plug:       true,
 		})
 		called++
-		return errForbidden
+		return daemon.InterfaceAccessOutcome{}, errForbidden
 	})
 	defer restore()
 	c.Check(ac.CheckAccess(s.d, req, ucred, nil, daemon.NewNopAuthzRecorder()), DeepEquals, errForbidden)
@@ -838,36 +839,33 @@ plugs:
 func (s *accessSuite) TestRequireInterfaceApiAccessErrorChecks(c *C) {
 	d := s.daemon(c)
 	req := &http.Request{}
+	rec := daemon.NewNopAuthzRecorder()
+	level := daemon.AccessLevelAuthenticated
 
 	// no side of the connection is specified
-	c.Check(daemon.RequireInterfaceApiAccessImpl(d, req, nil, daemon.InterfaceAccessReqs{}), DeepEquals,
-		daemon.InternalError("required connection side is unspecified"))
+	_, err := daemon.RequireInterfaceApiAccessImpl(d, req, nil, daemon.InterfaceAccessReqs{}, rec, level)
+	c.Check(err, DeepEquals, daemon.InternalError("required connection side is unspecified"))
 
 	// check on both sides
-	c.Check(
-		daemon.RequireInterfaceApiAccessImpl(d, req, nil, daemon.InterfaceAccessReqs{
-			Plug:       true,
-			Slot:       true,
-			Interfaces: []string{"foo"},
-		}),
-		DeepEquals,
-		daemon.InternalError("snap cannot be specified on both sides of the connection"))
+	_, err = daemon.RequireInterfaceApiAccessImpl(d, req, nil, daemon.InterfaceAccessReqs{
+		Plug:       true,
+		Slot:       true,
+		Interfaces: []string{"foo"},
+	}, rec, level)
+	c.Check(err, DeepEquals, daemon.InternalError("snap cannot be specified on both sides of the connection"))
 
 	// no interfaces
-	c.Check(
-		daemon.RequireInterfaceApiAccessImpl(d, req, nil, daemon.InterfaceAccessReqs{
-			Plug: true,
-		}),
-		DeepEquals,
-		daemon.InternalError("interfaces access check, but interfaces list is empty"))
+	_, err = daemon.RequireInterfaceApiAccessImpl(d, req, nil, daemon.InterfaceAccessReqs{
+		Plug: true,
+	}, rec, level)
+	c.Check(err, DeepEquals, daemon.InternalError("interfaces access check, but interfaces list is empty"))
 
 	// this one actually reaches the credentials check
-	c.Check(
-		daemon.RequireInterfaceApiAccessImpl(d, req, nil, daemon.InterfaceAccessReqs{
-			Plug:       true,
-			Interfaces: []string{"foo"},
-		}),
-		DeepEquals, errForbidden)
+	_, err = daemon.RequireInterfaceApiAccessImpl(d, req, nil, daemon.InterfaceAccessReqs{
+		Plug:       true,
+		Interfaces: []string{"foo"},
+	}, rec, level)
+	c.Check(err, DeepEquals, errForbidden)
 }
 
 func reqWithAction(c *C, action string, isJSON, malformed bool) *http.Request {
@@ -1069,4 +1067,75 @@ func (s *accessSuite) TestByActionAccessDataAfterJOSN(c *C) {
 	ucred := daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapdSocket}
 	err = ac.CheckAccess(nil, req, &ucred, nil, daemon.NewNopAuthzRecorder())
 	c.Assert(err, DeepEquals, daemon.BadRequest("unexpected data after request body"))
+}
+
+func (s *accessSuite) TestCheckAccessAuthzRecording(c *C) {
+	req := httptest.NewRequest("GET", "/", nil)
+
+	// Open access: denials are not audited.
+	rec := daemon.NewAuthzTestRecorder()
+	var ac daemon.AccessChecker = daemon.OpenAccess{}
+	c.Check(ac.CheckAccess(nil, nil, nil, nil, rec), DeepEquals, errForbidden)
+	c.Check(rec.DeniedReason, Equals, "")
+	c.Check(rec.GrantedReason, Equals, "")
+
+	// Authenticated access denied without credentials.
+	rec = daemon.NewAuthzTestRecorder()
+	ac = daemon.AuthenticatedAccess{}
+	ucred := &daemon.Ucrednet{Uid: 42, Pid: 100, Socket: dirs.SnapdSocket}
+	c.Check(ac.CheckAccess(nil, req, ucred, nil, rec), DeepEquals, errUnauthorized)
+	c.Check(rec.DeniedReason, Equals, seclog.ReasonDeniedUserAuthDenied)
+
+	// Authenticated access granted via macaroon.
+	rec = daemon.NewAuthzTestRecorder()
+	user := &auth.UserState{}
+	c.Check(ac.CheckAccess(nil, req, ucred, user, rec), IsNil)
+	c.Check(rec.GrantedReason, Equals, seclog.ReasonGrantedUserAuth)
+
+	// Root access granted.
+	rec = daemon.NewAuthzTestRecorder()
+	ac = daemon.RootAccess{}
+	ucred = &daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapdSocket}
+	c.Check(ac.CheckAccess(nil, nil, ucred, nil, rec), IsNil)
+	c.Check(rec.GrantedReason, Equals, seclog.ReasonGrantedRootAuth)
+
+	// Polkit grant and deny.
+	ac = daemon.AuthenticatedAccess{Polkit: "action-id"}
+	ucred = &daemon.Ucrednet{Uid: 42, Pid: 100, Socket: dirs.SnapdSocket}
+	restore := daemon.MockCheckPolkitAction(func(r *http.Request, u *daemon.Ucrednet, action string) *daemon.APIError {
+		c.Check(action, Equals, "action-id")
+		return nil
+	})
+	defer restore()
+	rec = daemon.NewAuthzTestRecorder()
+	c.Check(ac.CheckAccess(nil, req, ucred, nil, rec), IsNil)
+	c.Check(rec.GrantedReason, Equals, seclog.ReasonGrantedPolkitAuth)
+
+	restore = daemon.MockCheckPolkitAction(func(r *http.Request, u *daemon.Ucrednet, action string) *daemon.APIError {
+		return errUnauthorized
+	})
+	defer restore()
+	rec = daemon.NewAuthzTestRecorder()
+	c.Check(ac.CheckAccess(nil, req, ucred, nil, rec), DeepEquals, errUnauthorized)
+	c.Check(rec.DeniedReason, Equals, seclog.ReasonDeniedPolkitAuthDenied)
+
+	// Wrong socket on an audited endpoint.
+	rec = daemon.NewAuthzTestRecorder()
+	ac = daemon.AuthenticatedAccess{}
+	ucred = &daemon.Ucrednet{Uid: 42, Pid: 100, Socket: dirs.SnapSocket}
+	c.Check(ac.CheckAccess(nil, req, ucred, nil, rec), DeepEquals, errForbidden)
+	c.Check(rec.DeniedReason, Equals, seclog.ReasonDeniedSocketNotPermitted)
+
+	// Interface connection contributes to grant postfix.
+	rec = daemon.NewAuthzTestRecorder()
+	ac = daemon.InterfaceRootAccess{Interfaces: []string{"desktop-launch"}}
+	restore = daemon.MockRequireInterfaceApiAccess(func(
+		d *daemon.Daemon, r *http.Request, u *daemon.Ucrednet, reqs daemon.InterfaceAccessReqs, _ daemon.AuthzRecorder, _ daemon.AccessLevel,
+	) (daemon.InterfaceAccessOutcome, *daemon.APIError) {
+		return daemon.InterfaceAccessOutcome{MatchedIface: "desktop-launch", Plug: true}, nil
+	})
+	defer restore()
+	ucred = &daemon.Ucrednet{Uid: 0, Pid: 100, Socket: dirs.SnapSocket}
+	c.Check(ac.CheckAccess(nil, req, ucred, nil, rec), IsNil)
+	c.Check(rec.GrantedReason, Equals, seclog.ReasonGrantedRootAuth+" desktop-launch+plug")
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -160,13 +160,21 @@ func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if rspe := access.CheckAccess(c.d, r, ucred, user); rspe != nil {
+	action := tryExtractJSONAction(r)
+
+	authzRec := NewAuthzRecorder().
+		WithUser(seclogSnapdUserFromAuth(user)).
+		WithPeer(seclogPeerFromUcred(ucred)).
+		WithEndpoint(seclogEndpointFromRequest(c.Path, r.Method, action))
+
+	rspe := access.CheckAccess(c.d, r, ucred, user, authzRec)
+	authzRec.Emit()
+	if rspe != nil {
 		rspe.ServeHTTP(w, r)
 		return
 	}
 
 	if osutil.GetenvBool("SNAPD_TRACE") {
-		action := tryExtractJSONAction(r)
 		traceSnapdAPI(c, r, action)
 	}
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -202,19 +202,28 @@ func traceSnapdAPI(c *Command, r *http.Request, action string) {
 // looking for the top-level "action" key.
 const actionPeekSize = 4096
 
-// bodyWithCloser lets us replace r.Body with a buffered reader while
-// preserving the original Close so the http server can release the
-// underlying body normally.
-type bodyWithCloser struct {
+// peekableBody wraps a buffered reader as an http.Request body so the
+// prefix can be inspected via Peek without advancing the read position.
+// Close is delegated to the original body so the server can release it.
+type peekableBody struct {
 	io.Reader
 	io.Closer
 }
 
-// tryExtractJSONAction returns the top-level "action" field of a JSON
-// request body without consuming the body. It buffers at most
-// actionPeekSize bytes via bufio.Reader.Peek (which does not advance
-// the reader) and walks the prefix with a streaming JSON tokenizer.
-// On any failure (action beyond the peek window, malformed prefix,
+// tryExtractJSONAction returns the top-level "action" string field of a JSON
+// request body. It must be called at most once per request.
+//
+// The function replaces r.Body with a buffered wrapper (peekableBody) that
+// preserves the original body's Close while allowing a prefix peek without
+// advancing the read position. Subsequent handlers still read the full body.
+//
+// Only POST and PUT requests are considered. Content-Type must be absent or
+// exactly "application/json"; other types are ignored and the body is left
+// unchanged.
+//
+// Extraction inspects at most actionPeekSize (4 KiB) via bufio.Reader.Peek
+// and a streaming JSON tokenizer. It fails closed: on any error (action
+// beyond the peek window, malformed prefix, non-string action value,
 // preceding value too large) it returns an empty string.
 func tryExtractJSONAction(r *http.Request) string {
 	if (r.Method != "POST" && r.Method != "PUT") || r.Body == nil {
@@ -228,7 +237,7 @@ func tryExtractJSONAction(r *http.Request) string {
 	// advancing the read position.
 	orig := r.Body
 	br := bufio.NewReaderSize(orig, actionPeekSize)
-	r.Body = bodyWithCloser{Reader: br, Closer: orig}
+	r.Body = peekableBody{Reader: br, Closer: orig}
 
 	// Ignore the error: a short body (EOF) still yields the bytes we
 	// got, which is all we need. Any tokenize error below returns "".

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -20,6 +20,7 @@
 package daemon
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -210,6 +211,86 @@ func traceSnapdAPI(c *Command, w http.ResponseWriter, r *http.Request) {
 			logger.Trace("endpoint", "method", r.Method, "path", c.Path)
 		}
 	}
+}
+
+// actionPeekSize bounds how much of the request body we inspect when
+// looking for the top-level "action" key.
+const actionPeekSize = 4096
+
+// bodyWithCloser lets us replace r.Body with a buffered reader while
+// preserving the original Close so the http server can release the
+// underlying body normally.
+type bodyWithCloser struct {
+	io.Reader
+	io.Closer
+}
+
+// tryExtractJSONAction returns the top-level "action" field of a JSON
+// request body without consuming the body. It buffers at most
+// actionPeekSize bytes via bufio.Reader.Peek (which does not advance
+// the reader) and walks the prefix with a streaming JSON tokenizer.
+// On any failure (action beyond the peek window, malformed prefix,
+// preceding value too large) it returns an empty string.
+func tryExtractJSONAction(r *http.Request) string {
+	if (r.Method != "POST" && r.Method != "PUT") || r.Body == nil {
+		return ""
+	}
+	if ct := r.Header.Get("Content-Type"); ct != "" && ct != "application/json" {
+		return ""
+	}
+
+	// Wrap the body so Peek can inspect a bounded prefix without
+	// advancing the read position.
+	orig := r.Body
+	br := bufio.NewReaderSize(orig, actionPeekSize)
+	r.Body = bodyWithCloser{Reader: br, Closer: orig}
+
+	// Ignore the error: a short body (EOF) still yields the bytes we
+	// got, which is all we need. Any tokenize error below returns "".
+	peeked, _ := br.Peek(actionPeekSize)
+
+	dec := json.NewDecoder(bytes.NewReader(peeked))
+	t, err := dec.Token()
+	if err != nil || t != json.Delim('{') {
+		return ""
+	}
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			return ""
+		}
+		key, ok := keyTok.(string)
+		if !ok {
+			return ""
+		}
+		if key == "action" {
+			var v string
+			if dec.Decode(&v) != nil {
+				return ""
+			}
+			return v
+		}
+		// Skip this value (scalar, object or array) by depth counting.
+		depth := 0
+		for {
+			tok, err := dec.Token()
+			if err != nil {
+				return ""
+			}
+			if d, ok := tok.(json.Delim); ok {
+				switch d {
+				case '{', '[':
+					depth++
+				case '}', ']':
+					depth--
+				}
+			}
+			if depth == 0 {
+				break
+			}
+		}
+	}
+	return ""
 }
 
 type wrappedWriter struct {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -165,7 +165,10 @@ func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	traceSnapdAPI(c, w, r)
+	if osutil.GetenvBool("SNAPD_TRACE") {
+		action := tryExtractJSONAction(r)
+		traceSnapdAPI(c, r, action)
+	}
 
 	rsp := rspf(c, r, user)
 
@@ -187,30 +190,12 @@ func (c *Command) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	rsp.ServeHTTP(w, r)
 }
 
-func traceSnapdAPI(c *Command, w http.ResponseWriter, r *http.Request) {
-	if osutil.GetenvBool("SNAPD_TRACE") {
-		loggedWithAction := false
-		if r.Method == "POST" && (r.Header.Get("Content-Type") == "application/json" || r.Header.Get("Content-Type") == "") {
-			r.Body = http.MaxBytesReader(w, r.Body, 3*1024*1024) // 3 MB limit
-			bodyBytes, err := io.ReadAll(r.Body)
-			if err != nil {
-				logger.Trace("endpoint-error", "body-read", err)
-			}
-			var data struct {
-				Action string `json:"action"`
-			}
-			if err := json.Unmarshal(bodyBytes, &data); err == nil {
-				if data.Action != "" {
-					loggedWithAction = true
-					logger.Trace("endpoint", "method", r.Method, "path", c.Path, "action", data.Action)
-				}
-			}
-			r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
-		}
-		if !loggedWithAction {
-			logger.Trace("endpoint", "method", r.Method, "path", c.Path)
-		}
+func traceSnapdAPI(c *Command, r *http.Request, action string) {
+	if action != "" {
+		logger.Trace("endpoint", "method", r.Method, "path", c.Path, "action", action)
+		return
 	}
+	logger.Trace("endpoint", "method", r.Method, "path", c.Path)
 }
 
 // actionPeekSize bounds how much of the request body we inspect when

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -29,6 +29,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"syscall"
 	"testing"
@@ -1552,4 +1553,199 @@ func (s *daemonSuite) TestNoticesRequestCanceledOnStop(c *check.C) {
 			"message": "request canceled",
 		},
 		"type": "error"})
+}
+
+// TestTryExtractJSONActionDirect exercises the extractor in isolation
+// from the daemon/seclog pipeline. It pins the two robustness
+// guarantees that motivated the rewrite:
+//   - the body is never consumed (the handler still sees every byte),
+//     regardless of Content-Length;
+//   - extraction is bounded to actionPeekSize and fails closed when
+//     the action key is not reachable within that window.
+func (s *daemonSuite) TestTryExtractJSONActionDirect(c *check.C) {
+	for _, tc := range []struct {
+		name          string
+		method        string
+		body          string
+		contentType   string // empty = application/json; "-" = omit header
+		contentLength int64  // 0 means: use the reader's length (default)
+		wantAction    string
+	}{
+		{
+			name:       "action first key",
+			body:       `{"action":"install","snaps":["x"]}`,
+			wantAction: "install",
+		},
+		{
+			name:       "PUT with action",
+			method:     "PUT",
+			body:       `{"action":"refresh"}`,
+			wantAction: "refresh",
+		},
+		{
+			name:       "action second key",
+			body:       `{"snaps":["x"],"action":"refresh"}`,
+			wantAction: "refresh",
+		},
+		{
+			name:          "unknown content length",
+			body:          `{"action":"install"}`,
+			contentLength: -1,
+			wantAction:    "install",
+		},
+		{
+			name:          "lying content length (too large) is ignored",
+			body:          `{"action":"install"}`,
+			contentLength: maxBodySize,
+			wantAction:    "install",
+		},
+		{
+			name:          "lying content length (too small) does not truncate extraction or body",
+			body:          `{"action":"install","snaps":["x"]}`,
+			contentLength: 5,
+			wantAction:    "install",
+		},
+		{
+			name:       "non-object top-level",
+			body:       `[{"action":"install"}]`,
+			wantAction: "",
+		},
+		{
+			name:       "action only nested",
+			body:       `{"nested":{"action":"install"}}`,
+			wantAction: "",
+		},
+		{
+			name:       "action absent",
+			body:       `{"snaps":["x"]}`,
+			wantAction: "",
+		},
+		{
+			name:       "malformed json prefix",
+			body:       `{not json`,
+			wantAction: "",
+		},
+		{
+			name:       "not json body",
+			body:       "not json",
+			wantAction: "",
+		},
+		{
+			name:       "action beyond peek window",
+			body:       `{"pad":"` + strings.Repeat("x", ActionPeekSize) + `","action":"install"}`,
+			wantAction: "",
+		},
+		{
+			name:       "preceding string straddles window boundary",
+			body:       `{"pad":"` + strings.Repeat("x", ActionPeekSize-10) + `","action":"install"}`,
+			wantAction: "",
+		},
+		{
+			name:       "tokenizer not fooled by quoted action inside preceding string",
+			body:       `{"desc":"\"action\":\"fake\"","action":"install"}`,
+			wantAction: "install",
+		},
+		{
+			name:       "deeply nested object precedes action",
+			body:       `{"foo":{"a":{"b":{"c":{"d":{"e":{"f":{"g":{"h":{"i":{}}}}}}}}}},"action":"install"}`,
+			wantAction: "install",
+		},
+		{
+			name:       "action value is an array",
+			body:       `{"foo":{"a":{"b":{"c":{"d":{"e":{}}}}}},"action":[]}`,
+			wantAction: "",
+		},
+		{
+			name:       "action value is an object",
+			body:       `{"foo":{"a":{"b":{}}},"action":{}}`,
+			wantAction: "",
+		},
+		{
+			name:        "no content-type treated as json",
+			body:        `{"action":"install"}`,
+			contentType: "-",
+			wantAction:  "install",
+		},
+		{
+			name:        "multipart content-type skipped",
+			body:        `{"action":"install"}`,
+			contentType: "multipart/form-data",
+			wantAction:  "",
+		},
+	} {
+		method := tc.method
+		if method == "" {
+			method = "POST"
+		}
+		var body io.Reader
+		if tc.body != "" {
+			body = strings.NewReader(tc.body)
+		}
+		req := httptest.NewRequest(method, "/", body)
+		switch tc.contentType {
+		case "-":
+		case "":
+			req.Header.Set("Content-Type", "application/json")
+		default:
+			req.Header.Set("Content-Type", tc.contentType)
+		}
+		if tc.contentLength != 0 {
+			req.ContentLength = tc.contentLength
+		}
+
+		got := TryExtractJSONAction(req)
+		c.Check(got, check.Equals, tc.wantAction, check.Commentf("case: %s", tc.name))
+
+		if tc.body == "" {
+			continue
+		}
+		// The body must be readable in full afterwards, regardless of
+		// the (possibly lying) Content-Length header.
+		gotBody, err := io.ReadAll(req.Body)
+		c.Assert(err, check.IsNil, check.Commentf("case: %s", tc.name))
+		c.Check(string(gotBody), check.Equals, tc.body, check.Commentf("case: %s", tc.name))
+	}
+}
+
+func (s *daemonSuite) TestTryExtractJSONActionPreservesLargeUnknownBody(c *check.C) {
+	// Body far exceeds the actionPeekSize window; the extractor only
+	// peeks the first 4 KiB but the handler must still read the full
+	// original body byte-for-byte.
+	padding := strings.Repeat("x", maxBodySize)
+	body := `{"action":"install","pad":"` + padding + `"}`
+	req := httptest.NewRequest("POST", "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.ContentLength = -1
+
+	c.Check(TryExtractJSONAction(req), check.Equals, "install")
+
+	gotBody, err := io.ReadAll(req.Body)
+	c.Assert(err, check.IsNil)
+	c.Check(string(gotBody), check.Equals, body)
+}
+
+// TestTryExtractJSONActionShortCircuits verifies the early-return paths.
+func (s *daemonSuite) TestTryExtractJSONActionShortCircuits(c *check.C) {
+	// GET with no body.
+	req := httptest.NewRequest("GET", "/", nil)
+	c.Check(TryExtractJSONAction(req), check.Equals, "")
+
+	// POST with non-JSON content type.
+	req = httptest.NewRequest("POST", "/", strings.NewReader(`{"action":"install"}`))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	c.Check(TryExtractJSONAction(req), check.Equals, "")
+	// Body is unconsumed.
+	gotBody, err := io.ReadAll(req.Body)
+	c.Assert(err, check.IsNil)
+	c.Check(string(gotBody), check.Equals, `{"action":"install"}`)
+
+	// POST with no Content-Type is treated as JSON.
+	req = httptest.NewRequest("POST", "/", strings.NewReader(`{"action":"install"}`))
+	req.Header.Del("Content-Type")
+	c.Check(TryExtractJSONAction(req), check.Equals, "install")
+
+	// DELETE is not considered.
+	req = httptest.NewRequest("DELETE", "/", strings.NewReader(`{"action":"install"}`))
+	req.Header.Set("Content-Type", "application/json")
+	c.Check(TryExtractJSONAction(req), check.Equals, "")
 }

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -1621,6 +1621,11 @@ func (s *daemonSuite) TestTryExtractJSONActionDirect(c *check.C) {
 			wantAction: "",
 		},
 		{
+			name:       "empty action string",
+			body:       `{"action":""}`,
+			wantAction: "",
+		},
+		{
 			name:       "malformed json prefix",
 			body:       `{not json`,
 			wantAction: "",
@@ -1670,6 +1675,12 @@ func (s *daemonSuite) TestTryExtractJSONActionDirect(c *check.C) {
 			name:        "multipart content-type skipped",
 			body:        `{"action":"install"}`,
 			contentType: "multipart/form-data",
+			wantAction:  "",
+		},
+		{
+			name:        "application/json with charset not supported",
+			body:        `{"action":"install"}`,
+			contentType: "application/json; charset=utf-8",
 			wantAction:  "",
 		},
 	} {
@@ -1730,6 +1741,12 @@ func (s *daemonSuite) TestTryExtractJSONActionShortCircuits(c *check.C) {
 	req := httptest.NewRequest("GET", "/", nil)
 	c.Check(TryExtractJSONAction(req), check.Equals, "")
 
+	// POST with nil body.
+	req = httptest.NewRequest("POST", "/", nil)
+	req.Body = nil
+	req.Header.Set("Content-Type", "application/json")
+	c.Check(TryExtractJSONAction(req), check.Equals, "")
+
 	// POST with non-JSON content type.
 	req = httptest.NewRequest("POST", "/", strings.NewReader(`{"action":"install"}`))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
@@ -1778,4 +1795,24 @@ func (s *daemonSuite) TestServeHTTPTraceExtractsActionPreservesBody(c *check.C) 
 
 	c.Check(rec.Code, check.Equals, 200)
 	c.Check(gotBody, check.Equals, body)
+}
+
+func (s *daemonSuite) TestTryExtractJSONActionAfterByActionAccess(c *check.C) {
+	// byActionAccess fully reads and re-buffers the body before the
+	// handler runs; extraction must still work on the replaced body.
+	body := `{"action":"install","snaps":["x"]}`
+	req := httptest.NewRequest("POST", "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = fmt.Sprintf("pid=100;uid=0;socket=%s;", dirs.SnapdSocket)
+
+	ac := byActionAccess{Default: rootAccess{}}
+	ucred, err := ucrednetGet(req.RemoteAddr)
+	c.Assert(err, check.IsNil)
+	c.Check(ac.CheckAccess(nil, req, ucred, nil), check.IsNil)
+
+	c.Check(TryExtractJSONAction(req), check.Equals, "install")
+
+	gotBody, err := io.ReadAll(req.Body)
+	c.Assert(err, check.IsNil)
+	c.Check(string(gotBody), check.Equals, body)
 }

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -371,10 +371,10 @@ func (s *daemonSuite) TestFillsWarnings(c *check.C) {
 	c.Check(rst.WarningTimestamp, check.NotNil)
 }
 
-type accessCheckFunc func(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError
+type accessCheckFunc func(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState, rec AuthzRecorder) *apiError
 
-func (f accessCheckFunc) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
-	return f(d, r, ucred, user)
+func (f accessCheckFunc) CheckAccess(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState, rec AuthzRecorder) *apiError {
+	return f(d, r, ucred, user, rec)
 }
 
 func (s *daemonSuite) TestReadAccess(c *check.C) {
@@ -383,7 +383,7 @@ func (s *daemonSuite) TestReadAccess(c *check.C) {
 		return SyncResponse(nil)
 	}
 	var accessCalled bool
-	cmd.ReadAccess = accessCheckFunc(func(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
+	cmd.ReadAccess = accessCheckFunc(func(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState, rec AuthzRecorder) *apiError {
 		accessCalled = true
 		c.Check(d, check.Equals, cmd.d)
 		c.Check(r, check.NotNil)
@@ -394,7 +394,7 @@ func (s *daemonSuite) TestReadAccess(c *check.C) {
 		c.Check(user, check.IsNil)
 		return nil
 	})
-	cmd.WriteAccess = accessCheckFunc(func(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
+	cmd.WriteAccess = accessCheckFunc(func(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState, rec AuthzRecorder) *apiError {
 		c.Fail()
 		return Forbidden("")
 	})
@@ -415,12 +415,12 @@ func (s *daemonSuite) TestWriteAccess(c *check.C) {
 	cmd.POST = func(*Command, *http.Request, *auth.UserState) Response {
 		return SyncResponse(nil)
 	}
-	cmd.ReadAccess = accessCheckFunc(func(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
+	cmd.ReadAccess = accessCheckFunc(func(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState, rec AuthzRecorder) *apiError {
 		c.Fail()
 		return Forbidden("")
 	})
 	var accessCalled bool
-	cmd.WriteAccess = accessCheckFunc(func(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
+	cmd.WriteAccess = accessCheckFunc(func(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState, rec AuthzRecorder) *apiError {
 		accessCalled = true
 		c.Check(d, check.Equals, cmd.d)
 		c.Check(r, check.NotNil)
@@ -468,12 +468,12 @@ func (s *daemonSuite) TestWriteAccessWithUser(c *check.C) {
 	cmd.POST = func(*Command, *http.Request, *auth.UserState) Response {
 		return SyncResponse(nil)
 	}
-	cmd.ReadAccess = accessCheckFunc(func(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
+	cmd.ReadAccess = accessCheckFunc(func(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState, rec AuthzRecorder) *apiError {
 		c.Fail()
 		return Forbidden("")
 	})
 	var accessCalled bool
-	cmd.WriteAccess = accessCheckFunc(func(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState) *apiError {
+	cmd.WriteAccess = accessCheckFunc(func(d *Daemon, r *http.Request, ucred *ucrednet, user *auth.UserState, rec AuthzRecorder) *apiError {
 		accessCalled = true
 		c.Check(d, check.Equals, cmd.d)
 		c.Check(r, check.NotNil)
@@ -1808,7 +1808,7 @@ func (s *daemonSuite) TestTryExtractJSONActionAfterByActionAccess(c *check.C) {
 	ac := byActionAccess{Default: rootAccess{}}
 	ucred, err := ucrednetGet(req.RemoteAddr)
 	c.Assert(err, check.IsNil)
-	c.Check(ac.CheckAccess(nil, req, ucred, nil), check.IsNil)
+	c.Check(ac.CheckAccess(nil, req, ucred, nil, NewNopAuthzRecorder()), check.IsNil)
 
 	c.Check(TryExtractJSONAction(req), check.Equals, "install")
 

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -1749,3 +1749,33 @@ func (s *daemonSuite) TestTryExtractJSONActionShortCircuits(c *check.C) {
 	req.Header.Set("Content-Type", "application/json")
 	c.Check(TryExtractJSONAction(req), check.Equals, "")
 }
+
+func (s *daemonSuite) TestServeHTTPTraceExtractsActionPreservesBody(c *check.C) {
+	os.Setenv("SNAPD_TRACE", "1")
+	defer os.Unsetenv("SNAPD_TRACE")
+
+	d := s.newTestDaemon(c)
+	body := `{"action":"install","snaps":["x"]}`
+
+	var gotBody string
+	cmd := &Command{
+		d:    d,
+		Path: "/v2/test",
+	}
+	cmd.POST = func(_ *Command, r *http.Request, _ *auth.UserState) Response {
+		b, err := io.ReadAll(r.Body)
+		c.Assert(err, check.IsNil)
+		gotBody = string(b)
+		return SyncResponse(nil)
+	}
+	cmd.WriteAccess = openAccess{}
+
+	req := httptest.NewRequest("POST", "/", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = fmt.Sprintf("pid=100;uid=0;socket=%s;", dirs.SnapdSocket)
+	rec := httptest.NewRecorder()
+	cmd.ServeHTTP(rec, req)
+
+	c.Check(rec.Code, check.Equals, 200)
+	c.Check(gotBody, check.Equals, body)
+}

--- a/daemon/export_access_test.go
+++ b/daemon/export_access_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 
 	"github.com/snapcore/snapd/polkit"
+	"github.com/snapcore/snapd/seclog"
 )
 
 type (
@@ -41,6 +42,16 @@ type (
 	ByActionAccess               = byActionAccess
 
 	InterfaceAccessReqs = interfaceAccessReqs
+
+	InterfaceAccessOutcome = interfaceAccessOutcome
+
+	AccessLevel = accessLevel
+)
+
+const (
+	AccessLevelOpen          = accessLevelOpen
+	AccessLevelAuthenticated = accessLevelAuthenticated
+	AccessLevelRoot          = accessLevelRoot
 )
 
 var (
@@ -73,10 +84,52 @@ func MockCgroupSnapNameFromPid(new func(pid int) (string, error)) (restore func(
 	}
 }
 
-func MockRequireInterfaceApiAccess(new func(d *Daemon, r *http.Request, ucred *ucrednet, reqs InterfaceAccessReqs) *apiError) (restore func()) {
+func MockRequireInterfaceApiAccess(new func(d *Daemon, r *http.Request, ucred *ucrednet, reqs InterfaceAccessReqs, rec AuthzRecorder, level AccessLevel) (InterfaceAccessOutcome, *apiError)) (restore func()) {
 	old := requireInterfaceApiAccess
 	requireInterfaceApiAccess = new
 	return func() {
 		requireInterfaceApiAccess = old
 	}
 }
+
+// AuthzTestRecorder records the last Record* outcome for tests.
+type AuthzTestRecorder struct {
+	GrantedReason string
+	GrantedIface  string
+	GrantedPlug   bool
+	DeniedReason  string
+}
+
+func NewAuthzTestRecorder() *AuthzTestRecorder {
+	return &AuthzTestRecorder{}
+}
+
+func (rec *AuthzTestRecorder) WithUser(seclog.SnapdUser) AuthzRecorder {
+	return rec
+}
+
+func (rec *AuthzTestRecorder) WithPeer(seclog.Peer) AuthzRecorder {
+	return rec
+}
+
+func (rec *AuthzTestRecorder) WithEndpoint(seclog.Endpoint) AuthzRecorder {
+	return rec
+}
+
+func (rec *AuthzTestRecorder) RecordGranted(reason, iface string, plug bool) {
+	rec.DeniedReason = ""
+	rec.GrantedReason = reasonGrantedWithInterface(reason, iface, plug)
+	rec.GrantedIface = iface
+	rec.GrantedPlug = plug
+}
+
+func (rec *AuthzTestRecorder) RecordDenied(reason string) {
+	rec.GrantedReason = ""
+	rec.GrantedIface = ""
+	rec.GrantedPlug = false
+	rec.DeniedReason = reason
+}
+
+func (rec *AuthzTestRecorder) Emit() {}
+
+var _ AuthzRecorder = (*AuthzTestRecorder)(nil)

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -370,6 +370,10 @@ type (
 	SnapInstruction = snapInstruction
 )
 
+var TryExtractJSONAction = tryExtractJSONAction
+
+const ActionPeekSize = actionPeekSize
+
 func (inst *snapInstruction) Dispatch() snapActionFunc {
 	return inst.dispatch()
 }

--- a/daemon/export_test.go
+++ b/daemon/export_test.go
@@ -45,8 +45,9 @@ import (
 )
 
 var (
-	CreateQuotaValues = createQuotaValues
-	ParseOptionalTime = parseOptionalTime
+	CreateQuotaValues   = createQuotaValues
+	ParseOptionalTime   = parseOptionalTime
+	SeclogPeerFromUcred = seclogPeerFromUcred
 )
 
 func APICommands() []*Command {
@@ -421,6 +422,22 @@ func MockOsReadlink(f func(string) (string, error)) func() {
 	osReadlink = f
 	return func() {
 		osReadlink = old
+	}
+}
+
+func MockSecurityLabelsFromPid(f func(int) (map[string]string, error)) func() {
+	old := securityLabelsFromPid
+	securityLabelsFromPid = f
+	return func() {
+		securityLabelsFromPid = old
+	}
+}
+
+func MockCgroupPathFromPid(f func(int) (string, error)) func() {
+	old := cgroupPathFromPid
+	cgroupPathFromPid = f
+	return func() {
+		cgroupPathFromPid = old
 	}
 }
 

--- a/daemon/seclog.go
+++ b/daemon/seclog.go
@@ -29,6 +29,7 @@ import (
 	"path/filepath"
 
 	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/sandbox/cgroup"
 	"github.com/snapcore/snapd/sandbox/lsm"
 	"github.com/snapcore/snapd/seclog"
@@ -100,4 +101,128 @@ func snapAppFromLabel(label string) (snap, app string) {
 		return tag.InstanceName(), tag.HookName()
 	}
 	return "", ""
+}
+
+// AuthzRecorder accumulates one AUTHZ audit event during an access check.
+// Populate [seclog.SnapdUser], [seclog.Peer], and [seclog.Endpoint] via the
+// With* methods, record the outcome via Record*, then call [AuthzRecorder.Emit].
+type AuthzRecorder interface {
+	WithUser(user seclog.SnapdUser) AuthzRecorder
+	WithPeer(peer seclog.Peer) AuthzRecorder
+	WithEndpoint(endpoint seclog.Endpoint) AuthzRecorder
+
+	// RecordGranted records access granted. reason is one of [seclog.ReasonGranted*].
+	// When a snap interface connection also contributed, pass iface and set plug
+	// for the plug side or clear plug for the slot side.
+	RecordGranted(reason string, iface string, plug bool)
+
+	// RecordDenied records access denied. reason is one of [seclog.ReasonDenied*].
+	RecordDenied(reason string)
+
+	// Emit writes the accumulated event. It is a no-op when no outcome was
+	// recorded.
+	Emit()
+}
+
+// authzRecorder holds the seclog payload for a single authorization decision.
+type authzRecorder struct {
+	user          seclog.SnapdUser
+	peer          seclog.Peer
+	endpoint      seclog.Endpoint
+	reasonGranted string
+	reasonDenied  string
+}
+
+// Ensure [authzRecorder] implements [AuthzRecorder].
+var _ AuthzRecorder = (*authzRecorder)(nil)
+
+// NewAuthzRecorder returns an empty [AuthzRecorder].
+func NewAuthzRecorder() AuthzRecorder {
+	return &authzRecorder{}
+}
+
+// nopAuthzRecorder discards all recordings.
+type nopAuthzRecorder struct{}
+
+// Ensure [nopAuthzRecorder] implements [AuthzRecorder].
+var _ AuthzRecorder = nopAuthzRecorder{}
+
+// NewNopAuthzRecorder returns an [AuthzRecorder] that discards all recordings.
+func NewNopAuthzRecorder() AuthzRecorder {
+	return nopAuthzRecorder{}
+}
+
+func (nopAuthzRecorder) WithUser(seclog.SnapdUser) AuthzRecorder {
+	return nopAuthzRecorder{}
+}
+
+func (nopAuthzRecorder) WithPeer(seclog.Peer) AuthzRecorder {
+	return nopAuthzRecorder{}
+}
+
+func (nopAuthzRecorder) WithEndpoint(seclog.Endpoint) AuthzRecorder {
+	return nopAuthzRecorder{}
+}
+
+func (nopAuthzRecorder) RecordGranted(string, string, bool) {}
+
+func (nopAuthzRecorder) RecordDenied(string) {}
+
+func (nopAuthzRecorder) Emit() {}
+
+func (rec *authzRecorder) WithUser(user seclog.SnapdUser) AuthzRecorder {
+	rec.user = user
+	return rec
+}
+
+func (rec *authzRecorder) WithPeer(peer seclog.Peer) AuthzRecorder {
+	rec.peer = peer
+	return rec
+}
+
+func (rec *authzRecorder) WithEndpoint(endpoint seclog.Endpoint) AuthzRecorder {
+	rec.endpoint = endpoint
+	return rec
+}
+
+func (rec *authzRecorder) RecordGranted(reason, iface string, plug bool) {
+	rec.reasonDenied = ""
+	rec.reasonGranted = reasonGrantedWithInterface(reason, iface, plug)
+}
+
+func (rec *authzRecorder) RecordDenied(reason string) {
+	rec.reasonGranted = ""
+	rec.reasonDenied = reason
+}
+
+func (rec *authzRecorder) Emit() {
+	switch {
+	case rec.reasonDenied != "":
+		seclog.LogUnauthorizedAccess(rec.user, rec.peer, rec.endpoint, rec.reasonDenied)
+	case rec.reasonGranted != "":
+		seclog.LogAdminActivity(rec.user, rec.peer, rec.endpoint, rec.reasonGranted)
+	}
+}
+
+func seclogSnapdUserFromAuth(user *auth.UserState) seclog.SnapdUser {
+	if user == nil {
+		return seclog.SnapdUser{}
+	}
+	return seclog.SnapdUser{
+		ID:             int64(user.ID),
+		StoreUserName:  user.Username,
+		StoreUserEmail: user.Email,
+		Expiration:     user.Expiration,
+	}
+}
+
+func reasonGrantedWithInterface(reason, iface string, plug bool) string {
+	if iface == "" {
+		return reason
+	}
+	side := "slot"
+	if plug {
+		side = "plug"
+	}
+	return fmt.Sprintf("%s %s+%s", reason, iface, side)
 }

--- a/daemon/seclog.go
+++ b/daemon/seclog.go
@@ -103,6 +103,16 @@ func snapAppFromLabel(label string) (snap, app string) {
 	return "", ""
 }
 
+// seclogEndpointFromRequest builds a [seclog.Endpoint] for AUTHZ audit events.
+// action is typically obtained via [tryExtractJSONAction].
+func seclogEndpointFromRequest(path, method, action string) seclog.Endpoint {
+	return seclog.Endpoint{
+		Method: method,
+		Path:   path,
+		Action: action,
+	}
+}
+
 // AuthzRecorder accumulates one AUTHZ audit event during an access check.
 // Populate [seclog.SnapdUser], [seclog.Peer], and [seclog.Endpoint] via the
 // With* methods, record the outcome via Record*, then call [AuthzRecorder.Emit].

--- a/daemon/seclog.go
+++ b/daemon/seclog.go
@@ -1,0 +1,103 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// This file contains daemon-side helpers for building and emitting security
+// audit events via the [seclog] package. Keep seclog integration out of
+// daemon.go so new event categories can add helpers here without growing the
+// core daemon type.
+
+package daemon
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/sandbox/cgroup"
+	"github.com/snapcore/snapd/sandbox/lsm"
+	"github.com/snapcore/snapd/seclog"
+	"github.com/snapcore/snapd/snap/naming"
+)
+
+var (
+	securityLabelsFromPid = lsm.SecurityLabelsFromPid
+	cgroupPathFromPid     = cgroup.ProcessPathInTrackingCgroup
+)
+
+// seclogPeerFromUcred builds a [seclog.Peer] for AUTHZ audit events, including
+// best-effort enrichment from the peer process.
+func seclogPeerFromUcred(ucred *ucrednet) seclog.Peer {
+	if ucred == nil {
+		return seclog.Peer{
+			UID: ucrednetNobody,
+			PID: ucrednetNoProcess,
+		}
+	}
+	peer := seclog.Peer{
+		Socket: ucred.Socket,
+		UID:    ucred.Uid,
+		PID:    ucred.Pid,
+	}
+	return enrichSeclogPeer(peer)
+}
+
+func enrichSeclogPeer(peer seclog.Peer) seclog.Peer {
+	if peer.PID == ucrednetNoProcess {
+		return peer
+	}
+
+	pid := int(peer.PID)
+
+	exePath := filepath.Join(dirs.GlobalRootDir, fmt.Sprintf("proc/%d/exe", pid))
+	if exe, err := osReadlink(exePath); err == nil {
+		peer.Exe = exe
+	}
+
+	if labels, err := securityLabelsFromPid(pid); err == nil {
+		peer.SecurityLabels = labels
+	}
+
+	if cgroupPath, err := cgroupPathFromPid(pid); err == nil {
+		if tag := cgroup.SecurityTagFromCgroupPath(cgroupPath); tag != nil {
+			peer.CgroupLabel = tag.String()
+		}
+	}
+
+	snap, app := snapAppFromLabel(peer.SecurityLabels[seclog.PeerSecurityLabelAppArmor])
+	if snap == "" {
+		snap, app = snapAppFromLabel(peer.CgroupLabel)
+	}
+	peer.Snap = snap
+	peer.App = app
+
+	return peer
+}
+
+func snapAppFromLabel(label string) (snap, app string) {
+	if label == "" {
+		return "", ""
+	}
+	if tag, err := naming.ParseAppSecurityTag(label); err == nil {
+		return tag.InstanceName(), tag.AppName()
+	}
+	if tag, err := naming.ParseHookSecurityTag(label); err == nil {
+		return tag.InstanceName(), tag.HookName()
+	}
+	return "", ""
+}

--- a/daemon/seclog_test.go
+++ b/daemon/seclog_test.go
@@ -1,0 +1,234 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package daemon_test
+
+import (
+	"fmt"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/daemon"
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/seclog"
+)
+
+type seclogSuite struct{}
+
+var _ = Suite(&seclogSuite{})
+
+func (s *seclogSuite) TestSeclogPeerFromUcredNil(c *C) {
+	peer := daemon.SeclogPeerFromUcred(nil)
+
+	c.Check(peer, DeepEquals, seclog.Peer{
+		UID: ^uint32(0),
+		PID: 0,
+	})
+	c.Check(peer.String(), Equals, "<unknown>:<unknown>:<unknown>")
+}
+
+func (s *seclogSuite) TestSeclogPeerFromUcredEnrichment(c *C) {
+	restoreReadlink := daemon.MockOsReadlink(func(path string) (string, error) {
+		c.Check(path, Equals, filepath.Join(dirs.GlobalRootDir, "proc/4242/exe"))
+		return "/usr/bin/snap", nil
+	})
+	defer restoreReadlink()
+
+	restoreLabels := daemon.MockSecurityLabelsFromPid(func(pid int) (map[string]string, error) {
+		c.Check(pid, Equals, 4242)
+		return map[string]string{
+			seclog.PeerSecurityLabelAppArmor: "snap.firefox.firefox",
+		}, nil
+	})
+	defer restoreLabels()
+
+	restoreCgroup := daemon.MockCgroupPathFromPid(func(pid int) (string, error) {
+		c.Check(pid, Equals, 4242)
+		return "/system.slice/snap.firefox.firefox.service", nil
+	})
+	defer restoreCgroup()
+
+	peer := daemon.SeclogPeerFromUcred(&daemon.Ucrednet{
+		Socket: "/run/snapd.socket",
+		Uid:    1000,
+		Pid:    4242,
+	})
+
+	c.Check(peer, DeepEquals, seclog.Peer{
+		Socket: "/run/snapd.socket",
+		UID:    1000,
+		PID:    4242,
+		Exe:    "/usr/bin/snap",
+		SecurityLabels: map[string]string{
+			seclog.PeerSecurityLabelAppArmor: "snap.firefox.firefox",
+		},
+		CgroupLabel: "snap.firefox.firefox",
+		Snap:        "firefox",
+		App:         "firefox",
+	})
+}
+
+func (s *seclogSuite) TestSeclogPeerFromUcredUnconfined(c *C) {
+	restoreReadlink := daemon.MockOsReadlink(func(string) (string, error) {
+		return "/usr/bin/curl", nil
+	})
+	defer restoreReadlink()
+
+	restoreLabels := daemon.MockSecurityLabelsFromPid(func(int) (map[string]string, error) {
+		return map[string]string{
+			seclog.PeerSecurityLabelAppArmor: "unconfined",
+		}, nil
+	})
+	defer restoreLabels()
+
+	restoreCgroup := daemon.MockCgroupPathFromPid(func(int) (string, error) {
+		return "", fmt.Errorf("no cgroup")
+	})
+	defer restoreCgroup()
+
+	peer := daemon.SeclogPeerFromUcred(&daemon.Ucrednet{
+		Socket: "/run/snapd.socket",
+		Uid:    1000,
+		Pid:    99,
+	})
+
+	c.Check(peer.SecurityLabels, DeepEquals, map[string]string{
+		seclog.PeerSecurityLabelAppArmor: "unconfined",
+	})
+	c.Check(peer.CgroupLabel, Equals, "")
+	c.Check(peer.Snap, Equals, "")
+	c.Check(peer.App, Equals, "")
+}
+
+func (s *seclogSuite) TestSeclogPeerFromUcredSELinux(c *C) {
+	restoreReadlink := daemon.MockOsReadlink(func(string) (string, error) {
+		return "/snap/bin/firefox", nil
+	})
+	defer restoreReadlink()
+
+	restoreLabels := daemon.MockSecurityLabelsFromPid(func(int) (map[string]string, error) {
+		return map[string]string{
+			seclog.PeerSecurityLabelSELinux: "unconfined_u:unconfined_r:unconfined_service_t:s0",
+		}, nil
+	})
+	defer restoreLabels()
+
+	restoreCgroup := daemon.MockCgroupPathFromPid(func(int) (string, error) {
+		return "/user.slice/snap.firefox.firefox.scope", nil
+	})
+	defer restoreCgroup()
+
+	peer := daemon.SeclogPeerFromUcred(&daemon.Ucrednet{
+		Socket: "/run/snapd-snap.socket",
+		Uid:    1000,
+		Pid:    4242,
+	})
+
+	c.Check(peer.SecurityLabels, DeepEquals, map[string]string{
+		seclog.PeerSecurityLabelSELinux: "unconfined_u:unconfined_r:unconfined_service_t:s0",
+	})
+	c.Check(peer.CgroupLabel, Equals, "snap.firefox.firefox")
+	c.Check(peer.Snap, Equals, "firefox")
+	c.Check(peer.App, Equals, "firefox")
+}
+
+func (s *seclogSuite) TestSeclogPeerFromUcredHook(c *C) {
+	restoreReadlink := daemon.MockOsReadlink(func(string) (string, error) {
+		return "/snap/bin/snap", nil
+	})
+	defer restoreReadlink()
+
+	restoreLabels := daemon.MockSecurityLabelsFromPid(func(int) (map[string]string, error) {
+		return map[string]string{
+			seclog.PeerSecurityLabelAppArmor: "snap.mysnap.hook.install",
+		}, nil
+	})
+	defer restoreLabels()
+
+	restoreCgroup := daemon.MockCgroupPathFromPid(func(int) (string, error) {
+		return "", fmt.Errorf("no cgroup")
+	})
+	defer restoreCgroup()
+
+	peer := daemon.SeclogPeerFromUcred(&daemon.Ucrednet{
+		Socket: "/run/snapd-snap.socket",
+		Uid:    0,
+		Pid:    1,
+	})
+
+	c.Check(peer.Snap, Equals, "mysnap")
+	c.Check(peer.App, Equals, "install")
+}
+
+func (s *seclogSuite) TestSeclogPeerFromUcredCgroupFallback(c *C) {
+	restoreReadlink := daemon.MockOsReadlink(func(string) (string, error) {
+		return "", fmt.Errorf("no exe")
+	})
+	defer restoreReadlink()
+
+	restoreLabels := daemon.MockSecurityLabelsFromPid(func(int) (map[string]string, error) {
+		return nil, fmt.Errorf("permission denied")
+	})
+	defer restoreLabels()
+
+	restoreCgroup := daemon.MockCgroupPathFromPid(func(int) (string, error) {
+		return "/user.slice/snap.hello-world.hello-world.scope", nil
+	})
+	defer restoreCgroup()
+
+	peer := daemon.SeclogPeerFromUcred(&daemon.Ucrednet{
+		Socket: "/run/snapd-snap.socket",
+		Uid:    1000,
+		Pid:    55,
+	})
+
+	c.Check(peer.Exe, Equals, "")
+	c.Check(peer.SecurityLabels, IsNil)
+	c.Check(peer.CgroupLabel, Equals, "snap.hello-world.hello-world")
+	c.Check(peer.Snap, Equals, "hello-world")
+	c.Check(peer.App, Equals, "hello-world")
+}
+
+func (s *seclogSuite) TestSeclogPeerFromUcredLabelReadError(c *C) {
+	restoreReadlink := daemon.MockOsReadlink(func(string) (string, error) {
+		return "/usr/bin/snap", nil
+	})
+	defer restoreReadlink()
+
+	restoreLabels := daemon.MockSecurityLabelsFromPid(func(int) (map[string]string, error) {
+		return nil, fmt.Errorf("permission denied")
+	})
+	defer restoreLabels()
+
+	restoreCgroup := daemon.MockCgroupPathFromPid(func(int) (string, error) {
+		return "", fmt.Errorf("no cgroup")
+	})
+	defer restoreCgroup()
+
+	peer := daemon.SeclogPeerFromUcred(&daemon.Ucrednet{
+		Socket: "/run/snapd.socket",
+		Uid:    0,
+		Pid:    10,
+	})
+
+	c.Check(peer.SecurityLabels, IsNil)
+	c.Check(peer.Snap, Equals, "")
+	c.Check(peer.App, Equals, "")
+}

--- a/sandbox/apparmor/export_test.go
+++ b/sandbox/apparmor/export_test.go
@@ -103,3 +103,7 @@ var (
 func FreshAppArmorAssessment() {
 	appArmorAssessment = &appArmorAssess{appArmorProber: &appArmorProbe{}}
 }
+
+func MockSecurityLabelProbeLevel(f func() LevelType) (restore func()) {
+	return testutil.Mock(&securityLabelProbeLevel, f)
+}

--- a/sandbox/apparmor/process.go
+++ b/sandbox/apparmor/process.go
@@ -29,22 +29,49 @@ import (
 	"github.com/snapcore/snapd/osutil"
 )
 
-func labelFromPid(pid int) (string, error) {
-	// first check new kernel path, /proc/<pid>/attr/apparmor/current, falling
-	// back to the old path if that doesn't exist
-	procFile := filepath.Join(dirs.GlobalRootDir, fmt.Sprintf("proc/%v/attr/apparmor/current", pid))
-	if !osutil.FileExists(procFile) {
-		// fallback
-		procFile = filepath.Join(dirs.GlobalRootDir, fmt.Sprintf("proc/%v/attr/current", pid))
-	}
-	contents, err := os.ReadFile(procFile)
-	if os.IsNotExist(err) {
+var securityLabelProbeLevel = ProbedLevel
+
+// SecurityLabelFromPid returns the AppArmor security label of the process with
+// the given pid. When AppArmor is not in use on the system, "unconfined" is
+// returned.
+func SecurityLabelFromPid(pid int) (string, error) {
+	if securityLabelProbeLevel() == Unsupported {
 		return "unconfined", nil
-	} else if err != nil {
+	}
+
+	candidates := []string{
+		fmt.Sprintf("proc/%d/attr/apparmor/current", pid),
+	}
+	apparmorAttrDir := filepath.Join(dirs.GlobalRootDir, fmt.Sprintf("proc/%d/attr/apparmor", pid))
+	if !osutil.FileExists(apparmorAttrDir) {
+		// Legacy AppArmor kernels expose the profile via attr/current.
+		candidates = append(candidates, fmt.Sprintf("proc/%d/attr/current", pid))
+	}
+
+	for _, candidate := range candidates {
+		procFile := filepath.Join(dirs.GlobalRootDir, candidate)
+		if !osutil.FileExists(procFile) {
+			continue
+		}
+		label, err := readAppArmorSecurityLabel(procFile)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return "", err
+		}
+		return label, nil
+	}
+	return "unconfined", nil
+}
+
+func readAppArmorSecurityLabel(procFile string) (string, error) {
+	contents, err := os.ReadFile(procFile)
+	if err != nil {
 		return "", err
 	}
 	label := strings.TrimRight(string(contents), "\n")
-	// Trim off the mode
+	// Trim off the AppArmor mode suffix.
 	if strings.HasSuffix(label, ")") {
 		if pos := strings.LastIndex(label, " ("); pos != -1 {
 			label = label[:pos]
@@ -68,7 +95,7 @@ func DecodeLabel(label string) (snap, app, hook string, err error) {
 }
 
 func SnapAppFromPid(pid int) (snap, app, hook string, err error) {
-	label, err := labelFromPid(pid)
+	label, err := SecurityLabelFromPid(pid)
 	if err != nil {
 		return "", "", "", err
 	}

--- a/sandbox/apparmor/process_test.go
+++ b/sandbox/apparmor/process_test.go
@@ -29,6 +29,13 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
+func (s *apparmorSuite) mockSecurityLabelProbe(c *C) {
+	restore := apparmor.MockSecurityLabelProbeLevel(func() apparmor.LevelType {
+		return apparmor.Full
+	})
+	s.AddCleanup(restore)
+}
+
 func (s *apparmorSuite) TestDecodeLabel(c *C) {
 	label := snap.AppSecurityTag("snap_name", "my-app")
 	snapName, appName, hookName, err := apparmor.DecodeLabel(label)
@@ -56,7 +63,21 @@ func (s *apparmorSuite) TestDecodeLabelUnrecognisedSnapLabel(c *C) {
 	c.Assert(err, ErrorMatches, `unknown snap related security label "snap.weird"`)
 }
 
+func (s *apparmorSuite) TestSecurityLabelFromPidNewKernelPath(c *C) {
+	s.mockSecurityLabelProbe(c)
+
+	newProcFile := filepath.Join(s.fakeroot, "proc/42/attr/apparmor/current")
+	c.Assert(os.MkdirAll(filepath.Dir(newProcFile), 0755), IsNil)
+	c.Assert(os.WriteFile(newProcFile, []byte("snap.foo.app (complain)\n"), 0644), IsNil)
+
+	label, err := apparmor.SecurityLabelFromPid(42)
+	c.Assert(err, IsNil)
+	c.Check(label, Equals, "snap.foo.app")
+}
+
 func (s *apparmorSuite) TestSnapAppFromPidNewKernelPath(c *C) {
+	s.mockSecurityLabelProbe(c)
+
 	// when the new file exists we use that one
 	newProcFile := filepath.Join(s.fakeroot, "proc/42/attr/apparmor/current")
 	c.Assert(os.MkdirAll(filepath.Dir(newProcFile), 0755), IsNil)
@@ -74,6 +95,8 @@ func (s *apparmorSuite) TestSnapAppFromPidNewKernelPath(c *C) {
 }
 
 func (s *apparmorSuite) TestSnapAppFromPid(c *C) {
+	s.mockSecurityLabelProbe(c)
+
 	// When no /proc/$pid/attr/current exists, assume unconfined
 	_, _, _, err := apparmor.SnapAppFromPid(42)
 	c.Check(err, ErrorMatches, `security label "unconfined" does not belong to a snap`)

--- a/sandbox/lsm/export_test.go
+++ b/sandbox/lsm/export_test.go
@@ -1,0 +1,42 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package lsm
+
+import (
+	"github.com/snapcore/snapd/sandbox/apparmor"
+	"github.com/snapcore/snapd/sandbox/selinux"
+	"github.com/snapcore/snapd/testutil"
+)
+
+func MockApparmorSecurityLabelFromPid(f func(int) (string, error)) (restore func()) {
+	return testutil.Mock(&apparmorSecurityLabelFromPid, f)
+}
+
+func MockSELinuxSecurityLabelFromPid(f func(int) (string, error)) (restore func()) {
+	return testutil.Mock(&selinuxSecurityLabelFromPid, f)
+}
+
+func MockApparmorProbedLevel(f func() apparmor.LevelType) (restore func()) {
+	return testutil.Mock(&apparmorProbedLevel, f)
+}
+
+func MockSELinuxProbedLevel(f func() selinux.LevelType) (restore func()) {
+	return testutil.Mock(&selinuxProbedLevel, f)
+}

--- a/sandbox/lsm/process.go
+++ b/sandbox/lsm/process.go
@@ -1,0 +1,83 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package lsm
+
+import (
+	"github.com/snapcore/snapd/sandbox/apparmor"
+	"github.com/snapcore/snapd/sandbox/selinux"
+)
+
+const (
+	// SecurityLabelKeyAppArmor is the map key for an AppArmor security label.
+	SecurityLabelKeyAppArmor = "AppArmor"
+	// SecurityLabelKeySELinux is the map key for a SELinux security context.
+	SecurityLabelKeySELinux = "SELinux"
+)
+
+var (
+	apparmorSecurityLabelFromPid = apparmor.SecurityLabelFromPid
+	selinuxSecurityLabelFromPid  = selinux.SecurityLabelFromPid
+	apparmorProbedLevel          = apparmor.ProbedLevel
+	selinuxProbedLevel           = selinux.ProbedLevel
+)
+
+// SecurityLabelsFromPid returns the AppArmor and/or SELinux security labels of
+// the process with the given pid. Map keys are [SecurityLabelKeyAppArmor] and
+// [SecurityLabelKeySELinux]; entries are omitted when the corresponding LSM is
+// not in use or no label is available.
+func SecurityLabelsFromPid(pid int) (map[string]string, error) {
+	labels := make(map[string]string)
+
+	if apparmorProbedLevel() != apparmor.Unsupported {
+		label, err := apparmorSecurityLabelFromPid(pid)
+		if err != nil {
+			return nil, err
+		}
+		labels[SecurityLabelKeyAppArmor] = label
+	}
+
+	if selinuxProbedLevel() != selinux.Unsupported {
+		label, err := selinuxSecurityLabelFromPid(pid)
+		if err != nil {
+			return nil, err
+		}
+		if label != "" {
+			labels[SecurityLabelKeySELinux] = label
+		}
+	}
+
+	return labels, nil
+}
+
+// SecurityLabelFromPid returns the AppArmor or SELinux LSM security label of
+// the process with the given pid.
+func SecurityLabelFromPid(pid int) (string, error) {
+	labels, err := SecurityLabelsFromPid(pid)
+	if err != nil {
+		return "", err
+	}
+	if label, ok := labels[SecurityLabelKeyAppArmor]; ok && label != "unconfined" {
+		return label, nil
+	}
+	if label, ok := labels[SecurityLabelKeySELinux]; ok {
+		return label, nil
+	}
+	return "unconfined", nil
+}

--- a/sandbox/lsm/process_test.go
+++ b/sandbox/lsm/process_test.go
@@ -1,0 +1,214 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package lsm_test
+
+import (
+	"fmt"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/sandbox/apparmor"
+	"github.com/snapcore/snapd/sandbox/lsm"
+	"github.com/snapcore/snapd/sandbox/selinux"
+)
+
+func mockBothLSMsActive() (restore func()) {
+	restoreAA := lsm.MockApparmorProbedLevel(func() apparmor.LevelType {
+		return apparmor.Full
+	})
+	restoreSE := lsm.MockSELinuxProbedLevel(func() selinux.LevelType {
+		return selinux.Enforcing
+	})
+	return func() {
+		restoreSE()
+		restoreAA()
+	}
+}
+
+func (*lsmSuite) TestSecurityLabelsFromPidBoth(c *C) {
+	defer mockBothLSMsActive()()
+
+	restore := lsm.MockApparmorSecurityLabelFromPid(func(int) (string, error) {
+		return "snap.foo.app", nil
+	})
+	defer restore()
+	restore = lsm.MockSELinuxSecurityLabelFromPid(func(int) (string, error) {
+		return "system_u:system_r:snappy_t:s0", nil
+	})
+	defer restore()
+
+	labels, err := lsm.SecurityLabelsFromPid(42)
+	c.Assert(err, IsNil)
+	c.Check(labels, DeepEquals, map[string]string{
+		lsm.SecurityLabelKeyAppArmor: "snap.foo.app",
+		lsm.SecurityLabelKeySELinux:  "system_u:system_r:snappy_t:s0",
+	})
+}
+
+func (*lsmSuite) TestSecurityLabelsFromPidAppArmorOnly(c *C) {
+	restore := lsm.MockApparmorProbedLevel(func() apparmor.LevelType {
+		return apparmor.Full
+	})
+	defer restore()
+	restore = lsm.MockSELinuxProbedLevel(func() selinux.LevelType {
+		return selinux.Unsupported
+	})
+	defer restore()
+	restore = lsm.MockApparmorSecurityLabelFromPid(func(int) (string, error) {
+		return "snap.foo.app", nil
+	})
+	defer restore()
+
+	labels, err := lsm.SecurityLabelsFromPid(42)
+	c.Assert(err, IsNil)
+	c.Check(labels, DeepEquals, map[string]string{
+		lsm.SecurityLabelKeyAppArmor: "snap.foo.app",
+	})
+}
+
+func (*lsmSuite) TestSecurityLabelsFromPidSELinuxOnly(c *C) {
+	restore := lsm.MockApparmorProbedLevel(func() apparmor.LevelType {
+		return apparmor.Unsupported
+	})
+	defer restore()
+	restore = lsm.MockSELinuxProbedLevel(func() selinux.LevelType {
+		return selinux.Enforcing
+	})
+	defer restore()
+	restore = lsm.MockSELinuxSecurityLabelFromPid(func(int) (string, error) {
+		return "system_u:system_r:snappy_t:s0", nil
+	})
+	defer restore()
+
+	labels, err := lsm.SecurityLabelsFromPid(42)
+	c.Assert(err, IsNil)
+	c.Check(labels, DeepEquals, map[string]string{
+		lsm.SecurityLabelKeySELinux: "system_u:system_r:snappy_t:s0",
+	})
+}
+
+func (*lsmSuite) TestSecurityLabelsFromPidOmitsEmptySELinux(c *C) {
+	defer mockBothLSMsActive()()
+
+	restore := lsm.MockApparmorSecurityLabelFromPid(func(int) (string, error) {
+		return "unconfined", nil
+	})
+	defer restore()
+	restore = lsm.MockSELinuxSecurityLabelFromPid(func(int) (string, error) {
+		return "", nil
+	})
+	defer restore()
+
+	labels, err := lsm.SecurityLabelsFromPid(42)
+	c.Assert(err, IsNil)
+	c.Check(labels, DeepEquals, map[string]string{
+		lsm.SecurityLabelKeyAppArmor: "unconfined",
+	})
+}
+
+func (*lsmSuite) TestSecurityLabelsFromPidNoneActive(c *C) {
+	restore := lsm.MockApparmorProbedLevel(func() apparmor.LevelType {
+		return apparmor.Unsupported
+	})
+	defer restore()
+	restore = lsm.MockSELinuxProbedLevel(func() selinux.LevelType {
+		return selinux.Unsupported
+	})
+	defer restore()
+
+	labels, err := lsm.SecurityLabelsFromPid(42)
+	c.Assert(err, IsNil)
+	c.Check(labels, DeepEquals, map[string]string{})
+}
+
+func (*lsmSuite) TestSecurityLabelsFromPidAppArmorError(c *C) {
+	defer mockBothLSMsActive()()
+
+	restore := lsm.MockApparmorSecurityLabelFromPid(func(int) (string, error) {
+		return "", fmt.Errorf("boom")
+	})
+	defer restore()
+
+	_, err := lsm.SecurityLabelsFromPid(42)
+	c.Assert(err, ErrorMatches, "boom")
+}
+
+func (*lsmSuite) TestSecurityLabelFromPidAppArmor(c *C) {
+	defer mockBothLSMsActive()()
+
+	restore := lsm.MockApparmorSecurityLabelFromPid(func(int) (string, error) {
+		return "snap.foo.app", nil
+	})
+	defer restore()
+	restore = lsm.MockSELinuxSecurityLabelFromPid(func(int) (string, error) {
+		return "system_u:system_r:snappy_t:s0", nil
+	})
+	defer restore()
+
+	label, err := lsm.SecurityLabelFromPid(42)
+	c.Assert(err, IsNil)
+	c.Check(label, Equals, "snap.foo.app")
+}
+
+func (*lsmSuite) TestSecurityLabelFromPidSELinux(c *C) {
+	defer mockBothLSMsActive()()
+
+	restore := lsm.MockApparmorSecurityLabelFromPid(func(int) (string, error) {
+		return "unconfined", nil
+	})
+	defer restore()
+	restore = lsm.MockSELinuxSecurityLabelFromPid(func(int) (string, error) {
+		return "system_u:system_r:snappy_t:s0", nil
+	})
+	defer restore()
+
+	label, err := lsm.SecurityLabelFromPid(42)
+	c.Assert(err, IsNil)
+	c.Check(label, Equals, "system_u:system_r:snappy_t:s0")
+}
+
+func (*lsmSuite) TestSecurityLabelFromPidUnconfined(c *C) {
+	defer mockBothLSMsActive()()
+
+	restore := lsm.MockApparmorSecurityLabelFromPid(func(int) (string, error) {
+		return "unconfined", nil
+	})
+	defer restore()
+	restore = lsm.MockSELinuxSecurityLabelFromPid(func(int) (string, error) {
+		return "", nil
+	})
+	defer restore()
+
+	label, err := lsm.SecurityLabelFromPid(42)
+	c.Assert(err, IsNil)
+	c.Check(label, Equals, "unconfined")
+}
+
+func (*lsmSuite) TestSecurityLabelFromPidAppArmorError(c *C) {
+	defer mockBothLSMsActive()()
+
+	restore := lsm.MockApparmorSecurityLabelFromPid(func(int) (string, error) {
+		return "", fmt.Errorf("boom")
+	})
+	defer restore()
+
+	_, err := lsm.SecurityLabelFromPid(42)
+	c.Assert(err, ErrorMatches, "boom")
+}

--- a/sandbox/selinux/process.go
+++ b/sandbox/selinux/process.go
@@ -1,0 +1,72 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package selinux
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
+)
+
+// SecurityLabelFromPid returns the SELinux security context of the process with
+// the given pid. When SELinux is not in use on the system, an empty string is
+// returned.
+func SecurityLabelFromPid(pid int) (string, error) {
+	if ProbedLevel() == Unsupported {
+		return "", nil
+	}
+
+	candidates := []string{
+		fmt.Sprintf("proc/%d/attr/selinux/current", pid),
+	}
+	selinuxAttrDir := filepath.Join(dirs.GlobalRootDir, fmt.Sprintf("proc/%d/attr/selinux", pid))
+	if !osutil.FileExists(selinuxAttrDir) {
+		// Legacy SELinux kernels expose the context via attr/current.
+		candidates = append(candidates, fmt.Sprintf("proc/%d/attr/current", pid))
+	}
+
+	for _, candidate := range candidates {
+		procFile := filepath.Join(dirs.GlobalRootDir, candidate)
+		if !osutil.FileExists(procFile) {
+			continue
+		}
+		label, err := readSELinuxSecurityLabel(procFile)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return "", err
+		}
+		return label, nil
+	}
+	return "", nil
+}
+
+func readSELinuxSecurityLabel(procFile string) (string, error) {
+	contents, err := os.ReadFile(procFile)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimRight(string(contents), "\n"), nil
+}

--- a/sandbox/selinux/process_test.go
+++ b/sandbox/selinux/process_test.go
@@ -1,0 +1,80 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package selinux_test
+
+import (
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/sandbox/selinux"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type selinuxProcessSuite struct {
+	testutil.BaseTest
+	fakeroot string
+}
+
+var _ = Suite(&selinuxProcessSuite{})
+
+func (s *selinuxProcessSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+
+	s.fakeroot = c.MkDir()
+	dirs.SetRootDir(s.fakeroot)
+	s.AddCleanup(func() { dirs.SetRootDir("") })
+
+	restore := selinux.MockIsEnabled(func() (bool, error) { return true, nil })
+	s.AddCleanup(restore)
+	restore = selinux.MockIsEnforcing(func() (bool, error) { return true, nil })
+	s.AddCleanup(restore)
+}
+
+func (s *selinuxProcessSuite) TestSecurityLabelFromPidLegacyPath(c *C) {
+	procFile := filepath.Join(s.fakeroot, "proc/42/attr/current")
+	c.Assert(os.MkdirAll(filepath.Dir(procFile), 0755), IsNil)
+	c.Assert(os.WriteFile(procFile, []byte("system_u:system_r:snappy_t:s0\n"), 0644), IsNil)
+
+	label, err := selinux.SecurityLabelFromPid(42)
+	c.Assert(err, IsNil)
+	c.Check(label, Equals, "system_u:system_r:snappy_t:s0")
+}
+
+func (s *selinuxProcessSuite) TestSecurityLabelFromPidSubdir(c *C) {
+	procFile := filepath.Join(s.fakeroot, "proc/42/attr/selinux/current")
+	c.Assert(os.MkdirAll(filepath.Dir(procFile), 0755), IsNil)
+	c.Assert(os.WriteFile(procFile, []byte("unconfined_u:unconfined_r:unconfined_service_t:s0\n"), 0644), IsNil)
+
+	label, err := selinux.SecurityLabelFromPid(42)
+	c.Assert(err, IsNil)
+	c.Check(label, Equals, "unconfined_u:unconfined_r:unconfined_service_t:s0")
+}
+
+func (s *selinuxProcessSuite) TestSecurityLabelFromPidUnsupported(c *C) {
+	restore := selinux.MockIsEnabled(func() (bool, error) { return false, nil })
+	defer restore()
+
+	label, err := selinux.SecurityLabelFromPid(42)
+	c.Assert(err, IsNil)
+	c.Check(label, Equals, "")
+}

--- a/seclog/eventdata.go
+++ b/seclog/eventdata.go
@@ -87,19 +87,39 @@ type SnapdUser struct {
 	Expiration     time.Time `json:"expiration"`
 }
 
-// Peer describes the Unix-domain peer of an API request (Socket, UID, PID).
+// Peer describes the Unix-domain peer of an API request.
+//
+// Socket, UID, and PID come from peer credentials and are expected to be
+// set when emitting AUTHZ events (the access gate is not reached without
+// them). The remaining fields are best-effort enrichment and should use
+// "<unknown>" when unavailable.
 //
 // Callers may signal "unknown" by setting UID to [peerNobody] and/or PID to
-// [peerNoProcess]. These mirror the daemon ucrednetNobody and ucrednetNoProcess
-// sentinels (see daemon/ucrednet.go).
+// [peerNoProcess] for display via [Peer.String]; these mirror the daemon
+// `ucrednetNobody` and `ucrednetNoProcess` sentinels (see daemon/ucrednet.go).
 type Peer struct {
 	Socket string `json:"socket"`
 	UID    uint32 `json:"uid"`
 	PID    int32  `json:"pid"`
+	// Exe is the executable path of the peer process, read from
+	// /proc/<pid>/exe. "<unknown>" when not available.
+	Exe string `json:"exe"`
+	// SecurityLabel is the AppArmor or SELinux LSM label of the peer
+	// process. "<unknown>" when not available.
+	SecurityLabel string `json:"security_label"`
+	// CgroupLabel is the snap cgroup label of the peer process (e.g.
+	// snap.<instance>.<app>). "<unknown>" when not available.
+	CgroupLabel string `json:"cgroup_label"`
+	// Snap is the snap instance name of the peer process, derived from
+	// [Peer.SecurityLabel]. "<unknown>" when not available.
+	Snap string `json:"snap"`
+	// App is the snap application or service name of the peer process,
+	// derived from [Peer.SecurityLabel]. "<unknown>" when not available.
+	App string `json:"app"`
 }
 
-// [peerNobody] and [peerNoProcess] mirror the daemon ucrednetNobody and
-// ucrednetNoProcess sentinels. They are duplicated here to keep seclog
+// [peerNobody] and [peerNoProcess] mirror the daemon `ucrednetNobody` and
+// `ucrednetNoProcess` sentinels. They are duplicated here to keep seclog
 // free of snapd package imports.
 const (
 	peerNobody    = ^uint32(0)
@@ -132,11 +152,9 @@ func (p Peer) String() string {
 
 // Endpoint describes an API endpoint involved in an authorization event.
 type Endpoint struct {
-	Method        string `json:"method"`
-	Path          string `json:"path"`
-	Action        string `json:"action"`
-	AccessChecker string `json:"access_checker"`
-	AccessLevel   string `json:"access_level"`
+	Method string `json:"method"`
+	Path   string `json:"path"`
+	Action string `json:"action"`
 }
 
 // String returns a colon-separated representation in the form
@@ -160,6 +178,21 @@ func (e Endpoint) String() string {
 
 	return method + ":" + path + ":" + action
 }
+
+// ReasonGranted values identify the mechanism that granted access for
+// authz_admin events. They are passed to [LogAdminActivity] as the
+// reasonGranted argument and emitted as reason_granted.
+//
+// When access was granted via a snap interface connection, the value is
+// expanded by appending the interface name and plug or slot side, in the
+// form " <interface>+<plug|slot>" (e.g. "root-auth desktop-launch+plug").
+// The same postfix may apply to any of the base values when an interface
+// also contributed to the grant.
+const (
+	ReasonGrantedUserAuth   = "user-auth"
+	ReasonGrantedRootAuth   = "root-auth"
+	ReasonGrantedPolkitAuth = "polkit-auth"
+)
 
 // AuthzCheck represents the outcome of a single authorization check.
 type AuthzCheck string

--- a/seclog/eventdata.go
+++ b/seclog/eventdata.go
@@ -87,12 +87,24 @@ type SnapdUser struct {
 	Expiration     time.Time `json:"expiration"`
 }
 
+// LSM security label keys for [Peer.SecurityLabels].
+const (
+	PeerSecurityLabelAppArmor = "AppArmor"
+	PeerSecurityLabelSELinux  = "SELinux"
+)
+
 // Peer describes the Unix-domain peer of an API request.
 //
 // Socket, UID, and PID come from peer credentials and are expected to be
 // set when emitting AUTHZ events (the access gate is not reached without
-// them). The remaining fields are best-effort enrichment and should use
-// "<unknown>" when unavailable.
+// them). Exe, CgroupLabel, Snap, and App are best-effort enrichment fields.
+// When unavailable, leave them empty or set them to [unknown]; [Peer.LogValue]
+// logs empty values as [unknown].
+//
+// [Peer.SecurityLabels] is also best-effort enrichment: include only the LSM
+// keys that were obtained. Do not use [unknown] as a map value; omit unavailable
+// keys instead. An empty or nil map is logged as an empty JSON object. Keys are
+// emitted in alphabetical order.
 //
 // Callers may signal "unknown" by setting UID to [peerNobody] and/or PID to
 // [peerNoProcess] for display via [Peer.String]; these mirror the daemon
@@ -102,19 +114,20 @@ type Peer struct {
 	UID    uint32 `json:"uid"`
 	PID    int32  `json:"pid"`
 	// Exe is the executable path of the peer process, read from
-	// /proc/<pid>/exe. "<unknown>" when not available.
+	// /proc/<pid>/exe. [unknown] when unavailable.
 	Exe string `json:"exe"`
-	// SecurityLabel is the AppArmor or SELinux LSM label of the peer
-	// process. "<unknown>" when not available.
-	SecurityLabel string `json:"security_label"`
+	// SecurityLabels holds LSM security labels keyed by [PeerSecurityLabelAppArmor]
+	// and [PeerSecurityLabelSELinux]. Omit unavailable keys.
+	SecurityLabels map[string]string `json:"security_labels"`
 	// CgroupLabel is the snap cgroup label of the peer process (e.g.
-	// snap.<instance>.<app>). "<unknown>" when not available.
+	// snap.<instance>.<app>). [unknown] when unavailable.
 	CgroupLabel string `json:"cgroup_label"`
-	// Snap is the snap instance name of the peer process, derived from
-	// [Peer.SecurityLabel]. "<unknown>" when not available.
+	// Snap is the snap instance name of the peer process, typically derived
+	// from the AppArmor entry in [Peer.SecurityLabels]. [unknown] when unavailable.
 	Snap string `json:"snap"`
 	// App is the snap application or service name of the peer process,
-	// derived from [Peer.SecurityLabel]. "<unknown>" when not available.
+	// typically derived from the AppArmor entry in [Peer.SecurityLabels].
+	// [unknown] when unavailable.
 	App string `json:"app"`
 }
 
@@ -151,6 +164,9 @@ func (p Peer) String() string {
 }
 
 // Endpoint describes an API endpoint involved in an authorization event.
+// When unavailable, leave Method and Path empty or set them to [unknown], and
+// leave Action empty or set it to [none]; [Endpoint.LogValue] logs empty
+// method and path as [unknown] and an empty action as [none].
 type Endpoint struct {
 	Method string `json:"method"`
 	Path   string `json:"path"`

--- a/seclog/eventdata.go
+++ b/seclog/eventdata.go
@@ -194,45 +194,18 @@ const (
 	ReasonGrantedPolkitAuth = "polkit-auth"
 )
 
-// AuthzCheck represents the outcome of a single authorization check.
-type AuthzCheck string
-
-// AuthzCheck outcome values for a single authorization stage.
-// The default for a new [AuthzChecks] is [AuthzNotApplicable].
+// ReasonDenied values identify why access was denied for authz_fail events.
+// They are passed to [LogUnauthorizedAccess] as the reasonDenied argument
+// and emitted as reason_denied.
 const (
-	AuthzNotApplicable AuthzCheck = "not-applicable" // stage not used for this request
-	AuthzNotReached    AuthzCheck = "not-reached"    // applicable but not evaluated yet
-	AuthzFail          AuthzCheck = "fail"
-	AuthzPass          AuthzCheck = "pass"
+	ReasonDeniedNoPeerCredentials    = "no-peer-credentials"
+	ReasonDeniedSocketNotPermitted   = "socket-not-permitted"
+	ReasonDeniedMissingInterfacePlug = "missing-interface-plug"
+	ReasonDeniedMissingInterfaceSlot = "missing-interface-slot"
+	ReasonDeniedUserAuthDenied       = "user-auth-denied"
+	ReasonDeniedRootAuthDenied       = "root-auth-denied"
+	ReasonDeniedPolkitAuthDenied     = "polkit-auth-denied"
 )
-
-// AuthzChecks captures the outcome of each authorization stage evaluated
-// during an access check. Each field records whether that stage passed,
-// failed, or was not applicable to the request.
-type AuthzChecks struct {
-	AccessOptions AuthzCheck `json:"access_options"`
-	PeerCreds     AuthzCheck `json:"peer_credentials"`
-	Socket        AuthzCheck `json:"socket"`
-	Interface     AuthzCheck `json:"interface_requirements"`
-	OpenAccess    AuthzCheck `json:"open_access"`
-	UserAuth      AuthzCheck `json:"user_authentication"`
-	Root          AuthzCheck `json:"root"`
-	Polkit        AuthzCheck `json:"polkit"`
-}
-
-// NewAuthzChecks returns an [AuthzChecks] with all fields set to [AuthzNotApplicable].
-func NewAuthzChecks() AuthzChecks {
-	return AuthzChecks{
-		AccessOptions: AuthzNotApplicable,
-		PeerCreds:     AuthzNotApplicable,
-		Socket:        AuthzNotApplicable,
-		Interface:     AuthzNotApplicable,
-		OpenAccess:    AuthzNotApplicable,
-		UserAuth:      AuthzNotApplicable,
-		Root:          AuthzNotApplicable,
-		Polkit:        AuthzNotApplicable,
-	}
-}
 
 // String returns a colon-separated description of the user in the form
 // "<ID>:<StoreUserEmail>:<StoreUserName>". Fields that are unset use

--- a/seclog/eventdata_test.go
+++ b/seclog/eventdata_test.go
@@ -85,15 +85,3 @@ func (s *SecLogSuite) TestPeerString(c *C) {
 
 	c.Check(seclog.Peer{UID: ^uint32(0)}.String(), Equals, "<unknown>:<unknown>:<unknown>")
 }
-
-func (s *SecLogSuite) TestNewAuthzChecks(c *C) {
-	checks := seclog.NewAuthzChecks()
-	c.Check(checks.AccessOptions, Equals, seclog.AuthzNotApplicable)
-	c.Check(checks.PeerCreds, Equals, seclog.AuthzNotApplicable)
-	c.Check(checks.Socket, Equals, seclog.AuthzNotApplicable)
-	c.Check(checks.Interface, Equals, seclog.AuthzNotApplicable)
-	c.Check(checks.OpenAccess, Equals, seclog.AuthzNotApplicable)
-	c.Check(checks.UserAuth, Equals, seclog.AuthzNotApplicable)
-	c.Check(checks.Root, Equals, seclog.AuthzNotApplicable)
-	c.Check(checks.Polkit, Equals, seclog.AuthzNotApplicable)
-}

--- a/seclog/seclog.go
+++ b/seclog/seclog.go
@@ -193,17 +193,22 @@ func LogUserRemoved(user SnapdUser) {
 // LogAdminActivity logs an administrative API access event using the
 // global security logger. It is emitted when authorization succeeds (the
 // access gate passed), not when the API operation or handler succeeds.
-func LogAdminActivity(user SnapdUser, peer Peer, endpoint Endpoint, checks AuthzChecks) {
+//
+// reasonGranted identifies why access was granted; see [ReasonGrantedUserAuth],
+// [ReasonGrantedRootAuth], and [ReasonGrantedPolkitAuth], optionally expanded
+// with an interface plug/slot postfix when applicable.
+func LogAdminActivity(user SnapdUser, peer Peer, endpoint Endpoint, reasonGranted string) {
 	lock.Lock()
 	defer lock.Unlock()
 
 	globalLogger.LogEvent(
 		Event{Category: "AUTHZ", Name: "authz_admin", Level: LevelInfo},
-		fmt.Sprintf("User %s from %s accessed %s", user.String(), peer.String(), endpoint.String()),
+		fmt.Sprintf("User %s from %s granted access to %s (%s)",
+			user.String(), peer.String(), endpoint.String(), reasonGranted),
 		Attr{Key: "user", Value: user},
 		Attr{Key: "peer", Value: peer},
 		Attr{Key: "endpoint", Value: endpoint},
-		Attr{Key: "authz_checks", Value: checks},
+		Attr{Key: "reason_granted", Value: reasonGranted},
 	)
 }
 

--- a/seclog/seclog.go
+++ b/seclog/seclog.go
@@ -216,18 +216,22 @@ func LogAdminActivity(user SnapdUser, peer Peer, endpoint Endpoint, reasonGrante
 // global security logger. It is emitted when authorization fails (the
 // access gate denied the request), not when the API operation or handler
 // fails after access was granted.
-func LogUnauthorizedAccess(user SnapdUser, peer Peer, endpoint Endpoint, checks AuthzChecks, reason Reason) {
+//
+// reasonDenied identifies why access was denied; see [ReasonDeniedNoPeerCredentials],
+// [ReasonDeniedSocketNotPermitted], [ReasonDeniedMissingInterfacePlug],
+// [ReasonDeniedMissingInterfaceSlot], [ReasonDeniedUserAuthDenied],
+// [ReasonDeniedRootAuthDenied], and [ReasonDeniedPolkitAuthDenied].
+func LogUnauthorizedAccess(user SnapdUser, peer Peer, endpoint Endpoint, reasonDenied string) {
 	lock.Lock()
 	defer lock.Unlock()
 
 	globalLogger.LogEvent(
 		Event{Category: "AUTHZ", Name: "authz_fail", Level: LevelCritical},
-		fmt.Sprintf("User %s from %s attempted to access %s without authorization: %s",
-			user.String(), peer.String(), endpoint.String(), reason.String()),
+		fmt.Sprintf("User %s from %s denied access to %s (%s)",
+			user.String(), peer.String(), endpoint.String(), reasonDenied),
 		Attr{Key: "user", Value: user},
 		Attr{Key: "peer", Value: peer},
 		Attr{Key: "endpoint", Value: endpoint},
-		Attr{Key: "authz_checks", Value: checks},
-		Attr{Key: "error", Value: reason},
+		Attr{Key: "reason_denied", Value: reasonDenied},
 	)
 }

--- a/seclog/seclog_test.go
+++ b/seclog/seclog_test.go
@@ -242,23 +242,22 @@ func (s *SecLogSuite) TestLogAdminActivity(c *C) {
 	c.Check(s.buf.String(), testutil.Contains, "[user=")
 }
 
-// TestLogUnauthorizedAccess verifies that LogUnauthorizedAccess emits the expected event, peer, and reason.
+// TestLogUnauthorizedAccess verifies that LogUnauthorizedAccess emits the expected event and attributes.
 func (s *SecLogSuite) TestLogUnauthorizedAccess(c *C) {
 	user := seclog.SnapdUser{ID: 1, StoreUserEmail: "hacker@example.com", StoreUserName: "hacker"}
 	peer := seclog.Peer{Socket: "/run/snapd.socket", UID: 1000, PID: 12345}
 	endpoint := seclog.Endpoint{Method: "DELETE", Path: "/v2/snaps/core"}
-	checks := seclog.NewAuthzChecks()
-	reason := seclog.Reason{Code: 401, Kind: "invalid-credentials", Message: "no permission"}
 
-	seclog.LogUnauthorizedAccess(user, peer, endpoint, checks, reason)
+	seclog.LogUnauthorizedAccess(user, peer, endpoint, seclog.ReasonDeniedUserAuthDenied)
 
 	c.Check(s.buf.String(), testutil.Contains, "authz_fail")
 	c.Check(s.buf.String(), testutil.Contains, "from /run/snapd.socket")
-	c.Check(s.buf.String(), testutil.Contains, "without authorization:")
-	c.Check(s.buf.String(), testutil.Contains, "without authorization: 401:no permission")
+	c.Check(s.buf.String(), testutil.Contains, "denied access to DELETE:/v2/snaps/core:<none> (user-auth-denied)")
 	c.Check(s.buf.String(), testutil.Contains, "hacker@example.com")
-	c.Check(s.buf.String(), testutil.Contains, "DELETE:/v2/snaps/core:<none>")
+	c.Check(s.buf.String(), testutil.Contains, "/run/snapd.socket")
 	c.Check(s.buf.String(), testutil.Contains, "12345")
-	c.Check(s.buf.String(), testutil.Contains, "[error=")
+	c.Check(s.buf.String(), testutil.Contains, "[peer=")
+	c.Check(s.buf.String(), testutil.Contains, "[endpoint=")
+	c.Check(s.buf.String(), testutil.Contains, "[reason_denied=\"user-auth-denied\"]")
 	c.Check(s.buf.String(), testutil.Contains, "[user=")
 }

--- a/seclog/seclog_test.go
+++ b/seclog/seclog_test.go
@@ -224,25 +224,21 @@ func (s *SecLogSuite) TestLogAdminActivity(c *C) {
 	user := seclog.SnapdUser{ID: 1, StoreUserEmail: "admin@example.com", StoreUserName: "admin"}
 	peer := seclog.Peer{Socket: "/run/snapd.socket", UID: 0, PID: 4242}
 	endpoint := seclog.Endpoint{
-		Method:        "POST",
-		Path:          "/v2/snaps",
-		Action:        "install",
-		AccessChecker: "authenticated",
-		AccessLevel:   "authenticated",
+		Method: "POST",
+		Path:   "/v2/snaps",
+		Action: "install",
 	}
-	checks := seclog.NewAuthzChecks()
-
-	seclog.LogAdminActivity(user, peer, endpoint, checks)
+	seclog.LogAdminActivity(user, peer, endpoint, seclog.ReasonGrantedRootAuth)
 
 	c.Check(s.buf.String(), testutil.Contains, "authz_admin")
 	c.Check(s.buf.String(), testutil.Contains, "from /run/snapd.socket")
-	c.Check(s.buf.String(), testutil.Contains, "accessed POST:/v2/snaps:install")
+	c.Check(s.buf.String(), testutil.Contains, "granted access to POST:/v2/snaps:install (root-auth)")
 	c.Check(s.buf.String(), testutil.Contains, "admin@example.com")
 	c.Check(s.buf.String(), testutil.Contains, "/run/snapd.socket")
 	c.Check(s.buf.String(), testutil.Contains, "4242")
 	c.Check(s.buf.String(), testutil.Contains, "[peer=")
 	c.Check(s.buf.String(), testutil.Contains, "[endpoint=")
-	c.Check(s.buf.String(), testutil.Contains, "[authz_checks=")
+	c.Check(s.buf.String(), testutil.Contains, "[reason_granted=\"root-auth\"]")
 	c.Check(s.buf.String(), testutil.Contains, "[user=")
 }
 

--- a/seclog/slog.go
+++ b/seclog/slog.go
@@ -212,18 +212,3 @@ func (p Peer) LogValue() slog.Value {
 		slog.String("app", p.App),
 	)
 }
-
-// LogValue implements [slog.LogValuer], allowing [AuthzChecks] to be
-// used directly as a structured log attribute value.
-func (a AuthzChecks) LogValue() slog.Value {
-	return slog.GroupValue(
-		slog.String("access_options", string(a.AccessOptions)),
-		slog.String("peer_credentials", string(a.PeerCreds)),
-		slog.String("socket", string(a.Socket)),
-		slog.String("interface_requirements", string(a.Interface)),
-		slog.String("open_access", string(a.OpenAccess)),
-		slog.String("user_authentication", string(a.UserAuth)),
-		slog.String("root", string(a.Root)),
-		slog.String("polkit", string(a.Polkit)),
-	)
-}

--- a/seclog/slog.go
+++ b/seclog/slog.go
@@ -195,8 +195,6 @@ func (e Endpoint) LogValue() slog.Value {
 		slog.String("method", e.Method),
 		slog.String("path", e.Path),
 		slog.String("action", e.Action),
-		slog.String("access_checker", e.AccessChecker),
-		slog.String("access_level", e.AccessLevel),
 	)
 }
 
@@ -207,6 +205,11 @@ func (p Peer) LogValue() slog.Value {
 		slog.String("socket", p.Socket),
 		slog.Int64("uid", int64(p.UID)),
 		slog.Int64("pid", int64(p.PID)),
+		slog.String("exe", p.Exe),
+		slog.String("security_label", p.SecurityLabel),
+		slog.String("cgroup_label", p.CgroupLabel),
+		slog.String("snap", p.Snap),
+		slog.String("app", p.App),
 	)
 }
 

--- a/seclog/slog.go
+++ b/seclog/slog.go
@@ -28,6 +28,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"sort"
 	"sync/atomic"
 	"time"
 
@@ -192,9 +193,9 @@ func (u SnapdUser) LogValue() slog.Value {
 // used directly as a structured log attribute value.
 func (e Endpoint) LogValue() slog.Value {
 	return slog.GroupValue(
-		slog.String("method", e.Method),
-		slog.String("path", e.Path),
-		slog.String("action", e.Action),
+		slog.String("method", fieldOrUnknown(e.Method)),
+		slog.String("path", fieldOrUnknown(e.Path)),
+		slog.String("action", fieldOrNone(e.Action)),
 	)
 }
 
@@ -205,10 +206,44 @@ func (p Peer) LogValue() slog.Value {
 		slog.String("socket", p.Socket),
 		slog.Int64("uid", int64(p.UID)),
 		slog.Int64("pid", int64(p.PID)),
-		slog.String("exe", p.Exe),
-		slog.String("security_label", p.SecurityLabel),
-		slog.String("cgroup_label", p.CgroupLabel),
-		slog.String("snap", p.Snap),
-		slog.String("app", p.App),
+		slog.String("exe", fieldOrUnknown(p.Exe)),
+		peerSecurityLabelsAttr(p.SecurityLabels),
+		slog.String("cgroup_label", fieldOrUnknown(p.CgroupLabel)),
+		slog.String("snap", fieldOrUnknown(p.Snap)),
+		slog.String("app", fieldOrUnknown(p.App)),
 	)
+}
+
+// fieldOrUnknown returns [unknown] when value is empty.
+func fieldOrUnknown(value string) string {
+	if value == "" {
+		return unknown
+	}
+	return value
+}
+
+// fieldOrNone returns [none] when value is empty.
+func fieldOrNone(value string) string {
+	if value == "" {
+		return none
+	}
+	return value
+}
+
+// peerSecurityLabelsAttr renders security_labels as an empty JSON object when
+// no LSM labels were obtained, or as a key-sorted group otherwise.
+func peerSecurityLabelsAttr(labels map[string]string) slog.Attr {
+	if len(labels) == 0 {
+		return slog.Any("security_labels", map[string]string{})
+	}
+	keys := make([]string, 0, len(labels))
+	for key := range labels {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	attrs := make([]slog.Attr, 0, len(keys))
+	for _, key := range keys {
+		attrs = append(attrs, slog.String(key, labels[key]))
+	}
+	return slog.Attr{Key: "security_labels", Value: slog.GroupValue(attrs...)}
 }

--- a/seclog/slog_test.go
+++ b/seclog/slog_test.go
@@ -25,7 +25,9 @@
 //   Write failure handling              → TestWriteFailure*
 //   SnapdUser.LogValue                  → TestSnapdUserLogValue
 //   Reason.LogValue                     → TestReasonLogValue
-//   Peer.LogValue                       → TestPeerLogValue
+//   Peer.LogValue                       → TestPeerLogValue,
+//                                         TestPeerLogValueSecurityLabelsKeyOrder,
+//                                         TestPeerLogValueEmptySecurityLabels
 //   Endpoint.LogValue                   → TestEndpointLogValue
 
 package seclog_test
@@ -313,14 +315,14 @@ func (s *SlogSuite) TestReasonLogValue(c *C) {
 func (s *SlogSuite) TestPeerLogValue(c *C) {
 	type peerRecord struct {
 		Peer struct {
-			Socket        string `json:"socket"`
-			UID           int64  `json:"uid"`
-			PID           int64  `json:"pid"`
-			Exe           string `json:"exe"`
-			SecurityLabel string `json:"security_label"`
-			CgroupLabel   string `json:"cgroup_label"`
-			Snap          string `json:"snap"`
-			App           string `json:"app"`
+			Socket         string            `json:"socket"`
+			UID            int64             `json:"uid"`
+			PID            int64             `json:"pid"`
+			Exe            string            `json:"exe"`
+			SecurityLabels map[string]string `json:"security_labels"`
+			CgroupLabel    string            `json:"cgroup_label"`
+			Snap           string            `json:"snap"`
+			App            string            `json:"app"`
 		} `json:"peer"`
 	}
 
@@ -331,7 +333,10 @@ func (s *SlogSuite) TestPeerLogValue(c *C) {
 		seclog.Attr{Key: "peer", Value: seclog.Peer{
 			Socket: "/run/snapd.socket", UID: 0, PID: 4242,
 			Exe: "/usr/bin/snap", Snap: "<unknown>", App: "<unknown>",
-			SecurityLabel: "unconfined", CgroupLabel: "<unknown>",
+			SecurityLabels: map[string]string{
+				seclog.PeerSecurityLabelAppArmor: "unconfined",
+			},
+			CgroupLabel: "<unknown>",
 		}},
 	)
 
@@ -344,8 +349,49 @@ func (s *SlogSuite) TestPeerLogValue(c *C) {
 	c.Check(obtained.Peer.Exe, Equals, "/usr/bin/snap")
 	c.Check(obtained.Peer.Snap, Equals, "<unknown>")
 	c.Check(obtained.Peer.App, Equals, "<unknown>")
-	c.Check(obtained.Peer.SecurityLabel, Equals, "unconfined")
+	c.Check(obtained.Peer.SecurityLabels, DeepEquals, map[string]string{
+		seclog.PeerSecurityLabelAppArmor: "unconfined",
+	})
 	c.Check(obtained.Peer.CgroupLabel, Equals, "<unknown>")
+}
+
+func (s *SlogSuite) TestPeerLogValueSecurityLabelsKeyOrder(c *C) {
+	logger := s.newLogger(c)
+	logger.LogEvent(
+		seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo},
+		"test",
+		seclog.Attr{Key: "peer", Value: seclog.Peer{
+			Socket: "/run/snapd.socket", UID: 1000, PID: 4242,
+			SecurityLabels: map[string]string{
+				seclog.PeerSecurityLabelSELinux:  "system_u:system_r:snappy_t:s0",
+				seclog.PeerSecurityLabelAppArmor: "snap.snapd.snapd",
+			},
+		}},
+	)
+
+	// Keys are emitted in alphabetical order: AppArmor before SELinux.
+	c.Check(s.buf.String(), testutil.Contains, `"security_labels":{"AppArmor":"snap.snapd.snapd","SELinux":"system_u:system_r:snappy_t:s0"}`)
+	c.Check(s.buf.String(), testutil.Contains, `"exe":"<unknown>"`)
+	c.Check(s.buf.String(), testutil.Contains, `"cgroup_label":"<unknown>"`)
+	c.Check(s.buf.String(), testutil.Contains, `"snap":"<unknown>"`)
+	c.Check(s.buf.String(), testutil.Contains, `"app":"<unknown>"`)
+}
+
+func (s *SlogSuite) TestPeerLogValueEmptySecurityLabels(c *C) {
+	logger := s.newLogger(c)
+	logger.LogEvent(
+		seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo},
+		"test",
+		seclog.Attr{Key: "peer", Value: seclog.Peer{
+			Socket: "/run/snapd.socket", UID: 1000, PID: 4242,
+		}},
+	)
+
+	c.Check(s.buf.String(), testutil.Contains, `"security_labels":{}`)
+	c.Check(s.buf.String(), testutil.Contains, `"exe":"<unknown>"`)
+	c.Check(s.buf.String(), testutil.Contains, `"cgroup_label":"<unknown>"`)
+	c.Check(s.buf.String(), testutil.Contains, `"snap":"<unknown>"`)
+	c.Check(s.buf.String(), testutil.Contains, `"app":"<unknown>"`)
 }
 
 func (s *SlogSuite) TestEndpointLogValue(c *C) {
@@ -357,23 +403,49 @@ func (s *SlogSuite) TestEndpointLogValue(c *C) {
 		} `json:"endpoint"`
 	}
 
-	logger := s.newLogger(c)
-	logger.LogEvent(
-		seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo},
-		"test",
-		seclog.Attr{Key: "endpoint", Value: seclog.Endpoint{
-			Method: "POST",
-			Path:   "/v2/snaps",
-			Action: "install",
-		}},
-	)
+	cases := []struct {
+		endpoint   seclog.Endpoint
+		wantMethod string
+		wantPath   string
+		wantAction string
+	}{
+		{
+			endpoint: seclog.Endpoint{
+				Method: "POST",
+				Path:   "/v2/snaps",
+				Action: "install",
+			},
+			wantMethod: "POST",
+			wantPath:   "/v2/snaps",
+			wantAction: "install",
+		},
+		{
+			endpoint: seclog.Endpoint{
+				Method: "DELETE",
+				Path:   "/v2/snaps/core",
+			},
+			wantMethod: "DELETE",
+			wantPath:   "/v2/snaps/core",
+			wantAction: "<none>",
+		},
+	}
 
-	var obtained endpointRecord
-	err := json.Unmarshal(s.buf.Bytes(), &obtained)
-	c.Assert(err, IsNil)
-	c.Check(obtained.Endpoint.Method, Equals, "POST")
-	c.Check(obtained.Endpoint.Path, Equals, "/v2/snaps")
-	c.Check(obtained.Endpoint.Action, Equals, "install")
+	for _, tc := range cases {
+		s.buf.Reset()
+		logger := s.newLogger(c)
+		logger.LogEvent(
+			seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo},
+			"test",
+			seclog.Attr{Key: "endpoint", Value: tc.endpoint},
+		)
+
+		var obtained endpointRecord
+		err := json.Unmarshal(s.buf.Bytes(), &obtained)
+		c.Assert(err, IsNil)
+		c.Check(obtained.Endpoint.Method, Equals, tc.wantMethod)
+		c.Check(obtained.Endpoint.Path, Equals, tc.wantPath)
+		c.Check(obtained.Endpoint.Action, Equals, tc.wantAction)
+	}
 }
 
 func (s *SlogSuite) TestLevelFiltering(c *C) {

--- a/seclog/slog_test.go
+++ b/seclog/slog_test.go
@@ -303,9 +303,14 @@ func (s *SlogSuite) TestReasonLogValue(c *C) {
 func (s *SlogSuite) TestPeerLogValue(c *C) {
 	type peerRecord struct {
 		Peer struct {
-			Socket string `json:"socket"`
-			UID    int64  `json:"uid"`
-			PID    int64  `json:"pid"`
+			Socket        string `json:"socket"`
+			UID           int64  `json:"uid"`
+			PID           int64  `json:"pid"`
+			Exe           string `json:"exe"`
+			SecurityLabel string `json:"security_label"`
+			CgroupLabel   string `json:"cgroup_label"`
+			Snap          string `json:"snap"`
+			App           string `json:"app"`
 		} `json:"peer"`
 	}
 
@@ -315,6 +320,8 @@ func (s *SlogSuite) TestPeerLogValue(c *C) {
 		"test",
 		seclog.Attr{Key: "peer", Value: seclog.Peer{
 			Socket: "/run/snapd.socket", UID: 0, PID: 4242,
+			Exe: "/usr/bin/snap", Snap: "<unknown>", App: "<unknown>",
+			SecurityLabel: "unconfined", CgroupLabel: "<unknown>",
 		}},
 	)
 
@@ -324,16 +331,19 @@ func (s *SlogSuite) TestPeerLogValue(c *C) {
 	c.Check(obtained.Peer.Socket, Equals, "/run/snapd.socket")
 	c.Check(obtained.Peer.UID, Equals, int64(0))
 	c.Check(obtained.Peer.PID, Equals, int64(4242))
+	c.Check(obtained.Peer.Exe, Equals, "/usr/bin/snap")
+	c.Check(obtained.Peer.Snap, Equals, "<unknown>")
+	c.Check(obtained.Peer.App, Equals, "<unknown>")
+	c.Check(obtained.Peer.SecurityLabel, Equals, "unconfined")
+	c.Check(obtained.Peer.CgroupLabel, Equals, "<unknown>")
 }
 
 func (s *SlogSuite) TestEndpointLogValue(c *C) {
 	type endpointRecord struct {
 		Endpoint struct {
-			Method        string `json:"method"`
-			Path          string `json:"path"`
-			Action        string `json:"action"`
-			AccessChecker string `json:"access_checker"`
-			AccessLevel   string `json:"access_level"`
+			Method string `json:"method"`
+			Path   string `json:"path"`
+			Action string `json:"action"`
 		} `json:"endpoint"`
 	}
 
@@ -342,11 +352,9 @@ func (s *SlogSuite) TestEndpointLogValue(c *C) {
 		seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo},
 		"test",
 		seclog.Attr{Key: "endpoint", Value: seclog.Endpoint{
-			Method:        "POST",
-			Path:          "/v2/snaps",
-			Action:        "install",
-			AccessChecker: "authenticated",
-			AccessLevel:   "authenticated",
+			Method: "POST",
+			Path:   "/v2/snaps",
+			Action: "install",
 		}},
 	)
 
@@ -356,8 +364,6 @@ func (s *SlogSuite) TestEndpointLogValue(c *C) {
 	c.Check(obtained.Endpoint.Method, Equals, "POST")
 	c.Check(obtained.Endpoint.Path, Equals, "/v2/snaps")
 	c.Check(obtained.Endpoint.Action, Equals, "install")
-	c.Check(obtained.Endpoint.AccessChecker, Equals, "authenticated")
-	c.Check(obtained.Endpoint.AccessLevel, Equals, "authenticated")
 }
 
 func (s *SlogSuite) TestAuthzChecksLogValue(c *C) {

--- a/seclog/slog_test.go
+++ b/seclog/slog_test.go
@@ -27,7 +27,6 @@
 //   Reason.LogValue                     → TestReasonLogValue
 //   Peer.LogValue                       → TestPeerLogValue
 //   Endpoint.LogValue                   → TestEndpointLogValue
-//   AuthzChecks.LogValue                → TestAuthzChecksLogValue
 
 package seclog_test
 
@@ -173,11 +172,22 @@ func (s *SlogSuite) TestLogEventKeyOrder(c *C) {
 			attrs: []seclog.Attr{
 				{Key: "peer", Value: seclog.Peer{Socket: "/run/snapd.socket"}},
 				{Key: "endpoint", Value: seclog.Endpoint{Method: "GET", Path: "/v2/snaps"}},
-				{Key: "authz_checks", Value: seclog.NewAuthzChecks()},
+				{Key: "reason_granted", Value: seclog.ReasonGrantedRootAuth},
 			},
 			wantKeys: []string{
 				"datetime", "level", "description",
-				"app_id", "type", "category", "event", "peer", "endpoint", "authz_checks",
+				"app_id", "type", "category", "event", "peer", "endpoint", "reason_granted",
+			},
+		},
+		{
+			attrs: []seclog.Attr{
+				{Key: "peer", Value: seclog.Peer{Socket: "/run/snapd.socket"}},
+				{Key: "endpoint", Value: seclog.Endpoint{Method: "GET", Path: "/v2/snaps"}},
+				{Key: "reason_denied", Value: seclog.ReasonDeniedUserAuthDenied},
+			},
+			wantKeys: []string{
+				"datetime", "level", "description",
+				"app_id", "type", "category", "event", "peer", "endpoint", "reason_denied",
 			},
 		},
 	}
@@ -364,43 +374,6 @@ func (s *SlogSuite) TestEndpointLogValue(c *C) {
 	c.Check(obtained.Endpoint.Method, Equals, "POST")
 	c.Check(obtained.Endpoint.Path, Equals, "/v2/snaps")
 	c.Check(obtained.Endpoint.Action, Equals, "install")
-}
-
-func (s *SlogSuite) TestAuthzChecksLogValue(c *C) {
-	type authzChecksRecord struct {
-		AuthzChecks struct {
-			AccessOptions string `json:"access_options"`
-			PeerCreds     string `json:"peer_credentials"`
-			Socket        string `json:"socket"`
-			Interface     string `json:"interface_requirements"`
-			OpenAccess    string `json:"open_access"`
-			UserAuth      string `json:"user_authentication"`
-			Root          string `json:"root"`
-			Polkit        string `json:"polkit"`
-		} `json:"authz_checks"`
-	}
-
-	checks := seclog.NewAuthzChecks()
-	checks.PeerCreds = seclog.AuthzPass
-
-	logger := s.newLogger(c)
-	logger.LogEvent(
-		seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo},
-		"test",
-		seclog.Attr{Key: "authz_checks", Value: checks},
-	)
-
-	var obtained authzChecksRecord
-	err := json.Unmarshal(s.buf.Bytes(), &obtained)
-	c.Assert(err, IsNil)
-	c.Check(obtained.AuthzChecks.AccessOptions, Equals, string(seclog.AuthzNotApplicable))
-	c.Check(obtained.AuthzChecks.PeerCreds, Equals, string(seclog.AuthzPass))
-	c.Check(obtained.AuthzChecks.Socket, Equals, string(seclog.AuthzNotApplicable))
-	c.Check(obtained.AuthzChecks.Interface, Equals, string(seclog.AuthzNotApplicable))
-	c.Check(obtained.AuthzChecks.OpenAccess, Equals, string(seclog.AuthzNotApplicable))
-	c.Check(obtained.AuthzChecks.UserAuth, Equals, string(seclog.AuthzNotApplicable))
-	c.Check(obtained.AuthzChecks.Root, Equals, string(seclog.AuthzNotApplicable))
-	c.Check(obtained.AuthzChecks.Polkit, Equals, string(seclog.AuthzNotApplicable))
 }
 
 func (s *SlogSuite) TestLevelFiltering(c *C) {


### PR DESCRIPTION
Implement a recorder with a fixed set of functions to populate parts of the auth logging objects. I is passed downstream as  parameter of accessChecker.

Spec: [SD236- Security Event Logging - Admin actions allowed/denied](https://docs.google.com/document/d/1fl7Gy3GJVu8VwUtT1_LWwZ7DEAW9sUMAzF3XGrcZ_d4/edit?tab=t.0#heading=h.etzql0edger)
Jira: https://warthogs.atlassian.net/browse/SNAPDENG-37105