### PR TITLE
features: default enable quota-groups

### DIFF
--- a/features/features.go
+++ b/features/features.go
@@ -146,6 +146,7 @@ var featuresEnabledWhenUnset = map[SnapdFeature]bool{
 	RefreshAppAwareness:           true,
 	ClassicPreservesXdgRuntimeDir: true,
 	DbusActivation:                true,
+	QuotaGroups:                   true,
 }
 
 // featuresExported contains a set of features that are exported outside of snapd.

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -231,7 +231,7 @@ func (*featureSuite) TestIsEnabledWhenUnset(c *C) {
 	check(features.CheckDiskSpaceRefresh, false)
 	check(features.CheckDiskSpaceRemove, false)
 	check(features.GateAutoRefreshHook, false)
-	check(features.QuotaGroups, false)
+	check(features.QuotaGroups, true)
 	check(features.RefreshAppAwarenessUX, false)
 	check(features.Confdb, false)
 	check(features.AppArmorPrompting, false)


### PR DESCRIPTION
First step in graduating this feature, we'll turn it on by default in the 2.77 release.