### PR TITLE
seclog,overlord/devicestate: add seclog events for system user create/remove

### DIFF
--- a/daemon/api_users.go
+++ b/daemon/api_users.go
@@ -394,16 +394,16 @@ func doCreateUser(st *state.State, createData postUserCreateData) ([]*devicestat
 		var addReason seclog.SystemUserAddReason
 		switch {
 		case createData.Email != "":
-			addReason = seclog.AddReasonAPICreateUserFromAssertion
+			addReason = seclog.AddReasonAPIAssertion
 		case createData.Automatic:
 			addReason = seclog.AddReasonAPICreateUserFromAllAssertionsAutomatic
 		default:
-			addReason = seclog.AddReasonAPICreateUserFromAllAssertions
+			addReason = seclog.AddReasonAPIAssertionAll
 		}
 		return deviceStateCreateKnownUsers(st, createData.Sudoer, createData.Email, addReason)
 	}
 
-	user, err := deviceStateCreateUser(st, createData.Sudoer, createData.Email, createData.Expiration, seclog.AddReasonAPICreateUserFromStoreCredentials)
+	user, err := deviceStateCreateUser(st, createData.Sudoer, createData.Email, createData.Expiration, seclog.AddReasonAPIStoreEmail)
 	return []*devicestate.CreatedUser{user}, err
 }
 

