### PR TITLE
core-initrd: improve build reproducability and allow test skipping

### DIFF
--- a/core-initrd/build-source-pkgs.sh
+++ b/core-initrd/build-source-pkgs.sh
@@ -115,7 +115,7 @@ for rel; do
         dch --newversion "$next_ver" "Update to snapd version $SNAPD_VERSION"
     fi
     dch --distribution "$series" -r ""
-    if [ -n "${SKIP_TESTS-}" ]; then
+    if [ -n "${UNSIGNED-}" ]; then
         dpkg-buildpackage -S -sa -d  -us -uc
     else
         dpkg-buildpackage -S -sa -d

--- a/core-initrd/build-source-pkgs.sh
+++ b/core-initrd/build-source-pkgs.sh
@@ -109,8 +109,16 @@ for rel; do
     curr_ver=$(dpkg-parsechangelog --show-field Version)
     initrd_ver=${curr_ver%%+*}
     next_ver="$initrd_ver"+"$SNAPD_VERSION"+"$rel"
-    dch -v "$next_ver" "Update to snapd version $SNAPD_VERSION"
+    if [ -n "${ALLOW_ANY_VERSION-}" ]; then
+        dch --force-bad-version --newversion "$next_ver" "Update to snapd version $SNAPD_VERSION"
+    else
+        dch --newversion "$next_ver" "Update to snapd version $SNAPD_VERSION"
+    fi
     dch --distribution "$series" -r ""
-    dpkg-buildpackage -S -sa -d
+    if [ -n "${SKIP_TESTS-}" ]; then
+        dpkg-buildpackage -S -sa -d  -us -uc
+    else
+        dpkg-buildpackage -S -sa -d
+    fi
     popd
 done


### PR DESCRIPTION
This change aims to improve regression builds of core-inird package

It enables options to run core-initrd builds without running deb tests.
It also adds an option to build older versions of the core-initrd for reproducibility.