--- a/daemon/api_users.go
+++ b/daemon/api_users.go
@@ -262,7 +262,9 @@ func removeUser(c *Command, username string, opts postUserDeleteData) Response {
 	st.Lock()
 	defer st.Unlock()
 
-	u, err := deviceStateRemoveUser(st, username, &devicestate.RemoveUserOptions{})
+	u, err := deviceStateRemoveUser(st, username, &devicestate.RemoveUserOptions{
+		RemoveReason: seclog.RemoveReasonAdminRemove,
+	})
 	if err != nil {
 		if _, ok := err.(*devicestate.UserError); ok {
 			return BadRequest(err.Error())
@@ -389,10 +391,19 @@ func doCreateUser(st *state.State, createData postUserCreateData) ([]*devicestat
 	defer st.Unlock()
 
 	if createData.Known {
-		return deviceStateCreateKnownUsers(st, createData.Sudoer, createData.Email)
+		var addReason seclog.SystemUserAddReason
+		switch {
+		case createData.Email != "":
+			addReason = seclog.AddReasonAdminAssertion
+		case createData.Automatic:
+			addReason = seclog.AddReasonAutoProvision
+		default:
+			addReason = seclog.AddReasonAdminKnownAll
+		}
+		return deviceStateCreateKnownUsers(st, createData.Sudoer, createData.Email, addReason)
 	}
 
-	user, err := deviceStateCreateUser(st, createData.Sudoer, createData.Email, createData.Expiration)
+	user, err := deviceStateCreateUser(st, createData.Sudoer, createData.Email, createData.Expiration, seclog.AddReasonAdminStore)
 	return []*devicestate.CreatedUser{user}, err
 }
 

--- a/daemon/api_users.go
+++ b/daemon/api_users.go
@@ -263,7 +263,7 @@ func removeUser(c *Command, username string, opts postUserDeleteData) Response {
 	defer st.Unlock()
 
 	u, err := deviceStateRemoveUser(st, username, &devicestate.RemoveUserOptions{
-		RemoveReason: seclog.RemoveReasonAdminRemove,
+		RemoveReason: seclog.RemoveReasonAPIRemoveUser,
 	})
 	if err != nil {
 		if _, ok := err.(*devicestate.UserError); ok {
@@ -394,16 +394,16 @@ func doCreateUser(st *state.State, createData postUserCreateData) ([]*devicestat
 		var addReason seclog.SystemUserAddReason
 		switch {
 		case createData.Email != "":
-			addReason = seclog.AddReasonAdminAssertion
+			addReason = seclog.AddReasonAPICreateUserFromAssertion
 		case createData.Automatic:
-			addReason = seclog.AddReasonAutoProvision
+			addReason = seclog.AddReasonAPICreateUserFromAllAssertionsAutomatic
 		default:
-			addReason = seclog.AddReasonAdminKnownAll
+			addReason = seclog.AddReasonAPICreateUserFromAllAssertions
 		}
 		return deviceStateCreateKnownUsers(st, createData.Sudoer, createData.Email, addReason)
 	}
 
-	user, err := deviceStateCreateUser(st, createData.Sudoer, createData.Email, createData.Expiration, seclog.AddReasonAdminStore)
+	user, err := deviceStateCreateUser(st, createData.Sudoer, createData.Email, createData.Expiration, seclog.AddReasonAPICreateUserFromStoreCredentials)
 	return []*devicestate.CreatedUser{user}, err
 }
 

--- a/daemon/api_users.go
+++ b/daemon/api_users.go
@@ -396,7 +396,7 @@ func doCreateUser(st *state.State, createData postUserCreateData) ([]*devicestat
 		case createData.Email != "":
 			addReason = seclog.AddReasonAPIAssertion
 		case createData.Automatic:
-			addReason = seclog.AddReasonAPICreateUserFromAllAssertionsAutomatic
+			addReason = seclog.AddReasonAPIAssertionAllAutomatic
 		default:
 			addReason = seclog.AddReasonAPIAssertionAll
 		}

--- a/daemon/api_users.go
+++ b/daemon/api_users.go
@@ -262,7 +262,9 @@ func removeUser(c *Command, username string, opts postUserDeleteData) Response {
 	st.Lock()
 	defer st.Unlock()
 
-	u, err := deviceStateRemoveUser(st, username, &devicestate.RemoveUserOptions{})
+	u, err := deviceStateRemoveUser(st, username, &devicestate.RemoveUserOptions{
+		RemoveReason: seclog.RemoveReasonAPI,
+	})
 	if err != nil {
 		if _, ok := err.(*devicestate.UserError); ok {
 			return BadRequest(err.Error())
@@ -389,10 +391,24 @@ func doCreateUser(st *state.State, createData postUserCreateData) ([]*devicestat
 	defer st.Unlock()
 
 	if createData.Known {
-		return deviceStateCreateKnownUsers(st, createData.Sudoer, createData.Email)
+		// add_reason records both dimensions of the request: whether one
+		// assertion was selected by email or all were used, and whether the
+		// caller was automation or an operator.
+		var addReason seclog.SystemUserAddReason
+		switch {
+		case createData.Email != "" && createData.Automatic:
+			addReason = seclog.AddReasonAPIAssertionAutomatic
+		case createData.Email != "":
+			addReason = seclog.AddReasonAPIAssertion
+		case createData.Automatic:
+			addReason = seclog.AddReasonAPIAssertionAllAutomatic
+		default:
+			addReason = seclog.AddReasonAPIAssertionAll
+		}
+		return deviceStateCreateKnownUsers(st, createData.Sudoer, createData.Email, addReason)
 	}
 
-	user, err := deviceStateCreateUser(st, createData.Sudoer, createData.Email, createData.Expiration)
+	user, err := deviceStateCreateUser(st, createData.Sudoer, createData.Email, createData.Expiration, seclog.AddReasonAPIStoreEmail)
 	return []*devicestate.CreatedUser{user}, err
 }
 

--- a/daemon/api_users_test.go
+++ b/daemon/api_users_test.go
@@ -570,7 +570,7 @@ func (s *userSuite) testCreateUser(c *check.C, oldWay bool) {
 		c.Check(email, check.Equals, expectedEmail)
 		c.Check(sudoer, check.Equals, false)
 		c.Check(expiration, check.Equals, time.Time{})
-		c.Check(addReason, check.Equals, seclog.AddReasonAdminStore)
+		c.Check(addReason, check.Equals, seclog.AddReasonAPICreateUserFromStoreCredentials)
 		expected := &devicestate.CreatedUser{
 			Username: expectedUsername,
 			SSHKeys: []string{
@@ -624,7 +624,7 @@ func (s *userSuite) testCreateUserErr(c *check.C, internalErr bool) {
 	called := 0
 	defer daemon.MockDeviceStateCreateKnownUsers(func(st *state.State, sudoer bool, email string, addReason seclog.SystemUserAddReason) ([]*devicestate.CreatedUser, error) {
 		called++
-		c.Check(addReason, check.Equals, seclog.AddReasonAdminAssertion)
+		c.Check(addReason, check.Equals, seclog.AddReasonAPICreateUserFromAssertion)
 		if internalErr {
 			return nil, fmt.Errorf("internal error: wat-internal")
 		} else {
@@ -760,7 +760,7 @@ func (s *userSuite) TestPostUserActionRemove(c *check.C) {
 	called := 0
 	defer daemon.MockDeviceStateRemoveUser(func(st *state.State, username string, opts *devicestate.RemoveUserOptions) (*auth.UserState, error) {
 		called++
-		c.Check(opts.RemoveReason, check.Equals, seclog.RemoveReasonAdminRemove)
+		c.Check(opts.RemoveReason, check.Equals, seclog.RemoveReasonAPIRemoveUser)
 		removedUser := &auth.UserState{ID: expectedID, Username: expectedUsername, Email: expectedEmail}
 
 		return removedUser, nil
@@ -1045,7 +1045,7 @@ func (s *userSuite) TestPostCreateUserExpirationHappy(c *check.C) {
 		c.Check(email, check.Equals, expectedEmail)
 		c.Check(sudoer, check.Equals, false)
 		c.Check(expiration.Equal(expectedTime), check.Equals, true)
-		c.Check(addReason, check.Equals, seclog.AddReasonAdminStore)
+		c.Check(addReason, check.Equals, seclog.AddReasonAPICreateUserFromStoreCredentials)
 		expected := &devicestate.CreatedUser{
 			Username: expectedUsername,
 			SSHKeys: []string{
@@ -1190,9 +1190,9 @@ func (s *userSuite) testPostCreateUserFromAssertion(c *check.C, postData string,
 }
 
 func (s *userSuite) TestPostCreateUserFromAssertionAllKnown(c *check.C) {
-	s.testPostCreateUserFromAssertion(c, `{"known":true}`, false, seclog.AddReasonAdminKnownAll)
+	s.testPostCreateUserFromAssertion(c, `{"known":true}`, false, seclog.AddReasonAPICreateUserFromAllAssertions)
 }
 
 func (s *userSuite) TestPostCreateUserFromAssertionAllAutomatic(c *check.C) {
-	s.testPostCreateUserFromAssertion(c, `{"automatic":true}`, true, seclog.AddReasonAutoProvision)
+	s.testPostCreateUserFromAssertion(c, `{"automatic":true}`, true, seclog.AddReasonAPICreateUserFromAllAssertionsAutomatic)
 }

--- a/daemon/api_users_test.go
+++ b/daemon/api_users_test.go
@@ -570,7 +570,7 @@ func (s *userSuite) testCreateUser(c *check.C, oldWay bool) {
 		c.Check(email, check.Equals, expectedEmail)
 		c.Check(sudoer, check.Equals, false)
 		c.Check(expiration, check.Equals, time.Time{})
-		c.Check(addReason, check.Equals, seclog.AddReasonAPICreateUserFromStoreCredentials)
+		c.Check(addReason, check.Equals, seclog.AddReasonAPIStoreEmail)
 		expected := &devicestate.CreatedUser{
 			Username: expectedUsername,
 			SSHKeys: []string{
@@ -624,7 +624,7 @@ func (s *userSuite) testCreateUserErr(c *check.C, internalErr bool) {
 	called := 0
 	defer daemon.MockDeviceStateCreateKnownUsers(func(st *state.State, sudoer bool, email string, addReason seclog.SystemUserAddReason) ([]*devicestate.CreatedUser, error) {
 		called++
-		c.Check(addReason, check.Equals, seclog.AddReasonAPICreateUserFromAssertion)
+		c.Check(addReason, check.Equals, seclog.AddReasonAPIAssertion)
 		if internalErr {
 			return nil, fmt.Errorf("internal error: wat-internal")
 		} else {
@@ -1045,7 +1045,7 @@ func (s *userSuite) TestPostCreateUserExpirationHappy(c *check.C) {
 		c.Check(email, check.Equals, expectedEmail)
 		c.Check(sudoer, check.Equals, false)
 		c.Check(expiration.Equal(expectedTime), check.Equals, true)
-		c.Check(addReason, check.Equals, seclog.AddReasonAPICreateUserFromStoreCredentials)
+		c.Check(addReason, check.Equals, seclog.AddReasonAPIStoreEmail)
 		expected := &devicestate.CreatedUser{
 			Username: expectedUsername,
 			SSHKeys: []string{
@@ -1190,7 +1190,7 @@ func (s *userSuite) testPostCreateUserFromAssertion(c *check.C, postData string,
 }
 
 func (s *userSuite) TestPostCreateUserFromAssertionAllKnown(c *check.C) {
-	s.testPostCreateUserFromAssertion(c, `{"known":true}`, false, seclog.AddReasonAPICreateUserFromAllAssertions)
+	s.testPostCreateUserFromAssertion(c, `{"known":true}`, false, seclog.AddReasonAPIAssertionAll)
 }
 
 func (s *userSuite) TestPostCreateUserFromAssertionAllAutomatic(c *check.C) {

--- a/daemon/api_users_test.go
+++ b/daemon/api_users_test.go
@@ -1194,5 +1194,5 @@ func (s *userSuite) TestPostCreateUserFromAssertionAllKnown(c *check.C) {
 }
 
 func (s *userSuite) TestPostCreateUserFromAssertionAllAutomatic(c *check.C) {
-	s.testPostCreateUserFromAssertion(c, `{"automatic":true}`, true, seclog.AddReasonAPICreateUserFromAllAssertionsAutomatic)
+	s.testPostCreateUserFromAssertion(c, `{"automatic":true}`, true, seclog.AddReasonAPIAssertionAllAutomatic)
 }

--- a/daemon/api_users_test.go
+++ b/daemon/api_users_test.go
@@ -80,12 +80,12 @@ func (s *userSuite) SetUpTest(c *check.C) {
 	s.AddCleanup(daemon.MockHasUserAdmin(true))
 
 	// make sure we don't call these by accident)
-	s.AddCleanup(daemon.MockDeviceStateCreateUser(func(st *state.State, sudoer bool, email string, expiration time.Time) (createdUsers *devicestate.CreatedUser, internalErr error) {
+	s.AddCleanup(daemon.MockDeviceStateCreateUser(func(st *state.State, sudoer bool, email string, expiration time.Time, addReason seclog.SystemUserAddReason) (createdUsers *devicestate.CreatedUser, internalErr error) {
 		c.Fatalf("unexpected create user %q call", email)
 		return nil, &devicestate.UserError{Err: fmt.Errorf("unexpected create user %q call", email)}
 	}))
 
-	s.AddCleanup(daemon.MockDeviceStateCreateKnownUsers(func(st *state.State, sudoer bool, email string) (createdUsers []*devicestate.CreatedUser, internalErr error) {
+	s.AddCleanup(daemon.MockDeviceStateCreateKnownUsers(func(st *state.State, sudoer bool, email string, addReason seclog.SystemUserAddReason) (createdUsers []*devicestate.CreatedUser, internalErr error) {
 		c.Fatalf("unexpected create user %q call", email)
 		return nil, &devicestate.UserError{Err: fmt.Errorf("unexpected create user %q call", email)}
 	}))
@@ -566,10 +566,11 @@ func (s *userSuite) testCreateUser(c *check.C, oldWay bool) {
 	expectedEmail := "popper@lse.ac.uk"
 
 	var deviceStateCreateUserCalled bool
-	defer daemon.MockDeviceStateCreateUser(func(st *state.State, sudoer bool, email string, expiration time.Time) (*devicestate.CreatedUser, error) {
+	defer daemon.MockDeviceStateCreateUser(func(st *state.State, sudoer bool, email string, expiration time.Time, addReason seclog.SystemUserAddReason) (*devicestate.CreatedUser, error) {
 		c.Check(email, check.Equals, expectedEmail)
 		c.Check(sudoer, check.Equals, false)
 		c.Check(expiration, check.Equals, time.Time{})
+		c.Check(addReason, check.Equals, seclog.AddReasonAdminStore)
 		expected := &devicestate.CreatedUser{
 			Username: expectedUsername,
 			SSHKeys: []string{
@@ -621,8 +622,9 @@ func (s *userSuite) TestPostUserCreateErrInternal(c *check.C) {
 
 func (s *userSuite) testCreateUserErr(c *check.C, internalErr bool) {
 	called := 0
-	defer daemon.MockDeviceStateCreateKnownUsers(func(st *state.State, sudoer bool, email string) ([]*devicestate.CreatedUser, error) {
+	defer daemon.MockDeviceStateCreateKnownUsers(func(st *state.State, sudoer bool, email string, addReason seclog.SystemUserAddReason) ([]*devicestate.CreatedUser, error) {
 		called++
+		c.Check(addReason, check.Equals, seclog.AddReasonAdminAssertion)
 		if internalErr {
 			return nil, fmt.Errorf("internal error: wat-internal")
 		} else {
@@ -758,6 +760,7 @@ func (s *userSuite) TestPostUserActionRemove(c *check.C) {
 	called := 0
 	defer daemon.MockDeviceStateRemoveUser(func(st *state.State, username string, opts *devicestate.RemoveUserOptions) (*auth.UserState, error) {
 		called++
+		c.Check(opts.RemoveReason, check.Equals, seclog.RemoveReasonAdminRemove)
 		removedUser := &auth.UserState{ID: expectedID, Username: expectedUsername, Email: expectedEmail}
 
 		return removedUser, nil
@@ -1038,10 +1041,11 @@ func (s *userSuite) TestPostCreateUserExpirationHappy(c *check.C) {
 	expectedTime := time.Now().Add(time.Hour * 24).Round(time.Second)
 
 	var deviceStateCreateUserCalls int
-	defer daemon.MockDeviceStateCreateUser(func(st *state.State, sudoer bool, email string, expiration time.Time) (*devicestate.CreatedUser, error) {
+	defer daemon.MockDeviceStateCreateUser(func(st *state.State, sudoer bool, email string, expiration time.Time, addReason seclog.SystemUserAddReason) (*devicestate.CreatedUser, error) {
 		c.Check(email, check.Equals, expectedEmail)
 		c.Check(sudoer, check.Equals, false)
 		c.Check(expiration.Equal(expectedTime), check.Equals, true)
+		c.Check(addReason, check.Equals, seclog.AddReasonAdminStore)
 		expected := &devicestate.CreatedUser{
 			Username: expectedUsername,
 			SSHKeys: []string{
@@ -1136,17 +1140,18 @@ func (s *userSuite) TestUsersHasUser(c *check.C) {
 	c.Check(rsp.Result, check.DeepEquals, expected)
 }
 
-func (s *userSuite) testPostCreateUserFromAssertion(c *check.C, postData string, expectSudoer bool) {
+func (s *userSuite) testPostCreateUserFromAssertion(c *check.C, postData string, expectSudoer bool, expectAddReason seclog.SystemUserAddReason) {
 	s.makeSystemUsers(c, []map[string]any{goodUser, partnerUser, serialUser, badUser, badUserNoMatchingSerial, unknownUser})
 
 	// mock the calls that create the user
 	var deviceStateCreateUserCalled bool
-	defer daemon.MockDeviceStateCreateUser(func(st *state.State, sudoer bool, email string, expiration time.Time) (*devicestate.CreatedUser, error) {
+	defer daemon.MockDeviceStateCreateUser(func(st *state.State, sudoer bool, email string, expiration time.Time, addReason seclog.SystemUserAddReason) (*devicestate.CreatedUser, error) {
 		deviceStateCreateUserCalled = true
 		return nil, nil
 	})()
-	defer daemon.MockDeviceStateCreateKnownUsers(func(st *state.State, sudoer bool, email string) ([]*devicestate.CreatedUser, error) {
+	defer daemon.MockDeviceStateCreateKnownUsers(func(st *state.State, sudoer bool, email string, addReason seclog.SystemUserAddReason) ([]*devicestate.CreatedUser, error) {
 		c.Check(sudoer, check.Equals, expectSudoer)
+		c.Check(addReason, check.Equals, expectAddReason)
 		createdUsers := []*devicestate.CreatedUser{
 			{
 				Username: "goodserialguy",
@@ -1185,12 +1190,9 @@ func (s *userSuite) testPostCreateUserFromAssertion(c *check.C, postData string,
 }
 
 func (s *userSuite) TestPostCreateUserFromAssertionAllKnown(c *check.C) {
-	expectSudoer := false
-	s.testPostCreateUserFromAssertion(c, `{"known":true}`, expectSudoer)
+	s.testPostCreateUserFromAssertion(c, `{"known":true}`, false, seclog.AddReasonAdminKnownAll)
 }
 
 func (s *userSuite) TestPostCreateUserFromAssertionAllAutomatic(c *check.C) {
-	// automatic implies "sudoder"
-	expectSudoer := true
-	s.testPostCreateUserFromAssertion(c, `{"automatic":true}`, expectSudoer)
+	s.testPostCreateUserFromAssertion(c, `{"automatic":true}`, true, seclog.AddReasonAutoProvision)
 }

--- a/daemon/api_users_test.go
+++ b/daemon/api_users_test.go
@@ -80,12 +80,12 @@ func (s *userSuite) SetUpTest(c *check.C) {
 	s.AddCleanup(daemon.MockHasUserAdmin(true))
 
 	// make sure we don't call these by accident)
-	s.AddCleanup(daemon.MockDeviceStateCreateUser(func(st *state.State, sudoer bool, email string, expiration time.Time) (createdUsers *devicestate.CreatedUser, internalErr error) {
+	s.AddCleanup(daemon.MockDeviceStateCreateUser(func(st *state.State, sudoer bool, email string, expiration time.Time, addReason seclog.SystemUserAddReason) (createdUsers *devicestate.CreatedUser, internalErr error) {
 		c.Fatalf("unexpected create user %q call", email)
 		return nil, &devicestate.UserError{Err: fmt.Errorf("unexpected create user %q call", email)}
 	}))
 
-	s.AddCleanup(daemon.MockDeviceStateCreateKnownUsers(func(st *state.State, sudoer bool, email string) (createdUsers []*devicestate.CreatedUser, internalErr error) {
+	s.AddCleanup(daemon.MockDeviceStateCreateKnownUsers(func(st *state.State, sudoer bool, email string, addReason seclog.SystemUserAddReason) (createdUsers []*devicestate.CreatedUser, internalErr error) {
 		c.Fatalf("unexpected create user %q call", email)
 		return nil, &devicestate.UserError{Err: fmt.Errorf("unexpected create user %q call", email)}
 	}))
@@ -566,10 +566,11 @@ func (s *userSuite) testCreateUser(c *check.C, oldWay bool) {
 	expectedEmail := "popper@lse.ac.uk"
 
 	var deviceStateCreateUserCalled bool
-	defer daemon.MockDeviceStateCreateUser(func(st *state.State, sudoer bool, email string, expiration time.Time) (*devicestate.CreatedUser, error) {
+	defer daemon.MockDeviceStateCreateUser(func(st *state.State, sudoer bool, email string, expiration time.Time, addReason seclog.SystemUserAddReason) (*devicestate.CreatedUser, error) {
 		c.Check(email, check.Equals, expectedEmail)
 		c.Check(sudoer, check.Equals, false)
 		c.Check(expiration, check.Equals, time.Time{})
+		c.Check(addReason, check.Equals, seclog.AddReasonAPIStoreEmail)
 		expected := &devicestate.CreatedUser{
 			Username: expectedUsername,
 			SSHKeys: []string{
@@ -621,8 +622,9 @@ func (s *userSuite) TestPostUserCreateErrInternal(c *check.C) {
 
 func (s *userSuite) testCreateUserErr(c *check.C, internalErr bool) {
 	called := 0
-	defer daemon.MockDeviceStateCreateKnownUsers(func(st *state.State, sudoer bool, email string) ([]*devicestate.CreatedUser, error) {
+	defer daemon.MockDeviceStateCreateKnownUsers(func(st *state.State, sudoer bool, email string, addReason seclog.SystemUserAddReason) ([]*devicestate.CreatedUser, error) {
 		called++
+		c.Check(addReason, check.Equals, seclog.AddReasonAPIAssertion)
 		if internalErr {
 			return nil, fmt.Errorf("internal error: wat-internal")
 		} else {
@@ -758,6 +760,7 @@ func (s *userSuite) TestPostUserActionRemove(c *check.C) {
 	called := 0
 	defer daemon.MockDeviceStateRemoveUser(func(st *state.State, username string, opts *devicestate.RemoveUserOptions) (*auth.UserState, error) {
 		called++
+		c.Check(opts.RemoveReason, check.Equals, seclog.RemoveReasonAPI)
 		removedUser := &auth.UserState{ID: expectedID, Username: expectedUsername, Email: expectedEmail}
 
 		return removedUser, nil
@@ -1038,10 +1041,11 @@ func (s *userSuite) TestPostCreateUserExpirationHappy(c *check.C) {
 	expectedTime := time.Now().Add(time.Hour * 24).Round(time.Second)
 
 	var deviceStateCreateUserCalls int
-	defer daemon.MockDeviceStateCreateUser(func(st *state.State, sudoer bool, email string, expiration time.Time) (*devicestate.CreatedUser, error) {
+	defer daemon.MockDeviceStateCreateUser(func(st *state.State, sudoer bool, email string, expiration time.Time, addReason seclog.SystemUserAddReason) (*devicestate.CreatedUser, error) {
 		c.Check(email, check.Equals, expectedEmail)
 		c.Check(sudoer, check.Equals, false)
 		c.Check(expiration.Equal(expectedTime), check.Equals, true)
+		c.Check(addReason, check.Equals, seclog.AddReasonAPIStoreEmail)
 		expected := &devicestate.CreatedUser{
 			Username: expectedUsername,
 			SSHKeys: []string{
@@ -1136,17 +1140,18 @@ func (s *userSuite) TestUsersHasUser(c *check.C) {
 	c.Check(rsp.Result, check.DeepEquals, expected)
 }
 
-func (s *userSuite) testPostCreateUserFromAssertion(c *check.C, postData string, expectSudoer bool) {
+func (s *userSuite) testPostCreateUserFromAssertion(c *check.C, postData string, expectSudoer bool, expectAddReason seclog.SystemUserAddReason) {
 	s.makeSystemUsers(c, []map[string]any{goodUser, partnerUser, serialUser, badUser, badUserNoMatchingSerial, unknownUser})
 
 	// mock the calls that create the user
 	var deviceStateCreateUserCalled bool
-	defer daemon.MockDeviceStateCreateUser(func(st *state.State, sudoer bool, email string, expiration time.Time) (*devicestate.CreatedUser, error) {
+	defer daemon.MockDeviceStateCreateUser(func(st *state.State, sudoer bool, email string, expiration time.Time, addReason seclog.SystemUserAddReason) (*devicestate.CreatedUser, error) {
 		deviceStateCreateUserCalled = true
 		return nil, nil
 	})()
-	defer daemon.MockDeviceStateCreateKnownUsers(func(st *state.State, sudoer bool, email string) ([]*devicestate.CreatedUser, error) {
+	defer daemon.MockDeviceStateCreateKnownUsers(func(st *state.State, sudoer bool, email string, addReason seclog.SystemUserAddReason) ([]*devicestate.CreatedUser, error) {
 		c.Check(sudoer, check.Equals, expectSudoer)
+		c.Check(addReason, check.Equals, expectAddReason)
 		createdUsers := []*devicestate.CreatedUser{
 			{
 				Username: "goodserialguy",
@@ -1185,12 +1190,29 @@ func (s *userSuite) testPostCreateUserFromAssertion(c *check.C, postData string,
 }
 
 func (s *userSuite) TestPostCreateUserFromAssertionAllKnown(c *check.C) {
-	expectSudoer := false
-	s.testPostCreateUserFromAssertion(c, `{"known":true}`, expectSudoer)
+	s.testPostCreateUserFromAssertion(c, `{"known":true}`, false, seclog.AddReasonAPIAssertionAll)
 }
 
 func (s *userSuite) TestPostCreateUserFromAssertionAllAutomatic(c *check.C) {
-	// automatic implies "sudoder"
-	expectSudoer := true
-	s.testPostCreateUserFromAssertion(c, `{"automatic":true}`, expectSudoer)
+	s.testPostCreateUserFromAssertion(c, `{"automatic":true}`, true, seclog.AddReasonAPIAssertionAllAutomatic)
+}
+
+func (s *userSuite) TestPostUserCreateFromAssertionAutomaticWithEmail(c *check.C) {
+	called := 0
+	defer daemon.MockDeviceStateCreateKnownUsers(func(st *state.State, sudoer bool, email string, addReason seclog.SystemUserAddReason) ([]*devicestate.CreatedUser, error) {
+		called++
+		c.Check(email, check.Equals, "foo@bar.com")
+		// automatic implies sudoer
+		c.Check(sudoer, check.Equals, true)
+		c.Check(addReason, check.Equals, seclog.AddReasonAPIAssertionAutomatic)
+		return []*devicestate.CreatedUser{{Username: "guy"}}, nil
+	})()
+
+	buf := bytes.NewBufferString(`{"action":"create","email":"foo@bar.com","automatic":true}`)
+	req, err := http.NewRequest("POST", "/v2/users", buf)
+	c.Assert(err, check.IsNil)
+
+	rsp := s.syncReq(c, req, nil, actionIsExpected)
+	c.Check(called, check.Equals, 1)
+	c.Check(rsp.Result, check.DeepEquals, []daemon.UserResponseData{{Username: "guy"}})
 }

--- a/daemon/export_api_users_test.go
+++ b/daemon/export_api_users_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/seclog"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -34,14 +35,14 @@ func MockHasUserAdmin(mockHasUserAdmin bool) (restore func()) {
 	return restore
 }
 
-func MockDeviceStateCreateUser(createUser func(st *state.State, sudoer bool, email string, expiration time.Time) (*devicestate.CreatedUser, error)) (restore func()) {
+func MockDeviceStateCreateUser(createUser func(st *state.State, sudoer bool, email string, expiration time.Time, addReason seclog.SystemUserAddReason) (*devicestate.CreatedUser, error)) (restore func()) {
 	restore = testutil.Backup(&deviceStateCreateUser)
 	deviceStateCreateUser = createUser
 	return restore
 }
 
-func MockDeviceStateCreateKnownUsers(createKnownUser func(st *state.State, sudoer bool, email string) ([]*devicestate.CreatedUser, error)) (restore func()) {
-	restore = testutil.Backup(&deviceStateCreateUser)
+func MockDeviceStateCreateKnownUsers(createKnownUser func(st *state.State, sudoer bool, email string, addReason seclog.SystemUserAddReason) ([]*devicestate.CreatedUser, error)) (restore func()) {
+	restore = testutil.Backup(&deviceStateCreateKnownUsers)
 	deviceStateCreateKnownUsers = createKnownUser
 	return restore
 }

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -59,6 +59,7 @@ import (
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/secboot/keys"
+	"github.com/snapcore/snapd/seclog"
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snapfile"
@@ -1247,7 +1248,7 @@ func (m *DeviceManager) ensureSerialBoundSystemUserAssertionsProcessed() error {
 	db := assertstate.DB(m.state)
 
 	const sudoer = true
-	_, err = createAllKnownSystemUsers(m.state, db, model, serial, sudoer)
+	_, err = createAllKnownSystemUsers(m.state, db, model, serial, sudoer, seclog.AddReasonSerialBound)
 	if err != nil {
 		return err
 	}
@@ -1974,7 +1975,10 @@ func (m *DeviceManager) ensureExpiredUsersRemoved() error {
 		}
 		// Force the removal of the user as it's possible to block this expiration
 		// otherwise by the user having left a process or service running.
-		if _, err := RemoveUser(st, user.Username, &RemoveUserOptions{Force: true}); err != nil {
+		if _, err := RemoveUser(st, user.Username, &RemoveUserOptions{
+			Force:        true,
+			RemoveReason: seclog.RemoveReasonExpired,
+		}); err != nil {
 			return err
 		}
 	}

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -1248,7 +1248,7 @@ func (m *DeviceManager) ensureSerialBoundSystemUserAssertionsProcessed() error {
 	db := assertstate.DB(m.state)
 
 	const sudoer = true
-	_, err = createAllKnownSystemUsers(m.state, db, model, serial, sudoer, seclog.AddReasonDeferredSerialBoundAssertion)
+	_, err = createAllKnownSystemUsers(m.state, db, model, serial, sudoer, seclog.AddReasonEnsureSerialBoundAssertion)
 	if err != nil {
 		return err
 	}

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -1248,7 +1248,7 @@ func (m *DeviceManager) ensureSerialBoundSystemUserAssertionsProcessed() error {
 	db := assertstate.DB(m.state)
 
 	const sudoer = true
-	_, err = createAllKnownSystemUsers(m.state, db, model, serial, sudoer, seclog.AddReasonEnsureCreateUserFromSerialBoundAssertion)
+	_, err = createAllKnownSystemUsers(m.state, db, model, serial, sudoer, seclog.AddReasonDeferredSerialBoundAssertion)
 	if err != nil {
 		return err
 	}

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -1248,7 +1248,7 @@ func (m *DeviceManager) ensureSerialBoundSystemUserAssertionsProcessed() error {
 	db := assertstate.DB(m.state)
 
 	const sudoer = true
-	_, err = createAllKnownSystemUsers(m.state, db, model, serial, sudoer, seclog.AddReasonSerialBound)
+	_, err = createAllKnownSystemUsers(m.state, db, model, serial, sudoer, seclog.AddReasonEnsureCreateUserFromSerialBoundAssertion)
 	if err != nil {
 		return err
 	}
@@ -1977,7 +1977,7 @@ func (m *DeviceManager) ensureExpiredUsersRemoved() error {
 		// otherwise by the user having left a process or service running.
 		if _, err := RemoveUser(st, user.Username, &RemoveUserOptions{
 			Force:        true,
-			RemoveReason: seclog.RemoveReasonExpired,
+			RemoveReason: seclog.RemoveReasonEnsureRemoveExpiredUser,
 		}); err != nil {
 			return err
 		}

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -59,6 +59,7 @@ import (
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/secboot/keys"
+	"github.com/snapcore/snapd/seclog"
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snapfile"
@@ -1250,7 +1251,7 @@ func (m *DeviceManager) ensureSerialBoundSystemUserAssertionsProcessed() error {
 	db := assertstate.DB(m.state)
 
 	const sudoer = true
-	_, err = createAllKnownSystemUsers(m.state, db, model, serial, sudoer)
+	_, err = createAllKnownSystemUsers(m.state, db, model, serial, sudoer, seclog.AddReasonEnsureSerialBoundAssertion)
 	if err != nil {
 		return err
 	}
@@ -2004,7 +2005,10 @@ func (m *DeviceManager) ensureExpiredUsersRemoved() error {
 		}
 		// Force the removal of the user as it's possible to block this expiration
 		// otherwise by the user having left a process or service running.
-		if _, err := RemoveUser(st, user.Username, &RemoveUserOptions{Force: true}); err != nil {
+		if _, err := RemoveUser(st, user.Username, &RemoveUserOptions{
+			Force:        true,
+			RemoveReason: seclog.RemoveReasonEnsureExpired,
+		}); err != nil {
 			return err
 		}
 	}

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -20,6 +20,7 @@
 package devicestate_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -65,6 +66,8 @@ import (
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/secboot/keys"
+	"github.com/snapcore/snapd/seclog"
+	"github.com/snapcore/snapd/seclog/seclogtest"
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/seed/seedtest"
 	"github.com/snapcore/snapd/seed/seedwriter"
@@ -3203,6 +3206,10 @@ func (s *deviceMgrSuite) mockSystemMode(c *C, mode string) {
 }
 
 func (s *deviceMgrSuite) testExpiredUserRemoved(c *C, userToRemove string, extraUsers bool) {
+	seclogBuf := &bytes.Buffer{}
+	seclog.Setup(seclogtest.MockSecurityLogger(seclogBuf))
+	defer seclog.Setup(seclog.NewNopLogger())
+
 	// Mock the delete user callback to verify it's correctly called. On ubuntu core
 	// systems ExtraUsers should be set, where on classic systems ExtraUsers should not
 	// be set
@@ -3220,6 +3227,7 @@ func (s *deviceMgrSuite) testExpiredUserRemoved(c *C, userToRemove string, extra
 	err := devicestate.EnsureExpiredUsersRemoved(s.mgr)
 	c.Assert(err, IsNil)
 	c.Assert(delUserCalled, Equals, true)
+	c.Check(seclogBuf.String(), testutil.Contains, `remove_reason="expired"`)
 }
 
 func (s *deviceMgrSuite) testExpiredUserNotRemoved(c *C) {

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -3227,7 +3227,7 @@ func (s *deviceMgrSuite) testExpiredUserRemoved(c *C, userToRemove string, extra
 	err := devicestate.EnsureExpiredUsersRemoved(s.mgr)
 	c.Assert(err, IsNil)
 	c.Assert(delUserCalled, Equals, true)
-	c.Check(seclogBuf.String(), testutil.Contains, `remove_reason="expired"`)
+	c.Check(seclogBuf.String(), testutil.Contains, `remove_reason="ensure-remove-expired-user"`)
 }
 
 func (s *deviceMgrSuite) testExpiredUserNotRemoved(c *C) {

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -20,6 +20,7 @@
 package devicestate_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -67,6 +68,8 @@ import (
 	"github.com/snapcore/snapd/sandbox/cgroup"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/secboot/keys"
+	"github.com/snapcore/snapd/seclog"
+	"github.com/snapcore/snapd/seclog/seclogtest"
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/seed/seedtest"
 	"github.com/snapcore/snapd/seed/seedwriter"
@@ -3731,6 +3734,10 @@ func (s *deviceMgrSuite) mockSystemMode(c *C, mode string) {
 }
 
 func (s *deviceMgrSuite) testExpiredUserRemoved(c *C, userToRemove string, extraUsers bool) {
+	seclogBuf := &bytes.Buffer{}
+	seclog.Setup(seclogtest.MockSecurityLogger(seclogBuf))
+	defer seclog.Setup(seclog.NewNopLogger())
+
 	// Mock the delete user callback to verify it's correctly called. On ubuntu core
 	// systems ExtraUsers should be set, where on classic systems ExtraUsers should not
 	// be set
@@ -3748,6 +3755,7 @@ func (s *deviceMgrSuite) testExpiredUserRemoved(c *C, userToRemove string, extra
 	err := devicestate.EnsureExpiredUsersRemoved(s.mgr)
 	c.Assert(err, IsNil)
 	c.Assert(delUserCalled, Equals, true)
+	c.Check(seclogBuf.String(), testutil.Contains, `remove_reason="ensure-remove-expired-user"`)
 }
 
 func (s *deviceMgrSuite) testExpiredUserNotRemoved(c *C) {

--- a/overlord/devicestate/devicestate_users_test.go
+++ b/overlord/devicestate/devicestate_users_test.go
@@ -134,7 +134,7 @@ func (s *usersSuite) TestCreateUserNoSSHKeys(c *check.C) {
 
 	// create user
 	s.state.Lock()
-	createdUser, err := devicestate.CreateUser(s.state, true, "popper@lse.ac.uk", time.Time{}, seclog.AddReasonAPICreateUserFromStoreCredentials)
+	createdUser, err := devicestate.CreateUser(s.state, true, "popper@lse.ac.uk", time.Time{}, seclog.AddReasonAPIStoreEmail)
 	s.state.Unlock()
 
 	c.Assert(err, check.NotNil)
@@ -169,7 +169,7 @@ func (s *usersSuite) TestCreateUser(c *check.C) {
 	// user was setup in state
 	// create user
 	s.state.Lock()
-	createdUser, userErr := devicestate.CreateUser(s.state, false, "popper@lse.ac.uk", expectedExpiration, seclog.AddReasonAPICreateUserFromStoreCredentials)
+	createdUser, userErr := devicestate.CreateUser(s.state, false, "popper@lse.ac.uk", expectedExpiration, seclog.AddReasonAPIStoreEmail)
 	s.state.Unlock()
 
 	c.Assert(userErr, check.IsNil)
@@ -200,7 +200,7 @@ func (s *usersSuite) TestCreateUser(c *check.C) {
 	c.Check(s.seclogBuf.String(), testutil.Contains, "Created system user karl")
 	c.Check(s.seclogBuf.String(), testutil.Contains, "xxyyzz")
 	c.Check(s.seclogBuf.String(), testutil.Contains, "Known:false")
-	c.Check(s.seclogBuf.String(), testutil.Contains, `add_reason="api-create-user-from-store-credentials"`)
+	c.Check(s.seclogBuf.String(), testutil.Contains, `add_reason="api-store-email"`)
 }
 
 func (s *usersSuite) TestUserActionRemoveDelUserErr(c *check.C) {
@@ -584,7 +584,7 @@ func (s *usersSuite) createUserFromAssertion(c *check.C, forcePasswordChange boo
 
 	// create user
 	s.state.Lock()
-	createdUsers, err := devicestate.CreateKnownUsers(s.state, false, "foo@bar.com", seclog.AddReasonAPICreateUserFromAssertion)
+	createdUsers, err := devicestate.CreateKnownUsers(s.state, false, "foo@bar.com", seclog.AddReasonAPIAssertion)
 	s.state.Unlock()
 
 	expected := []*devicestate.CreatedUser{
@@ -602,7 +602,7 @@ func (s *usersSuite) createUserFromAssertion(c *check.C, forcePasswordChange boo
 	c.Check(s.seclogBuf.String(), testutil.Contains, "Created system user example-user")
 	c.Check(s.seclogBuf.String(), testutil.Contains, "Example User")
 	c.Check(s.seclogBuf.String(), testutil.Contains, "Known:true")
-	c.Check(s.seclogBuf.String(), testutil.Contains, `add_reason="api-create-user-from-assertion"`)
+	c.Check(s.seclogBuf.String(), testutil.Contains, `add_reason="api-assertion"`)
 	c.Check(s.seclogBuf.String(), testutil.Contains, "my-brand")
 	c.Check(s.seclogBuf.String(), testutil.Contains, "foo@bar.com")
 	if forcePasswordChange {
@@ -621,7 +621,7 @@ func (s *usersSuite) createUserFromAssertion(c *check.C, forcePasswordChange boo
 }
 
 func (s *usersSuite) TestCreateUserFromAssertionAllKnown(c *check.C) {
-	s.testCreateUserFromAssertion(c, true, false, seclog.AddReasonAPICreateUserFromAllAssertions)
+	s.testCreateUserFromAssertion(c, true, false, seclog.AddReasonAPIAssertionAll)
 }
 
 func (s *usersSuite) TestCreateUserFromAssertionAllAutomatic(c *check.C) {
@@ -667,7 +667,7 @@ func (s *usersSuite) testCreateUserFromAssertion(c *check.C, createKnown bool, e
 		createdUsers, err = devicestate.CreateKnownUsers(s.state, expectSudoer, "", addReason)
 	} else {
 		var createdUser *devicestate.CreatedUser
-		createdUser, err = devicestate.CreateUser(s.state, expectSudoer, "", time.Time{}, seclog.AddReasonAPICreateUserFromStoreCredentials)
+		createdUser, err = devicestate.CreateUser(s.state, expectSudoer, "", time.Time{}, seclog.AddReasonAPIStoreEmail)
 		createdUsers = append(createdUsers, createdUser)
 	}
 	s.state.Unlock()
@@ -737,7 +737,7 @@ func (s *usersSuite) TestCreateAllKnownUsersWithExpiration(c *check.C) {
 	var createdUsers []*devicestate.CreatedUser
 	var err error
 	s.state.Lock()
-	createdUsers, err = devicestate.CreateKnownUsers(s.state, false, "", seclog.AddReasonAPICreateUserFromAllAssertions)
+	createdUsers, err = devicestate.CreateKnownUsers(s.state, false, "", seclog.AddReasonAPIAssertionAll)
 	s.state.Unlock()
 
 	c.Check(created, check.DeepEquals, map[string]bool{"example-user": true})
@@ -772,7 +772,7 @@ func (s *usersSuite) TestCreateUserFromAssertionAllKnownNoModelError(c *check.C)
 
 	// create user
 	s.state.Lock()
-	createdUsers, userErr := devicestate.CreateKnownUsers(s.state, true, "", seclog.AddReasonAPICreateUserFromAllAssertions)
+	createdUsers, userErr := devicestate.CreateKnownUsers(s.state, true, "", seclog.AddReasonAPIAssertionAll)
 	s.state.Unlock()
 
 	c.Assert(userErr, check.NotNil)
@@ -797,7 +797,7 @@ func (s *usersSuite) TestCreateUserFromAssertionNoSerial(c *check.C) {
 
 	// create user
 	s.state.Lock()
-	createdUsers, userErr := devicestate.CreateKnownUsers(s.state, true, "serial@bar.com", seclog.AddReasonAPICreateUserFromAssertion)
+	createdUsers, userErr := devicestate.CreateKnownUsers(s.state, true, "serial@bar.com", seclog.AddReasonAPIAssertion)
 	s.state.Unlock()
 
 	c.Check(userErr, check.NotNil)
@@ -842,7 +842,7 @@ func (s *usersSuite) TestCreateUserFromAssertionDelayedAfterSerialAcquisition(c 
 
 	// try creating user
 	s.state.Lock()
-	createdUsers, userErr := devicestate.CreateKnownUsers(s.state, true, "", seclog.AddReasonAPICreateUserFromAllAssertions)
+	createdUsers, userErr := devicestate.CreateKnownUsers(s.state, true, "", seclog.AddReasonAPIAssertionAll)
 	s.state.Unlock()
 
 	// make sure that no users were created
@@ -895,7 +895,7 @@ func (s *usersSuite) TestCreateUserFromAssertionDelayedAfterSerialAcquisition(c 
 	c.Check(len(users), check.Equals, 1)
 	c.Check(users[0].Email, check.Equals, serialUser["email"])
 	c.Check(users[0].Username, check.Equals, serialUser["username"])
-	c.Check(s.seclogBuf.String(), testutil.Contains, `add_reason="ensure-create-user-from-serial-bound-assertion"`)
+	c.Check(s.seclogBuf.String(), testutil.Contains, `add_reason="deferred-serial-bound-assertion"`)
 }
 
 func (s *usersSuite) TestCreateAllKnownUsersFromAssertionNoSerial(c *check.C) {
@@ -917,7 +917,7 @@ func (s *usersSuite) TestCreateAllKnownUsersFromAssertionNoSerial(c *check.C) {
 
 	// create user
 	s.state.Lock()
-	createdUsers, userErr := devicestate.CreateKnownUsers(s.state, true, "", seclog.AddReasonAPICreateUserFromAllAssertions)
+	createdUsers, userErr := devicestate.CreateKnownUsers(s.state, true, "", seclog.AddReasonAPIAssertionAll)
 	s.state.Unlock()
 
 	c.Check(userErr, check.IsNil)
@@ -959,7 +959,7 @@ func (s *usersSuite) TestCreateUserFromAssertionAllKnownButOwned(c *check.C) {
 
 	// create user
 	s.state.Lock()
-	createdUsers, err := devicestate.CreateKnownUsers(s.state, false, "", seclog.AddReasonAPICreateUserFromAllAssertions)
+	createdUsers, err := devicestate.CreateKnownUsers(s.state, false, "", seclog.AddReasonAPIAssertionAll)
 	s.state.Unlock()
 	c.Assert(err, check.IsNil)
 	c.Check(created, check.DeepEquals, map[string]bool{
@@ -1005,7 +1005,7 @@ func (s *usersSuite) TestCreateUserFromAssertionAllKnownButSkipExists(c *check.C
 
 	// create user
 	s.state.Lock()
-	createdUsers, err := devicestate.CreateKnownUsers(s.state, false, "", seclog.AddReasonAPICreateUserFromAllAssertions)
+	createdUsers, err := devicestate.CreateKnownUsers(s.state, false, "", seclog.AddReasonAPIAssertionAll)
 	s.state.Unlock()
 	c.Assert(err, check.IsNil)
 	c.Check(len(createdUsers), check.Equals, 0)
@@ -1019,7 +1019,7 @@ func (s *usersSuite) TestCreateUserMissingEmail(c *check.C) {
 
 	// create user
 	s.state.Lock()
-	createdUser, err := devicestate.CreateUser(s.state, true, "", time.Time{}, seclog.AddReasonAPICreateUserFromStoreCredentials)
+	createdUser, err := devicestate.CreateUser(s.state, true, "", time.Time{}, seclog.AddReasonAPIStoreEmail)
 	s.state.Unlock()
 
 	c.Assert(err, check.NotNil)

--- a/overlord/devicestate/devicestate_users_test.go
+++ b/overlord/devicestate/devicestate_users_test.go
@@ -530,7 +530,7 @@ func (s *usersSuite) TestGetUserDetailsFromAssertionHappy(c *check.C) {
 
 	// ensure that if we query the details from the assert DB we get
 	// the expected user
-	username, expiration, opts, err := devicestate.GetUserDetailsFromAssertion(db, model, nil, "foo@bar.com")
+	username, expiration, opts, _, err := devicestate.GetUserDetailsFromAssertion(db, model, nil, "foo@bar.com")
 	c.Assert(err, check.IsNil)
 	c.Check(username, check.Equals, "example-user")
 	c.Check(opts, check.DeepEquals, &osutil.AddUserOptions{
@@ -599,6 +599,9 @@ func (s *usersSuite) createUserFromAssertion(c *check.C, forcePasswordChange boo
 	c.Check(s.seclogBuf.String(), testutil.Contains, "Created system user example-user")
 	c.Check(s.seclogBuf.String(), testutil.Contains, "Example User")
 	c.Check(s.seclogBuf.String(), testutil.Contains, "Known:true")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "system-user")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "my-brand")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "foo@bar.com")
 	if forcePasswordChange {
 		c.Check(s.seclogBuf.String(), testutil.Contains, "ForcePasswordChange:true")
 	} else {

--- a/overlord/devicestate/devicestate_users_test.go
+++ b/overlord/devicestate/devicestate_users_test.go
@@ -20,6 +20,7 @@
 package devicestate_test
 
 import (
+	"bytes"
 	"fmt"
 	"path/filepath"
 	"sort"
@@ -40,6 +41,8 @@ import (
 	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/seclog"
+	"github.com/snapcore/snapd/seclog/seclogtest"
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/store/storetest"
 	"github.com/snapcore/snapd/testutil"
@@ -60,6 +63,8 @@ type usersSuite struct {
 	trivialUserLookup func(username string) (*user.User, error)
 
 	StoreSigning *assertstest.StoreStack
+
+	seclogBuf *bytes.Buffer
 }
 
 func (s *usersSuite) UserInfo(email string) (userinfo *store.User, err error) {
@@ -105,6 +110,10 @@ func (s *usersSuite) SetUpTest(c *check.C) {
 
 	s.userInfoResult = nil
 	s.userInfoExpectedEmail = ""
+
+	s.seclogBuf = &bytes.Buffer{}
+	seclog.Setup(seclogtest.MockSecurityLogger(s.seclogBuf))
+	s.AddCleanup(func() { seclog.Setup(seclog.NewNopLogger()) })
 }
 
 func mkUserLookup(userHomeDir string) func(string) (*user.User, error) {
@@ -186,6 +195,11 @@ func (s *usersSuite) TestCreateUser(c *check.C) {
 	c.Check(outfile, testutil.FileEquals,
 		fmt.Sprintf(`{"id":%d,"username":"%s","email":"%s","macaroon":"%s"}`,
 			1, expectedUsername, s.userInfoExpectedEmail, user.Macaroon))
+
+	c.Check(s.seclogBuf.String(), testutil.Contains, "user_created_system")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "Created system user karl")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "xxyyzz")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "Known:false")
 }
 
 func (s *usersSuite) TestUserActionRemoveDelUserErr(c *check.C) {
@@ -206,14 +220,16 @@ func (s *usersSuite) TestUserActionRemoveDelUserErr(c *check.C) {
 		return fmt.Errorf("wat")
 	})()
 
+	s.seclogBuf.Reset()
 	s.state.Lock()
 	userState, userErr := devicestate.RemoveUser(s.state, "some-user", &devicestate.RemoveUserOptions{})
 	s.state.Unlock()
 	c.Check(userErr, check.NotNil)
-	c.Check(s.errorIsInternal(err), check.Equals, true)
+	c.Check(s.errorIsInternal(userErr), check.Equals, true)
 	c.Check(userErr.Error(), check.Matches, "wat")
 	c.Assert(userState, check.IsNil)
 	c.Check(called, check.Equals, 1)
+	c.Check(s.seclogBuf.String(), check.Equals, "")
 }
 
 func (s *usersSuite) TestUserActionRemoveDelUserForce(c *check.C) {
@@ -240,6 +256,10 @@ func (s *usersSuite) TestUserActionRemoveDelUserForce(c *check.C) {
 	s.state.Unlock()
 	c.Check(err, check.IsNil)
 	c.Check(calls, check.Equals, 1)
+
+	c.Check(s.seclogBuf.String(), testutil.Contains, "user_removed_system")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "Removed system user some-user")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "Force:true")
 }
 
 func (s *usersSuite) TestUserActionRemoveStateErr(c *check.C) {
@@ -316,6 +336,10 @@ func (s *usersSuite) TestUserActionRemove(c *check.C) {
 	_, err = auth.User(s.state, user.ID)
 	s.state.Unlock()
 	c.Check(err, check.Equals, auth.ErrInvalidUser)
+
+	c.Check(s.seclogBuf.String(), testutil.Contains, "user_removed_system")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "Removed system user some-user")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "Force:false")
 }
 
 func (s *usersSuite) TestUserActionRemoveNoUsername(c *check.C) {
@@ -403,8 +427,8 @@ var goodUser = map[string]any{
 	"email":        "foo@bar.com",
 	"series":       []any{"16", "18"},
 	"models":       []any{"my-model", "other-model"},
-	"name":         "Boring Guy",
-	"username":     "guy",
+	"name":         "Example User",
+	"username":     "example-user",
 	"password":     "$6$salt$hash",
 	"since":        time.Now().Format(time.RFC3339),
 	"until":        time.Now().Add(24 * 30 * time.Hour).Format(time.RFC3339),
@@ -487,8 +511,8 @@ var expireUser = map[string]any{
 	"email":         "foo@bar.com",
 	"series":        []any{"16", "18"},
 	"models":        []any{"my-model", "other-model"},
-	"name":          "Boring Guy",
-	"username":      "guy",
+	"name":          "Example User",
+	"username":      "example-user",
 	"password":      "$6$salt$hash",
 	"user-presence": "until-expiration",
 	"since":         time.Now().Format(time.RFC3339),
@@ -508,9 +532,9 @@ func (s *usersSuite) TestGetUserDetailsFromAssertionHappy(c *check.C) {
 	// the expected user
 	username, expiration, opts, err := devicestate.GetUserDetailsFromAssertion(db, model, nil, "foo@bar.com")
 	c.Assert(err, check.IsNil)
-	c.Check(username, check.Equals, "guy")
+	c.Check(username, check.Equals, "example-user")
 	c.Check(opts, check.DeepEquals, &osutil.AddUserOptions{
-		Gecos:    "foo@bar.com,Boring Guy",
+		Gecos:    "foo@bar.com,Example User",
 		Password: "$6$salt$hash",
 	})
 	c.Check(expiration.IsZero(), check.Equals, true)
@@ -546,8 +570,8 @@ func (s *usersSuite) createUserFromAssertion(c *check.C, forcePasswordChange boo
 	// mock the calls that create the user
 	var addUserCalled bool
 	defer devicestate.MockOsutilAddUser(func(username string, opts *osutil.AddUserOptions) error {
-		c.Check(username, check.Equals, "guy")
-		c.Check(opts.Gecos, check.Equals, "foo@bar.com,Boring Guy")
+		c.Check(username, check.Equals, "example-user")
+		c.Check(opts.Gecos, check.Equals, "foo@bar.com,Example User")
 		c.Check(opts.Sudoer, check.Equals, false)
 		c.Check(opts.Password, check.Equals, "$6$salt$hash")
 		c.Check(opts.ForcePasswordChange, check.Equals, forcePasswordChange)
@@ -562,7 +586,7 @@ func (s *usersSuite) createUserFromAssertion(c *check.C, forcePasswordChange boo
 
 	expected := []*devicestate.CreatedUser{
 		{
-			Username: "guy",
+			Username: "example-user",
 		},
 	}
 	c.Assert(err, check.IsNil)
@@ -570,6 +594,16 @@ func (s *usersSuite) createUserFromAssertion(c *check.C, forcePasswordChange boo
 	c.Check(createdUsers, check.FitsTypeOf, expected)
 	c.Check(createdUsers, check.DeepEquals, expected)
 	c.Check(addUserCalled, check.Equals, true)
+
+	c.Check(s.seclogBuf.String(), testutil.Contains, "user_created_system")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "Created system user example-user")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "Example User")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "Known:true")
+	if forcePasswordChange {
+		c.Check(s.seclogBuf.String(), testutil.Contains, "ForcePasswordChange:true")
+	} else {
+		c.Check(s.seclogBuf.String(), testutil.Contains, "ForcePasswordChange:false")
+	}
 
 	// ensure the user was added to the state
 	s.state.Lock()
@@ -600,8 +634,8 @@ func (s *usersSuite) testCreateUserFromAssertion(c *check.C, createKnown bool, e
 	// mock the calls that create the user
 	defer devicestate.MockOsutilAddUser(func(username string, opts *osutil.AddUserOptions) error {
 		switch username {
-		case "guy":
-			c.Check(opts.Gecos, check.Equals, "foo@bar.com,Boring Guy")
+		case "example-user":
+			c.Check(opts.Gecos, check.Equals, "foo@bar.com,Example User")
 		case "partnerguy":
 			c.Check(opts.Gecos, check.Equals, "p@partner.com,Partner Guy")
 		case "goodserialguy":
@@ -638,14 +672,14 @@ func (s *usersSuite) testCreateUserFromAssertion(c *check.C, createKnown bool, e
 	s.state.Unlock()
 
 	c.Check(created, check.DeepEquals, map[string]bool{
-		"guy":           true,
+		"example-user":  true,
 		"partnerguy":    true,
 		"goodserialguy": true,
 	})
 
 	expected := []*devicestate.CreatedUser{
 		{
-			Username: "guy",
+			Username: "example-user",
 		},
 		{
 			Username: "partnerguy",
@@ -682,7 +716,7 @@ func (s *usersSuite) TestCreateAllKnownUsersWithExpiration(c *check.C) {
 
 	// mock the calls that create the user
 	defer devicestate.MockOsutilAddUser(func(username string, opts *osutil.AddUserOptions) error {
-		c.Check(opts.Gecos, check.Equals, "foo@bar.com,Boring Guy")
+		c.Check(opts.Gecos, check.Equals, "foo@bar.com,Example User")
 		c.Check(opts.Sudoer, check.Equals, false)
 		c.Check(opts.Password, check.Equals, "$6$salt$hash")
 		created[username] = true
@@ -704,8 +738,8 @@ func (s *usersSuite) TestCreateAllKnownUsersWithExpiration(c *check.C) {
 	createdUsers, err = devicestate.CreateKnownUsers(s.state, false, "")
 	s.state.Unlock()
 
-	c.Check(created, check.DeepEquals, map[string]bool{"guy": true})
-	expected := []*devicestate.CreatedUser{{Username: "guy"}}
+	c.Check(created, check.DeepEquals, map[string]bool{"example-user": true})
+	expected := []*devicestate.CreatedUser{{Username: "example-user"}}
 	c.Assert(err, check.IsNil)
 	c.Check(len(createdUsers), check.Equals, 1)
 	c.Check(createdUsers, check.FitsTypeOf, expected)
@@ -905,8 +939,8 @@ func (s *usersSuite) TestCreateUserFromAssertionAllKnownButOwned(c *check.C) {
 	// mock the calls that create the user
 	created := map[string]bool{}
 	defer devicestate.MockOsutilAddUser(func(username string, opts *osutil.AddUserOptions) error {
-		c.Check(username, check.Equals, "guy")
-		c.Check(opts.Gecos, check.Equals, "foo@bar.com,Boring Guy")
+		c.Check(username, check.Equals, "example-user")
+		c.Check(opts.Gecos, check.Equals, "foo@bar.com,Example User")
 		c.Check(opts.Sudoer, check.Equals, false)
 		c.Check(opts.Password, check.Equals, "$6$salt$hash")
 		created[username] = true
@@ -926,11 +960,11 @@ func (s *usersSuite) TestCreateUserFromAssertionAllKnownButOwned(c *check.C) {
 	s.state.Unlock()
 	c.Assert(err, check.IsNil)
 	c.Check(created, check.DeepEquals, map[string]bool{
-		"guy": true,
+		"example-user": true,
 	})
 	expected := []*devicestate.CreatedUser{
 		{
-			Username: "guy",
+			Username: "example-user",
 		},
 	}
 	c.Check(len(createdUsers), check.Equals, 1)

--- a/overlord/devicestate/devicestate_users_test.go
+++ b/overlord/devicestate/devicestate_users_test.go
@@ -134,7 +134,7 @@ func (s *usersSuite) TestCreateUserNoSSHKeys(c *check.C) {
 
 	// create user
 	s.state.Lock()
-	createdUser, err := devicestate.CreateUser(s.state, true, "popper@lse.ac.uk", time.Time{}, seclog.AddReasonAdminStore)
+	createdUser, err := devicestate.CreateUser(s.state, true, "popper@lse.ac.uk", time.Time{}, seclog.AddReasonAPICreateUserFromStoreCredentials)
 	s.state.Unlock()
 
 	c.Assert(err, check.NotNil)
@@ -169,7 +169,7 @@ func (s *usersSuite) TestCreateUser(c *check.C) {
 	// user was setup in state
 	// create user
 	s.state.Lock()
-	createdUser, userErr := devicestate.CreateUser(s.state, false, "popper@lse.ac.uk", expectedExpiration, seclog.AddReasonAdminStore)
+	createdUser, userErr := devicestate.CreateUser(s.state, false, "popper@lse.ac.uk", expectedExpiration, seclog.AddReasonAPICreateUserFromStoreCredentials)
 	s.state.Unlock()
 
 	c.Assert(userErr, check.IsNil)
@@ -200,7 +200,7 @@ func (s *usersSuite) TestCreateUser(c *check.C) {
 	c.Check(s.seclogBuf.String(), testutil.Contains, "Created system user karl")
 	c.Check(s.seclogBuf.String(), testutil.Contains, "xxyyzz")
 	c.Check(s.seclogBuf.String(), testutil.Contains, "Known:false")
-	c.Check(s.seclogBuf.String(), testutil.Contains, `add_reason="admin-store"`)
+	c.Check(s.seclogBuf.String(), testutil.Contains, `add_reason="api-create-user-from-store-credentials"`)
 }
 
 func (s *usersSuite) TestUserActionRemoveDelUserErr(c *check.C) {
@@ -223,7 +223,7 @@ func (s *usersSuite) TestUserActionRemoveDelUserErr(c *check.C) {
 
 	s.seclogBuf.Reset()
 	s.state.Lock()
-	userState, userErr := devicestate.RemoveUser(s.state, "some-user", &devicestate.RemoveUserOptions{RemoveReason: seclog.RemoveReasonAdminRemove})
+	userState, userErr := devicestate.RemoveUser(s.state, "some-user", &devicestate.RemoveUserOptions{RemoveReason: seclog.RemoveReasonAPIRemoveUser})
 	s.state.Unlock()
 	c.Check(userErr, check.NotNil)
 	c.Check(s.errorIsInternal(userErr), check.Equals, true)
@@ -253,7 +253,7 @@ func (s *usersSuite) TestUserActionRemoveDelUserForce(c *check.C) {
 	})()
 
 	s.state.Lock()
-	_, err = devicestate.RemoveUser(s.state, "some-user", &devicestate.RemoveUserOptions{Force: true, RemoveReason: seclog.RemoveReasonAdminRemove})
+	_, err = devicestate.RemoveUser(s.state, "some-user", &devicestate.RemoveUserOptions{Force: true, RemoveReason: seclog.RemoveReasonAPIRemoveUser})
 	s.state.Unlock()
 	c.Check(err, check.IsNil)
 	c.Check(calls, check.Equals, 1)
@@ -261,7 +261,7 @@ func (s *usersSuite) TestUserActionRemoveDelUserForce(c *check.C) {
 	c.Check(s.seclogBuf.String(), testutil.Contains, "user_removed_system")
 	c.Check(s.seclogBuf.String(), testutil.Contains, "Removed system user some-user")
 	c.Check(s.seclogBuf.String(), testutil.Contains, "Force:true")
-	c.Check(s.seclogBuf.String(), testutil.Contains, `remove_reason="admin-remove"`)
+	c.Check(s.seclogBuf.String(), testutil.Contains, `remove_reason="api-remove-user"`)
 }
 
 func (s *usersSuite) TestUserActionRemoveStateErr(c *check.C) {
@@ -276,7 +276,7 @@ func (s *usersSuite) TestUserActionRemoveStateErr(c *check.C) {
 	})()
 
 	s.state.Lock()
-	userState, err := devicestate.RemoveUser(s.state, "some-user", &devicestate.RemoveUserOptions{RemoveReason: seclog.RemoveReasonAdminRemove})
+	userState, err := devicestate.RemoveUser(s.state, "some-user", &devicestate.RemoveUserOptions{RemoveReason: seclog.RemoveReasonAPIRemoveUser})
 	s.state.Unlock()
 
 	c.Check(err, check.NotNil)
@@ -295,7 +295,7 @@ func (s *usersSuite) TestUserActionRemoveNoUserInState(c *check.C) {
 	})
 
 	s.state.Lock()
-	userState, err := devicestate.RemoveUser(s.state, "some-user", &devicestate.RemoveUserOptions{RemoveReason: seclog.RemoveReasonAdminRemove})
+	userState, err := devicestate.RemoveUser(s.state, "some-user", &devicestate.RemoveUserOptions{RemoveReason: seclog.RemoveReasonAPIRemoveUser})
 	s.state.Unlock()
 
 	c.Check(err, check.NotNil)
@@ -324,7 +324,7 @@ func (s *usersSuite) TestUserActionRemove(c *check.C) {
 	})()
 
 	s.state.Lock()
-	userState, err := devicestate.RemoveUser(s.state, "some-user", &devicestate.RemoveUserOptions{RemoveReason: seclog.RemoveReasonAdminRemove})
+	userState, err := devicestate.RemoveUser(s.state, "some-user", &devicestate.RemoveUserOptions{RemoveReason: seclog.RemoveReasonAPIRemoveUser})
 	s.state.Unlock()
 
 	c.Check(err, check.IsNil)
@@ -342,12 +342,12 @@ func (s *usersSuite) TestUserActionRemove(c *check.C) {
 	c.Check(s.seclogBuf.String(), testutil.Contains, "user_removed_system")
 	c.Check(s.seclogBuf.String(), testutil.Contains, "Removed system user some-user")
 	c.Check(s.seclogBuf.String(), testutil.Contains, "Force:false")
-	c.Check(s.seclogBuf.String(), testutil.Contains, `remove_reason="admin-remove"`)
+	c.Check(s.seclogBuf.String(), testutil.Contains, `remove_reason="api-remove-user"`)
 }
 
 func (s *usersSuite) TestUserActionRemoveNoUsername(c *check.C) {
 
-	userState, err := devicestate.RemoveUser(s.state, "", &devicestate.RemoveUserOptions{RemoveReason: seclog.RemoveReasonAdminRemove})
+	userState, err := devicestate.RemoveUser(s.state, "", &devicestate.RemoveUserOptions{RemoveReason: seclog.RemoveReasonAPIRemoveUser})
 	c.Check(err, check.NotNil)
 	c.Check(err.Error(), check.Matches, "need a username to remove")
 	c.Check(s.errorIsInternal(err), check.Equals, false)
@@ -584,7 +584,7 @@ func (s *usersSuite) createUserFromAssertion(c *check.C, forcePasswordChange boo
 
 	// create user
 	s.state.Lock()
-	createdUsers, err := devicestate.CreateKnownUsers(s.state, false, "foo@bar.com", seclog.AddReasonAdminAssertion)
+	createdUsers, err := devicestate.CreateKnownUsers(s.state, false, "foo@bar.com", seclog.AddReasonAPICreateUserFromAssertion)
 	s.state.Unlock()
 
 	expected := []*devicestate.CreatedUser{
@@ -602,7 +602,7 @@ func (s *usersSuite) createUserFromAssertion(c *check.C, forcePasswordChange boo
 	c.Check(s.seclogBuf.String(), testutil.Contains, "Created system user example-user")
 	c.Check(s.seclogBuf.String(), testutil.Contains, "Example User")
 	c.Check(s.seclogBuf.String(), testutil.Contains, "Known:true")
-	c.Check(s.seclogBuf.String(), testutil.Contains, `add_reason="admin-assertion"`)
+	c.Check(s.seclogBuf.String(), testutil.Contains, `add_reason="api-create-user-from-assertion"`)
 	c.Check(s.seclogBuf.String(), testutil.Contains, "my-brand")
 	c.Check(s.seclogBuf.String(), testutil.Contains, "foo@bar.com")
 	if forcePasswordChange {
@@ -621,11 +621,11 @@ func (s *usersSuite) createUserFromAssertion(c *check.C, forcePasswordChange boo
 }
 
 func (s *usersSuite) TestCreateUserFromAssertionAllKnown(c *check.C) {
-	s.testCreateUserFromAssertion(c, true, false, seclog.AddReasonAdminKnownAll)
+	s.testCreateUserFromAssertion(c, true, false, seclog.AddReasonAPICreateUserFromAllAssertions)
 }
 
 func (s *usersSuite) TestCreateUserFromAssertionAllAutomatic(c *check.C) {
-	s.testCreateUserFromAssertion(c, true, true, seclog.AddReasonAutoProvision)
+	s.testCreateUserFromAssertion(c, true, true, seclog.AddReasonAPICreateUserFromAllAssertionsAutomatic)
 }
 
 func (s *usersSuite) testCreateUserFromAssertion(c *check.C, createKnown bool, expectSudoer bool, addReason seclog.SystemUserAddReason) {
@@ -667,7 +667,7 @@ func (s *usersSuite) testCreateUserFromAssertion(c *check.C, createKnown bool, e
 		createdUsers, err = devicestate.CreateKnownUsers(s.state, expectSudoer, "", addReason)
 	} else {
 		var createdUser *devicestate.CreatedUser
-		createdUser, err = devicestate.CreateUser(s.state, expectSudoer, "", time.Time{}, seclog.AddReasonAdminStore)
+		createdUser, err = devicestate.CreateUser(s.state, expectSudoer, "", time.Time{}, seclog.AddReasonAPICreateUserFromStoreCredentials)
 		createdUsers = append(createdUsers, createdUser)
 	}
 	s.state.Unlock()
@@ -737,7 +737,7 @@ func (s *usersSuite) TestCreateAllKnownUsersWithExpiration(c *check.C) {
 	var createdUsers []*devicestate.CreatedUser
 	var err error
 	s.state.Lock()
-	createdUsers, err = devicestate.CreateKnownUsers(s.state, false, "", seclog.AddReasonAdminKnownAll)
+	createdUsers, err = devicestate.CreateKnownUsers(s.state, false, "", seclog.AddReasonAPICreateUserFromAllAssertions)
 	s.state.Unlock()
 
 	c.Check(created, check.DeepEquals, map[string]bool{"example-user": true})
@@ -772,7 +772,7 @@ func (s *usersSuite) TestCreateUserFromAssertionAllKnownNoModelError(c *check.C)
 
 	// create user
 	s.state.Lock()
-	createdUsers, userErr := devicestate.CreateKnownUsers(s.state, true, "", seclog.AddReasonAdminKnownAll)
+	createdUsers, userErr := devicestate.CreateKnownUsers(s.state, true, "", seclog.AddReasonAPICreateUserFromAllAssertions)
 	s.state.Unlock()
 
 	c.Assert(userErr, check.NotNil)
@@ -797,7 +797,7 @@ func (s *usersSuite) TestCreateUserFromAssertionNoSerial(c *check.C) {
 
 	// create user
 	s.state.Lock()
-	createdUsers, userErr := devicestate.CreateKnownUsers(s.state, true, "serial@bar.com", seclog.AddReasonAdminAssertion)
+	createdUsers, userErr := devicestate.CreateKnownUsers(s.state, true, "serial@bar.com", seclog.AddReasonAPICreateUserFromAssertion)
 	s.state.Unlock()
 
 	c.Check(userErr, check.NotNil)
@@ -842,7 +842,7 @@ func (s *usersSuite) TestCreateUserFromAssertionDelayedAfterSerialAcquisition(c 
 
 	// try creating user
 	s.state.Lock()
-	createdUsers, userErr := devicestate.CreateKnownUsers(s.state, true, "", seclog.AddReasonAdminKnownAll)
+	createdUsers, userErr := devicestate.CreateKnownUsers(s.state, true, "", seclog.AddReasonAPICreateUserFromAllAssertions)
 	s.state.Unlock()
 
 	// make sure that no users were created
@@ -895,7 +895,7 @@ func (s *usersSuite) TestCreateUserFromAssertionDelayedAfterSerialAcquisition(c 
 	c.Check(len(users), check.Equals, 1)
 	c.Check(users[0].Email, check.Equals, serialUser["email"])
 	c.Check(users[0].Username, check.Equals, serialUser["username"])
-	c.Check(s.seclogBuf.String(), testutil.Contains, `add_reason="serial-bound"`)
+	c.Check(s.seclogBuf.String(), testutil.Contains, `add_reason="ensure-create-user-from-serial-bound-assertion"`)
 }
 
 func (s *usersSuite) TestCreateAllKnownUsersFromAssertionNoSerial(c *check.C) {
@@ -917,7 +917,7 @@ func (s *usersSuite) TestCreateAllKnownUsersFromAssertionNoSerial(c *check.C) {
 
 	// create user
 	s.state.Lock()
-	createdUsers, userErr := devicestate.CreateKnownUsers(s.state, true, "", seclog.AddReasonAdminKnownAll)
+	createdUsers, userErr := devicestate.CreateKnownUsers(s.state, true, "", seclog.AddReasonAPICreateUserFromAllAssertions)
 	s.state.Unlock()
 
 	c.Check(userErr, check.IsNil)
@@ -959,7 +959,7 @@ func (s *usersSuite) TestCreateUserFromAssertionAllKnownButOwned(c *check.C) {
 
 	// create user
 	s.state.Lock()
-	createdUsers, err := devicestate.CreateKnownUsers(s.state, false, "", seclog.AddReasonAdminKnownAll)
+	createdUsers, err := devicestate.CreateKnownUsers(s.state, false, "", seclog.AddReasonAPICreateUserFromAllAssertions)
 	s.state.Unlock()
 	c.Assert(err, check.IsNil)
 	c.Check(created, check.DeepEquals, map[string]bool{
@@ -1005,7 +1005,7 @@ func (s *usersSuite) TestCreateUserFromAssertionAllKnownButSkipExists(c *check.C
 
 	// create user
 	s.state.Lock()
-	createdUsers, err := devicestate.CreateKnownUsers(s.state, false, "", seclog.AddReasonAdminKnownAll)
+	createdUsers, err := devicestate.CreateKnownUsers(s.state, false, "", seclog.AddReasonAPICreateUserFromAllAssertions)
 	s.state.Unlock()
 	c.Assert(err, check.IsNil)
 	c.Check(len(createdUsers), check.Equals, 0)
@@ -1019,7 +1019,7 @@ func (s *usersSuite) TestCreateUserMissingEmail(c *check.C) {
 
 	// create user
 	s.state.Lock()
-	createdUser, err := devicestate.CreateUser(s.state, true, "", time.Time{}, seclog.AddReasonAdminStore)
+	createdUser, err := devicestate.CreateUser(s.state, true, "", time.Time{}, seclog.AddReasonAPICreateUserFromStoreCredentials)
 	s.state.Unlock()
 
 	c.Assert(err, check.NotNil)

--- a/overlord/devicestate/devicestate_users_test.go
+++ b/overlord/devicestate/devicestate_users_test.go
@@ -134,7 +134,7 @@ func (s *usersSuite) TestCreateUserNoSSHKeys(c *check.C) {
 
 	// create user
 	s.state.Lock()
-	createdUser, err := devicestate.CreateUser(s.state, true, "popper@lse.ac.uk", time.Time{})
+	createdUser, err := devicestate.CreateUser(s.state, true, "popper@lse.ac.uk", time.Time{}, seclog.AddReasonAdminStore)
 	s.state.Unlock()
 
 	c.Assert(err, check.NotNil)
@@ -169,7 +169,7 @@ func (s *usersSuite) TestCreateUser(c *check.C) {
 	// user was setup in state
 	// create user
 	s.state.Lock()
-	createdUser, userErr := devicestate.CreateUser(s.state, false, "popper@lse.ac.uk", expectedExpiration)
+	createdUser, userErr := devicestate.CreateUser(s.state, false, "popper@lse.ac.uk", expectedExpiration, seclog.AddReasonAdminStore)
 	s.state.Unlock()
 
 	c.Assert(userErr, check.IsNil)
@@ -200,6 +200,7 @@ func (s *usersSuite) TestCreateUser(c *check.C) {
 	c.Check(s.seclogBuf.String(), testutil.Contains, "Created system user karl")
 	c.Check(s.seclogBuf.String(), testutil.Contains, "xxyyzz")
 	c.Check(s.seclogBuf.String(), testutil.Contains, "Known:false")
+	c.Check(s.seclogBuf.String(), testutil.Contains, `add_reason="admin-store"`)
 }
 
 func (s *usersSuite) TestUserActionRemoveDelUserErr(c *check.C) {
@@ -222,7 +223,7 @@ func (s *usersSuite) TestUserActionRemoveDelUserErr(c *check.C) {
 
 	s.seclogBuf.Reset()
 	s.state.Lock()
-	userState, userErr := devicestate.RemoveUser(s.state, "some-user", &devicestate.RemoveUserOptions{})
+	userState, userErr := devicestate.RemoveUser(s.state, "some-user", &devicestate.RemoveUserOptions{RemoveReason: seclog.RemoveReasonAdminRemove})
 	s.state.Unlock()
 	c.Check(userErr, check.NotNil)
 	c.Check(s.errorIsInternal(userErr), check.Equals, true)
@@ -252,7 +253,7 @@ func (s *usersSuite) TestUserActionRemoveDelUserForce(c *check.C) {
 	})()
 
 	s.state.Lock()
-	_, err = devicestate.RemoveUser(s.state, "some-user", &devicestate.RemoveUserOptions{Force: true})
+	_, err = devicestate.RemoveUser(s.state, "some-user", &devicestate.RemoveUserOptions{Force: true, RemoveReason: seclog.RemoveReasonAdminRemove})
 	s.state.Unlock()
 	c.Check(err, check.IsNil)
 	c.Check(calls, check.Equals, 1)
@@ -260,6 +261,7 @@ func (s *usersSuite) TestUserActionRemoveDelUserForce(c *check.C) {
 	c.Check(s.seclogBuf.String(), testutil.Contains, "user_removed_system")
 	c.Check(s.seclogBuf.String(), testutil.Contains, "Removed system user some-user")
 	c.Check(s.seclogBuf.String(), testutil.Contains, "Force:true")
+	c.Check(s.seclogBuf.String(), testutil.Contains, `remove_reason="admin-remove"`)
 }
 
 func (s *usersSuite) TestUserActionRemoveStateErr(c *check.C) {
@@ -274,7 +276,7 @@ func (s *usersSuite) TestUserActionRemoveStateErr(c *check.C) {
 	})()
 
 	s.state.Lock()
-	userState, err := devicestate.RemoveUser(s.state, "some-user", &devicestate.RemoveUserOptions{})
+	userState, err := devicestate.RemoveUser(s.state, "some-user", &devicestate.RemoveUserOptions{RemoveReason: seclog.RemoveReasonAdminRemove})
 	s.state.Unlock()
 
 	c.Check(err, check.NotNil)
@@ -293,7 +295,7 @@ func (s *usersSuite) TestUserActionRemoveNoUserInState(c *check.C) {
 	})
 
 	s.state.Lock()
-	userState, err := devicestate.RemoveUser(s.state, "some-user", &devicestate.RemoveUserOptions{})
+	userState, err := devicestate.RemoveUser(s.state, "some-user", &devicestate.RemoveUserOptions{RemoveReason: seclog.RemoveReasonAdminRemove})
 	s.state.Unlock()
 
 	c.Check(err, check.NotNil)
@@ -322,7 +324,7 @@ func (s *usersSuite) TestUserActionRemove(c *check.C) {
 	})()
 
 	s.state.Lock()
-	userState, err := devicestate.RemoveUser(s.state, "some-user", &devicestate.RemoveUserOptions{})
+	userState, err := devicestate.RemoveUser(s.state, "some-user", &devicestate.RemoveUserOptions{RemoveReason: seclog.RemoveReasonAdminRemove})
 	s.state.Unlock()
 
 	c.Check(err, check.IsNil)
@@ -340,11 +342,12 @@ func (s *usersSuite) TestUserActionRemove(c *check.C) {
 	c.Check(s.seclogBuf.String(), testutil.Contains, "user_removed_system")
 	c.Check(s.seclogBuf.String(), testutil.Contains, "Removed system user some-user")
 	c.Check(s.seclogBuf.String(), testutil.Contains, "Force:false")
+	c.Check(s.seclogBuf.String(), testutil.Contains, `remove_reason="admin-remove"`)
 }
 
 func (s *usersSuite) TestUserActionRemoveNoUsername(c *check.C) {
 
-	userState, err := devicestate.RemoveUser(s.state, "", &devicestate.RemoveUserOptions{})
+	userState, err := devicestate.RemoveUser(s.state, "", &devicestate.RemoveUserOptions{RemoveReason: seclog.RemoveReasonAdminRemove})
 	c.Check(err, check.NotNil)
 	c.Check(err.Error(), check.Matches, "need a username to remove")
 	c.Check(s.errorIsInternal(err), check.Equals, false)
@@ -581,7 +584,7 @@ func (s *usersSuite) createUserFromAssertion(c *check.C, forcePasswordChange boo
 
 	// create user
 	s.state.Lock()
-	createdUsers, err := devicestate.CreateKnownUsers(s.state, false, "foo@bar.com")
+	createdUsers, err := devicestate.CreateKnownUsers(s.state, false, "foo@bar.com", seclog.AddReasonAdminAssertion)
 	s.state.Unlock()
 
 	expected := []*devicestate.CreatedUser{
@@ -599,7 +602,7 @@ func (s *usersSuite) createUserFromAssertion(c *check.C, forcePasswordChange boo
 	c.Check(s.seclogBuf.String(), testutil.Contains, "Created system user example-user")
 	c.Check(s.seclogBuf.String(), testutil.Contains, "Example User")
 	c.Check(s.seclogBuf.String(), testutil.Contains, "Known:true")
-	c.Check(s.seclogBuf.String(), testutil.Contains, "system-user")
+	c.Check(s.seclogBuf.String(), testutil.Contains, `add_reason="admin-assertion"`)
 	c.Check(s.seclogBuf.String(), testutil.Contains, "my-brand")
 	c.Check(s.seclogBuf.String(), testutil.Contains, "foo@bar.com")
 	if forcePasswordChange {
@@ -618,19 +621,14 @@ func (s *usersSuite) createUserFromAssertion(c *check.C, forcePasswordChange boo
 }
 
 func (s *usersSuite) TestCreateUserFromAssertionAllKnown(c *check.C) {
-	expectSudoer := false
-	createKnown := true
-	s.testCreateUserFromAssertion(c, createKnown, expectSudoer)
+	s.testCreateUserFromAssertion(c, true, false, seclog.AddReasonAdminKnownAll)
 }
 
 func (s *usersSuite) TestCreateUserFromAssertionAllAutomatic(c *check.C) {
-	// automatic implies "sudoder" and "createKnown"
-	expectSudoer := true
-	createKnown := true
-	s.testCreateUserFromAssertion(c, createKnown, expectSudoer)
+	s.testCreateUserFromAssertion(c, true, true, seclog.AddReasonAutoProvision)
 }
 
-func (s *usersSuite) testCreateUserFromAssertion(c *check.C, createKnown bool, expectSudoer bool) {
+func (s *usersSuite) testCreateUserFromAssertion(c *check.C, createKnown bool, expectSudoer bool, addReason seclog.SystemUserAddReason) {
 	s.makeSystemUsers(c, []map[string]any{goodUser, partnerUser, serialUser, badUser, badUserNoMatchingSerial, unknownUser})
 	created := map[string]bool{}
 
@@ -666,10 +664,10 @@ func (s *usersSuite) testCreateUserFromAssertion(c *check.C, createKnown bool, e
 	var err error
 	s.state.Lock()
 	if createKnown {
-		createdUsers, err = devicestate.CreateKnownUsers(s.state, expectSudoer, "")
+		createdUsers, err = devicestate.CreateKnownUsers(s.state, expectSudoer, "", addReason)
 	} else {
 		var createdUser *devicestate.CreatedUser
-		createdUser, err = devicestate.CreateUser(s.state, expectSudoer, "", time.Time{})
+		createdUser, err = devicestate.CreateUser(s.state, expectSudoer, "", time.Time{}, seclog.AddReasonAdminStore)
 		createdUsers = append(createdUsers, createdUser)
 	}
 	s.state.Unlock()
@@ -711,6 +709,7 @@ func (s *usersSuite) testCreateUserFromAssertion(c *check.C, createKnown bool, e
 	s.state.Unlock()
 	c.Assert(userErr, check.IsNil)
 	c.Check(users, check.HasLen, 3)
+	c.Check(s.seclogBuf.String(), testutil.Contains, fmt.Sprintf(`add_reason=%q`, addReason))
 }
 
 func (s *usersSuite) TestCreateAllKnownUsersWithExpiration(c *check.C) {
@@ -738,7 +737,7 @@ func (s *usersSuite) TestCreateAllKnownUsersWithExpiration(c *check.C) {
 	var createdUsers []*devicestate.CreatedUser
 	var err error
 	s.state.Lock()
-	createdUsers, err = devicestate.CreateKnownUsers(s.state, false, "")
+	createdUsers, err = devicestate.CreateKnownUsers(s.state, false, "", seclog.AddReasonAdminKnownAll)
 	s.state.Unlock()
 
 	c.Check(created, check.DeepEquals, map[string]bool{"example-user": true})
@@ -773,7 +772,7 @@ func (s *usersSuite) TestCreateUserFromAssertionAllKnownNoModelError(c *check.C)
 
 	// create user
 	s.state.Lock()
-	createdUsers, userErr := devicestate.CreateKnownUsers(s.state, true, "")
+	createdUsers, userErr := devicestate.CreateKnownUsers(s.state, true, "", seclog.AddReasonAdminKnownAll)
 	s.state.Unlock()
 
 	c.Assert(userErr, check.NotNil)
@@ -798,7 +797,7 @@ func (s *usersSuite) TestCreateUserFromAssertionNoSerial(c *check.C) {
 
 	// create user
 	s.state.Lock()
-	createdUsers, userErr := devicestate.CreateKnownUsers(s.state, true, "serial@bar.com")
+	createdUsers, userErr := devicestate.CreateKnownUsers(s.state, true, "serial@bar.com", seclog.AddReasonAdminAssertion)
 	s.state.Unlock()
 
 	c.Check(userErr, check.NotNil)
@@ -843,7 +842,7 @@ func (s *usersSuite) TestCreateUserFromAssertionDelayedAfterSerialAcquisition(c 
 
 	// try creating user
 	s.state.Lock()
-	createdUsers, userErr := devicestate.CreateKnownUsers(s.state, true, "")
+	createdUsers, userErr := devicestate.CreateKnownUsers(s.state, true, "", seclog.AddReasonAdminKnownAll)
 	s.state.Unlock()
 
 	// make sure that no users were created
@@ -896,6 +895,7 @@ func (s *usersSuite) TestCreateUserFromAssertionDelayedAfterSerialAcquisition(c 
 	c.Check(len(users), check.Equals, 1)
 	c.Check(users[0].Email, check.Equals, serialUser["email"])
 	c.Check(users[0].Username, check.Equals, serialUser["username"])
+	c.Check(s.seclogBuf.String(), testutil.Contains, `add_reason="serial-bound"`)
 }
 
 func (s *usersSuite) TestCreateAllKnownUsersFromAssertionNoSerial(c *check.C) {
@@ -917,7 +917,7 @@ func (s *usersSuite) TestCreateAllKnownUsersFromAssertionNoSerial(c *check.C) {
 
 	// create user
 	s.state.Lock()
-	createdUsers, userErr := devicestate.CreateKnownUsers(s.state, true, "")
+	createdUsers, userErr := devicestate.CreateKnownUsers(s.state, true, "", seclog.AddReasonAdminKnownAll)
 	s.state.Unlock()
 
 	c.Check(userErr, check.IsNil)
@@ -959,7 +959,7 @@ func (s *usersSuite) TestCreateUserFromAssertionAllKnownButOwned(c *check.C) {
 
 	// create user
 	s.state.Lock()
-	createdUsers, err := devicestate.CreateKnownUsers(s.state, false, "")
+	createdUsers, err := devicestate.CreateKnownUsers(s.state, false, "", seclog.AddReasonAdminKnownAll)
 	s.state.Unlock()
 	c.Assert(err, check.IsNil)
 	c.Check(created, check.DeepEquals, map[string]bool{
@@ -1005,7 +1005,7 @@ func (s *usersSuite) TestCreateUserFromAssertionAllKnownButSkipExists(c *check.C
 
 	// create user
 	s.state.Lock()
-	createdUsers, err := devicestate.CreateKnownUsers(s.state, false, "")
+	createdUsers, err := devicestate.CreateKnownUsers(s.state, false, "", seclog.AddReasonAdminKnownAll)
 	s.state.Unlock()
 	c.Assert(err, check.IsNil)
 	c.Check(len(createdUsers), check.Equals, 0)
@@ -1019,7 +1019,7 @@ func (s *usersSuite) TestCreateUserMissingEmail(c *check.C) {
 
 	// create user
 	s.state.Lock()
-	createdUser, err := devicestate.CreateUser(s.state, true, "", time.Time{})
+	createdUser, err := devicestate.CreateUser(s.state, true, "", time.Time{}, seclog.AddReasonAdminStore)
 	s.state.Unlock()
 
 	c.Assert(err, check.NotNil)

--- a/overlord/devicestate/devicestate_users_test.go
+++ b/overlord/devicestate/devicestate_users_test.go
@@ -625,7 +625,7 @@ func (s *usersSuite) TestCreateUserFromAssertionAllKnown(c *check.C) {
 }
 
 func (s *usersSuite) TestCreateUserFromAssertionAllAutomatic(c *check.C) {
-	s.testCreateUserFromAssertion(c, true, true, seclog.AddReasonAPICreateUserFromAllAssertionsAutomatic)
+	s.testCreateUserFromAssertion(c, true, true, seclog.AddReasonAPIAssertionAllAutomatic)
 }
 
 func (s *usersSuite) testCreateUserFromAssertion(c *check.C, createKnown bool, expectSudoer bool, addReason seclog.SystemUserAddReason) {
@@ -895,7 +895,7 @@ func (s *usersSuite) TestCreateUserFromAssertionDelayedAfterSerialAcquisition(c 
 	c.Check(len(users), check.Equals, 1)
 	c.Check(users[0].Email, check.Equals, serialUser["email"])
 	c.Check(users[0].Username, check.Equals, serialUser["username"])
-	c.Check(s.seclogBuf.String(), testutil.Contains, `add_reason="deferred-serial-bound-assertion"`)
+	c.Check(s.seclogBuf.String(), testutil.Contains, `add_reason="ensure-serial-bound-assertion"`)
 }
 
 func (s *usersSuite) TestCreateAllKnownUsersFromAssertionNoSerial(c *check.C) {

--- a/overlord/devicestate/devicestate_users_test.go
+++ b/overlord/devicestate/devicestate_users_test.go
@@ -20,6 +20,7 @@
 package devicestate_test
 
 import (
+	"bytes"
 	"fmt"
 	"path/filepath"
 	"sort"
@@ -40,6 +41,8 @@ import (
 	"github.com/snapcore/snapd/overlord/devicestate/devicestatetest"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/seclog"
+	"github.com/snapcore/snapd/seclog/seclogtest"
 	"github.com/snapcore/snapd/store"
 	"github.com/snapcore/snapd/store/storetest"
 	"github.com/snapcore/snapd/testutil"
@@ -60,6 +63,8 @@ type usersSuite struct {
 	trivialUserLookup func(username string) (*user.User, error)
 
 	StoreSigning *assertstest.StoreStack
+
+	seclogBuf *bytes.Buffer
 }
 
 func (s *usersSuite) UserInfo(email string) (userinfo *store.User, err error) {
@@ -105,6 +110,10 @@ func (s *usersSuite) SetUpTest(c *check.C) {
 
 	s.userInfoResult = nil
 	s.userInfoExpectedEmail = ""
+
+	s.seclogBuf = &bytes.Buffer{}
+	seclog.Setup(seclogtest.MockSecurityLogger(s.seclogBuf))
+	s.AddCleanup(func() { seclog.Setup(seclog.NewNopLogger()) })
 }
 
 func mkUserLookup(userHomeDir string) func(string) (*user.User, error) {
@@ -125,7 +134,7 @@ func (s *usersSuite) TestCreateUserNoSSHKeys(c *check.C) {
 
 	// create user
 	s.state.Lock()
-	createdUser, err := devicestate.CreateUser(s.state, true, "popper@lse.ac.uk", time.Time{})
+	createdUser, err := devicestate.CreateUser(s.state, true, "popper@lse.ac.uk", time.Time{}, seclog.AddReasonAPIStoreEmail)
 	s.state.Unlock()
 
 	c.Assert(err, check.NotNil)
@@ -160,7 +169,7 @@ func (s *usersSuite) TestCreateUser(c *check.C) {
 	// user was setup in state
 	// create user
 	s.state.Lock()
-	createdUser, userErr := devicestate.CreateUser(s.state, false, "popper@lse.ac.uk", expectedExpiration)
+	createdUser, userErr := devicestate.CreateUser(s.state, false, "popper@lse.ac.uk", expectedExpiration, seclog.AddReasonAPIStoreEmail)
 	s.state.Unlock()
 
 	c.Assert(userErr, check.IsNil)
@@ -186,6 +195,39 @@ func (s *usersSuite) TestCreateUser(c *check.C) {
 	c.Check(outfile, testutil.FileEquals,
 		fmt.Sprintf(`{"id":%d,"username":"%s","email":"%s","macaroon":"%s"}`,
 			1, expectedUsername, s.userInfoExpectedEmail, user.Macaroon))
+
+	c.Check(s.seclogBuf.String(), testutil.Contains, "user_created_system")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "Created system user karl")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "xxyyzz")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "Known:false")
+	c.Check(s.seclogBuf.String(), testutil.Contains, `add_reason="api-store-email"`)
+}
+
+func (s *usersSuite) TestCreateUserAddUserErr(c *check.C) {
+	s.userInfoExpectedEmail = "popper@lse.ac.uk"
+	s.userInfoResult = &store.User{
+		Username:         "karl",
+		SSHKeys:          []string{"ssh1"},
+		OpenIDIdentifier: "xxyyzz",
+	}
+
+	called := 0
+	defer devicestate.MockOsutilAddUser(func(username string, opts *osutil.AddUserOptions) error {
+		called++
+		c.Check(username, check.Equals, "karl")
+		return fmt.Errorf("wat")
+	})()
+
+	s.state.Lock()
+	createdUser, userErr := devicestate.CreateUser(s.state, false, "popper@lse.ac.uk", time.Time{}, seclog.AddReasonAPIStoreEmail)
+	s.state.Unlock()
+
+	c.Check(userErr, check.NotNil)
+	c.Check(s.errorIsInternal(userErr), check.Equals, true)
+	c.Check(userErr.Error(), check.Matches, `cannot add user "karl": wat`)
+	c.Assert(createdUser, check.IsNil)
+	c.Check(called, check.Equals, 1)
+	c.Check(s.seclogBuf.String(), check.Equals, "")
 }
 
 func (s *usersSuite) TestUserActionRemoveDelUserErr(c *check.C) {
@@ -206,14 +248,16 @@ func (s *usersSuite) TestUserActionRemoveDelUserErr(c *check.C) {
 		return fmt.Errorf("wat")
 	})()
 
+	s.seclogBuf.Reset()
 	s.state.Lock()
-	userState, userErr := devicestate.RemoveUser(s.state, "some-user", &devicestate.RemoveUserOptions{})
+	userState, userErr := devicestate.RemoveUser(s.state, "some-user", &devicestate.RemoveUserOptions{RemoveReason: seclog.RemoveReasonAPI})
 	s.state.Unlock()
 	c.Check(userErr, check.NotNil)
-	c.Check(s.errorIsInternal(err), check.Equals, true)
+	c.Check(s.errorIsInternal(userErr), check.Equals, true)
 	c.Check(userErr.Error(), check.Matches, "wat")
 	c.Assert(userState, check.IsNil)
 	c.Check(called, check.Equals, 1)
+	c.Check(s.seclogBuf.String(), check.Equals, "")
 }
 
 func (s *usersSuite) TestUserActionRemoveDelUserForce(c *check.C) {
@@ -236,10 +280,15 @@ func (s *usersSuite) TestUserActionRemoveDelUserForce(c *check.C) {
 	})()
 
 	s.state.Lock()
-	_, err = devicestate.RemoveUser(s.state, "some-user", &devicestate.RemoveUserOptions{Force: true})
+	_, err = devicestate.RemoveUser(s.state, "some-user", &devicestate.RemoveUserOptions{Force: true, RemoveReason: seclog.RemoveReasonAPI})
 	s.state.Unlock()
 	c.Check(err, check.IsNil)
 	c.Check(calls, check.Equals, 1)
+
+	c.Check(s.seclogBuf.String(), testutil.Contains, "user_removed_system")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "Removed system user some-user")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "Force:true")
+	c.Check(s.seclogBuf.String(), testutil.Contains, `remove_reason="api-remove-user"`)
 }
 
 func (s *usersSuite) TestUserActionRemoveStateErr(c *check.C) {
@@ -254,7 +303,7 @@ func (s *usersSuite) TestUserActionRemoveStateErr(c *check.C) {
 	})()
 
 	s.state.Lock()
-	userState, err := devicestate.RemoveUser(s.state, "some-user", &devicestate.RemoveUserOptions{})
+	userState, err := devicestate.RemoveUser(s.state, "some-user", &devicestate.RemoveUserOptions{RemoveReason: seclog.RemoveReasonAPI})
 	s.state.Unlock()
 
 	c.Check(err, check.NotNil)
@@ -273,7 +322,7 @@ func (s *usersSuite) TestUserActionRemoveNoUserInState(c *check.C) {
 	})
 
 	s.state.Lock()
-	userState, err := devicestate.RemoveUser(s.state, "some-user", &devicestate.RemoveUserOptions{})
+	userState, err := devicestate.RemoveUser(s.state, "some-user", &devicestate.RemoveUserOptions{RemoveReason: seclog.RemoveReasonAPI})
 	s.state.Unlock()
 
 	c.Check(err, check.NotNil)
@@ -302,7 +351,7 @@ func (s *usersSuite) TestUserActionRemove(c *check.C) {
 	})()
 
 	s.state.Lock()
-	userState, err := devicestate.RemoveUser(s.state, "some-user", &devicestate.RemoveUserOptions{})
+	userState, err := devicestate.RemoveUser(s.state, "some-user", &devicestate.RemoveUserOptions{RemoveReason: seclog.RemoveReasonAPI})
 	s.state.Unlock()
 
 	c.Check(err, check.IsNil)
@@ -316,11 +365,16 @@ func (s *usersSuite) TestUserActionRemove(c *check.C) {
 	_, err = auth.User(s.state, user.ID)
 	s.state.Unlock()
 	c.Check(err, check.Equals, auth.ErrInvalidUser)
+
+	c.Check(s.seclogBuf.String(), testutil.Contains, "user_removed_system")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "Removed system user some-user")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "Force:false")
+	c.Check(s.seclogBuf.String(), testutil.Contains, `remove_reason="api-remove-user"`)
 }
 
 func (s *usersSuite) TestUserActionRemoveNoUsername(c *check.C) {
 
-	userState, err := devicestate.RemoveUser(s.state, "", &devicestate.RemoveUserOptions{})
+	userState, err := devicestate.RemoveUser(s.state, "", &devicestate.RemoveUserOptions{RemoveReason: seclog.RemoveReasonAPI})
 	c.Check(err, check.NotNil)
 	c.Check(err.Error(), check.Matches, "need a username to remove")
 	c.Check(s.errorIsInternal(err), check.Equals, false)
@@ -403,8 +457,8 @@ var goodUser = map[string]any{
 	"email":        "foo@bar.com",
 	"series":       []any{"16", "18"},
 	"models":       []any{"my-model", "other-model"},
-	"name":         "Boring Guy",
-	"username":     "guy",
+	"name":         "Example User",
+	"username":     "example-user",
 	"password":     "$6$salt$hash",
 	"since":        time.Now().Format(time.RFC3339),
 	"until":        time.Now().Add(24 * 30 * time.Hour).Format(time.RFC3339),
@@ -487,15 +541,15 @@ var expireUser = map[string]any{
 	"email":         "foo@bar.com",
 	"series":        []any{"16", "18"},
 	"models":        []any{"my-model", "other-model"},
-	"name":          "Boring Guy",
-	"username":      "guy",
+	"name":          "Example User",
+	"username":      "example-user",
 	"password":      "$6$salt$hash",
 	"user-presence": "until-expiration",
 	"since":         time.Now().Format(time.RFC3339),
 	"until":         time.Now().Add(24 * 30 * time.Hour).Format(time.RFC3339),
 }
 
-func (s *usersSuite) TestGetUserDetailsFromAssertionHappy(c *check.C) {
+func (s *usersSuite) TestFindVerifiedSystemUserAssertionHappy(c *check.C) {
 	s.makeSystemUsers(c, []map[string]any{goodUser})
 
 	s.state.Lock()
@@ -504,16 +558,15 @@ func (s *usersSuite) TestGetUserDetailsFromAssertionHappy(c *check.C) {
 	s.state.Unlock()
 	c.Assert(err, check.IsNil)
 
-	// ensure that if we query the details from the assert DB we get
-	// the expected user
-	username, expiration, opts, err := devicestate.GetUserDetailsFromAssertion(db, model, nil, "foo@bar.com")
+	// ensure that if we query the assert DB we get the expected user
+	userAssertion, err := devicestate.FindVerifiedSystemUserAssertion(db, model, nil, "foo@bar.com")
 	c.Assert(err, check.IsNil)
-	c.Check(username, check.Equals, "guy")
-	c.Check(opts, check.DeepEquals, &osutil.AddUserOptions{
-		Gecos:    "foo@bar.com,Boring Guy",
+	c.Check(userAssertion.Username(), check.Equals, "example-user")
+	c.Check(userAssertion.UserExpiration().IsZero(), check.Equals, true)
+	c.Check(devicestate.AddUserOptionsFromAssertion(userAssertion), check.DeepEquals, &osutil.AddUserOptions{
+		Gecos:    "foo@bar.com,Example User",
 		Password: "$6$salt$hash",
 	})
-	c.Check(expiration.IsZero(), check.Equals, true)
 }
 
 func (s *usersSuite) TestCreateUserFromAssertion(c *check.C) {
@@ -546,8 +599,8 @@ func (s *usersSuite) createUserFromAssertion(c *check.C, forcePasswordChange boo
 	// mock the calls that create the user
 	var addUserCalled bool
 	defer devicestate.MockOsutilAddUser(func(username string, opts *osutil.AddUserOptions) error {
-		c.Check(username, check.Equals, "guy")
-		c.Check(opts.Gecos, check.Equals, "foo@bar.com,Boring Guy")
+		c.Check(username, check.Equals, "example-user")
+		c.Check(opts.Gecos, check.Equals, "foo@bar.com,Example User")
 		c.Check(opts.Sudoer, check.Equals, false)
 		c.Check(opts.Password, check.Equals, "$6$salt$hash")
 		c.Check(opts.ForcePasswordChange, check.Equals, forcePasswordChange)
@@ -557,12 +610,12 @@ func (s *usersSuite) createUserFromAssertion(c *check.C, forcePasswordChange boo
 
 	// create user
 	s.state.Lock()
-	createdUsers, err := devicestate.CreateKnownUsers(s.state, false, "foo@bar.com")
+	createdUsers, err := devicestate.CreateKnownUsers(s.state, false, "foo@bar.com", seclog.AddReasonAPIAssertion)
 	s.state.Unlock()
 
 	expected := []*devicestate.CreatedUser{
 		{
-			Username: "guy",
+			Username: "example-user",
 		},
 	}
 	c.Assert(err, check.IsNil)
@@ -570,6 +623,20 @@ func (s *usersSuite) createUserFromAssertion(c *check.C, forcePasswordChange boo
 	c.Check(createdUsers, check.FitsTypeOf, expected)
 	c.Check(createdUsers, check.DeepEquals, expected)
 	c.Check(addUserCalled, check.Equals, true)
+
+	c.Check(s.seclogBuf.String(), testutil.Contains, "user_created_system")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "Created system user example-user")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "Example User")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "Known:true")
+	c.Check(s.seclogBuf.String(), testutil.Contains, `add_reason="api-assertion"`)
+	c.Check(s.seclogBuf.String(), testutil.Contains, "type:system-user")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "my-brand")
+	c.Check(s.seclogBuf.String(), testutil.Contains, "foo@bar.com")
+	if forcePasswordChange {
+		c.Check(s.seclogBuf.String(), testutil.Contains, "ForcePasswordChange:true")
+	} else {
+		c.Check(s.seclogBuf.String(), testutil.Contains, "ForcePasswordChange:false")
+	}
 
 	// ensure the user was added to the state
 	s.state.Lock()
@@ -581,27 +648,22 @@ func (s *usersSuite) createUserFromAssertion(c *check.C, forcePasswordChange boo
 }
 
 func (s *usersSuite) TestCreateUserFromAssertionAllKnown(c *check.C) {
-	expectSudoer := false
-	createKnown := true
-	s.testCreateUserFromAssertion(c, createKnown, expectSudoer)
+	s.testCreateUserFromAssertion(c, true, false, seclog.AddReasonAPIAssertionAll)
 }
 
 func (s *usersSuite) TestCreateUserFromAssertionAllAutomatic(c *check.C) {
-	// automatic implies "sudoder" and "createKnown"
-	expectSudoer := true
-	createKnown := true
-	s.testCreateUserFromAssertion(c, createKnown, expectSudoer)
+	s.testCreateUserFromAssertion(c, true, true, seclog.AddReasonAPIAssertionAllAutomatic)
 }
 
-func (s *usersSuite) testCreateUserFromAssertion(c *check.C, createKnown bool, expectSudoer bool) {
+func (s *usersSuite) testCreateUserFromAssertion(c *check.C, createKnown bool, expectSudoer bool, addReason seclog.SystemUserAddReason) {
 	s.makeSystemUsers(c, []map[string]any{goodUser, partnerUser, serialUser, badUser, badUserNoMatchingSerial, unknownUser})
 	created := map[string]bool{}
 
 	// mock the calls that create the user
 	defer devicestate.MockOsutilAddUser(func(username string, opts *osutil.AddUserOptions) error {
 		switch username {
-		case "guy":
-			c.Check(opts.Gecos, check.Equals, "foo@bar.com,Boring Guy")
+		case "example-user":
+			c.Check(opts.Gecos, check.Equals, "foo@bar.com,Example User")
 		case "partnerguy":
 			c.Check(opts.Gecos, check.Equals, "p@partner.com,Partner Guy")
 		case "goodserialguy":
@@ -629,23 +691,23 @@ func (s *usersSuite) testCreateUserFromAssertion(c *check.C, createKnown bool, e
 	var err error
 	s.state.Lock()
 	if createKnown {
-		createdUsers, err = devicestate.CreateKnownUsers(s.state, expectSudoer, "")
+		createdUsers, err = devicestate.CreateKnownUsers(s.state, expectSudoer, "", addReason)
 	} else {
 		var createdUser *devicestate.CreatedUser
-		createdUser, err = devicestate.CreateUser(s.state, expectSudoer, "", time.Time{})
+		createdUser, err = devicestate.CreateUser(s.state, expectSudoer, "", time.Time{}, seclog.AddReasonAPIStoreEmail)
 		createdUsers = append(createdUsers, createdUser)
 	}
 	s.state.Unlock()
 
 	c.Check(created, check.DeepEquals, map[string]bool{
-		"guy":           true,
+		"example-user":  true,
 		"partnerguy":    true,
 		"goodserialguy": true,
 	})
 
 	expected := []*devicestate.CreatedUser{
 		{
-			Username: "guy",
+			Username: "example-user",
 		},
 		{
 			Username: "partnerguy",
@@ -674,6 +736,7 @@ func (s *usersSuite) testCreateUserFromAssertion(c *check.C, createKnown bool, e
 	s.state.Unlock()
 	c.Assert(userErr, check.IsNil)
 	c.Check(users, check.HasLen, 3)
+	c.Check(s.seclogBuf.String(), testutil.Contains, fmt.Sprintf(`add_reason=%q`, addReason))
 }
 
 func (s *usersSuite) TestCreateAllKnownUsersWithExpiration(c *check.C) {
@@ -682,7 +745,7 @@ func (s *usersSuite) TestCreateAllKnownUsersWithExpiration(c *check.C) {
 
 	// mock the calls that create the user
 	defer devicestate.MockOsutilAddUser(func(username string, opts *osutil.AddUserOptions) error {
-		c.Check(opts.Gecos, check.Equals, "foo@bar.com,Boring Guy")
+		c.Check(opts.Gecos, check.Equals, "foo@bar.com,Example User")
 		c.Check(opts.Sudoer, check.Equals, false)
 		c.Check(opts.Password, check.Equals, "$6$salt$hash")
 		created[username] = true
@@ -701,11 +764,11 @@ func (s *usersSuite) TestCreateAllKnownUsersWithExpiration(c *check.C) {
 	var createdUsers []*devicestate.CreatedUser
 	var err error
 	s.state.Lock()
-	createdUsers, err = devicestate.CreateKnownUsers(s.state, false, "")
+	createdUsers, err = devicestate.CreateKnownUsers(s.state, false, "", seclog.AddReasonAPIAssertionAll)
 	s.state.Unlock()
 
-	c.Check(created, check.DeepEquals, map[string]bool{"guy": true})
-	expected := []*devicestate.CreatedUser{{Username: "guy"}}
+	c.Check(created, check.DeepEquals, map[string]bool{"example-user": true})
+	expected := []*devicestate.CreatedUser{{Username: "example-user"}}
 	c.Assert(err, check.IsNil)
 	c.Check(len(createdUsers), check.Equals, 1)
 	c.Check(createdUsers, check.FitsTypeOf, expected)
@@ -736,7 +799,7 @@ func (s *usersSuite) TestCreateUserFromAssertionAllKnownNoModelError(c *check.C)
 
 	// create user
 	s.state.Lock()
-	createdUsers, userErr := devicestate.CreateKnownUsers(s.state, true, "")
+	createdUsers, userErr := devicestate.CreateKnownUsers(s.state, true, "", seclog.AddReasonAPIAssertionAll)
 	s.state.Unlock()
 
 	c.Assert(userErr, check.NotNil)
@@ -761,7 +824,7 @@ func (s *usersSuite) TestCreateUserFromAssertionNoSerial(c *check.C) {
 
 	// create user
 	s.state.Lock()
-	createdUsers, userErr := devicestate.CreateKnownUsers(s.state, true, "serial@bar.com")
+	createdUsers, userErr := devicestate.CreateKnownUsers(s.state, true, "serial@bar.com", seclog.AddReasonAPIAssertion)
 	s.state.Unlock()
 
 	c.Check(userErr, check.NotNil)
@@ -806,7 +869,7 @@ func (s *usersSuite) TestCreateUserFromAssertionDelayedAfterSerialAcquisition(c 
 
 	// try creating user
 	s.state.Lock()
-	createdUsers, userErr := devicestate.CreateKnownUsers(s.state, true, "")
+	createdUsers, userErr := devicestate.CreateKnownUsers(s.state, true, "", seclog.AddReasonAPIAssertionAll)
 	s.state.Unlock()
 
 	// make sure that no users were created
@@ -859,6 +922,7 @@ func (s *usersSuite) TestCreateUserFromAssertionDelayedAfterSerialAcquisition(c 
 	c.Check(len(users), check.Equals, 1)
 	c.Check(users[0].Email, check.Equals, serialUser["email"])
 	c.Check(users[0].Username, check.Equals, serialUser["username"])
+	c.Check(s.seclogBuf.String(), testutil.Contains, `add_reason="ensure-serial-bound-assertion"`)
 }
 
 func (s *usersSuite) TestCreateAllKnownUsersFromAssertionNoSerial(c *check.C) {
@@ -880,7 +944,7 @@ func (s *usersSuite) TestCreateAllKnownUsersFromAssertionNoSerial(c *check.C) {
 
 	// create user
 	s.state.Lock()
-	createdUsers, userErr := devicestate.CreateKnownUsers(s.state, true, "")
+	createdUsers, userErr := devicestate.CreateKnownUsers(s.state, true, "", seclog.AddReasonAPIAssertionAll)
 	s.state.Unlock()
 
 	c.Check(userErr, check.IsNil)
@@ -905,8 +969,8 @@ func (s *usersSuite) TestCreateUserFromAssertionAllKnownButOwned(c *check.C) {
 	// mock the calls that create the user
 	created := map[string]bool{}
 	defer devicestate.MockOsutilAddUser(func(username string, opts *osutil.AddUserOptions) error {
-		c.Check(username, check.Equals, "guy")
-		c.Check(opts.Gecos, check.Equals, "foo@bar.com,Boring Guy")
+		c.Check(username, check.Equals, "example-user")
+		c.Check(opts.Gecos, check.Equals, "foo@bar.com,Example User")
 		c.Check(opts.Sudoer, check.Equals, false)
 		c.Check(opts.Password, check.Equals, "$6$salt$hash")
 		created[username] = true
@@ -922,15 +986,15 @@ func (s *usersSuite) TestCreateUserFromAssertionAllKnownButOwned(c *check.C) {
 
 	// create user
 	s.state.Lock()
-	createdUsers, err := devicestate.CreateKnownUsers(s.state, false, "")
+	createdUsers, err := devicestate.CreateKnownUsers(s.state, false, "", seclog.AddReasonAPIAssertionAll)
 	s.state.Unlock()
 	c.Assert(err, check.IsNil)
 	c.Check(created, check.DeepEquals, map[string]bool{
-		"guy": true,
+		"example-user": true,
 	})
 	expected := []*devicestate.CreatedUser{
 		{
-			Username: "guy",
+			Username: "example-user",
 		},
 	}
 	c.Check(len(createdUsers), check.Equals, 1)
@@ -968,7 +1032,7 @@ func (s *usersSuite) TestCreateUserFromAssertionAllKnownButSkipExists(c *check.C
 
 	// create user
 	s.state.Lock()
-	createdUsers, err := devicestate.CreateKnownUsers(s.state, false, "")
+	createdUsers, err := devicestate.CreateKnownUsers(s.state, false, "", seclog.AddReasonAPIAssertionAll)
 	s.state.Unlock()
 	c.Assert(err, check.IsNil)
 	c.Check(len(createdUsers), check.Equals, 0)
@@ -982,7 +1046,7 @@ func (s *usersSuite) TestCreateUserMissingEmail(c *check.C) {
 
 	// create user
 	s.state.Lock()
-	createdUser, err := devicestate.CreateUser(s.state, true, "", time.Time{})
+	createdUser, err := devicestate.CreateUser(s.state, true, "", time.Time{}, seclog.AddReasonAPIStoreEmail)
 	s.state.Unlock()
 
 	c.Assert(err, check.NotNil)

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/snapcore/snapd/overlord/storecontext"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/secboot/keys"
+	"github.com/snapcore/snapd/seclog"
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/sysconfig"
@@ -608,7 +609,7 @@ func EnsureExtraSnapdKernelCommandLineFragmentsApplied(m *DeviceManager) error {
 
 var ProcessAutoImportAssertions = processAutoImportAssertions
 
-func MockCreateAllKnownSystemUsers(createAllUsers func(state *state.State, assertDb asserts.RODatabase, model *asserts.Model, serial *asserts.Serial, sudoer bool) ([]*CreatedUser, error)) (restore func()) {
+func MockCreateAllKnownSystemUsers(createAllUsers func(state *state.State, assertDb asserts.RODatabase, model *asserts.Model, serial *asserts.Serial, sudoer bool, addReason seclog.SystemUserAddReason) ([]*CreatedUser, error)) (restore func()) {
 	restore = testutil.Backup(&createAllKnownSystemUsers)
 	createAllKnownSystemUsers = createAllUsers
 	return restore

--- a/overlord/devicestate/export_test.go
+++ b/overlord/devicestate/export_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/snapcore/snapd/overlord/storecontext"
 	"github.com/snapcore/snapd/secboot"
 	"github.com/snapcore/snapd/secboot/keys"
+	"github.com/snapcore/snapd/seclog"
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/sysconfig"
@@ -51,9 +52,10 @@ import (
 )
 
 var (
-	SystemForPreseeding         = systemForPreseeding
-	GetUserDetailsFromAssertion = getUserDetailsFromAssertion
-	ShouldRequestSerial         = shouldRequestSerial
+	SystemForPreseeding             = systemForPreseeding
+	FindVerifiedSystemUserAssertion = findVerifiedSystemUserAssertion
+	AddUserOptionsFromAssertion     = addUserOptionsFromAssertion
+	ShouldRequestSerial             = shouldRequestSerial
 )
 
 func MockKeyLength(n int) (restore func()) {
@@ -613,7 +615,7 @@ func EnsureExtraSnapdKernelCommandLineFragmentsApplied(m *DeviceManager) error {
 
 var ProcessAutoImportAssertions = processAutoImportAssertions
 
-func MockCreateAllKnownSystemUsers(createAllUsers func(state *state.State, assertDb asserts.RODatabase, model *asserts.Model, serial *asserts.Serial, sudoer bool) ([]*CreatedUser, error)) (restore func()) {
+func MockCreateAllKnownSystemUsers(createAllUsers func(state *state.State, assertDb asserts.RODatabase, model *asserts.Model, serial *asserts.Serial, sudoer bool, addReason seclog.SystemUserAddReason) ([]*CreatedUser, error)) (restore func()) {
 	restore = testutil.Backup(&createAllKnownSystemUsers)
 	createAllKnownSystemUsers = createAllUsers
 	return restore

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -36,6 +36,7 @@ import (
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/seclog"
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/timings"
@@ -515,7 +516,7 @@ func processAutoImportAssertions(st *state.State, deviceSeed seed.Seed, db asser
 	}
 	// automatic user creation is meant to imply sudoers
 	const sudoer = true
-	_, err = createAllKnownSystemUsers(st, db, deviceSeed.Model(), nil, sudoer)
+	_, err = createAllKnownSystemUsers(st, db, deviceSeed.Model(), nil, sudoer, seclog.AddReasonFirstbootSeedAutoImport)
 	return err
 }
 

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -516,7 +516,7 @@ func processAutoImportAssertions(st *state.State, deviceSeed seed.Seed, db asser
 	}
 	// automatic user creation is meant to imply sudoers
 	const sudoer = true
-	_, err = createAllKnownSystemUsers(st, db, deviceSeed.Model(), nil, sudoer, seclog.AddReasonSeedFirstboot)
+	_, err = createAllKnownSystemUsers(st, db, deviceSeed.Model(), nil, sudoer, seclog.AddReasonFirstbootCreateUserFromSeedAutoImport)
 	return err
 }
 

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -36,6 +36,7 @@ import (
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/seclog"
 	"github.com/snapcore/snapd/seed"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/timings"
@@ -515,7 +516,7 @@ func processAutoImportAssertions(st *state.State, deviceSeed seed.Seed, db asser
 	}
 	// automatic user creation is meant to imply sudoers
 	const sudoer = true
-	_, err = createAllKnownSystemUsers(st, db, deviceSeed.Model(), nil, sudoer)
+	_, err = createAllKnownSystemUsers(st, db, deviceSeed.Model(), nil, sudoer, seclog.AddReasonSeedFirstboot)
 	return err
 }
 

--- a/overlord/devicestate/firstboot.go
+++ b/overlord/devicestate/firstboot.go
@@ -516,7 +516,7 @@ func processAutoImportAssertions(st *state.State, deviceSeed seed.Seed, db asser
 	}
 	// automatic user creation is meant to imply sudoers
 	const sudoer = true
-	_, err = createAllKnownSystemUsers(st, db, deviceSeed.Model(), nil, sudoer, seclog.AddReasonFirstbootCreateUserFromSeedAutoImport)
+	_, err = createAllKnownSystemUsers(st, db, deviceSeed.Model(), nil, sudoer, seclog.AddReasonFirstbootSeedAutoImport)
 	return err
 }
 

--- a/overlord/devicestate/firstboot20_test.go
+++ b/overlord/devicestate/firstboot20_test.go
@@ -830,7 +830,7 @@ func (s *firstBoot20Suite) TestLoadDeviceSeedCore20DangerousAutoImport(c *C) {
 	var calledcreateAllUsers = false
 	r := devicestate.MockCreateAllKnownSystemUsers(func(state *state.State, assertDb asserts.RODatabase, model *asserts.Model, serial *asserts.Serial, sudoer bool, addReason seclog.SystemUserAddReason) ([]*devicestate.CreatedUser, error) {
 		calledcreateAllUsers = true
-		c.Check(addReason, Equals, seclog.AddReasonSeedFirstboot)
+		c.Check(addReason, Equals, seclog.AddReasonFirstbootCreateUserFromSeedAutoImport)
 		var createdUsers []*devicestate.CreatedUser
 		return createdUsers, nil
 	})

--- a/overlord/devicestate/firstboot20_test.go
+++ b/overlord/devicestate/firstboot20_test.go
@@ -830,7 +830,7 @@ func (s *firstBoot20Suite) TestLoadDeviceSeedCore20DangerousAutoImport(c *C) {
 	var calledcreateAllUsers = false
 	r := devicestate.MockCreateAllKnownSystemUsers(func(state *state.State, assertDb asserts.RODatabase, model *asserts.Model, serial *asserts.Serial, sudoer bool, addReason seclog.SystemUserAddReason) ([]*devicestate.CreatedUser, error) {
 		calledcreateAllUsers = true
-		c.Check(addReason, Equals, seclog.AddReasonFirstbootCreateUserFromSeedAutoImport)
+		c.Check(addReason, Equals, seclog.AddReasonFirstbootSeedAutoImport)
 		var createdUsers []*devicestate.CreatedUser
 		return createdUsers, nil
 	})

--- a/overlord/devicestate/firstboot20_test.go
+++ b/overlord/devicestate/firstboot20_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/seclog"
 	"github.com/snapcore/snapd/seed/seedtest"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/channel"
@@ -722,7 +723,7 @@ func (s *firstBoot20Suite) TestPopulateFromSeedCore20RecoverModeWithComps(c *C) 
 }
 
 func (s *firstBoot20Suite) TestLoadDeviceSeedCore20(c *C) {
-	r := devicestate.MockCreateAllKnownSystemUsers(func(state *state.State, assertDb asserts.RODatabase, model *asserts.Model, serial *asserts.Serial, sudoer bool) ([]*devicestate.CreatedUser, error) {
+	r := devicestate.MockCreateAllKnownSystemUsers(func(state *state.State, assertDb asserts.RODatabase, model *asserts.Model, serial *asserts.Serial, sudoer bool, addReason seclog.SystemUserAddReason) ([]*devicestate.CreatedUser, error) {
 		err := errors.New("unexpected call to CreateAllSystemUsers")
 		c.Error(err)
 		return nil, err
@@ -799,7 +800,7 @@ func (s *firstBoot20Suite) testProcessAutoImportAssertions(c *C, withAutoImportA
 }
 
 func (s *firstBoot20Suite) TestLoadDeviceSeedCore20DangerousNoAutoImport(c *C) {
-	r := devicestate.MockCreateAllKnownSystemUsers(func(state *state.State, assertDb asserts.RODatabase, model *asserts.Model, serial *asserts.Serial, sudoer bool) ([]*devicestate.CreatedUser, error) {
+	r := devicestate.MockCreateAllKnownSystemUsers(func(state *state.State, assertDb asserts.RODatabase, model *asserts.Model, serial *asserts.Serial, sudoer bool, addReason seclog.SystemUserAddReason) ([]*devicestate.CreatedUser, error) {
 		err := errors.New("unexpected call to CreateAllSystemUsers")
 		c.Error(err)
 		return nil, err
@@ -813,7 +814,7 @@ func (s *firstBoot20Suite) TestLoadDeviceSeedCore20DangerousNoAutoImport(c *C) {
 
 func (s *firstBoot20Suite) TestLoadDeviceSeedCore20DangerousAutoImportUserCreateFail(c *C) {
 	var calledcreateAllUsers = false
-	r := devicestate.MockCreateAllKnownSystemUsers(func(state *state.State, assertDb asserts.RODatabase, model *asserts.Model, serial *asserts.Serial, sudoer bool) ([]*devicestate.CreatedUser, error) {
+	r := devicestate.MockCreateAllKnownSystemUsers(func(state *state.State, assertDb asserts.RODatabase, model *asserts.Model, serial *asserts.Serial, sudoer bool, addReason seclog.SystemUserAddReason) ([]*devicestate.CreatedUser, error) {
 		calledcreateAllUsers = true
 		return nil, errors.New("User already exists")
 	})
@@ -827,8 +828,9 @@ func (s *firstBoot20Suite) TestLoadDeviceSeedCore20DangerousAutoImportUserCreate
 
 func (s *firstBoot20Suite) TestLoadDeviceSeedCore20DangerousAutoImport(c *C) {
 	var calledcreateAllUsers = false
-	r := devicestate.MockCreateAllKnownSystemUsers(func(state *state.State, assertDb asserts.RODatabase, model *asserts.Model, serial *asserts.Serial, sudoer bool) ([]*devicestate.CreatedUser, error) {
+	r := devicestate.MockCreateAllKnownSystemUsers(func(state *state.State, assertDb asserts.RODatabase, model *asserts.Model, serial *asserts.Serial, sudoer bool, addReason seclog.SystemUserAddReason) ([]*devicestate.CreatedUser, error) {
 		calledcreateAllUsers = true
+		c.Check(addReason, Equals, seclog.AddReasonSeedFirstboot)
 		var createdUsers []*devicestate.CreatedUser
 		return createdUsers, nil
 	})

--- a/overlord/devicestate/firstboot20_test.go
+++ b/overlord/devicestate/firstboot20_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/sandbox/cgroup"
+	"github.com/snapcore/snapd/seclog"
 	"github.com/snapcore/snapd/seed/seedtest"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/channel"
@@ -723,7 +724,7 @@ func (s *firstBoot20Suite) TestPopulateFromSeedCore20RecoverModeWithComps(c *C) 
 }
 
 func (s *firstBoot20Suite) TestLoadDeviceSeedCore20(c *C) {
-	r := devicestate.MockCreateAllKnownSystemUsers(func(state *state.State, assertDb asserts.RODatabase, model *asserts.Model, serial *asserts.Serial, sudoer bool) ([]*devicestate.CreatedUser, error) {
+	r := devicestate.MockCreateAllKnownSystemUsers(func(state *state.State, assertDb asserts.RODatabase, model *asserts.Model, serial *asserts.Serial, sudoer bool, addReason seclog.SystemUserAddReason) ([]*devicestate.CreatedUser, error) {
 		err := errors.New("unexpected call to CreateAllSystemUsers")
 		c.Error(err)
 		return nil, err
@@ -800,7 +801,7 @@ func (s *firstBoot20Suite) testProcessAutoImportAssertions(c *C, withAutoImportA
 }
 
 func (s *firstBoot20Suite) TestLoadDeviceSeedCore20DangerousNoAutoImport(c *C) {
-	r := devicestate.MockCreateAllKnownSystemUsers(func(state *state.State, assertDb asserts.RODatabase, model *asserts.Model, serial *asserts.Serial, sudoer bool) ([]*devicestate.CreatedUser, error) {
+	r := devicestate.MockCreateAllKnownSystemUsers(func(state *state.State, assertDb asserts.RODatabase, model *asserts.Model, serial *asserts.Serial, sudoer bool, addReason seclog.SystemUserAddReason) ([]*devicestate.CreatedUser, error) {
 		err := errors.New("unexpected call to CreateAllSystemUsers")
 		c.Error(err)
 		return nil, err
@@ -814,7 +815,7 @@ func (s *firstBoot20Suite) TestLoadDeviceSeedCore20DangerousNoAutoImport(c *C) {
 
 func (s *firstBoot20Suite) TestLoadDeviceSeedCore20DangerousAutoImportUserCreateFail(c *C) {
 	var calledcreateAllUsers = false
-	r := devicestate.MockCreateAllKnownSystemUsers(func(state *state.State, assertDb asserts.RODatabase, model *asserts.Model, serial *asserts.Serial, sudoer bool) ([]*devicestate.CreatedUser, error) {
+	r := devicestate.MockCreateAllKnownSystemUsers(func(state *state.State, assertDb asserts.RODatabase, model *asserts.Model, serial *asserts.Serial, sudoer bool, addReason seclog.SystemUserAddReason) ([]*devicestate.CreatedUser, error) {
 		calledcreateAllUsers = true
 		return nil, errors.New("User already exists")
 	})
@@ -828,8 +829,9 @@ func (s *firstBoot20Suite) TestLoadDeviceSeedCore20DangerousAutoImportUserCreate
 
 func (s *firstBoot20Suite) TestLoadDeviceSeedCore20DangerousAutoImport(c *C) {
 	var calledcreateAllUsers = false
-	r := devicestate.MockCreateAllKnownSystemUsers(func(state *state.State, assertDb asserts.RODatabase, model *asserts.Model, serial *asserts.Serial, sudoer bool) ([]*devicestate.CreatedUser, error) {
+	r := devicestate.MockCreateAllKnownSystemUsers(func(state *state.State, assertDb asserts.RODatabase, model *asserts.Model, serial *asserts.Serial, sudoer bool, addReason seclog.SystemUserAddReason) ([]*devicestate.CreatedUser, error) {
 		calledcreateAllUsers = true
+		c.Check(addReason, Equals, seclog.AddReasonFirstbootSeedAutoImport)
 		var createdUsers []*devicestate.CreatedUser
 		return createdUsers, nil
 	})

--- a/overlord/devicestate/users.go
+++ b/overlord/devicestate/users.go
@@ -80,7 +80,8 @@ func CreateUser(st *state.State, sudoer bool, email string, expiration time.Time
 	}
 
 	opts.Sudoer = sudoer
-	return addUser(st, username, email, expiration, opts, false)
+	const known = false
+	return addUser(st, username, email, expiration, opts, known)
 }
 
 // CreateKnownUsers creates known users. The user details are fetched
@@ -109,7 +110,8 @@ func CreateKnownUsers(st *state.State, sudoer bool, email string) ([]*CreatedUse
 	}
 
 	opts.Sudoer = sudoer
-	createdUser, err := addUser(st, username, email, expiration, opts, true)
+	const known = true
+	createdUser, err := addUser(st, username, email, expiration, opts, known)
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +205,8 @@ func createKnownSystemUser(state *state.State, userAssertion *asserts.SystemUser
 	}
 
 	addUserOpts.Sudoer = sudoer
-	return addUser(state, username, email, expiration, addUserOpts, true)
+	const known = true
+	return addUser(state, username, email, expiration, addUserOpts, known)
 }
 
 var createAllKnownSystemUsers = func(state *state.State, assertDb asserts.RODatabase, model *asserts.Model, serial *asserts.Serial, sudoer bool) ([]*CreatedUser, error) {

--- a/overlord/devicestate/users.go
+++ b/overlord/devicestate/users.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/snapcore/snapd/asserts"
@@ -34,6 +35,7 @@ import (
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/seclog"
 	"github.com/snapcore/snapd/strutil"
 )
 
@@ -78,7 +80,7 @@ func CreateUser(st *state.State, sudoer bool, email string, expiration time.Time
 	}
 
 	opts.Sudoer = sudoer
-	return addUser(st, username, email, expiration, opts)
+	return addUser(st, username, email, expiration, opts, false)
 }
 
 // CreateKnownUsers creates known users. The user details are fetched
@@ -107,7 +109,7 @@ func CreateKnownUsers(st *state.State, sudoer bool, email string) ([]*CreatedUse
 	}
 
 	opts.Sudoer = sudoer
-	createdUser, err := addUser(st, username, email, expiration, opts)
+	createdUser, err := addUser(st, username, email, expiration, opts, true)
 	if err != nil {
 		return nil, err
 	}
@@ -143,6 +145,8 @@ func RemoveUser(st *state.State, username string, opts *RemoveUserOptions) (*aut
 	if err := osutilDelUser(username, delUseropts); err != nil {
 		return nil, err
 	}
+
+	seclog.LogSystemUserRemoved(username, seclog.RemoveOptions{Force: opts.Force})
 
 	// then the UserState
 	u, err := auth.RemoveUserByUsername(st, username)
@@ -199,7 +203,7 @@ func createKnownSystemUser(state *state.State, userAssertion *asserts.SystemUser
 	}
 
 	addUserOpts.Sudoer = sudoer
-	return addUser(state, username, email, expiration, addUserOpts)
+	return addUser(state, username, email, expiration, addUserOpts, true)
 }
 
 var createAllKnownSystemUsers = func(state *state.State, assertDb asserts.RODatabase, model *asserts.Model, serial *asserts.Serial, sudoer bool) ([]*CreatedUser, error) {
@@ -334,11 +338,31 @@ func setupLocalUser(state *state.State, username, email string, expiration time.
 	return nil
 }
 
-func addUser(state *state.State, username string, email string, expiration time.Time, opts *osutil.AddUserOptions) (*CreatedUser, error) {
+func seclogAddOptions(opts *osutil.AddUserOptions, known bool) seclog.AddOptions {
+	// RealUserName is taken from the portion of Gecos after the first comma
+	// (assertion display name or store OpenID identifier).
+	addOpts := seclog.AddOptions{
+		Known:               known,
+		Sudoer:              opts.Sudoer,
+		ExtraUsers:          opts.ExtraUsers,
+		ForcePasswordChange: opts.ForcePasswordChange,
+	}
+	if _, realUserName, ok := strings.Cut(opts.Gecos, ","); ok {
+		addOpts.RealUserName = realUserName
+	}
+	return addOpts
+}
+
+func addUser(state *state.State, username string, email string, expiration time.Time, opts *osutil.AddUserOptions, known bool) (*CreatedUser, error) {
 	opts.ExtraUsers = !release.OnClassic
 	if err := osutilAddUser(username, opts); err != nil {
 		return nil, fmt.Errorf("cannot add user %q: %s", username, err)
 	}
+
+	// user_created_system records the Linux account, which exists even if
+	// setupLocalUser fails below.
+	seclog.LogSystemUserCreated(username, seclogAddOptions(opts, known))
+
 	if err := setupLocalUser(state, username, email, expiration); err != nil {
 		return nil, err
 	}

--- a/overlord/devicestate/users.go
+++ b/overlord/devicestate/users.go
@@ -360,10 +360,8 @@ func seclogAddOptions(opts *osutil.AddUserOptions, known bool) seclog.AddOptions
 }
 
 func seclogAssertionRef(a asserts.Assertion) *seclog.Ref {
-	ref := a.Ref()
 	return &seclog.Ref{
-		Type:       ref.Type.Name,
-		PrimaryKey: ref.PrimaryKey,
+		PrimaryKey: a.Ref().PrimaryKey,
 		Revision:   a.Revision(),
 	}
 }

--- a/overlord/devicestate/users.go
+++ b/overlord/devicestate/users.go
@@ -56,7 +56,8 @@ func (e *UserError) Error() string {
 }
 
 type RemoveUserOptions struct {
-	Force bool
+	Force        bool
+	RemoveReason seclog.SystemUserRemoveReason
 }
 
 // CreatedUser holds the results from a create user operation.
@@ -68,7 +69,7 @@ type CreatedUser struct {
 // CreateUser creates a Linux user based on the specified email.
 // The username and public ssh keys for the created account are
 // determined from Ubuntu store based on the email.
-func CreateUser(st *state.State, sudoer bool, email string, expiration time.Time) (*CreatedUser, error) {
+func CreateUser(st *state.State, sudoer bool, email string, expiration time.Time, addReason seclog.SystemUserAddReason) (*CreatedUser, error) {
 	if email == "" {
 		return nil, &UserError{Err: fmt.Errorf("cannot create user: 'email' field is empty")}
 	}
@@ -81,14 +82,14 @@ func CreateUser(st *state.State, sudoer bool, email string, expiration time.Time
 
 	opts.Sudoer = sudoer
 	const known = false
-	return addUser(st, username, email, expiration, opts, known, nil)
+	return addUser(st, username, email, expiration, opts, known, nil, addReason)
 }
 
 // CreateKnownUsers creates known users. The user details are fetched
 // from existing system user assertions.
 // If no email is passed, all known users will be created based on valid system user assertions.
 // If an email is passed, only the corresponding system user assertion is used.
-func CreateKnownUsers(st *state.State, sudoer bool, email string) ([]*CreatedUser, error) {
+func CreateKnownUsers(st *state.State, sudoer bool, email string, addReason seclog.SystemUserAddReason) ([]*CreatedUser, error) {
 	model, err := findModel(st)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create user: cannot get model assertion: %v", err)
@@ -101,7 +102,7 @@ func CreateKnownUsers(st *state.State, sudoer bool, email string) ([]*CreatedUse
 
 	db := assertstate.DB(st)
 	if email == "" {
-		return createAllKnownSystemUsers(st, db, model, serial, sudoer)
+		return createAllKnownSystemUsers(st, db, model, serial, sudoer, addReason)
 	}
 
 	username, expiration, opts, userAssertion, err := getUserDetailsFromAssertion(db, model, serial, email)
@@ -111,7 +112,7 @@ func CreateKnownUsers(st *state.State, sudoer bool, email string) ([]*CreatedUse
 
 	opts.Sudoer = sudoer
 	const known = true
-	createdUser, err := addUser(st, username, email, expiration, opts, known, userAssertion)
+	createdUser, err := addUser(st, username, email, expiration, opts, known, userAssertion, addReason)
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +149,9 @@ func RemoveUser(st *state.State, username string, opts *RemoveUserOptions) (*aut
 		return nil, err
 	}
 
-	seclog.LogSystemUserRemoved(username, seclog.RemoveOptions{Force: opts.Force})
+	seclog.LogSystemUserRemoved(username, seclog.RemoveOptions{
+		Force: opts.Force,
+	}, opts.RemoveReason)
 
 	// then the UserState
 	u, err := auth.RemoveUserByUsername(st, username)
@@ -185,7 +188,7 @@ func getUserDetailsFromStore(st *state.State, theStore snapstate.StoreService, e
 	return v.Username, opts, nil
 }
 
-func createKnownSystemUser(state *state.State, userAssertion *asserts.SystemUser, assertDb asserts.RODatabase, model *asserts.Model, serial *asserts.Serial, sudoer bool) (*CreatedUser, error) {
+func createKnownSystemUser(state *state.State, userAssertion *asserts.SystemUser, assertDb asserts.RODatabase, model *asserts.Model, serial *asserts.Serial, sudoer bool, addReason seclog.SystemUserAddReason) (*CreatedUser, error) {
 	email := userAssertion.Email()
 	// we need to use getUserDetailsFromAssertion as this verifies
 	// the assertion against the current brand/model/time
@@ -206,10 +209,10 @@ func createKnownSystemUser(state *state.State, userAssertion *asserts.SystemUser
 
 	addUserOpts.Sudoer = sudoer
 	const known = true
-	return addUser(state, username, email, expiration, addUserOpts, known, userAssertion)
+	return addUser(state, username, email, expiration, addUserOpts, known, userAssertion, addReason)
 }
 
-var createAllKnownSystemUsers = func(state *state.State, assertDb asserts.RODatabase, model *asserts.Model, serial *asserts.Serial, sudoer bool) ([]*CreatedUser, error) {
+var createAllKnownSystemUsers = func(state *state.State, assertDb asserts.RODatabase, model *asserts.Model, serial *asserts.Serial, sudoer bool, addReason seclog.SystemUserAddReason) ([]*CreatedUser, error) {
 	headers := map[string]string{
 		"brand-id": model.BrandID(),
 	}
@@ -222,7 +225,7 @@ var createAllKnownSystemUsers = func(state *state.State, assertDb asserts.ROData
 	var createdUsers []*CreatedUser
 	for _, as := range assertions {
 		userAs := as.(*asserts.SystemUser)
-		createdUser, err := createKnownSystemUser(state, userAs, assertDb, model, serial, sudoer)
+		createdUser, err := createKnownSystemUser(state, userAs, assertDb, model, serial, sudoer, addReason)
 		if err != nil {
 			if errors.Is(err, errSystemUserBoundToSerialButTooEarly) {
 				state.Set("system-user-waiting-on-serial", true)
@@ -365,7 +368,7 @@ func seclogAssertionRef(a asserts.Assertion) *seclog.Ref {
 	}
 }
 
-func addUser(state *state.State, username string, email string, expiration time.Time, opts *osutil.AddUserOptions, known bool, assertion asserts.Assertion) (*CreatedUser, error) {
+func addUser(state *state.State, username string, email string, expiration time.Time, opts *osutil.AddUserOptions, known bool, assertion asserts.Assertion, addReason seclog.SystemUserAddReason) (*CreatedUser, error) {
 	opts.ExtraUsers = !release.OnClassic
 	if err := osutilAddUser(username, opts); err != nil {
 		return nil, fmt.Errorf("cannot add user %q: %s", username, err)
@@ -377,7 +380,7 @@ func addUser(state *state.State, username string, email string, expiration time.
 	if assertion != nil {
 		addOpts.Assertion = seclogAssertionRef(assertion)
 	}
-	seclog.LogSystemUserCreated(username, addOpts)
+	seclog.LogSystemUserCreated(username, addOpts, addReason)
 
 	if err := setupLocalUser(state, username, email, expiration); err != nil {
 		return nil, err

--- a/overlord/devicestate/users.go
+++ b/overlord/devicestate/users.go
@@ -81,7 +81,7 @@ func CreateUser(st *state.State, sudoer bool, email string, expiration time.Time
 
 	opts.Sudoer = sudoer
 	const known = false
-	return addUser(st, username, email, expiration, opts, known)
+	return addUser(st, username, email, expiration, opts, known, nil)
 }
 
 // CreateKnownUsers creates known users. The user details are fetched
@@ -104,14 +104,14 @@ func CreateKnownUsers(st *state.State, sudoer bool, email string) ([]*CreatedUse
 		return createAllKnownSystemUsers(st, db, model, serial, sudoer)
 	}
 
-	username, expiration, opts, err := getUserDetailsFromAssertion(db, model, serial, email)
+	username, expiration, opts, userAssertion, err := getUserDetailsFromAssertion(db, model, serial, email)
 	if err != nil {
 		return nil, &UserError{Err: fmt.Errorf("cannot create user %q: %v", email, err)}
 	}
 
 	opts.Sudoer = sudoer
 	const known = true
-	createdUser, err := addUser(st, username, email, expiration, opts, known)
+	createdUser, err := addUser(st, username, email, expiration, opts, known, userAssertion)
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +189,7 @@ func createKnownSystemUser(state *state.State, userAssertion *asserts.SystemUser
 	email := userAssertion.Email()
 	// we need to use getUserDetailsFromAssertion as this verifies
 	// the assertion against the current brand/model/time
-	username, expiration, addUserOpts, err := getUserDetailsFromAssertion(assertDb, model, serial, email)
+	username, expiration, addUserOpts, userAssertion, err := getUserDetailsFromAssertion(assertDb, model, serial, email)
 	if err != nil {
 		if errors.Is(err, errSystemUserBoundToSerialButTooEarly) {
 			// let callers decide how to proceed
@@ -206,7 +206,7 @@ func createKnownSystemUser(state *state.State, userAssertion *asserts.SystemUser
 
 	addUserOpts.Sudoer = sudoer
 	const known = true
-	return addUser(state, username, email, expiration, addUserOpts, known)
+	return addUser(state, username, email, expiration, addUserOpts, known, userAssertion)
 }
 
 var createAllKnownSystemUsers = func(state *state.State, assertDb asserts.RODatabase, model *asserts.Model, serial *asserts.Serial, sudoer bool) ([]*CreatedUser, error) {
@@ -242,7 +242,7 @@ var createAllKnownSystemUsers = func(state *state.State, assertDb asserts.ROData
 
 var errSystemUserBoundToSerialButTooEarly = errors.New("bound to serial assertion but device not yet registered")
 
-func getUserDetailsFromAssertion(assertDb asserts.RODatabase, modelAs *asserts.Model, serialAs *asserts.Serial, email string) (string, time.Time, *osutil.AddUserOptions, error) {
+func getUserDetailsFromAssertion(assertDb asserts.RODatabase, modelAs *asserts.Model, serialAs *asserts.Serial, email string) (string, time.Time, *osutil.AddUserOptions, *asserts.SystemUser, error) {
 	brandID := modelAs.BrandID()
 	series := modelAs.Series()
 	model := modelAs.Model()
@@ -252,7 +252,7 @@ func getUserDetailsFromAssertion(assertDb asserts.RODatabase, modelAs *asserts.M
 		"email":    email,
 	})
 	if err != nil {
-		return "", time.Time{}, nil, err
+		return "", time.Time{}, nil, nil, err
 	}
 	// the asserts package guarantees that this cast will work
 	su := a.(*asserts.SystemUser)
@@ -260,27 +260,27 @@ func getUserDetailsFromAssertion(assertDb asserts.RODatabase, modelAs *asserts.M
 	// check that the signer of the assertion is one of the accepted ones
 	sysUserAuths := modelAs.SystemUserAuthority()
 	if len(sysUserAuths) > 0 && !strutil.ListContains(sysUserAuths, su.AuthorityID()) {
-		return "", time.Time{}, nil, fmt.Errorf("%q not in accepted authorities %q", su.AuthorityID(), sysUserAuths)
+		return "", time.Time{}, nil, nil, fmt.Errorf("%q not in accepted authorities %q", su.AuthorityID(), sysUserAuths)
 	}
 	// cross check that the assertion is valid for the given series/model
 	if len(su.Series()) > 0 && !strutil.ListContains(su.Series(), series) {
-		return "", time.Time{}, nil, fmt.Errorf("%q not in series %q", series, su.Series())
+		return "", time.Time{}, nil, nil, fmt.Errorf("%q not in series %q", series, su.Series())
 	}
 	if len(su.Models()) > 0 && !strutil.ListContains(su.Models(), model) {
-		return "", time.Time{}, nil, fmt.Errorf("%q not in models %q", model, su.Models())
+		return "", time.Time{}, nil, nil, fmt.Errorf("%q not in models %q", model, su.Models())
 	}
 	if len(su.Serials()) > 0 {
 		if serialAs == nil {
-			return "", time.Time{}, nil, errSystemUserBoundToSerialButTooEarly
+			return "", time.Time{}, nil, nil, errSystemUserBoundToSerialButTooEarly
 		}
 		serial := serialAs.Serial()
 		if !strutil.ListContains(su.Serials(), serial) {
-			return "", time.Time{}, nil, fmt.Errorf("%q not in serials %q", serial, su.Serials())
+			return "", time.Time{}, nil, nil, fmt.Errorf("%q not in serials %q", serial, su.Serials())
 		}
 	}
 
 	if !su.ValidAt(time.Now()) {
-		return "", time.Time{}, nil, fmt.Errorf("assertion not valid anymore")
+		return "", time.Time{}, nil, nil, fmt.Errorf("assertion not valid anymore")
 	}
 
 	gecos := fmt.Sprintf("%s,%s", email, su.Name())
@@ -290,7 +290,7 @@ func getUserDetailsFromAssertion(assertDb asserts.RODatabase, modelAs *asserts.M
 		Password:            su.Password(),
 		ForcePasswordChange: su.ForcePasswordChange(),
 	}
-	return su.Username(), su.UserExpiration(), opts, nil
+	return su.Username(), su.UserExpiration(), opts, su, nil
 }
 
 func setupLocalUser(state *state.State, username, email string, expiration time.Time) error {
@@ -356,7 +356,16 @@ func seclogAddOptions(opts *osutil.AddUserOptions, known bool) seclog.AddOptions
 	return addOpts
 }
 
-func addUser(state *state.State, username string, email string, expiration time.Time, opts *osutil.AddUserOptions, known bool) (*CreatedUser, error) {
+func seclogAssertionRef(a asserts.Assertion) *seclog.Ref {
+	ref := a.Ref()
+	return &seclog.Ref{
+		Type:       ref.Type.Name,
+		PrimaryKey: ref.PrimaryKey,
+		Revision:   a.Revision(),
+	}
+}
+
+func addUser(state *state.State, username string, email string, expiration time.Time, opts *osutil.AddUserOptions, known bool, assertion asserts.Assertion) (*CreatedUser, error) {
 	opts.ExtraUsers = !release.OnClassic
 	if err := osutilAddUser(username, opts); err != nil {
 		return nil, fmt.Errorf("cannot add user %q: %s", username, err)
@@ -364,7 +373,11 @@ func addUser(state *state.State, username string, email string, expiration time.
 
 	// user_created_system records the Linux account, which exists even if
 	// setupLocalUser fails below.
-	seclog.LogSystemUserCreated(username, seclogAddOptions(opts, known))
+	addOpts := seclogAddOptions(opts, known)
+	if assertion != nil {
+		addOpts.Assertion = seclogAssertionRef(assertion)
+	}
+	seclog.LogSystemUserCreated(username, addOpts)
 
 	if err := setupLocalUser(state, username, email, expiration); err != nil {
 		return nil, err

--- a/overlord/devicestate/users.go
+++ b/overlord/devicestate/users.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/snapcore/snapd/asserts"
@@ -34,6 +35,7 @@ import (
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
 	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/seclog"
 	"github.com/snapcore/snapd/strutil"
 )
 
@@ -54,7 +56,8 @@ func (e *UserError) Error() string {
 }
 
 type RemoveUserOptions struct {
-	Force bool
+	Force        bool
+	RemoveReason seclog.SystemUserRemoveReason
 }
 
 // CreatedUser holds the results from a create user operation.
@@ -66,7 +69,7 @@ type CreatedUser struct {
 // CreateUser creates a Linux user based on the specified email.
 // The username and public ssh keys for the created account are
 // determined from Ubuntu store based on the email.
-func CreateUser(st *state.State, sudoer bool, email string, expiration time.Time) (*CreatedUser, error) {
+func CreateUser(st *state.State, sudoer bool, email string, expiration time.Time, addReason seclog.SystemUserAddReason) (*CreatedUser, error) {
 	if email == "" {
 		return nil, &UserError{Err: fmt.Errorf("cannot create user: 'email' field is empty")}
 	}
@@ -78,14 +81,15 @@ func CreateUser(st *state.State, sudoer bool, email string, expiration time.Time
 	}
 
 	opts.Sudoer = sudoer
-	return addUser(st, username, email, expiration, opts)
+	// no assertion: the account details came from the store
+	return addUser(st, username, email, expiration, opts, nil, addReason)
 }
 
 // CreateKnownUsers creates known users. The user details are fetched
 // from existing system user assertions.
 // If no email is passed, all known users will be created based on valid system user assertions.
 // If an email is passed, only the corresponding system user assertion is used.
-func CreateKnownUsers(st *state.State, sudoer bool, email string) ([]*CreatedUser, error) {
+func CreateKnownUsers(st *state.State, sudoer bool, email string, addReason seclog.SystemUserAddReason) ([]*CreatedUser, error) {
 	model, err := findModel(st)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create user: cannot get model assertion: %v", err)
@@ -98,16 +102,17 @@ func CreateKnownUsers(st *state.State, sudoer bool, email string) ([]*CreatedUse
 
 	db := assertstate.DB(st)
 	if email == "" {
-		return createAllKnownSystemUsers(st, db, model, serial, sudoer)
+		return createAllKnownSystemUsers(st, db, model, serial, sudoer, addReason)
 	}
 
-	username, expiration, opts, err := getUserDetailsFromAssertion(db, model, serial, email)
+	userAssertion, err := findVerifiedSystemUserAssertion(db, model, serial, email)
 	if err != nil {
 		return nil, &UserError{Err: fmt.Errorf("cannot create user %q: %v", email, err)}
 	}
 
+	opts := addUserOptionsFromAssertion(userAssertion)
 	opts.Sudoer = sudoer
-	createdUser, err := addUser(st, username, email, expiration, opts)
+	createdUser, err := addUser(st, userAssertion.Username(), email, userAssertion.UserExpiration(), opts, userAssertion, addReason)
 	if err != nil {
 		return nil, err
 	}
@@ -144,6 +149,10 @@ func RemoveUser(st *state.State, username string, opts *RemoveUserOptions) (*aut
 		return nil, err
 	}
 
+	seclog.LogSystemUserRemoved(username, seclog.SystemUserRemoveOptions{
+		Force: opts.Force,
+	}, opts.RemoveReason)
+
 	// then the UserState
 	u, err := auth.RemoveUserByUsername(st, username)
 	// ErrInvalidUser means "not found" in this case
@@ -179,11 +188,11 @@ func getUserDetailsFromStore(st *state.State, theStore snapstate.StoreService, e
 	return v.Username, opts, nil
 }
 
-func createKnownSystemUser(state *state.State, userAssertion *asserts.SystemUser, assertDb asserts.RODatabase, model *asserts.Model, serial *asserts.Serial, sudoer bool) (*CreatedUser, error) {
+func createKnownSystemUser(state *state.State, userAssertion *asserts.SystemUser, assertDb asserts.RODatabase, model *asserts.Model, serial *asserts.Serial, sudoer bool, addReason seclog.SystemUserAddReason) (*CreatedUser, error) {
 	email := userAssertion.Email()
-	// we need to use getUserDetailsFromAssertion as this verifies
-	// the assertion against the current brand/model/time
-	username, expiration, addUserOpts, err := getUserDetailsFromAssertion(assertDb, model, serial, email)
+	// re-find the assertion, as this verifies it against the current
+	// brand/model/serial/time
+	verifiedAssertion, err := findVerifiedSystemUserAssertion(assertDb, model, serial, email)
 	if err != nil {
 		if errors.Is(err, errSystemUserBoundToSerialButTooEarly) {
 			// let callers decide how to proceed
@@ -193,16 +202,19 @@ func createKnownSystemUser(state *state.State, userAssertion *asserts.SystemUser
 		return nil, nil
 	}
 
+	username := verifiedAssertion.Username()
+
 	// ignore already existing users
 	if _, err := userLookup(username); err == nil {
 		return nil, nil
 	}
 
+	addUserOpts := addUserOptionsFromAssertion(verifiedAssertion)
 	addUserOpts.Sudoer = sudoer
-	return addUser(state, username, email, expiration, addUserOpts)
+	return addUser(state, username, email, verifiedAssertion.UserExpiration(), addUserOpts, verifiedAssertion, addReason)
 }
 
-var createAllKnownSystemUsers = func(state *state.State, assertDb asserts.RODatabase, model *asserts.Model, serial *asserts.Serial, sudoer bool) ([]*CreatedUser, error) {
+var createAllKnownSystemUsers = func(state *state.State, assertDb asserts.RODatabase, model *asserts.Model, serial *asserts.Serial, sudoer bool, addReason seclog.SystemUserAddReason) ([]*CreatedUser, error) {
 	headers := map[string]string{
 		"brand-id": model.BrandID(),
 	}
@@ -215,7 +227,7 @@ var createAllKnownSystemUsers = func(state *state.State, assertDb asserts.ROData
 	var createdUsers []*CreatedUser
 	for _, as := range assertions {
 		userAs := as.(*asserts.SystemUser)
-		createdUser, err := createKnownSystemUser(state, userAs, assertDb, model, serial, sudoer)
+		createdUser, err := createKnownSystemUser(state, userAs, assertDb, model, serial, sudoer, addReason)
 		if err != nil {
 			if errors.Is(err, errSystemUserBoundToSerialButTooEarly) {
 				state.Set("system-user-waiting-on-serial", true)
@@ -235,7 +247,10 @@ var createAllKnownSystemUsers = func(state *state.State, assertDb asserts.ROData
 
 var errSystemUserBoundToSerialButTooEarly = errors.New("bound to serial assertion but device not yet registered")
 
-func getUserDetailsFromAssertion(assertDb asserts.RODatabase, modelAs *asserts.Model, serialAs *asserts.Serial, email string) (string, time.Time, *osutil.AddUserOptions, error) {
+// findVerifiedSystemUserAssertion returns the system-user assertion for email,
+// checked against the accepted system-user authorities and cross checked
+// against the current series, model, serial and time.
+func findVerifiedSystemUserAssertion(assertDb asserts.RODatabase, modelAs *asserts.Model, serialAs *asserts.Serial, email string) (*asserts.SystemUser, error) {
 	brandID := modelAs.BrandID()
 	series := modelAs.Series()
 	model := modelAs.Model()
@@ -245,7 +260,7 @@ func getUserDetailsFromAssertion(assertDb asserts.RODatabase, modelAs *asserts.M
 		"email":    email,
 	})
 	if err != nil {
-		return "", time.Time{}, nil, err
+		return nil, err
 	}
 	// the asserts package guarantees that this cast will work
 	su := a.(*asserts.SystemUser)
@@ -253,37 +268,42 @@ func getUserDetailsFromAssertion(assertDb asserts.RODatabase, modelAs *asserts.M
 	// check that the signer of the assertion is one of the accepted ones
 	sysUserAuths := modelAs.SystemUserAuthority()
 	if len(sysUserAuths) > 0 && !strutil.ListContains(sysUserAuths, su.AuthorityID()) {
-		return "", time.Time{}, nil, fmt.Errorf("%q not in accepted authorities %q", su.AuthorityID(), sysUserAuths)
+		return nil, fmt.Errorf("%q not in accepted authorities %q", su.AuthorityID(), sysUserAuths)
 	}
 	// cross check that the assertion is valid for the given series/model
 	if len(su.Series()) > 0 && !strutil.ListContains(su.Series(), series) {
-		return "", time.Time{}, nil, fmt.Errorf("%q not in series %q", series, su.Series())
+		return nil, fmt.Errorf("%q not in series %q", series, su.Series())
 	}
 	if len(su.Models()) > 0 && !strutil.ListContains(su.Models(), model) {
-		return "", time.Time{}, nil, fmt.Errorf("%q not in models %q", model, su.Models())
+		return nil, fmt.Errorf("%q not in models %q", model, su.Models())
 	}
 	if len(su.Serials()) > 0 {
 		if serialAs == nil {
-			return "", time.Time{}, nil, errSystemUserBoundToSerialButTooEarly
+			return nil, errSystemUserBoundToSerialButTooEarly
 		}
 		serial := serialAs.Serial()
 		if !strutil.ListContains(su.Serials(), serial) {
-			return "", time.Time{}, nil, fmt.Errorf("%q not in serials %q", serial, su.Serials())
+			return nil, fmt.Errorf("%q not in serials %q", serial, su.Serials())
 		}
 	}
 
 	if !su.ValidAt(time.Now()) {
-		return "", time.Time{}, nil, fmt.Errorf("assertion not valid anymore")
+		return nil, fmt.Errorf("assertion not valid anymore")
 	}
 
-	gecos := fmt.Sprintf("%s,%s", email, su.Name())
-	opts := &osutil.AddUserOptions{
+	return su, nil
+}
+
+// addUserOptionsFromAssertion derives the options for creating the local
+// account described by su. It performs no lookup or verification, so callers
+// must pass an assertion obtained from findVerifiedSystemUserAssertion.
+func addUserOptionsFromAssertion(su *asserts.SystemUser) *osutil.AddUserOptions {
+	return &osutil.AddUserOptions{
 		SSHKeys:             su.SSHKeys(),
-		Gecos:               gecos,
+		Gecos:               fmt.Sprintf("%s,%s", su.Email(), su.Name()),
 		Password:            su.Password(),
 		ForcePasswordChange: su.ForcePasswordChange(),
 	}
-	return su.Username(), su.UserExpiration(), opts, nil
 }
 
 func setupLocalUser(state *state.State, username, email string, expiration time.Time) error {
@@ -334,11 +354,45 @@ func setupLocalUser(state *state.State, username, email string, expiration time.
 	return nil
 }
 
-func addUser(state *state.State, username string, email string, expiration time.Time, opts *osutil.AddUserOptions) (*CreatedUser, error) {
+func seclogAddOptions(opts *osutil.AddUserOptions, userAssertion *asserts.SystemUser) seclog.SystemUserAddOptions {
+	// RealUserName is taken from the portion of Gecos after the first comma
+	// (assertion display name or store OpenID identifier).
+	addOpts := seclog.SystemUserAddOptions{
+		Known:               userAssertion != nil,
+		Sudoer:              opts.Sudoer,
+		ExtraUsers:          opts.ExtraUsers,
+		ForcePasswordChange: opts.ForcePasswordChange,
+	}
+	if _, realUserName, ok := strings.Cut(opts.Gecos, ","); ok {
+		addOpts.RealUserName = realUserName
+	}
+	if userAssertion != nil {
+		addOpts.Assertion = seclogAssertionRef(userAssertion)
+	}
+	return addOpts
+}
+
+func seclogAssertionRef(a *asserts.SystemUser) *seclog.AssertionRef {
+	ref := a.Ref()
+	return &seclog.AssertionRef{
+		Type:       ref.Type.Name,
+		PrimaryKey: ref.PrimaryKey,
+		Revision:   a.Revision(),
+	}
+}
+
+// addUser creates the local account and records the audit event. A non-nil
+// userAssertion means the account is assertion-backed, logged as known.
+func addUser(state *state.State, username string, email string, expiration time.Time, opts *osutil.AddUserOptions, userAssertion *asserts.SystemUser, addReason seclog.SystemUserAddReason) (*CreatedUser, error) {
 	opts.ExtraUsers = !release.OnClassic
 	if err := osutilAddUser(username, opts); err != nil {
 		return nil, fmt.Errorf("cannot add user %q: %s", username, err)
 	}
+
+	// user_created_system records the Linux account, which exists even if
+	// setupLocalUser fails below.
+	seclog.LogSystemUserCreated(username, seclogAddOptions(opts, userAssertion), addReason)
+
 	if err := setupLocalUser(state, username, email, expiration); err != nil {
 		return nil, err
 	}

--- a/overlord/devicestate/users.go
+++ b/overlord/devicestate/users.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/snapcore/snapd/asserts"
@@ -354,33 +353,6 @@ func setupLocalUser(state *state.State, username, email string, expiration time.
 	return nil
 }
 
-func seclogAddOptions(opts *osutil.AddUserOptions, userAssertion *asserts.SystemUser) seclog.SystemUserAddOptions {
-	// RealUserName is taken from the portion of Gecos after the first comma
-	// (assertion display name or store OpenID identifier).
-	addOpts := seclog.SystemUserAddOptions{
-		Known:               userAssertion != nil,
-		Sudoer:              opts.Sudoer,
-		ExtraUsers:          opts.ExtraUsers,
-		ForcePasswordChange: opts.ForcePasswordChange,
-	}
-	if _, realUserName, ok := strings.Cut(opts.Gecos, ","); ok {
-		addOpts.RealUserName = realUserName
-	}
-	if userAssertion != nil {
-		addOpts.Assertion = seclogAssertionRef(userAssertion)
-	}
-	return addOpts
-}
-
-func seclogAssertionRef(a *asserts.SystemUser) *seclog.AssertionRef {
-	ref := a.Ref()
-	return &seclog.AssertionRef{
-		Type:       ref.Type.Name,
-		PrimaryKey: ref.PrimaryKey,
-		Revision:   a.Revision(),
-	}
-}
-
 // addUser creates the local account and records the audit event. A non-nil
 // userAssertion means the account is assertion-backed, logged as known.
 func addUser(state *state.State, username string, email string, expiration time.Time, opts *osutil.AddUserOptions, userAssertion *asserts.SystemUser, addReason seclog.SystemUserAddReason) (*CreatedUser, error) {
@@ -391,7 +363,7 @@ func addUser(state *state.State, username string, email string, expiration time.
 
 	// user_created_system records the Linux account, which exists even if
 	// setupLocalUser fails below.
-	seclog.LogSystemUserCreated(username, seclogAddOptions(opts, userAssertion), addReason)
+	seclog.LogSystemUserCreated(username, seclog.SystemUserAddOptionsFrom(opts, userAssertion), addReason)
 
 	if err := setupLocalUser(state, username, email, expiration); err != nil {
 		return nil, err

--- a/seclog/eventdata.go
+++ b/seclog/eventdata.go
@@ -223,6 +223,39 @@ func (u SnapdUser) String() string {
 	return id + ":" + email + ":" + name
 }
 
+// SystemUserAddReason identifies why a system user account was created.
+// Values are logged as add_reason on user_created_system events.
+type SystemUserAddReason string
+
+// SystemUserAddReason values for user_created_system events.
+const (
+	// AddReasonAdminStore is set when an operator requested a user from store email lookup.
+	AddReasonAdminStore SystemUserAddReason = "admin-store"
+	// AddReasonAdminAssertion is set when an operator requested one assertion-backed user by email.
+	AddReasonAdminAssertion SystemUserAddReason = "admin-assertion"
+	// AddReasonAdminKnownAll is set when an operator requested all valid assertion users.
+	AddReasonAdminKnownAll SystemUserAddReason = "admin-known-all"
+	// AddReasonAutoProvision is set for unattended automatic provisioning via the
+	// user-admin API (automatic: true), e.g. snap auto-import.
+	AddReasonAutoProvision SystemUserAddReason = "admin-auto-provision"
+	// AddReasonSeedFirstboot is set when users are created from seed auto-import on dangerous models.
+	AddReasonSeedFirstboot SystemUserAddReason = "seed-firstboot"
+	// AddReasonSerialBound is set when a serial-bound assertion is applied after registration.
+	AddReasonSerialBound SystemUserAddReason = "serial-bound"
+)
+
+// SystemUserRemoveReason identifies why a system user account was removed.
+// Values are logged as remove_reason on user_removed_system events.
+type SystemUserRemoveReason string
+
+// SystemUserRemoveReason values for user_removed_system events.
+const (
+	// RemoveReasonAdminRemove is set when an operator explicitly removed the account.
+	RemoveReasonAdminRemove SystemUserRemoveReason = "admin-remove"
+	// RemoveReasonExpired is set when an expired account was removed by the ensure loop.
+	RemoveReasonExpired SystemUserRemoveReason = "expired"
+)
+
 // Ref identifies an assertion by type and primary key. It mirrors asserts.Ref
 // but uses plain strings so seclog stays import-free.
 type Ref struct {

--- a/seclog/eventdata.go
+++ b/seclog/eventdata.go
@@ -231,33 +231,31 @@ type SystemUserAddReason string
 
 // SystemUserAddReason values for user_created_system events.
 const (
-	// AddReasonAPICreateUserFromStoreCredentials is set when POST /v2/users or
-	// POST /v2/create-user creates a system user with known: false; account
-	// details are looked up from the Snap Store by email.
-	AddReasonAPICreateUserFromStoreCredentials SystemUserAddReason = "api-create-user-from-store-credentials"
-	// AddReasonAPICreateUserFromAssertion is set when POST /v2/users or
-	// POST /v2/create-user creates one user with known: true and an email;
-	// details come from a pre-imported system-user assertion selected by
-	// brand-id and email.
-	AddReasonAPICreateUserFromAssertion SystemUserAddReason = "api-create-user-from-assertion"
-	// AddReasonAPICreateUserFromAllAssertions is set when POST /v2/users or
-	// POST /v2/create-user creates every applicable system user with known: true
-	// and no email; details come from all valid pre-imported system-user
-	// assertions for the device model.
-	AddReasonAPICreateUserFromAllAssertions SystemUserAddReason = "api-create-user-from-all-assertions"
+	// AddReasonAPIStoreEmail is set when POST /v2/users or POST /v2/create-user
+	// creates a system user with known: false; account details are looked up
+	// from the Snap Store by email.
+	AddReasonAPIStoreEmail SystemUserAddReason = "api-store-email"
+	// AddReasonAPIAssertion is set when POST /v2/users or POST /v2/create-user
+	// creates one user with known: true and an email; details come from a
+	// pre-imported system-user assertion selected by brand-id and email.
+	AddReasonAPIAssertion SystemUserAddReason = "api-assertion"
+	// AddReasonAPIAssertionAll is set when POST /v2/users or POST /v2/create-user
+	// creates every applicable system user with known: true and no email; details
+	// come from all valid pre-imported system-user assertions for the device model.
+	AddReasonAPIAssertionAll SystemUserAddReason = "api-assertion-all"
 	// AddReasonAPICreateUserFromAllAssertionsAutomatic is set when POST /v2/users
 	// or POST /v2/create-user is called with automatic: true (e.g. snap
 	// auto-import); all applicable assertion-backed users are created on an
 	// unmanaged device.
 	AddReasonAPICreateUserFromAllAssertionsAutomatic SystemUserAddReason = "api-create-user-from-all-assertions-automatic"
-	// AddReasonFirstbootCreateUserFromSeedAutoImport is set during first boot on
-	// dangerous models when system-user assertions from the seed are
-	// auto-imported and applied (not via the user-admin API).
-	AddReasonFirstbootCreateUserFromSeedAutoImport SystemUserAddReason = "firstboot-create-user-from-seed-auto-import"
-	// AddReasonEnsureCreateUserFromSerialBoundAssertion is set when the device
-	// manager ensure loop creates users from serial-bound system-user assertions
-	// that could not be applied until after device registration.
-	AddReasonEnsureCreateUserFromSerialBoundAssertion SystemUserAddReason = "ensure-create-user-from-serial-bound-assertion"
+	// AddReasonFirstbootSeedAutoImport is set during first boot on dangerous
+	// models when system-user assertions from the seed are auto-imported and
+	// applied (not via the user-admin API).
+	AddReasonFirstbootSeedAutoImport SystemUserAddReason = "firstboot-seed-auto-import"
+	// AddReasonDeferredSerialBoundAssertion is set when the device manager
+	// ensure loop creates users from serial-bound system-user assertions that
+	// could not be applied until after device registration.
+	AddReasonDeferredSerialBoundAssertion SystemUserAddReason = "deferred-serial-bound-assertion"
 )
 
 // SystemUserRemoveReason identifies why a system user account was removed.

--- a/seclog/eventdata.go
+++ b/seclog/eventdata.go
@@ -223,6 +223,16 @@ func (u SnapdUser) String() string {
 	return id + ":" + email + ":" + name
 }
 
+// Ref identifies an assertion by type and primary key. It mirrors asserts.Ref
+// but uses plain strings so seclog stays import-free.
+type Ref struct {
+	Type       string   `json:"type"`
+	PrimaryKey []string `json:"primary_key"`
+	// Revision is the assertion revision applied when the user was created.
+	// It supplements the ref; the ref itself is the store-shared identity.
+	Revision int `json:"revision,omitempty"`
+}
+
 // AddOptions holds the options recorded for a system user creation event.
 // JSON tags match the security audit specification field names.
 type AddOptions struct {
@@ -241,6 +251,8 @@ type AddOptions struct {
 	// Known is true when the account was created from a system-user assertion
 	// rather than from a store email lookup.
 	Known bool `json:"known"`
+	// Assertion is set when Known is true; identifies the system-user assertion used.
+	Assertion *Ref `json:"assertion,omitempty"`
 }
 
 // RemoveOptions holds the options recorded for a system user removal event.

--- a/seclog/eventdata.go
+++ b/seclog/eventdata.go
@@ -226,15 +226,26 @@ func (u SnapdUser) String() string {
 // AddOptions holds the options recorded for a system user creation event.
 // JSON tags match the security audit specification field names.
 type AddOptions struct {
-	RealUserName        string `json:"real_user_name"`
-	Sudoer              bool   `json:"sudoer"`
-	ExtraUsers          bool   `json:"extra_users"`
-	ForcePasswordChange bool   `json:"force_password_change"`
-	Known               bool   `json:"known"`
+	// RealUserName is the display name from the GECOS field of the created
+	// account. devicestate populates Gecos as "email,display-name" for
+	// osutil.AddUser; this field is the portion after the comma.
+	RealUserName string `json:"real_user_name"`
+	// Sudoer is true when the account was created with sudo privileges.
+	Sudoer bool `json:"sudoer"`
+	// ExtraUsers is true when the account was created in the extrausers
+	// database (Ubuntu Core) rather than /etc/passwd.
+	ExtraUsers bool `json:"extra_users"`
+	// ForcePasswordChange is true when the user must change their password
+	// on first login.
+	ForcePasswordChange bool `json:"force_password_change"`
+	// Known is true when the account was created from a system-user assertion
+	// rather than from a store email lookup.
+	Known bool `json:"known"`
 }
 
 // RemoveOptions holds the options recorded for a system user removal event.
 // JSON tags match the security audit specification field names.
 type RemoveOptions struct {
+	// Force is true when the account was removed even if it was logged in.
 	Force bool `json:"force"`
 }

--- a/seclog/eventdata.go
+++ b/seclog/eventdata.go
@@ -222,3 +222,19 @@ func (u SnapdUser) String() string {
 
 	return id + ":" + email + ":" + name
 }
+
+// AddOptions holds the options recorded for a system user creation event.
+// JSON tags match the security audit specification field names.
+type AddOptions struct {
+	RealUserName        string `json:"real_user_name"`
+	Sudoer              bool   `json:"sudoer"`
+	ExtraUsers          bool   `json:"extra_users"`
+	ForcePasswordChange bool   `json:"force_password_change"`
+	Known               bool   `json:"known"`
+}
+
+// RemoveOptions holds the options recorded for a system user removal event.
+// JSON tags match the security audit specification field names.
+type RemoveOptions struct {
+	Force bool `json:"force"`
+}

--- a/seclog/eventdata.go
+++ b/seclog/eventdata.go
@@ -241,21 +241,28 @@ const (
 	AddReasonAPIAssertion SystemUserAddReason = "api-assertion"
 	// AddReasonAPIAssertionAll is set when POST /v2/users or POST /v2/create-user
 	// creates every applicable system user with known: true and no email; details
-	// come from all valid pre-imported system-user assertions for the device model.
+	// come from all valid pre-imported system-user assertions for the device
+	// model. This is the explicit admin path (e.g. snap create-user --known):
+	// sudoer is optional, and the request fails if the device is already managed.
 	AddReasonAPIAssertionAll SystemUserAddReason = "api-assertion-all"
-	// AddReasonAPICreateUserFromAllAssertionsAutomatic is set when POST /v2/users
-	// or POST /v2/create-user is called with automatic: true (e.g. snap
-	// auto-import); all applicable assertion-backed users are created on an
-	// unmanaged device.
-	AddReasonAPICreateUserFromAllAssertionsAutomatic SystemUserAddReason = "api-create-user-from-all-assertions-automatic"
+	// AddReasonAPIAssertionAllAutomatic is set when POST /v2/users
+	// or POST /v2/create-user is called with automatic: true. Like
+	// [AddReasonAPIAssertionAll], all applicable assertion-backed users are
+	// created, but this is the automation path: callers are typically
+	// background machinery (e.g. snap auto-import after a USB hardware event)
+	// rather than an operator. The API forces sudoer, respects
+	// core.users.create.automatic, and treats an already-managed device as a
+	// silent no-op instead of an error so repeated or late triggers do not
+	// fail noisily when provisioning has already succeeded.
+	AddReasonAPIAssertionAllAutomatic SystemUserAddReason = "api-assertion-all-automatic"
 	// AddReasonFirstbootSeedAutoImport is set during first boot on dangerous
 	// models when system-user assertions from the seed are auto-imported and
 	// applied (not via the user-admin API).
 	AddReasonFirstbootSeedAutoImport SystemUserAddReason = "firstboot-seed-auto-import"
-	// AddReasonDeferredSerialBoundAssertion is set when the device manager
+	// AddReasonEnsureSerialBoundAssertion is set when the device manager
 	// ensure loop creates users from serial-bound system-user assertions that
 	// could not be applied until after device registration.
-	AddReasonDeferredSerialBoundAssertion SystemUserAddReason = "deferred-serial-bound-assertion"
+	AddReasonEnsureSerialBoundAssertion SystemUserAddReason = "ensure-serial-bound-assertion"
 )
 
 // SystemUserRemoveReason identifies why a system user account was removed.
@@ -275,10 +282,9 @@ const (
 	RemoveReasonEnsureRemoveExpiredUser SystemUserRemoveReason = "ensure-remove-expired-user"
 )
 
-// Ref identifies an assertion by type and primary key. It mirrors asserts.Ref
-// but uses plain strings so seclog stays import-free.
+// Ref identifies an assertion by primary key. It mirrors the primary-key
+// portion of asserts.Ref but uses plain strings so seclog stays import-free.
 type Ref struct {
-	Type       string   `json:"type"`
 	PrimaryKey []string `json:"primary_key"`
 	// Revision is the assertion revision applied when the user was created.
 	// It supplements the ref; the ref itself is the store-shared identity.

--- a/seclog/eventdata.go
+++ b/seclog/eventdata.go
@@ -224,36 +224,57 @@ func (u SnapdUser) String() string {
 }
 
 // SystemUserAddReason identifies why a system user account was created.
-// Values are logged as add_reason on user_created_system events.
+// Values follow {trigger}-create-user-from-{source} (with optional modifiers)
+// and describe where account details came from, not who invoked the operation.
+// They are logged as add_reason on user_created_system events.
 type SystemUserAddReason string
 
 // SystemUserAddReason values for user_created_system events.
 const (
-	// AddReasonAdminStore is set when an operator requested a user from store email lookup.
-	AddReasonAdminStore SystemUserAddReason = "admin-store"
-	// AddReasonAdminAssertion is set when an operator requested one assertion-backed user by email.
-	AddReasonAdminAssertion SystemUserAddReason = "admin-assertion"
-	// AddReasonAdminKnownAll is set when an operator requested all valid assertion users.
-	AddReasonAdminKnownAll SystemUserAddReason = "admin-known-all"
-	// AddReasonAutoProvision is set for unattended automatic provisioning via the
-	// user-admin API (automatic: true), e.g. snap auto-import.
-	AddReasonAutoProvision SystemUserAddReason = "admin-auto-provision"
-	// AddReasonSeedFirstboot is set when users are created from seed auto-import on dangerous models.
-	AddReasonSeedFirstboot SystemUserAddReason = "seed-firstboot"
-	// AddReasonSerialBound is set when a serial-bound assertion is applied after registration.
-	AddReasonSerialBound SystemUserAddReason = "serial-bound"
+	// AddReasonAPICreateUserFromStoreCredentials is set when POST /v2/users or
+	// POST /v2/create-user creates a system user with known: false; account
+	// details are looked up from the Snap Store by email.
+	AddReasonAPICreateUserFromStoreCredentials SystemUserAddReason = "api-create-user-from-store-credentials"
+	// AddReasonAPICreateUserFromAssertion is set when POST /v2/users or
+	// POST /v2/create-user creates one user with known: true and an email;
+	// details come from a pre-imported system-user assertion selected by
+	// brand-id and email.
+	AddReasonAPICreateUserFromAssertion SystemUserAddReason = "api-create-user-from-assertion"
+	// AddReasonAPICreateUserFromAllAssertions is set when POST /v2/users or
+	// POST /v2/create-user creates every applicable system user with known: true
+	// and no email; details come from all valid pre-imported system-user
+	// assertions for the device model.
+	AddReasonAPICreateUserFromAllAssertions SystemUserAddReason = "api-create-user-from-all-assertions"
+	// AddReasonAPICreateUserFromAllAssertionsAutomatic is set when POST /v2/users
+	// or POST /v2/create-user is called with automatic: true (e.g. snap
+	// auto-import); all applicable assertion-backed users are created on an
+	// unmanaged device.
+	AddReasonAPICreateUserFromAllAssertionsAutomatic SystemUserAddReason = "api-create-user-from-all-assertions-automatic"
+	// AddReasonFirstbootCreateUserFromSeedAutoImport is set during first boot on
+	// dangerous models when system-user assertions from the seed are
+	// auto-imported and applied (not via the user-admin API).
+	AddReasonFirstbootCreateUserFromSeedAutoImport SystemUserAddReason = "firstboot-create-user-from-seed-auto-import"
+	// AddReasonEnsureCreateUserFromSerialBoundAssertion is set when the device
+	// manager ensure loop creates users from serial-bound system-user assertions
+	// that could not be applied until after device registration.
+	AddReasonEnsureCreateUserFromSerialBoundAssertion SystemUserAddReason = "ensure-create-user-from-serial-bound-assertion"
 )
 
 // SystemUserRemoveReason identifies why a system user account was removed.
-// Values are logged as remove_reason on user_removed_system events.
+// Values follow {trigger}-remove-{cause} and describe the trigger, not who
+// invoked the operation. They are logged as remove_reason on
+// user_removed_system events.
 type SystemUserRemoveReason string
 
 // SystemUserRemoveReason values for user_removed_system events.
 const (
-	// RemoveReasonAdminRemove is set when an operator explicitly removed the account.
-	RemoveReasonAdminRemove SystemUserRemoveReason = "admin-remove"
-	// RemoveReasonExpired is set when an expired account was removed by the ensure loop.
-	RemoveReasonExpired SystemUserRemoveReason = "expired"
+	// RemoveReasonAPIRemoveUser is set when POST /v2/users (DELETE) or
+	// POST /v2/create-user remove-user removes the account explicitly.
+	RemoveReasonAPIRemoveUser SystemUserRemoveReason = "api-remove-user"
+	// RemoveReasonEnsureRemoveExpiredUser is set when the device manager ensure
+	// loop removes an account whose assertion or API-provided expiration time
+	// has passed.
+	RemoveReasonEnsureRemoveExpiredUser SystemUserRemoveReason = "ensure-remove-expired-user"
 )
 
 // Ref identifies an assertion by type and primary key. It mirrors asserts.Ref

--- a/seclog/eventdata.go
+++ b/seclog/eventdata.go
@@ -27,11 +27,12 @@
 //  1. Spec alignment: field names and JSON tags match the security audit
 //     specification directly.
 //
-//  2. No imports from other snapd packages: seclog is imported by
-//     packages such as overlord/auth, so it cannot import them back.
-//     Types here must be self-contained. The translation from an
-//     internal type (e.g. [auth.UserState]) to an audit event type is
-//     the responsibility of the caller.
+//  2. Self-contained event types: seclog is imported by packages such as
+//     overlord/auth, so it cannot import them back. Event types here must
+//     not embed those packages' types; callers in such packages still
+//     translate (e.g. [auth.UserState] → [SnapdUser]). Conversion helpers
+//     may import utility packages (osutil, asserts) that will never need
+//     to log.
 //
 // When adding a new event category, define its types here.
 
@@ -39,7 +40,11 @@ package seclog
 
 import (
 	"fmt"
+	"strings"
 	"time"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/osutil"
 )
 
 // unknown is the placeholder for empty fields in descriptions.
@@ -318,7 +323,7 @@ const (
 )
 
 // AssertionRef identifies an assertion by type and primary key. It mirrors
-// asserts.Ref but uses plain strings so seclog stays import-free.
+// asserts.Ref but uses plain strings so the audit payload stays self-contained.
 type AssertionRef struct {
 	// Type is the assertion type name, e.g. "system-user".
 	Type string `json:"type"`
@@ -351,6 +356,41 @@ type SystemUserAddOptions struct {
 	Known bool `json:"known"`
 	// Assertion is set when Known is true; identifies the system-user assertion used.
 	Assertion *AssertionRef `json:"assertion"`
+}
+
+// AssertionRefFrom returns an [AssertionRef] for a. If a is nil,
+// AssertionRefFrom returns nil.
+func AssertionRefFrom(a asserts.Assertion) *AssertionRef {
+	if a == nil {
+		return nil
+	}
+	ref := a.Ref()
+	return &AssertionRef{
+		Type:       ref.Type.Name,
+		PrimaryKey: ref.PrimaryKey,
+		Revision:   a.Revision(),
+	}
+}
+
+// SystemUserAddOptionsFrom builds the audit payload for a system user
+// creation from the options passed to osutil.AddUser and, when known, the
+// backing system-user assertion.
+func SystemUserAddOptionsFrom(opts *osutil.AddUserOptions, userAssertion *asserts.SystemUser) SystemUserAddOptions {
+	// RealUserName is taken from the portion of Gecos after the first comma
+	// (assertion display name or store OpenID identifier).
+	addOpts := SystemUserAddOptions{
+		Known:               userAssertion != nil,
+		Sudoer:              opts.Sudoer,
+		ExtraUsers:          opts.ExtraUsers,
+		ForcePasswordChange: opts.ForcePasswordChange,
+	}
+	if _, realUserName, ok := strings.Cut(opts.Gecos, ","); ok {
+		addOpts.RealUserName = realUserName
+	}
+	if userAssertion != nil {
+		addOpts.Assertion = AssertionRefFrom(userAssertion)
+	}
+	return addOpts
 }
 
 // SystemUserRemoveOptions holds the options recorded for a system user removal

--- a/seclog/eventdata.go
+++ b/seclog/eventdata.go
@@ -268,3 +268,94 @@ func (u SnapdUser) String() string {
 
 	return id + ":" + email + ":" + name
 }
+
+// SystemUserAddReason identifies why a system user account was created.
+// Values follow {trigger}-{source}: the subsystem that started the operation
+// and where the account details came from. They are logged as add_reason on
+// user_created_system events.
+type SystemUserAddReason string
+
+// SystemUserAddReason values for user_created_system events. The api-* values
+// are set by the user-admin API (POST /v2/users, POST /v2/create-user).
+const (
+	// AddReasonAPIStoreEmail is set when a user is created from store account
+	// details looked up by email.
+	AddReasonAPIStoreEmail SystemUserAddReason = "api-store-email"
+	// AddReasonAPIAssertion is set when a single user is created from the
+	// system-user assertion for a given email.
+	AddReasonAPIAssertion SystemUserAddReason = "api-assertion"
+	// AddReasonAPIAssertionAutomatic is like [AddReasonAPIAssertion], but the
+	// request came from automation rather than an operator.
+	AddReasonAPIAssertionAutomatic SystemUserAddReason = "api-assertion-automatic"
+	// AddReasonAPIAssertionAll is set when every user allowed by the device's
+	// system-user assertions is created.
+	AddReasonAPIAssertionAll SystemUserAddReason = "api-assertion-all"
+	// AddReasonAPIAssertionAllAutomatic is like [AddReasonAPIAssertionAll],
+	// but the request came from automation rather than an operator.
+	AddReasonAPIAssertionAllAutomatic SystemUserAddReason = "api-assertion-all-automatic"
+	// AddReasonFirstbootSeedAutoImport is set when auto-import assertions from
+	// the seed are applied during first boot, on dangerous models only.
+	AddReasonFirstbootSeedAutoImport SystemUserAddReason = "firstboot-seed-auto-import"
+	// AddReasonEnsureSerialBoundAssertion is set when the device manager
+	// applies serial-bound system-user assertions after registration.
+	AddReasonEnsureSerialBoundAssertion SystemUserAddReason = "ensure-serial-bound-assertion"
+)
+
+// SystemUserRemoveReason identifies why a system user account was removed.
+// Values follow {trigger}-remove-{target}: the subsystem that started the
+// operation and the kind of account removed. They are logged as remove_reason
+// on user_removed_system events.
+type SystemUserRemoveReason string
+
+// SystemUserRemoveReason values for user_removed_system events. The api-*
+// value is set by the user-admin API (POST /v2/users, action "remove").
+const (
+	// RemoveReasonAPI is set when an account is removed by explicit request.
+	RemoveReasonAPI SystemUserRemoveReason = "api-remove-user"
+	// RemoveReasonEnsureExpired is set when the device manager removes an
+	// account whose expiration time has passed.
+	RemoveReasonEnsureExpired SystemUserRemoveReason = "ensure-remove-expired-user"
+)
+
+// AssertionRef identifies an assertion by type and primary key. It mirrors
+// asserts.Ref but uses plain strings so seclog stays import-free.
+type AssertionRef struct {
+	// Type is the assertion type name, e.g. "system-user".
+	Type string `json:"type"`
+	// PrimaryKey holds the primary key values in the order declared by Type.
+	PrimaryKey []string `json:"primary_key"`
+	// Revision is the assertion revision applied when the user was created.
+	// It supplements the ref; the ref itself is the store-shared identity.
+	Revision int `json:"revision"`
+}
+
+// SystemUserAddOptions holds the options recorded for a system user creation
+// event. JSON tags match the security audit specification field names.
+type SystemUserAddOptions struct {
+	// RealUserName is the display name recorded for the created account,
+	// taken from the account's GECOS field. For accounts created from store
+	// details (see [AddReasonAPIStoreEmail]) it holds the store account
+	// identifier rather than a person's name. It may be empty when no name
+	// is available.
+	RealUserName string `json:"real_user_name"`
+	// Sudoer is true when the account was created with sudo privileges.
+	Sudoer bool `json:"sudoer"`
+	// ExtraUsers is true when the account was created in the extrausers
+	// database (Ubuntu Core) rather than /etc/passwd.
+	ExtraUsers bool `json:"extra_users"`
+	// ForcePasswordChange is true when the user must change their password
+	// on first login.
+	ForcePasswordChange bool `json:"force_password_change"`
+	// Known is true when the account was created from a system-user assertion
+	// rather than from a store email lookup.
+	Known bool `json:"known"`
+	// Assertion is set when Known is true; identifies the system-user assertion used.
+	Assertion *AssertionRef `json:"assertion"`
+}
+
+// SystemUserRemoveOptions holds the options recorded for a system user removal
+// event. JSON tags match the security audit specification field names.
+type SystemUserRemoveOptions struct {
+	// Force is true when the account was removed even if it was logged in.
+	Force bool `json:"force"`
+}

--- a/seclog/eventdata_test.go
+++ b/seclog/eventdata_test.go
@@ -20,8 +20,13 @@
 package seclog_test
 
 import (
+	"time"
+
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/assertstest"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/seclog"
 )
 
@@ -97,4 +102,81 @@ func (s *SecLogSuite) TestGrantReasonWithInterface(c *C) {
 	// Empty iface means no interface contributed; the base reason is unchanged.
 	c.Check(seclog.GrantRootAuth.WithInterface("", true), Equals, seclog.GrantRootAuth)
 	c.Check(seclog.GrantRootAuth.WithInterface("", false), Equals, seclog.GrantRootAuth)
+}
+
+func (s *SecLogSuite) TestSystemUserAddOptionsFromStoreEmail(c *C) {
+	opts := &osutil.AddUserOptions{
+		Gecos:               "karl@example.com,Karl Popper",
+		Sudoer:              true,
+		ExtraUsers:          true,
+		ForcePasswordChange: true,
+	}
+
+	got := seclog.SystemUserAddOptionsFrom(opts, nil)
+	c.Check(got, DeepEquals, seclog.SystemUserAddOptions{
+		RealUserName:        "Karl Popper",
+		Sudoer:              true,
+		ExtraUsers:          true,
+		ForcePasswordChange: true,
+		Known:               false,
+		Assertion:           nil,
+	})
+}
+
+func (s *SecLogSuite) TestSystemUserAddOptionsFromGecosWithoutName(c *C) {
+	// No comma: RealUserName is left empty.
+	c.Check(seclog.SystemUserAddOptionsFrom(&osutil.AddUserOptions{
+		Gecos: "only-email@example.com",
+	}, nil).RealUserName, Equals, "")
+
+	c.Check(seclog.SystemUserAddOptionsFrom(&osutil.AddUserOptions{}, nil).RealUserName, Equals, "")
+}
+
+func (s *SecLogSuite) TestSystemUserAddOptionsFromAssertion(c *C) {
+	su := assertstest.FakeAssertion(map[string]any{
+		"type":         "system-user",
+		"authority-id": "my-brand",
+		"brand-id":     "my-brand",
+		"email":        "foo@bar.com",
+		"username":     "example-user",
+		"name":         "Example User",
+		"since":        time.Now().Format(time.RFC3339),
+		"until":        time.Now().Add(24 * time.Hour).Format(time.RFC3339),
+		"revision":     "3",
+	}).(*asserts.SystemUser)
+
+	got := seclog.SystemUserAddOptionsFrom(&osutil.AddUserOptions{
+		Gecos:  "foo@bar.com,Example User",
+		Sudoer: true,
+	}, su)
+	c.Check(got, DeepEquals, seclog.SystemUserAddOptions{
+		RealUserName: "Example User",
+		Sudoer:       true,
+		Known:        true,
+		Assertion: &seclog.AssertionRef{
+			Type:       "system-user",
+			PrimaryKey: []string{"my-brand", "foo@bar.com"},
+			Revision:   3,
+		},
+	})
+}
+
+func (s *SecLogSuite) TestAssertionRefFrom(c *C) {
+	c.Check(seclog.AssertionRefFrom(nil), IsNil)
+
+	su := assertstest.FakeAssertion(map[string]any{
+		"type":         "system-user",
+		"authority-id": "my-brand",
+		"brand-id":     "my-brand",
+		"email":        "foo@bar.com",
+		"username":     "example-user",
+		"since":        time.Now().Format(time.RFC3339),
+		"until":        time.Now().Add(24 * time.Hour).Format(time.RFC3339),
+	}).(*asserts.SystemUser)
+
+	c.Check(seclog.AssertionRefFrom(su), DeepEquals, &seclog.AssertionRef{
+		Type:       "system-user",
+		PrimaryKey: []string{"my-brand", "foo@bar.com"},
+		Revision:   0,
+	})
 }

--- a/seclog/seclog.go
+++ b/seclog/seclog.go
@@ -218,6 +218,36 @@ func LogUserRemoved(user SnapdUser) {
 	)
 }
 
+// LogSystemUserCreated logs creation of a Linux system account using the
+// global security logger. This is distinct from [LogUserCreated], which
+// records snapd user state.
+func LogSystemUserCreated(systemUser string, opts AddOptions) {
+	lock.Lock()
+	defer lock.Unlock()
+
+	globalLogger.LogEvent(
+		Event{Category: "USER", Name: "user_created_system", Level: LevelInfo},
+		fmt.Sprintf("Created system user %s", systemUser),
+		Attr{Key: "system_user", Value: systemUser},
+		Attr{Key: "add_options", Value: opts},
+	)
+}
+
+// LogSystemUserRemoved logs removal of a Linux system account using the
+// global security logger. This is distinct from [LogUserRemoved], which
+// records snapd user state.
+func LogSystemUserRemoved(systemUser string, opts RemoveOptions) {
+	lock.Lock()
+	defer lock.Unlock()
+
+	globalLogger.LogEvent(
+		Event{Category: "USER", Name: "user_removed_system", Level: LevelInfo},
+		fmt.Sprintf("Removed system user %s", systemUser),
+		Attr{Key: "system_user", Value: systemUser},
+		Attr{Key: "remove_options", Value: opts},
+	)
+}
+
 // LogAdminActivity logs an administrative API access event using the
 // global security logger. It is emitted when authorization succeeds (the
 // access gate passed), not when the API operation or handler succeeds.

--- a/seclog/seclog.go
+++ b/seclog/seclog.go
@@ -227,7 +227,7 @@ func LogSystemUserCreated(systemUser string, opts AddOptions, addReason SystemUs
 
 	globalLogger.LogEvent(
 		Event{Category: "USER", Name: "user_created_system", Level: LevelInfo},
-		fmt.Sprintf("Created system user %s", systemUser),
+		fmt.Sprintf("Created system user %s (%s)", systemUser, addReason),
 		Attr{Key: "system_user", Value: systemUser},
 		Attr{Key: "add_options", Value: opts},
 		Attr{Key: "add_reason", Value: string(addReason)},
@@ -243,7 +243,7 @@ func LogSystemUserRemoved(systemUser string, opts RemoveOptions, removeReason Sy
 
 	globalLogger.LogEvent(
 		Event{Category: "USER", Name: "user_removed_system", Level: LevelInfo},
-		fmt.Sprintf("Removed system user %s", systemUser),
+		fmt.Sprintf("Removed system user %s (%s)", systemUser, removeReason),
 		Attr{Key: "system_user", Value: systemUser},
 		Attr{Key: "remove_options", Value: opts},
 		Attr{Key: "remove_reason", Value: string(removeReason)},

--- a/seclog/seclog.go
+++ b/seclog/seclog.go
@@ -221,7 +221,7 @@ func LogUserRemoved(user SnapdUser) {
 // LogSystemUserCreated logs creation of a Linux system account using the
 // global security logger. This is distinct from [LogUserCreated], which
 // records snapd user state.
-func LogSystemUserCreated(systemUser string, opts AddOptions) {
+func LogSystemUserCreated(systemUser string, opts AddOptions, addReason SystemUserAddReason) {
 	lock.Lock()
 	defer lock.Unlock()
 
@@ -230,13 +230,14 @@ func LogSystemUserCreated(systemUser string, opts AddOptions) {
 		fmt.Sprintf("Created system user %s", systemUser),
 		Attr{Key: "system_user", Value: systemUser},
 		Attr{Key: "add_options", Value: opts},
+		Attr{Key: "add_reason", Value: string(addReason)},
 	)
 }
 
 // LogSystemUserRemoved logs removal of a Linux system account using the
 // global security logger. This is distinct from [LogUserRemoved], which
 // records snapd user state.
-func LogSystemUserRemoved(systemUser string, opts RemoveOptions) {
+func LogSystemUserRemoved(systemUser string, opts RemoveOptions, removeReason SystemUserRemoveReason) {
 	lock.Lock()
 	defer lock.Unlock()
 
@@ -245,6 +246,7 @@ func LogSystemUserRemoved(systemUser string, opts RemoveOptions) {
 		fmt.Sprintf("Removed system user %s", systemUser),
 		Attr{Key: "system_user", Value: systemUser},
 		Attr{Key: "remove_options", Value: opts},
+		Attr{Key: "remove_reason", Value: string(removeReason)},
 	)
 }
 

--- a/seclog/seclog.go
+++ b/seclog/seclog.go
@@ -218,6 +218,38 @@ func LogUserRemoved(user SnapdUser) {
 	)
 }
 
+// LogSystemUserCreated logs creation of a Linux system account using the
+// global security logger. This is distinct from [LogUserCreated], which
+// records snapd user state.
+func LogSystemUserCreated(systemUser string, opts SystemUserAddOptions, addReason SystemUserAddReason) {
+	lock.Lock()
+	defer lock.Unlock()
+
+	globalLogger.LogEvent(
+		Event{Category: "USER", Name: "user_created_system", Level: LevelInfo},
+		fmt.Sprintf("Created system user %s (%s)", systemUser, addReason),
+		Attr{Key: "system_user", Value: systemUser},
+		Attr{Key: "add_options", Value: opts},
+		Attr{Key: "add_reason", Value: string(addReason)},
+	)
+}
+
+// LogSystemUserRemoved logs removal of a Linux system account using the
+// global security logger. This is distinct from [LogUserRemoved], which
+// records snapd user state.
+func LogSystemUserRemoved(systemUser string, opts SystemUserRemoveOptions, removeReason SystemUserRemoveReason) {
+	lock.Lock()
+	defer lock.Unlock()
+
+	globalLogger.LogEvent(
+		Event{Category: "USER", Name: "user_removed_system", Level: LevelInfo},
+		fmt.Sprintf("Removed system user %s (%s)", systemUser, removeReason),
+		Attr{Key: "system_user", Value: systemUser},
+		Attr{Key: "remove_options", Value: opts},
+		Attr{Key: "remove_reason", Value: string(removeReason)},
+	)
+}
+
 // LogAdminActivity logs an administrative API access event using the
 // global security logger. It is emitted when authorization succeeds (the
 // access gate passed), not when the API operation or handler succeeds.

--- a/seclog/seclog_test.go
+++ b/seclog/seclog_test.go
@@ -253,7 +253,7 @@ func (s *SecLogSuite) TestLogSystemUserCreated(c *C) {
 		ForcePasswordChange: false,
 		Known:               false,
 	}
-	seclog.LogSystemUserCreated("karl", opts)
+	seclog.LogSystemUserCreated("karl", opts, seclog.AddReasonAdminStore)
 
 	c.Check(s.buf.String(), testutil.Contains, "user_created_system")
 	c.Check(s.buf.String(), testutil.Contains, "Created system user karl")
@@ -261,6 +261,7 @@ func (s *SecLogSuite) TestLogSystemUserCreated(c *C) {
 	c.Check(s.buf.String(), testutil.Contains, "Karl Popper")
 	c.Check(s.buf.String(), testutil.Contains, "Sudoer:true")
 	c.Check(s.buf.String(), testutil.Contains, "Known:false")
+	c.Check(s.buf.String(), testutil.Contains, `add_reason="admin-store"`)
 }
 
 func (s *SecLogSuite) TestLogSystemUserCreatedWithAssertion(c *C) {
@@ -272,23 +273,25 @@ func (s *SecLogSuite) TestLogSystemUserCreatedWithAssertion(c *C) {
 			Revision:   0,
 		},
 	}
-	seclog.LogSystemUserCreated("example-user", opts)
+	seclog.LogSystemUserCreated("example-user", opts, seclog.AddReasonAdminAssertion)
 
 	c.Check(s.buf.String(), testutil.Contains, "user_created_system")
 	c.Check(s.buf.String(), testutil.Contains, "system-user")
 	c.Check(s.buf.String(), testutil.Contains, "my-brand")
 	c.Check(s.buf.String(), testutil.Contains, "foo@bar.com")
 	c.Check(s.buf.String(), testutil.Contains, "Known:true")
+	c.Check(s.buf.String(), testutil.Contains, `add_reason="admin-assertion"`)
 }
 
 func (s *SecLogSuite) TestLogSystemUserRemoved(c *C) {
 	opts := seclog.RemoveOptions{Force: true}
-	seclog.LogSystemUserRemoved("some-user", opts)
+	seclog.LogSystemUserRemoved("some-user", opts, seclog.RemoveReasonExpired)
 
 	c.Check(s.buf.String(), testutil.Contains, "user_removed_system")
 	c.Check(s.buf.String(), testutil.Contains, "Removed system user some-user")
 	c.Check(s.buf.String(), testutil.Contains, "some-user")
 	c.Check(s.buf.String(), testutil.Contains, "Force:true")
+	c.Check(s.buf.String(), testutil.Contains, `remove_reason="expired"`)
 }
 
 // TestLogAdminActivity verifies that LogAdminActivity emits the expected event and attributes.

--- a/seclog/seclog_test.go
+++ b/seclog/seclog_test.go
@@ -253,15 +253,15 @@ func (s *SecLogSuite) TestLogSystemUserCreated(c *C) {
 		ForcePasswordChange: false,
 		Known:               false,
 	}
-	seclog.LogSystemUserCreated("karl", opts, seclog.AddReasonAPICreateUserFromStoreCredentials)
+	seclog.LogSystemUserCreated("karl", opts, seclog.AddReasonAPIStoreEmail)
 
 	c.Check(s.buf.String(), testutil.Contains, "user_created_system")
-	c.Check(s.buf.String(), testutil.Contains, "Created system user karl")
+	c.Check(s.buf.String(), testutil.Contains, "Created system user karl (api-store-email)")
 	c.Check(s.buf.String(), testutil.Contains, "karl")
 	c.Check(s.buf.String(), testutil.Contains, "Karl Popper")
 	c.Check(s.buf.String(), testutil.Contains, "Sudoer:true")
 	c.Check(s.buf.String(), testutil.Contains, "Known:false")
-	c.Check(s.buf.String(), testutil.Contains, `add_reason="api-create-user-from-store-credentials"`)
+	c.Check(s.buf.String(), testutil.Contains, `add_reason="api-store-email"`)
 }
 
 func (s *SecLogSuite) TestLogSystemUserCreatedWithAssertion(c *C) {
@@ -273,14 +273,14 @@ func (s *SecLogSuite) TestLogSystemUserCreatedWithAssertion(c *C) {
 			Revision:   0,
 		},
 	}
-	seclog.LogSystemUserCreated("example-user", opts, seclog.AddReasonAPICreateUserFromAssertion)
+	seclog.LogSystemUserCreated("example-user", opts, seclog.AddReasonAPIAssertion)
 
 	c.Check(s.buf.String(), testutil.Contains, "user_created_system")
 	c.Check(s.buf.String(), testutil.Contains, "system-user")
 	c.Check(s.buf.String(), testutil.Contains, "my-brand")
 	c.Check(s.buf.String(), testutil.Contains, "foo@bar.com")
 	c.Check(s.buf.String(), testutil.Contains, "Known:true")
-	c.Check(s.buf.String(), testutil.Contains, `add_reason="api-create-user-from-assertion"`)
+	c.Check(s.buf.String(), testutil.Contains, `add_reason="api-assertion"`)
 }
 
 func (s *SecLogSuite) TestLogSystemUserRemoved(c *C) {
@@ -288,7 +288,7 @@ func (s *SecLogSuite) TestLogSystemUserRemoved(c *C) {
 	seclog.LogSystemUserRemoved("some-user", opts, seclog.RemoveReasonEnsureRemoveExpiredUser)
 
 	c.Check(s.buf.String(), testutil.Contains, "user_removed_system")
-	c.Check(s.buf.String(), testutil.Contains, "Removed system user some-user")
+	c.Check(s.buf.String(), testutil.Contains, "Removed system user some-user (ensure-remove-expired-user)")
 	c.Check(s.buf.String(), testutil.Contains, "some-user")
 	c.Check(s.buf.String(), testutil.Contains, "Force:true")
 	c.Check(s.buf.String(), testutil.Contains, `remove_reason="ensure-remove-expired-user"`)

--- a/seclog/seclog_test.go
+++ b/seclog/seclog_test.go
@@ -253,7 +253,7 @@ func (s *SecLogSuite) TestLogSystemUserCreated(c *C) {
 		ForcePasswordChange: false,
 		Known:               false,
 	}
-	seclog.LogSystemUserCreated("karl", opts, seclog.AddReasonAdminStore)
+	seclog.LogSystemUserCreated("karl", opts, seclog.AddReasonAPICreateUserFromStoreCredentials)
 
 	c.Check(s.buf.String(), testutil.Contains, "user_created_system")
 	c.Check(s.buf.String(), testutil.Contains, "Created system user karl")
@@ -261,7 +261,7 @@ func (s *SecLogSuite) TestLogSystemUserCreated(c *C) {
 	c.Check(s.buf.String(), testutil.Contains, "Karl Popper")
 	c.Check(s.buf.String(), testutil.Contains, "Sudoer:true")
 	c.Check(s.buf.String(), testutil.Contains, "Known:false")
-	c.Check(s.buf.String(), testutil.Contains, `add_reason="admin-store"`)
+	c.Check(s.buf.String(), testutil.Contains, `add_reason="api-create-user-from-store-credentials"`)
 }
 
 func (s *SecLogSuite) TestLogSystemUserCreatedWithAssertion(c *C) {
@@ -273,25 +273,25 @@ func (s *SecLogSuite) TestLogSystemUserCreatedWithAssertion(c *C) {
 			Revision:   0,
 		},
 	}
-	seclog.LogSystemUserCreated("example-user", opts, seclog.AddReasonAdminAssertion)
+	seclog.LogSystemUserCreated("example-user", opts, seclog.AddReasonAPICreateUserFromAssertion)
 
 	c.Check(s.buf.String(), testutil.Contains, "user_created_system")
 	c.Check(s.buf.String(), testutil.Contains, "system-user")
 	c.Check(s.buf.String(), testutil.Contains, "my-brand")
 	c.Check(s.buf.String(), testutil.Contains, "foo@bar.com")
 	c.Check(s.buf.String(), testutil.Contains, "Known:true")
-	c.Check(s.buf.String(), testutil.Contains, `add_reason="admin-assertion"`)
+	c.Check(s.buf.String(), testutil.Contains, `add_reason="api-create-user-from-assertion"`)
 }
 
 func (s *SecLogSuite) TestLogSystemUserRemoved(c *C) {
 	opts := seclog.RemoveOptions{Force: true}
-	seclog.LogSystemUserRemoved("some-user", opts, seclog.RemoveReasonExpired)
+	seclog.LogSystemUserRemoved("some-user", opts, seclog.RemoveReasonEnsureRemoveExpiredUser)
 
 	c.Check(s.buf.String(), testutil.Contains, "user_removed_system")
 	c.Check(s.buf.String(), testutil.Contains, "Removed system user some-user")
 	c.Check(s.buf.String(), testutil.Contains, "some-user")
 	c.Check(s.buf.String(), testutil.Contains, "Force:true")
-	c.Check(s.buf.String(), testutil.Contains, `remove_reason="expired"`)
+	c.Check(s.buf.String(), testutil.Contains, `remove_reason="ensure-remove-expired-user"`)
 }
 
 // TestLogAdminActivity verifies that LogAdminActivity emits the expected event and attributes.

--- a/seclog/seclog_test.go
+++ b/seclog/seclog_test.go
@@ -245,6 +245,34 @@ func (s *SecLogSuite) TestLogUserRemoved(c *C) {
 	c.Check(s.buf.String(), testutil.Contains, "jdoe@test.com")
 }
 
+func (s *SecLogSuite) TestLogSystemUserCreated(c *C) {
+	opts := seclog.AddOptions{
+		RealUserName:        "Karl Popper",
+		Sudoer:              true,
+		ExtraUsers:          true,
+		ForcePasswordChange: false,
+		Known:               false,
+	}
+	seclog.LogSystemUserCreated("karl", opts)
+
+	c.Check(s.buf.String(), testutil.Contains, "user_created_system")
+	c.Check(s.buf.String(), testutil.Contains, "Created system user karl")
+	c.Check(s.buf.String(), testutil.Contains, "karl")
+	c.Check(s.buf.String(), testutil.Contains, "Karl Popper")
+	c.Check(s.buf.String(), testutil.Contains, "Sudoer:true")
+	c.Check(s.buf.String(), testutil.Contains, "Known:false")
+}
+
+func (s *SecLogSuite) TestLogSystemUserRemoved(c *C) {
+	opts := seclog.RemoveOptions{Force: true}
+	seclog.LogSystemUserRemoved("some-user", opts)
+
+	c.Check(s.buf.String(), testutil.Contains, "user_removed_system")
+	c.Check(s.buf.String(), testutil.Contains, "Removed system user some-user")
+	c.Check(s.buf.String(), testutil.Contains, "some-user")
+	c.Check(s.buf.String(), testutil.Contains, "Force:true")
+}
+
 // TestLogAdminActivity verifies that LogAdminActivity emits the expected event and attributes.
 func (s *SecLogSuite) TestLogAdminActivity(c *C) {
 	user := seclog.SnapdUser{ID: 1, StoreUserEmail: "admin@example.com", StoreUserName: "admin"}

--- a/seclog/seclog_test.go
+++ b/seclog/seclog_test.go
@@ -263,6 +263,24 @@ func (s *SecLogSuite) TestLogSystemUserCreated(c *C) {
 	c.Check(s.buf.String(), testutil.Contains, "Known:false")
 }
 
+func (s *SecLogSuite) TestLogSystemUserCreatedWithAssertion(c *C) {
+	opts := seclog.AddOptions{
+		Known: true,
+		Assertion: &seclog.Ref{
+			Type:       "system-user",
+			PrimaryKey: []string{"my-brand", "foo@bar.com"},
+			Revision:   0,
+		},
+	}
+	seclog.LogSystemUserCreated("example-user", opts)
+
+	c.Check(s.buf.String(), testutil.Contains, "user_created_system")
+	c.Check(s.buf.String(), testutil.Contains, "system-user")
+	c.Check(s.buf.String(), testutil.Contains, "my-brand")
+	c.Check(s.buf.String(), testutil.Contains, "foo@bar.com")
+	c.Check(s.buf.String(), testutil.Contains, "Known:true")
+}
+
 func (s *SecLogSuite) TestLogSystemUserRemoved(c *C) {
 	opts := seclog.RemoveOptions{Force: true}
 	seclog.LogSystemUserRemoved("some-user", opts)

--- a/seclog/seclog_test.go
+++ b/seclog/seclog_test.go
@@ -268,7 +268,6 @@ func (s *SecLogSuite) TestLogSystemUserCreatedWithAssertion(c *C) {
 	opts := seclog.AddOptions{
 		Known: true,
 		Assertion: &seclog.Ref{
-			Type:       "system-user",
 			PrimaryKey: []string{"my-brand", "foo@bar.com"},
 			Revision:   0,
 		},
@@ -276,7 +275,6 @@ func (s *SecLogSuite) TestLogSystemUserCreatedWithAssertion(c *C) {
 	seclog.LogSystemUserCreated("example-user", opts, seclog.AddReasonAPIAssertion)
 
 	c.Check(s.buf.String(), testutil.Contains, "user_created_system")
-	c.Check(s.buf.String(), testutil.Contains, "system-user")
 	c.Check(s.buf.String(), testutil.Contains, "my-brand")
 	c.Check(s.buf.String(), testutil.Contains, "foo@bar.com")
 	c.Check(s.buf.String(), testutil.Contains, "Known:true")

--- a/seclog/seclog_test.go
+++ b/seclog/seclog_test.go
@@ -245,6 +245,55 @@ func (s *SecLogSuite) TestLogUserRemoved(c *C) {
 	c.Check(s.buf.String(), testutil.Contains, "jdoe@test.com")
 }
 
+func (s *SecLogSuite) TestLogSystemUserCreated(c *C) {
+	opts := seclog.SystemUserAddOptions{
+		RealUserName:        "Karl Popper",
+		Sudoer:              true,
+		ExtraUsers:          true,
+		ForcePasswordChange: false,
+		Known:               false,
+	}
+	seclog.LogSystemUserCreated("karl", opts, seclog.AddReasonAPIStoreEmail)
+
+	c.Check(s.buf.String(), testutil.Contains, "user_created_system")
+	c.Check(s.buf.String(), testutil.Contains, "Created system user karl (api-store-email)")
+	c.Check(s.buf.String(), testutil.Contains, "karl")
+	c.Check(s.buf.String(), testutil.Contains, "Karl Popper")
+	c.Check(s.buf.String(), testutil.Contains, "Sudoer:true")
+	c.Check(s.buf.String(), testutil.Contains, "Known:false")
+	c.Check(s.buf.String(), testutil.Contains, `add_reason="api-store-email"`)
+}
+
+func (s *SecLogSuite) TestLogSystemUserCreatedWithAssertion(c *C) {
+	opts := seclog.SystemUserAddOptions{
+		Known: true,
+		Assertion: &seclog.AssertionRef{
+			Type:       "system-user",
+			PrimaryKey: []string{"my-brand", "foo@bar.com"},
+			Revision:   0,
+		},
+	}
+	seclog.LogSystemUserCreated("example-user", opts, seclog.AddReasonAPIAssertion)
+
+	c.Check(s.buf.String(), testutil.Contains, "user_created_system")
+	c.Check(s.buf.String(), testutil.Contains, "type:system-user")
+	c.Check(s.buf.String(), testutil.Contains, "my-brand")
+	c.Check(s.buf.String(), testutil.Contains, "foo@bar.com")
+	c.Check(s.buf.String(), testutil.Contains, "Known:true")
+	c.Check(s.buf.String(), testutil.Contains, `add_reason="api-assertion"`)
+}
+
+func (s *SecLogSuite) TestLogSystemUserRemoved(c *C) {
+	opts := seclog.SystemUserRemoveOptions{Force: true}
+	seclog.LogSystemUserRemoved("some-user", opts, seclog.RemoveReasonEnsureExpired)
+
+	c.Check(s.buf.String(), testutil.Contains, "user_removed_system")
+	c.Check(s.buf.String(), testutil.Contains, "Removed system user some-user (ensure-remove-expired-user)")
+	c.Check(s.buf.String(), testutil.Contains, "some-user")
+	c.Check(s.buf.String(), testutil.Contains, "Force:true")
+	c.Check(s.buf.String(), testutil.Contains, `remove_reason="ensure-remove-expired-user"`)
+}
+
 // TestLogAdminActivity verifies that LogAdminActivity emits the expected event and attributes.
 func (s *SecLogSuite) TestLogAdminActivity(c *C) {
 	user := seclog.SnapdUser{ID: 1, StoreUserEmail: "admin@example.com", StoreUserName: "admin"}

--- a/seclog/seclogtest/seclogtest.go
+++ b/seclog/seclogtest/seclogtest.go
@@ -69,7 +69,7 @@ func attrValueString(v any) string {
 }
 
 func formatRef(r seclog.Ref) string {
-	return fmt.Sprintf("{type:%q primary_key:%v revision:%d}", r.Type, r.PrimaryKey, r.Revision)
+	return fmt.Sprintf("{primary_key:%v revision:%d}", r.PrimaryKey, r.Revision)
 }
 
 func formatAddOptions(o seclog.AddOptions) string {

--- a/seclog/seclogtest/seclogtest.go
+++ b/seclog/seclogtest/seclogtest.go
@@ -49,9 +49,36 @@ func MockSecurityLogger(buf *bytes.Buffer) seclog.SecurityLogger {
 func (m *mockLogger) LogEvent(event seclog.Event, description string, attrs ...seclog.Attr) {
 	fmt.Fprintf(m.buf, "%s %s", event.Name, description)
 	for _, a := range attrs {
-		fmt.Fprintf(m.buf, " [%s=%#v]", a.Key, a.Value)
+		fmt.Fprintf(m.buf, " [%s=%s]", a.Key, attrValueString(a.Value))
 	}
 	fmt.Fprintln(m.buf)
+}
+
+func attrValueString(v any) string {
+	switch val := v.(type) {
+	case seclog.AddOptions:
+		return formatAddOptions(val)
+	case *seclog.Ref:
+		if val == nil {
+			return "<nil>"
+		}
+		return formatRef(*val)
+	default:
+		return fmt.Sprintf("%#v", v)
+	}
+}
+
+func formatRef(r seclog.Ref) string {
+	return fmt.Sprintf("{type:%q primary_key:%v revision:%d}", r.Type, r.PrimaryKey, r.Revision)
+}
+
+func formatAddOptions(o seclog.AddOptions) string {
+	assertion := ""
+	if o.Assertion != nil {
+		assertion = fmt.Sprintf(" Assertion:%s", formatRef(*o.Assertion))
+	}
+	return fmt.Sprintf("AddOptions{RealUserName:%q Sudoer:%v ExtraUsers:%v ForcePasswordChange:%v Known:%v%s}",
+		o.RealUserName, o.Sudoer, o.ExtraUsers, o.ForcePasswordChange, o.Known, assertion)
 }
 
 // MockSlogLogger returns a buffer and a constructor function matching the

--- a/seclog/seclogtest/seclogtest.go
+++ b/seclog/seclogtest/seclogtest.go
@@ -49,9 +49,36 @@ func MockSecurityLogger(buf *bytes.Buffer) seclog.SecurityLogger {
 func (m *mockLogger) LogEvent(event seclog.Event, description string, attrs ...seclog.Attr) {
 	fmt.Fprintf(m.buf, "%s %s", event.Name, description)
 	for _, a := range attrs {
-		fmt.Fprintf(m.buf, " [%s=%#v]", a.Key, a.Value)
+		fmt.Fprintf(m.buf, " [%s=%s]", a.Key, attrValueString(a.Value))
 	}
 	fmt.Fprintln(m.buf)
+}
+
+func attrValueString(v any) string {
+	switch val := v.(type) {
+	case seclog.SystemUserAddOptions:
+		return formatSystemUserAddOptions(val)
+	case *seclog.AssertionRef:
+		if val == nil {
+			return "<nil>"
+		}
+		return formatAssertionRef(*val)
+	default:
+		return fmt.Sprintf("%#v", v)
+	}
+}
+
+func formatAssertionRef(r seclog.AssertionRef) string {
+	return fmt.Sprintf("{type:%s primary_key:%v revision:%d}", r.Type, r.PrimaryKey, r.Revision)
+}
+
+func formatSystemUserAddOptions(o seclog.SystemUserAddOptions) string {
+	assertion := ""
+	if o.Assertion != nil {
+		assertion = fmt.Sprintf(" Assertion:%s", formatAssertionRef(*o.Assertion))
+	}
+	return fmt.Sprintf("SystemUserAddOptions{RealUserName:%q Sudoer:%v ExtraUsers:%v ForcePasswordChange:%v Known:%v%s}",
+		o.RealUserName, o.Sudoer, o.ExtraUsers, o.ForcePasswordChange, o.Known, assertion)
 }
 
 // MockSlogLogger returns a buffer and a constructor function matching the

--- a/seclog/slog.go
+++ b/seclog/slog.go
@@ -214,7 +214,6 @@ func (p Peer) LogValue() slog.Value {
 // as a structured log attribute value.
 func (r Ref) LogValue() slog.Value {
 	return slog.GroupValue(
-		slog.String("type", r.Type),
 		slog.Any("primary_key", r.PrimaryKey),
 		slog.Int("revision", r.Revision),
 	)

--- a/seclog/slog.go
+++ b/seclog/slog.go
@@ -210,16 +210,30 @@ func (p Peer) LogValue() slog.Value {
 	)
 }
 
+// LogValue implements [slog.LogValuer], allowing [Ref] to be used directly
+// as a structured log attribute value.
+func (r Ref) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("type", r.Type),
+		slog.Any("primary_key", r.PrimaryKey),
+		slog.Int("revision", r.Revision),
+	)
+}
+
 // LogValue implements [slog.LogValuer], allowing [AddOptions] to be
 // used directly as a structured log attribute value.
 func (o AddOptions) LogValue() slog.Value {
-	return slog.GroupValue(
+	attrs := []slog.Attr{
 		slog.String("real_user_name", o.RealUserName),
 		slog.Bool("sudoer", o.Sudoer),
 		slog.Bool("extra_users", o.ExtraUsers),
 		slog.Bool("force_password_change", o.ForcePasswordChange),
 		slog.Bool("known", o.Known),
-	)
+	}
+	if o.Assertion != nil {
+		attrs = append(attrs, slog.Any("assertion", o.Assertion))
+	}
+	return slog.GroupValue(attrs...)
 }
 
 // LogValue implements [slog.LogValuer], allowing [RemoveOptions] to be

--- a/seclog/slog.go
+++ b/seclog/slog.go
@@ -210,6 +210,26 @@ func (p Peer) LogValue() slog.Value {
 	)
 }
 
+// LogValue implements [slog.LogValuer], allowing [AddOptions] to be
+// used directly as a structured log attribute value.
+func (o AddOptions) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("real_user_name", o.RealUserName),
+		slog.Bool("sudoer", o.Sudoer),
+		slog.Bool("extra_users", o.ExtraUsers),
+		slog.Bool("force_password_change", o.ForcePasswordChange),
+		slog.Bool("known", o.Known),
+	)
+}
+
+// LogValue implements [slog.LogValuer], allowing [RemoveOptions] to be
+// used directly as a structured log attribute value.
+func (o RemoveOptions) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.Bool("force", o.Force),
+	)
+}
+
 // LogValue implements [slog.LogValuer], allowing [AuthzChecks] to be
 // used directly as a structured log attribute value.
 func (a AuthzChecks) LogValue() slog.Value {

--- a/seclog/slog.go
+++ b/seclog/slog.go
@@ -259,3 +259,37 @@ func peerSecurityLabelsAttr(labels map[string]string) slog.Attr {
 	}
 	return slog.Attr{Key: "security_labels", Value: slog.GroupValue(attrs...)}
 }
+
+// LogValue implements [slog.LogValuer], allowing [AssertionRef] to be used
+// directly as a structured log attribute value.
+func (r AssertionRef) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("type", r.Type),
+		slog.Any("primary_key", r.PrimaryKey),
+		slog.Int("revision", r.Revision),
+	)
+}
+
+// LogValue implements [slog.LogValuer], allowing [SystemUserAddOptions] to be
+// used directly as a structured log attribute value.
+func (o SystemUserAddOptions) LogValue() slog.Value {
+	attrs := []slog.Attr{
+		slog.String("real_user_name", o.RealUserName),
+		slog.Bool("sudoer", o.Sudoer),
+		slog.Bool("extra_users", o.ExtraUsers),
+		slog.Bool("force_password_change", o.ForcePasswordChange),
+		slog.Bool("known", o.Known),
+	}
+	if o.Assertion != nil {
+		attrs = append(attrs, slog.Any("assertion", o.Assertion))
+	}
+	return slog.GroupValue(attrs...)
+}
+
+// LogValue implements [slog.LogValuer], allowing [SystemUserRemoveOptions] to
+// be used directly as a structured log attribute value.
+func (o SystemUserRemoveOptions) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.Bool("force", o.Force),
+	)
+}

--- a/seclog/slog_test.go
+++ b/seclog/slog_test.go
@@ -183,6 +183,28 @@ func (s *SlogSuite) TestLogEventKeyOrder(c *C) {
 				"app_id", "type", "category", "event", "peer", "endpoint", "authz_checks",
 			},
 		},
+		{
+			attrs: []seclog.Attr{
+				{Key: "system_user", Value: "karl"},
+				{Key: "add_options", Value: seclog.AddOptions{Known: false}},
+				{Key: "add_reason", Value: string(seclog.AddReasonAdminStore)},
+			},
+			wantKeys: []string{
+				"datetime", "level", "description",
+				"app_id", "type", "category", "event", "system_user", "add_options", "add_reason",
+			},
+		},
+		{
+			attrs: []seclog.Attr{
+				{Key: "system_user", Value: "karl"},
+				{Key: "remove_options", Value: seclog.RemoveOptions{Force: true}},
+				{Key: "remove_reason", Value: string(seclog.RemoveReasonExpired)},
+			},
+			wantKeys: []string{
+				"datetime", "level", "description",
+				"app_id", "type", "category", "event", "system_user", "remove_options", "remove_reason",
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -459,6 +481,54 @@ func (s *SlogSuite) TestRemoveOptionsLogValue(c *C) {
 	var obtained removeOptionsRecord
 	err := json.Unmarshal(s.buf.Bytes(), &obtained)
 	c.Assert(err, IsNil)
+	c.Check(obtained.RemoveOptions.Force, Equals, true)
+}
+
+func (s *SlogSuite) TestSystemUserAddReasonLogValue(c *C) {
+	type record struct {
+		SystemUser string            `json:"system_user"`
+		AddReason  string            `json:"add_reason"`
+		AddOptions seclog.AddOptions `json:"add_options"`
+	}
+
+	logger := s.newLogger(c)
+	logger.LogEvent(
+		seclog.Event{Category: "USER", Name: "user_created_system", Level: seclog.LevelInfo},
+		"test",
+		seclog.Attr{Key: "system_user", Value: "foo"},
+		seclog.Attr{Key: "add_options", Value: seclog.AddOptions{Known: true}},
+		seclog.Attr{Key: "add_reason", Value: string(seclog.AddReasonAdminAssertion)},
+	)
+
+	var obtained record
+	err := json.Unmarshal(s.buf.Bytes(), &obtained)
+	c.Assert(err, IsNil)
+	c.Check(obtained.SystemUser, Equals, "foo")
+	c.Check(obtained.AddReason, Equals, "admin-assertion")
+	c.Check(obtained.AddOptions.Known, Equals, true)
+}
+
+func (s *SlogSuite) TestSystemUserRemoveReasonLogValue(c *C) {
+	type record struct {
+		SystemUser    string               `json:"system_user"`
+		RemoveReason  string               `json:"remove_reason"`
+		RemoveOptions seclog.RemoveOptions `json:"remove_options"`
+	}
+
+	logger := s.newLogger(c)
+	logger.LogEvent(
+		seclog.Event{Category: "USER", Name: "user_removed_system", Level: seclog.LevelInfo},
+		"test",
+		seclog.Attr{Key: "system_user", Value: "foo"},
+		seclog.Attr{Key: "remove_options", Value: seclog.RemoveOptions{Force: true}},
+		seclog.Attr{Key: "remove_reason", Value: string(seclog.RemoveReasonExpired)},
+	)
+
+	var obtained record
+	err := json.Unmarshal(s.buf.Bytes(), &obtained)
+	c.Assert(err, IsNil)
+	c.Check(obtained.SystemUser, Equals, "foo")
+	c.Check(obtained.RemoveReason, Equals, "expired")
 	c.Check(obtained.RemoveOptions.Force, Equals, true)
 }
 

--- a/seclog/slog_test.go
+++ b/seclog/slog_test.go
@@ -187,7 +187,7 @@ func (s *SlogSuite) TestLogEventKeyOrder(c *C) {
 			attrs: []seclog.Attr{
 				{Key: "system_user", Value: "karl"},
 				{Key: "add_options", Value: seclog.AddOptions{Known: false}},
-				{Key: "add_reason", Value: string(seclog.AddReasonAdminStore)},
+				{Key: "add_reason", Value: string(seclog.AddReasonAPICreateUserFromStoreCredentials)},
 			},
 			wantKeys: []string{
 				"datetime", "level", "description",
@@ -198,7 +198,7 @@ func (s *SlogSuite) TestLogEventKeyOrder(c *C) {
 			attrs: []seclog.Attr{
 				{Key: "system_user", Value: "karl"},
 				{Key: "remove_options", Value: seclog.RemoveOptions{Force: true}},
-				{Key: "remove_reason", Value: string(seclog.RemoveReasonExpired)},
+				{Key: "remove_reason", Value: string(seclog.RemoveReasonEnsureRemoveExpiredUser)},
 			},
 			wantKeys: []string{
 				"datetime", "level", "description",
@@ -497,14 +497,14 @@ func (s *SlogSuite) TestSystemUserAddReasonLogValue(c *C) {
 		"test",
 		seclog.Attr{Key: "system_user", Value: "foo"},
 		seclog.Attr{Key: "add_options", Value: seclog.AddOptions{Known: true}},
-		seclog.Attr{Key: "add_reason", Value: string(seclog.AddReasonAdminAssertion)},
+		seclog.Attr{Key: "add_reason", Value: string(seclog.AddReasonAPICreateUserFromAssertion)},
 	)
 
 	var obtained record
 	err := json.Unmarshal(s.buf.Bytes(), &obtained)
 	c.Assert(err, IsNil)
 	c.Check(obtained.SystemUser, Equals, "foo")
-	c.Check(obtained.AddReason, Equals, "admin-assertion")
+	c.Check(obtained.AddReason, Equals, "api-create-user-from-assertion")
 	c.Check(obtained.AddOptions.Known, Equals, true)
 }
 
@@ -521,14 +521,14 @@ func (s *SlogSuite) TestSystemUserRemoveReasonLogValue(c *C) {
 		"test",
 		seclog.Attr{Key: "system_user", Value: "foo"},
 		seclog.Attr{Key: "remove_options", Value: seclog.RemoveOptions{Force: true}},
-		seclog.Attr{Key: "remove_reason", Value: string(seclog.RemoveReasonExpired)},
+		seclog.Attr{Key: "remove_reason", Value: string(seclog.RemoveReasonEnsureRemoveExpiredUser)},
 	)
 
 	var obtained record
 	err := json.Unmarshal(s.buf.Bytes(), &obtained)
 	c.Assert(err, IsNil)
 	c.Check(obtained.SystemUser, Equals, "foo")
-	c.Check(obtained.RemoveReason, Equals, "expired")
+	c.Check(obtained.RemoveReason, Equals, "ensure-remove-expired-user")
 	c.Check(obtained.RemoveOptions.Force, Equals, true)
 }
 

--- a/seclog/slog_test.go
+++ b/seclog/slog_test.go
@@ -364,13 +364,7 @@ func (s *SlogSuite) TestEndpointLogValue(c *C) {
 
 func (s *SlogSuite) TestAddOptionsLogValue(c *C) {
 	type addOptionsRecord struct {
-		AddOptions struct {
-			RealUserName        string `json:"real_user_name"`
-			Sudoer              bool   `json:"sudoer"`
-			ExtraUsers          bool   `json:"extra_users"`
-			ForcePasswordChange bool   `json:"force_password_change"`
-			Known               bool   `json:"known"`
-		} `json:"add_options"`
+		seclog.AddOptions `json:"add_options"`
 	}
 
 	logger := s.newLogger(c)
@@ -398,9 +392,7 @@ func (s *SlogSuite) TestAddOptionsLogValue(c *C) {
 
 func (s *SlogSuite) TestRemoveOptionsLogValue(c *C) {
 	type removeOptionsRecord struct {
-		RemoveOptions struct {
-			Force bool `json:"force"`
-		} `json:"remove_options"`
+		seclog.RemoveOptions `json:"remove_options"`
 	}
 
 	logger := s.newLogger(c)

--- a/seclog/slog_test.go
+++ b/seclog/slog_test.go
@@ -187,7 +187,7 @@ func (s *SlogSuite) TestLogEventKeyOrder(c *C) {
 			attrs: []seclog.Attr{
 				{Key: "system_user", Value: "karl"},
 				{Key: "add_options", Value: seclog.AddOptions{Known: false}},
-				{Key: "add_reason", Value: string(seclog.AddReasonAPICreateUserFromStoreCredentials)},
+				{Key: "add_reason", Value: string(seclog.AddReasonAPIStoreEmail)},
 			},
 			wantKeys: []string{
 				"datetime", "level", "description",
@@ -497,14 +497,14 @@ func (s *SlogSuite) TestSystemUserAddReasonLogValue(c *C) {
 		"test",
 		seclog.Attr{Key: "system_user", Value: "foo"},
 		seclog.Attr{Key: "add_options", Value: seclog.AddOptions{Known: true}},
-		seclog.Attr{Key: "add_reason", Value: string(seclog.AddReasonAPICreateUserFromAssertion)},
+		seclog.Attr{Key: "add_reason", Value: string(seclog.AddReasonAPIAssertion)},
 	)
 
 	var obtained record
 	err := json.Unmarshal(s.buf.Bytes(), &obtained)
 	c.Assert(err, IsNil)
 	c.Check(obtained.SystemUser, Equals, "foo")
-	c.Check(obtained.AddReason, Equals, "api-create-user-from-assertion")
+	c.Check(obtained.AddReason, Equals, "api-assertion")
 	c.Check(obtained.AddOptions.Known, Equals, true)
 }
 

--- a/seclog/slog_test.go
+++ b/seclog/slog_test.go
@@ -423,7 +423,6 @@ func (s *SlogSuite) TestRefLogValue(c *C) {
 		seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo},
 		"test",
 		seclog.Attr{Key: "ref", Value: seclog.Ref{
-			Type:       "system-user",
 			PrimaryKey: []string{"my-brand", "foo@bar.com"},
 			Revision:   2,
 		}},
@@ -432,7 +431,6 @@ func (s *SlogSuite) TestRefLogValue(c *C) {
 	var obtained refRecord
 	err := json.Unmarshal(s.buf.Bytes(), &obtained)
 	c.Assert(err, IsNil)
-	c.Check(obtained.Ref.Type, Equals, "system-user")
 	c.Check(obtained.Ref.PrimaryKey, DeepEquals, []string{"my-brand", "foo@bar.com"})
 	c.Check(obtained.Ref.Revision, Equals, 2)
 }
@@ -449,7 +447,6 @@ func (s *SlogSuite) TestAddOptionsWithAssertionLogValue(c *C) {
 		seclog.Attr{Key: "add_options", Value: seclog.AddOptions{
 			Known: true,
 			Assertion: &seclog.Ref{
-				Type:       "system-user",
 				PrimaryKey: []string{"my-brand", "foo@bar.com"},
 				Revision:   1,
 			},
@@ -461,7 +458,6 @@ func (s *SlogSuite) TestAddOptionsWithAssertionLogValue(c *C) {
 	c.Assert(err, IsNil)
 	c.Check(obtained.AddOptions.Known, Equals, true)
 	c.Assert(obtained.AddOptions.Assertion, NotNil)
-	c.Check(obtained.AddOptions.Assertion.Type, Equals, "system-user")
 	c.Check(obtained.AddOptions.Assertion.PrimaryKey, DeepEquals, []string{"my-brand", "foo@bar.com"})
 	c.Check(obtained.AddOptions.Assertion.Revision, Equals, 1)
 }

--- a/seclog/slog_test.go
+++ b/seclog/slog_test.go
@@ -28,6 +28,8 @@
 //   Peer.LogValue                       → TestPeerLogValue
 //   Endpoint.LogValue                   → TestEndpointLogValue
 //   AuthzChecks.LogValue                → TestAuthzChecksLogValue
+//   AddOptions.LogValue                 → TestAddOptionsLogValue
+//   RemoveOptions.LogValue              → TestRemoveOptionsLogValue
 
 package seclog_test
 
@@ -358,6 +360,60 @@ func (s *SlogSuite) TestEndpointLogValue(c *C) {
 	c.Check(obtained.Endpoint.Action, Equals, "install")
 	c.Check(obtained.Endpoint.AccessChecker, Equals, "authenticated")
 	c.Check(obtained.Endpoint.AccessLevel, Equals, "authenticated")
+}
+
+func (s *SlogSuite) TestAddOptionsLogValue(c *C) {
+	type addOptionsRecord struct {
+		AddOptions struct {
+			RealUserName        string `json:"real_user_name"`
+			Sudoer              bool   `json:"sudoer"`
+			ExtraUsers          bool   `json:"extra_users"`
+			ForcePasswordChange bool   `json:"force_password_change"`
+			Known               bool   `json:"known"`
+		} `json:"add_options"`
+	}
+
+	logger := s.newLogger(c)
+	logger.LogEvent(
+		seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo},
+		"test",
+		seclog.Attr{Key: "add_options", Value: seclog.AddOptions{
+			RealUserName:        "Karl Popper",
+			Sudoer:              true,
+			ExtraUsers:          true,
+			ForcePasswordChange: true,
+			Known:               false,
+		}},
+	)
+
+	var obtained addOptionsRecord
+	err := json.Unmarshal(s.buf.Bytes(), &obtained)
+	c.Assert(err, IsNil)
+	c.Check(obtained.AddOptions.RealUserName, Equals, "Karl Popper")
+	c.Check(obtained.AddOptions.Sudoer, Equals, true)
+	c.Check(obtained.AddOptions.ExtraUsers, Equals, true)
+	c.Check(obtained.AddOptions.ForcePasswordChange, Equals, true)
+	c.Check(obtained.AddOptions.Known, Equals, false)
+}
+
+func (s *SlogSuite) TestRemoveOptionsLogValue(c *C) {
+	type removeOptionsRecord struct {
+		RemoveOptions struct {
+			Force bool `json:"force"`
+		} `json:"remove_options"`
+	}
+
+	logger := s.newLogger(c)
+	logger.LogEvent(
+		seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo},
+		"test",
+		seclog.Attr{Key: "remove_options", Value: seclog.RemoveOptions{Force: true}},
+	)
+
+	var obtained removeOptionsRecord
+	err := json.Unmarshal(s.buf.Bytes(), &obtained)
+	c.Assert(err, IsNil)
+	c.Check(obtained.RemoveOptions.Force, Equals, true)
 }
 
 func (s *SlogSuite) TestAuthzChecksLogValue(c *C) {

--- a/seclog/slog_test.go
+++ b/seclog/slog_test.go
@@ -29,6 +29,7 @@
 //   Endpoint.LogValue                   → TestEndpointLogValue
 //   AuthzChecks.LogValue                → TestAuthzChecksLogValue
 //   AddOptions.LogValue                 → TestAddOptionsLogValue
+//   Ref.LogValue                        → TestRefLogValue
 //   RemoveOptions.LogValue              → TestRemoveOptionsLogValue
 
 package seclog_test
@@ -388,6 +389,59 @@ func (s *SlogSuite) TestAddOptionsLogValue(c *C) {
 	c.Check(obtained.AddOptions.ExtraUsers, Equals, true)
 	c.Check(obtained.AddOptions.ForcePasswordChange, Equals, true)
 	c.Check(obtained.AddOptions.Known, Equals, false)
+}
+
+func (s *SlogSuite) TestRefLogValue(c *C) {
+	type refRecord struct {
+		Ref seclog.Ref `json:"ref"`
+	}
+
+	logger := s.newLogger(c)
+	logger.LogEvent(
+		seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo},
+		"test",
+		seclog.Attr{Key: "ref", Value: seclog.Ref{
+			Type:       "system-user",
+			PrimaryKey: []string{"my-brand", "foo@bar.com"},
+			Revision:   2,
+		}},
+	)
+
+	var obtained refRecord
+	err := json.Unmarshal(s.buf.Bytes(), &obtained)
+	c.Assert(err, IsNil)
+	c.Check(obtained.Ref.Type, Equals, "system-user")
+	c.Check(obtained.Ref.PrimaryKey, DeepEquals, []string{"my-brand", "foo@bar.com"})
+	c.Check(obtained.Ref.Revision, Equals, 2)
+}
+
+func (s *SlogSuite) TestAddOptionsWithAssertionLogValue(c *C) {
+	type addOptionsRecord struct {
+		seclog.AddOptions `json:"add_options"`
+	}
+
+	logger := s.newLogger(c)
+	logger.LogEvent(
+		seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo},
+		"test",
+		seclog.Attr{Key: "add_options", Value: seclog.AddOptions{
+			Known: true,
+			Assertion: &seclog.Ref{
+				Type:       "system-user",
+				PrimaryKey: []string{"my-brand", "foo@bar.com"},
+				Revision:   1,
+			},
+		}},
+	)
+
+	var obtained addOptionsRecord
+	err := json.Unmarshal(s.buf.Bytes(), &obtained)
+	c.Assert(err, IsNil)
+	c.Check(obtained.AddOptions.Known, Equals, true)
+	c.Assert(obtained.AddOptions.Assertion, NotNil)
+	c.Check(obtained.AddOptions.Assertion.Type, Equals, "system-user")
+	c.Check(obtained.AddOptions.Assertion.PrimaryKey, DeepEquals, []string{"my-brand", "foo@bar.com"})
+	c.Check(obtained.AddOptions.Assertion.Revision, Equals, 1)
 }
 
 func (s *SlogSuite) TestRemoveOptionsLogValue(c *C) {

--- a/seclog/slog_test.go
+++ b/seclog/slog_test.go
@@ -180,6 +180,28 @@ func (s *SlogSuite) TestLogEventKeyOrder(c *C) {
 				"app_id", "type", "category", "event", "peer", "endpoint", "reason_denied",
 			},
 		},
+		{
+			attrs: []seclog.Attr{
+				{Key: "system_user", Value: "karl"},
+				{Key: "add_options", Value: seclog.SystemUserAddOptions{Known: false}},
+				{Key: "add_reason", Value: string(seclog.AddReasonAPIStoreEmail)},
+			},
+			wantKeys: []string{
+				"datetime", "level", "description",
+				"app_id", "type", "category", "event", "system_user", "add_options", "add_reason",
+			},
+		},
+		{
+			attrs: []seclog.Attr{
+				{Key: "system_user", Value: "karl"},
+				{Key: "remove_options", Value: seclog.SystemUserRemoveOptions{Force: true}},
+				{Key: "remove_reason", Value: string(seclog.RemoveReasonEnsureExpired)},
+			},
+			wantKeys: []string{
+				"datetime", "level", "description",
+				"app_id", "type", "category", "event", "system_user", "remove_options", "remove_reason",
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -398,6 +420,153 @@ func (s *SlogSuite) TestPeerLogValueEmptySecurityLabels(c *C) {
 	c.Check(s.buf.String(), testutil.Contains, `"cgroup_label":"<unknown>"`)
 	c.Check(s.buf.String(), testutil.Contains, `"snap":"<unknown>"`)
 	c.Check(s.buf.String(), testutil.Contains, `"app":"<unknown>"`)
+}
+
+func (s *SlogSuite) TestSystemUserAddOptionsLogValue(c *C) {
+	type addOptionsRecord struct {
+		seclog.SystemUserAddOptions `json:"add_options"`
+	}
+
+	logger := s.newLogger(c)
+	logger.LogEvent(
+		seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo},
+		"test",
+		seclog.Attr{Key: "add_options", Value: seclog.SystemUserAddOptions{
+			RealUserName:        "Karl Popper",
+			Sudoer:              true,
+			ExtraUsers:          true,
+			ForcePasswordChange: true,
+			Known:               false,
+		}},
+	)
+
+	var obtained addOptionsRecord
+	err := json.Unmarshal(s.buf.Bytes(), &obtained)
+	c.Assert(err, IsNil)
+	c.Check(obtained.SystemUserAddOptions.RealUserName, Equals, "Karl Popper")
+	c.Check(obtained.SystemUserAddOptions.Sudoer, Equals, true)
+	c.Check(obtained.SystemUserAddOptions.ExtraUsers, Equals, true)
+	c.Check(obtained.SystemUserAddOptions.ForcePasswordChange, Equals, true)
+	c.Check(obtained.SystemUserAddOptions.Known, Equals, false)
+}
+
+func (s *SlogSuite) TestAssertionRefLogValue(c *C) {
+	type refRecord struct {
+		Ref seclog.AssertionRef `json:"ref"`
+	}
+
+	logger := s.newLogger(c)
+	logger.LogEvent(
+		seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo},
+		"test",
+		seclog.Attr{Key: "ref", Value: seclog.AssertionRef{
+			Type:       "system-user",
+			PrimaryKey: []string{"my-brand", "foo@bar.com"},
+			Revision:   2,
+		}},
+	)
+
+	var obtained refRecord
+	err := json.Unmarshal(s.buf.Bytes(), &obtained)
+	c.Assert(err, IsNil)
+	c.Check(obtained.Ref.Type, Equals, "system-user")
+	c.Check(obtained.Ref.PrimaryKey, DeepEquals, []string{"my-brand", "foo@bar.com"})
+	c.Check(obtained.Ref.Revision, Equals, 2)
+}
+
+func (s *SlogSuite) TestSystemUserAddOptionsWithAssertionLogValue(c *C) {
+	type addOptionsRecord struct {
+		seclog.SystemUserAddOptions `json:"add_options"`
+	}
+
+	logger := s.newLogger(c)
+	logger.LogEvent(
+		seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo},
+		"test",
+		seclog.Attr{Key: "add_options", Value: seclog.SystemUserAddOptions{
+			Known: true,
+			Assertion: &seclog.AssertionRef{
+				Type:       "system-user",
+				PrimaryKey: []string{"my-brand", "foo@bar.com"},
+				Revision:   1,
+			},
+		}},
+	)
+
+	var obtained addOptionsRecord
+	err := json.Unmarshal(s.buf.Bytes(), &obtained)
+	c.Assert(err, IsNil)
+	c.Check(obtained.SystemUserAddOptions.Known, Equals, true)
+	c.Assert(obtained.SystemUserAddOptions.Assertion, NotNil)
+	c.Check(obtained.SystemUserAddOptions.Assertion.Type, Equals, "system-user")
+	c.Check(obtained.SystemUserAddOptions.Assertion.PrimaryKey, DeepEquals, []string{"my-brand", "foo@bar.com"})
+	c.Check(obtained.SystemUserAddOptions.Assertion.Revision, Equals, 1)
+}
+
+func (s *SlogSuite) TestSystemUserRemoveOptionsLogValue(c *C) {
+	type removeOptionsRecord struct {
+		seclog.SystemUserRemoveOptions `json:"remove_options"`
+	}
+
+	logger := s.newLogger(c)
+	logger.LogEvent(
+		seclog.Event{Category: "TEST", Name: "test_event", Level: seclog.LevelInfo},
+		"test",
+		seclog.Attr{Key: "remove_options", Value: seclog.SystemUserRemoveOptions{Force: true}},
+	)
+
+	var obtained removeOptionsRecord
+	err := json.Unmarshal(s.buf.Bytes(), &obtained)
+	c.Assert(err, IsNil)
+	c.Check(obtained.SystemUserRemoveOptions.Force, Equals, true)
+}
+
+func (s *SlogSuite) TestSystemUserAddReasonLogValue(c *C) {
+	type record struct {
+		SystemUser string                      `json:"system_user"`
+		AddReason  string                      `json:"add_reason"`
+		AddOptions seclog.SystemUserAddOptions `json:"add_options"`
+	}
+
+	logger := s.newLogger(c)
+	logger.LogEvent(
+		seclog.Event{Category: "USER", Name: "user_created_system", Level: seclog.LevelInfo},
+		"test",
+		seclog.Attr{Key: "system_user", Value: "foo"},
+		seclog.Attr{Key: "add_options", Value: seclog.SystemUserAddOptions{Known: true}},
+		seclog.Attr{Key: "add_reason", Value: string(seclog.AddReasonAPIAssertion)},
+	)
+
+	var obtained record
+	err := json.Unmarshal(s.buf.Bytes(), &obtained)
+	c.Assert(err, IsNil)
+	c.Check(obtained.SystemUser, Equals, "foo")
+	c.Check(obtained.AddReason, Equals, "api-assertion")
+	c.Check(obtained.AddOptions.Known, Equals, true)
+}
+
+func (s *SlogSuite) TestSystemUserRemoveReasonLogValue(c *C) {
+	type record struct {
+		SystemUser    string                         `json:"system_user"`
+		RemoveReason  string                         `json:"remove_reason"`
+		RemoveOptions seclog.SystemUserRemoveOptions `json:"remove_options"`
+	}
+
+	logger := s.newLogger(c)
+	logger.LogEvent(
+		seclog.Event{Category: "USER", Name: "user_removed_system", Level: seclog.LevelInfo},
+		"test",
+		seclog.Attr{Key: "system_user", Value: "foo"},
+		seclog.Attr{Key: "remove_options", Value: seclog.SystemUserRemoveOptions{Force: true}},
+		seclog.Attr{Key: "remove_reason", Value: string(seclog.RemoveReasonEnsureExpired)},
+	)
+
+	var obtained record
+	err := json.Unmarshal(s.buf.Bytes(), &obtained)
+	c.Assert(err, IsNil)
+	c.Check(obtained.SystemUser, Equals, "foo")
+	c.Check(obtained.RemoveReason, Equals, "ensure-remove-expired-user")
+	c.Check(obtained.RemoveOptions.Force, Equals, true)
 }
 
 func (s *SlogSuite) TestEndpointLogValue(c *C) {

--- a/tests/main/security-logging/task.yaml
+++ b/tests/main/security-logging/task.yaml
@@ -10,7 +10,10 @@ details: |
     recorded when users are created via login, updated on re-login, and
     removed via logout. Token lifecycle events (authn_token_created,
     authn_token_delete) are recorded when a local snapd macaroon is
-    created on first login and removed on logout.
+    created on first login and removed on logout. System account events
+    (user_created_system, user_removed_system) are recorded when a local
+    system user is created via create-user and removed via remove-user,
+    including add_reason and remove_reason fields.
 
 # Amazon Linux 2: systemd-journald-audit.socket is not available
 systems: [ -amazon-linux-2-64 ]
@@ -34,6 +37,11 @@ restore: |
     fi
 
     snap logout || true
+
+    if [ -f system-user-name ]; then
+        snap remove-user "$(cat system-user-name)" || true
+        rm -f system-user-name
+    fi
 
 execute: |
     # auditd holds the netlink audit socket exclusively; if it is running,
@@ -136,4 +144,21 @@ execute: |
 
         echo "Checking that logout removes the local snapd macaroon audit event"
         journal_match '"category":"AUTHN","event":"authn_token_delete".*"token_id":[0-9]+'
+
+        echo "Checking that create-user produces a system user creation audit event"
+        journal_pin
+        create_user_output=$(snap create-user --json "$SPREAD_STORE_USER")
+        system_username=$(echo "$create_user_output" | python3 -c 'import json,sys; print(json.load(sys.stdin)["username"])')
+        echo "$system_username" > system-user-name
+
+        journal_match '"category":"USER","event":"user_created_system".*"description":"Created system user '"$system_username"' \(api-store-email\)"'
+        journal_match '"category":"USER","event":"user_created_system".*"system_user":"'"$system_username"'".*"known":false.*"add_reason":"api-store-email"'
+
+        echo "Checking that remove-user produces a system user removal audit event"
+        journal_pin
+        snap remove-user "$system_username"
+        rm -f system-user-name
+
+        journal_match '"category":"USER","event":"user_removed_system".*"description":"Removed system user '"$system_username"' \(api-remove-user\)"'
+        journal_match '"category":"USER","event":"user_removed_system".*"system_user":"'"$system_username"'".*"force":false.*"remove_reason":"api-remove-user"'
     fi

--- a/tests/main/security-logging/task.yaml
+++ b/tests/main/security-logging/task.yaml
@@ -10,7 +10,10 @@ details: |
     recorded when users are created via login, updated on re-login, and
     removed via logout. Token lifecycle events (authn_token_created,
     authn_token_delete) are recorded when a local snapd macaroon is
-    created on first login and removed on logout.
+    created on first login and removed on logout. System account events
+    (user_created_system, user_removed_system) are recorded when a local
+    system user is created via create-user and removed via remove-user,
+    including add_reason and remove_reason fields.
 
 prepare: |
     python3 "$PWD/enable-audit.py"
@@ -31,6 +34,11 @@ restore: |
     fi
 
     snap logout || true
+
+    if [ -f system-user-name ]; then
+        snap remove-user "$(cat system-user-name)" || true
+        rm -f system-user-name
+    fi
 
 execute: |
     # auditd holds the netlink audit socket exclusively; if it is running,
@@ -133,4 +141,20 @@ execute: |
 
         echo "Checking that logout removes the local snapd macaroon audit event"
         journal_match '"category":"AUTHN","event":"authn_token_delete".*"token_id":[0-9]+'
+
+        echo "Checking that create-user produces a system user creation audit event"
+        journal_pin
+        system_username=$(snap create-user --json "$SPREAD_STORE_USER" | gojq -r .username)
+        echo "$system_username" > system-user-name
+
+        journal_match '"description":"Created system user '"$system_username"' \(api-store-email\)".*"category":"USER","event":"user_created_system"'
+        journal_match '"category":"USER","event":"user_created_system".*"system_user":"'"$system_username"'".*"known":false.*"add_reason":"api-store-email"'
+
+        echo "Checking that remove-user produces a system user removal audit event"
+        journal_pin
+        snap remove-user "$system_username"
+        rm -f system-user-name
+
+        journal_match '"description":"Removed system user '"$system_username"' \(api-remove-user\)".*"category":"USER","event":"user_removed_system"'
+        journal_match '"category":"USER","event":"user_removed_system".*"system_user":"'"$system_username"'".*"force":false.*"remove_reason":"api-remove-user"'
     fi


### PR DESCRIPTION
Add seclog events for system user create/remove.

Spec: [SD236- Security Event Logging - System User Created/Removed](https://docs.google.com/document/d/1fl7Gy3GJVu8VwUtT1_LWwZ7DEAW9sUMAzF3XGrcZ_d4/edit?tab=t.0#heading=h.c86p8vigba6v)
Jira: https://warthogs.atlassian.net/browse/SNAPDENG-37101