### PR TITLE
asserts,interfaces/policy: add variant-aware on-classic constraints 

### DIFF
--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -222,7 +222,8 @@ func init() {
 	// 4: support for plug-names/slot-names constraints
 	// 5: alt attr matcher usage (was unused before, has new behavior now)
 	// 6: support for $PLUG_PUBLISHER_ID/$SLOT_PUBLISHER_ID in attr constraints
-	maxSupportedFormat[SnapDeclarationType.Name] = 6
+	// 7: support for on-classic distro/variant constraints
+	maxSupportedFormat[SnapDeclarationType.Name] = 7
 
 	// 1: support to limit to device serials
 	// 2: support for user-presence constraint

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -47,6 +47,9 @@ var DecodePrivateKeyInTest = decodePrivateKey
 // readOpenPGPRSAPublicKey exposed for tests
 var ReadOpenPGPRSAPublicKeyInTest = readOpenPGPRSAPublicKey
 
+// CompileOnClassicSystemConstraintForTest exposes the on-classic system parser for focused tests.
+var CompileOnClassicSystemConstraintForTest = compileOnClassicSystemConstraint
+
 // NewDecoderStressed makes a Decoder with a stressed setup with the given buffer and maximum sizes.
 func NewDecoderStressed(r io.Reader, bufSize, maxHeadersSize, maxBodySize, maxSigSize int) *Decoder {
 	return (&Decoder{

--- a/asserts/ifacedecls.go
+++ b/asserts/ifacedecls.go
@@ -44,6 +44,8 @@ const (
 	deviceScopeConstraintsFeature = "device-scope-constraints"
 	// feature label for plug-names/slot-names constraints
 	nameConstraintsFeature = "name-constraints"
+	// feature label for on-classic distro/variant constraints
+	onClassicVariantConstraintsFeature = "on-classic-variant-constraints"
 )
 
 // AttributeConstraints implements a set of constraints on the attributes of a slot or plug.
@@ -184,7 +186,100 @@ var (
 // OnClassicConstraint specifies a constraint based whether the system is classic and optional specific distros' sets.
 type OnClassicConstraint struct {
 	Classic   bool
-	SystemIDs []string
+	SystemIDs []OnClassicSystemConstraint
+}
+
+// OnClassicSystemConstraint specifies an operating system distro/variant matcher.
+//
+// VariantAny is true for constraints that accept any VARIANT_ID, including the
+// legacy distro-only form (for example "ubuntu") and the explicit wildcard form
+// (for example "ubuntu/*"). VariantID preserves the explicit wildcard so format
+// detection can distinguish old and new syntax.
+type OnClassicSystemConstraint struct {
+	DistroID   string
+	VariantID  string
+	VariantAny bool
+}
+
+func (c *OnClassicConstraint) feature(flabel string) bool {
+	if flabel != onClassicVariantConstraintsFeature {
+		return false
+	}
+	for _, systemID := range c.SystemIDs {
+		// Explicit variant syntax requires format 7, even when it still matches any
+		// variant (for example "ubuntu/*"). The legacy distro-only form keeps the
+		// zero VariantID while still setting VariantAny.
+		if !systemID.VariantAny || systemID.VariantID == "*" {
+			return true
+		}
+	}
+	return false
+}
+
+func compileOnClassicConstraint(context *subruleContext, onClassic any) (*OnClassicConstraint, error) {
+	what := fmt.Sprintf("on-classic in %s", context)
+	syntaxError := fmt.Errorf("%s must be 'true', 'false' or a list of operating system IDs with optional /variant IDs", what)
+
+	switch x := onClassic.(type) {
+	case string:
+		switch x {
+		case "true":
+			return &OnClassicConstraint{Classic: true}, nil
+		case "false":
+			return &OnClassicConstraint{Classic: false}, nil
+		default:
+			return nil, syntaxError
+		}
+	case []any:
+		if len(x) == 0 {
+			return &OnClassicConstraint{Classic: true}, nil
+		}
+		systems := make([]OnClassicSystemConstraint, len(x))
+		for i, v := range x {
+			s, ok := v.(string)
+			if !ok {
+				return nil, fmt.Errorf("%s must be a list of strings", what)
+			}
+			systemID, err := compileOnClassicSystemConstraint(s)
+			if err != nil {
+				return nil, fmt.Errorf("%s contains an invalid element: %q", what, s)
+			}
+			systems[i] = systemID
+		}
+		return &OnClassicConstraint{Classic: true, SystemIDs: systems}, nil
+	default:
+		return nil, syntaxError
+	}
+}
+
+func compileOnClassicSystemConstraint(s string) (OnClassicSystemConstraint, error) {
+	if strings.Count(s, "/") > 1 {
+		return OnClassicSystemConstraint{}, fmt.Errorf("invalid operating system constraint")
+	}
+	if distroID, variantID, hasVariant := strings.Cut(s, "/"); hasVariant {
+		if !validDistro.MatchString(distroID) {
+			return OnClassicSystemConstraint{}, fmt.Errorf("invalid operating system constraint")
+		}
+		constraint := OnClassicSystemConstraint{
+			DistroID: distroID,
+		}
+		switch {
+		case variantID == "*":
+			constraint.VariantAny = true
+			constraint.VariantID = "*"
+		case variantID == "":
+			// Match only when VARIANT_ID is unset.
+		case validDistro.MatchString(variantID):
+			constraint.VariantID = variantID
+		default:
+			return OnClassicSystemConstraint{}, fmt.Errorf("invalid operating system constraint")
+		}
+		return constraint, nil
+	}
+	if !validDistro.MatchString(s) {
+		return OnClassicSystemConstraint{}, fmt.Errorf("invalid operating system constraint")
+	}
+	return OnClassicSystemConstraint{DistroID: s, VariantAny: true}, nil
 }
 
 // OnCoreDesktopConstraint specifies a constraint based whether the system is core desktop.
@@ -387,24 +482,9 @@ func baseCompileConstraints(context *subruleContext, cDef constraintsDef, target
 	if onClassic == nil {
 		defaultUsed++
 	} else {
-		var c *OnClassicConstraint
-		switch x := onClassic.(type) {
-		case string:
-			switch x {
-			case "true":
-				c = &OnClassicConstraint{Classic: true}
-			case "false":
-				c = &OnClassicConstraint{Classic: false}
-			}
-		case []any:
-			lst, err := checkStringListInMap(cMap, "on-classic", fmt.Sprintf("on-classic in %s", context), validDistro)
-			if err != nil {
-				return err
-			}
-			c = &OnClassicConstraint{Classic: true, SystemIDs: lst}
-		}
-		if c == nil {
-			return fmt.Errorf("on-classic in %s must be 'true', 'false' or a list of operating system IDs", context)
+		c, err := compileOnClassicConstraint(context, onClassic)
+		if err != nil {
+			return err
 		}
 		target.setOnClassicConstraint(c)
 	}
@@ -667,6 +747,9 @@ func (c *PlugInstallationConstraints) feature(flabel string) bool {
 	if flabel == deviceScopeConstraintsFeature {
 		return c.DeviceScope != nil
 	}
+	if flabel == onClassicVariantConstraintsFeature {
+		return c.OnClassic != nil && c.OnClassic.feature(flabel)
+	}
 	if flabel == nameConstraintsFeature {
 		return c.PlugNames != nil
 	}
@@ -753,6 +836,9 @@ type PlugConnectionConstraints struct {
 func (c *PlugConnectionConstraints) feature(flabel string) bool {
 	if flabel == deviceScopeConstraintsFeature {
 		return c.DeviceScope != nil
+	}
+	if flabel == onClassicVariantConstraintsFeature {
+		return c.OnClassic != nil && c.OnClassic.feature(flabel)
 	}
 	if flabel == nameConstraintsFeature {
 		return c.PlugNames != nil || c.SlotNames != nil
@@ -986,6 +1072,9 @@ func (c *SlotInstallationConstraints) feature(flabel string) bool {
 	if flabel == deviceScopeConstraintsFeature {
 		return c.DeviceScope != nil
 	}
+	if flabel == onClassicVariantConstraintsFeature {
+		return c.OnClassic != nil && c.OnClassic.feature(flabel)
+	}
 	if flabel == nameConstraintsFeature {
 		return c.SlotNames != nil
 	}
@@ -1086,6 +1175,9 @@ type SlotConnectionConstraints struct {
 func (c *SlotConnectionConstraints) feature(flabel string) bool {
 	if flabel == deviceScopeConstraintsFeature {
 		return c.DeviceScope != nil
+	}
+	if flabel == onClassicVariantConstraintsFeature {
+		return c.OnClassic != nil && c.OnClassic.feature(flabel)
 	}
 	if flabel == nameConstraintsFeature {
 		return c.PlugNames != nil || c.SlotNames != nil

--- a/asserts/ifacedecls.go
+++ b/asserts/ifacedecls.go
@@ -231,9 +231,6 @@ func compileOnClassicConstraint(context *subruleContext, onClassic any) (*OnClas
 			return nil, syntaxError
 		}
 	case []any:
-		if len(x) == 0 {
-			return &OnClassicConstraint{Classic: true}, nil
-		}
 		systems := make([]OnClassicSystemConstraint, len(x))
 		for i, v := range x {
 			s, ok := v.(string)

--- a/asserts/ifacedecls.go
+++ b/asserts/ifacedecls.go
@@ -242,7 +242,7 @@ func compileOnClassicConstraint(context *subruleContext, onClassic any) (*OnClas
 			}
 			systemID, err := compileOnClassicSystemConstraint(s)
 			if err != nil {
-				return nil, fmt.Errorf("%s contains an invalid element: %q", what, s)
+				return nil, fmt.Errorf("%s contains an invalid element: %q: %v", what, s, err)
 			}
 			systems[i] = systemID
 		}
@@ -254,11 +254,11 @@ func compileOnClassicConstraint(context *subruleContext, onClassic any) (*OnClas
 
 func compileOnClassicSystemConstraint(s string) (OnClassicSystemConstraint, error) {
 	if strings.Count(s, "/") > 1 {
-		return OnClassicSystemConstraint{}, fmt.Errorf("invalid operating system constraint")
+		return OnClassicSystemConstraint{}, fmt.Errorf("invalid operating system constraint: too many '/' separators")
 	}
 	if distroID, variantID, hasVariant := strings.Cut(s, "/"); hasVariant {
 		if !validDistro.MatchString(distroID) {
-			return OnClassicSystemConstraint{}, fmt.Errorf("invalid operating system constraint")
+			return OnClassicSystemConstraint{}, fmt.Errorf("invalid operating system constraint: invalid distro ID")
 		}
 		constraint := OnClassicSystemConstraint{
 			DistroID: distroID,
@@ -272,12 +272,12 @@ func compileOnClassicSystemConstraint(s string) (OnClassicSystemConstraint, erro
 		case validDistro.MatchString(variantID):
 			constraint.VariantID = variantID
 		default:
-			return OnClassicSystemConstraint{}, fmt.Errorf("invalid operating system constraint")
+			return OnClassicSystemConstraint{}, fmt.Errorf("invalid operating system constraint: invalid variant ID")
 		}
 		return constraint, nil
 	}
 	if !validDistro.MatchString(s) {
-		return OnClassicSystemConstraint{}, fmt.Errorf("invalid operating system constraint")
+		return OnClassicSystemConstraint{}, fmt.Errorf("invalid operating system constraint: invalid distro ID")
 	}
 	return OnClassicSystemConstraint{DistroID: s, VariantAny: true}, nil
 }

--- a/asserts/ifacedecls_test.go
+++ b/asserts/ifacedecls_test.go
@@ -855,7 +855,38 @@ func (s *plugSlotRulesSuite) TestCompilePlugRuleInstallationConstraintsOnClassic
 	rule, err = asserts.CompilePlugRule("iface", m["iface"].(map[string]any))
 	c.Assert(err, IsNil)
 
-	c.Check(rule.AllowInstallation[0].OnClassic, DeepEquals, &asserts.OnClassicConstraint{Classic: true, SystemIDs: []string{"ubuntu", "debian"}})
+	c.Check(rule.AllowInstallation[0].OnClassic, DeepEquals, &asserts.OnClassicConstraint{Classic: true, SystemIDs: []asserts.OnClassicSystemConstraint{{DistroID: "ubuntu", VariantAny: true}, {DistroID: "debian", VariantAny: true}}})
+
+	m, err = asserts.ParseHeaders([]byte("iface:\n  allow-installation:\n    on-classic:\n      - ubuntu/touch\n      - ubuntu/*\n      - ubuntu/"))
+	c.Assert(err, IsNil)
+
+	rule, err = asserts.CompilePlugRule("iface", m["iface"].(map[string]any))
+	c.Assert(err, IsNil)
+
+	c.Check(rule.AllowInstallation[0].OnClassic, DeepEquals, &asserts.OnClassicConstraint{Classic: true, SystemIDs: []asserts.OnClassicSystemConstraint{{DistroID: "ubuntu", VariantID: "touch"}, {DistroID: "ubuntu", VariantID: "*", VariantAny: true}, {DistroID: "ubuntu"}}})
+}
+
+func (s *plugSlotRulesSuite) TestCompileOnClassicSystemConstraint(c *C) {
+	validTests := []struct {
+		input    string
+		expected asserts.OnClassicSystemConstraint
+	}{
+		{input: "ubuntu", expected: asserts.OnClassicSystemConstraint{DistroID: "ubuntu", VariantAny: true}},
+		{input: "ubuntu/touch", expected: asserts.OnClassicSystemConstraint{DistroID: "ubuntu", VariantID: "touch"}},
+		{input: "ubuntu/*", expected: asserts.OnClassicSystemConstraint{DistroID: "ubuntu", VariantID: "*", VariantAny: true}},
+		{input: "ubuntu/", expected: asserts.OnClassicSystemConstraint{DistroID: "ubuntu"}},
+	}
+
+	for _, test := range validTests {
+		constraint, err := asserts.CompileOnClassicSystemConstraintForTest(test.input)
+		c.Assert(err, IsNil)
+		c.Check(constraint, DeepEquals, test.expected)
+	}
+
+	for _, input := range []string{"ubuntu/touch/stable", "ubuntu/!desktop", "ubuntu//", "/touch", "*"} {
+		_, err := asserts.CompileOnClassicSystemConstraintForTest(input)
+		c.Check(err, ErrorMatches, "invalid operating system constraint")
+	}
 }
 
 func (s *plugSlotRulesSuite) TestCompilePlugRuleInstallationConstraintsDeviceScope(c *C) {
@@ -1021,7 +1052,15 @@ func (s *plugSlotRulesSuite) TestCompilePlugRuleConnectionConstraintsOnClassic(c
 	rule, err = asserts.CompilePlugRule("iface", m["iface"].(map[string]any))
 	c.Assert(err, IsNil)
 
-	c.Check(rule.AllowConnection[0].OnClassic, DeepEquals, &asserts.OnClassicConstraint{Classic: true, SystemIDs: []string{"ubuntu", "debian"}})
+	c.Check(rule.AllowConnection[0].OnClassic, DeepEquals, &asserts.OnClassicConstraint{Classic: true, SystemIDs: []asserts.OnClassicSystemConstraint{{DistroID: "ubuntu", VariantAny: true}, {DistroID: "debian", VariantAny: true}}})
+
+	m, err = asserts.ParseHeaders([]byte("iface:\n  allow-connection:\n    on-classic:\n      - ubuntu/touch\n      - ubuntu/*\n      - ubuntu/"))
+	c.Assert(err, IsNil)
+
+	rule, err = asserts.CompilePlugRule("iface", m["iface"].(map[string]any))
+	c.Assert(err, IsNil)
+
+	c.Check(rule.AllowConnection[0].OnClassic, DeepEquals, &asserts.OnClassicConstraint{Classic: true, SystemIDs: []asserts.OnClassicSystemConstraint{{DistroID: "ubuntu", VariantID: "touch"}, {DistroID: "ubuntu", VariantID: "*", VariantAny: true}, {DistroID: "ubuntu"}}})
 }
 
 func (s *plugSlotRulesSuite) TestCompilePlugRuleConnectionConstraintsDeviceScope(c *C) {
@@ -1701,7 +1740,15 @@ func (s *plugSlotRulesSuite) TestCompileSlotRuleInstallationConstraintsOnClassic
 	rule, err = asserts.CompileSlotRule("iface", m["iface"].(map[string]any))
 	c.Assert(err, IsNil)
 
-	c.Check(rule.AllowInstallation[0].OnClassic, DeepEquals, &asserts.OnClassicConstraint{Classic: true, SystemIDs: []string{"ubuntu", "debian"}})
+	c.Check(rule.AllowInstallation[0].OnClassic, DeepEquals, &asserts.OnClassicConstraint{Classic: true, SystemIDs: []asserts.OnClassicSystemConstraint{{DistroID: "ubuntu", VariantAny: true}, {DistroID: "debian", VariantAny: true}}})
+
+	m, err = asserts.ParseHeaders([]byte("iface:\n  allow-installation:\n    on-classic:\n      - ubuntu/touch\n      - ubuntu/*\n      - ubuntu/"))
+	c.Assert(err, IsNil)
+
+	rule, err = asserts.CompileSlotRule("iface", m["iface"].(map[string]any))
+	c.Assert(err, IsNil)
+
+	c.Check(rule.AllowInstallation[0].OnClassic, DeepEquals, &asserts.OnClassicConstraint{Classic: true, SystemIDs: []asserts.OnClassicSystemConstraint{{DistroID: "ubuntu", VariantID: "touch"}, {DistroID: "ubuntu", VariantID: "*", VariantAny: true}, {DistroID: "ubuntu"}}})
 }
 
 func (s *plugSlotRulesSuite) TestCompileSlotRuleInstallationConstraintsDeviceScope(c *C) {
@@ -1868,7 +1915,15 @@ func (s *plugSlotRulesSuite) TestCompileSlotRuleConnectionConstraintsOnClassic(c
 	rule, err = asserts.CompileSlotRule("iface", m["iface"].(map[string]any))
 	c.Assert(err, IsNil)
 
-	c.Check(rule.AllowConnection[0].OnClassic, DeepEquals, &asserts.OnClassicConstraint{Classic: true, SystemIDs: []string{"ubuntu", "debian"}})
+	c.Check(rule.AllowConnection[0].OnClassic, DeepEquals, &asserts.OnClassicConstraint{Classic: true, SystemIDs: []asserts.OnClassicSystemConstraint{{DistroID: "ubuntu", VariantAny: true}, {DistroID: "debian", VariantAny: true}}})
+
+	m, err = asserts.ParseHeaders([]byte("iface:\n  allow-connection:\n    on-classic:\n      - ubuntu/touch\n      - ubuntu/*\n      - ubuntu/"))
+	c.Assert(err, IsNil)
+
+	rule, err = asserts.CompileSlotRule("iface", m["iface"].(map[string]any))
+	c.Assert(err, IsNil)
+
+	c.Check(rule.AllowConnection[0].OnClassic, DeepEquals, &asserts.OnClassicConstraint{Classic: true, SystemIDs: []asserts.OnClassicSystemConstraint{{DistroID: "ubuntu", VariantID: "touch"}, {DistroID: "ubuntu", VariantID: "*", VariantAny: true}, {DistroID: "ubuntu"}}})
 }
 
 func (s *plugSlotRulesSuite) TestCompileSlotRuleConnectionConstraintsDeviceScope(c *C) {
@@ -2117,14 +2172,16 @@ func (s *plugSlotRulesSuite) TestCompileSlotRuleErrors(c *C) {
   allow-connection:
     plug-snap-type:
       - xapp`, `plug-snap-type in allow-connection in slot rule for interface "iface" contains an invalid element: "xapp"`},
-		{`iface:
-  allow-connection:
-    on-classic:
-      x: 1`, `on-classic in allow-connection in slot rule for interface \"iface\" must be 'true', 'false' or a list of operating system IDs`},
+		{"iface:\n  allow-connection:\n    on-classic:\n      x: 1", `on-classic in allow-connection in slot rule for interface \"iface\" must be 'true', 'false' or a list of operating system IDs with optional /variant IDs`},
 		{`iface:
   allow-connection:
     on-classic:
       - zoom!`, `on-classic in allow-connection in slot rule for interface \"iface\" contains an invalid element: \"zoom!\"`},
+		{"iface:\n  allow-connection:\n    on-classic:\n      - ubuntu/touch/stable", `on-classic in allow-connection in slot rule for interface \"iface\" contains an invalid element: \"ubuntu/touch/stable\"`},
+		{`iface:
+  allow-connection:
+    on-classic:
+      - ubuntu/!desktop`, `on-classic in allow-connection in slot rule for interface \"iface\" contains an invalid element: \"ubuntu/!desktop\"`},
 		{`iface:
   allow-connection:
     plug-snap-ids:

--- a/asserts/ifacedecls_test.go
+++ b/asserts/ifacedecls_test.go
@@ -883,9 +883,19 @@ func (s *plugSlotRulesSuite) TestCompileOnClassicSystemConstraint(c *C) {
 		c.Check(constraint, DeepEquals, test.expected)
 	}
 
-	for _, input := range []string{"ubuntu/touch/stable", "ubuntu/!desktop", "ubuntu//", "/touch", "*"} {
-		_, err := asserts.CompileOnClassicSystemConstraintForTest(input)
-		c.Check(err, ErrorMatches, "invalid operating system constraint")
+	invalidTests := []struct {
+		input string
+		err   string
+	}{
+		{input: "ubuntu/touch/stable", err: "invalid operating system constraint: too many '/' separators"},
+		{input: "ubuntu/!desktop", err: "invalid operating system constraint: invalid variant ID"},
+		{input: "ubuntu//", err: "invalid operating system constraint: too many '/' separators"},
+		{input: "/touch", err: "invalid operating system constraint: invalid distro ID"},
+		{input: "*", err: "invalid operating system constraint: invalid distro ID"},
+	}
+	for _, test := range invalidTests {
+		_, err := asserts.CompileOnClassicSystemConstraintForTest(test.input)
+		c.Check(err, ErrorMatches, test.err)
 	}
 }
 
@@ -2173,15 +2183,10 @@ func (s *plugSlotRulesSuite) TestCompileSlotRuleErrors(c *C) {
     plug-snap-type:
       - xapp`, `plug-snap-type in allow-connection in slot rule for interface "iface" contains an invalid element: "xapp"`},
 		{"iface:\n  allow-connection:\n    on-classic:\n      x: 1", `on-classic in allow-connection in slot rule for interface \"iface\" must be 'true', 'false' or a list of operating system IDs with optional /variant IDs`},
-		{`iface:
-  allow-connection:
-    on-classic:
-      - zoom!`, `on-classic in allow-connection in slot rule for interface \"iface\" contains an invalid element: \"zoom!\"`},
-		{"iface:\n  allow-connection:\n    on-classic:\n      - ubuntu/touch/stable", `on-classic in allow-connection in slot rule for interface \"iface\" contains an invalid element: \"ubuntu/touch/stable\"`},
-		{`iface:
-  allow-connection:
-    on-classic:
-      - ubuntu/!desktop`, `on-classic in allow-connection in slot rule for interface \"iface\" contains an invalid element: \"ubuntu/!desktop\"`},
+		{"iface:\n  allow-connection:\n    on-classic:\n      -\n        distro: ubuntu", `on-classic in allow-connection in slot rule for interface "iface" must be a list of strings`},
+		{"iface:\n  allow-connection:\n    on-classic:\n      - zoom!", `on-classic in allow-connection in slot rule for interface "iface" contains an invalid element: "zoom!": invalid operating system constraint: invalid distro ID`},
+		{"iface:\n  allow-connection:\n    on-classic:\n      - ubuntu/touch/stable", `on-classic in allow-connection in slot rule for interface "iface" contains an invalid element: "ubuntu/touch/stable": invalid operating system constraint: too many '/' separators`},
+		{"iface:\n  allow-connection:\n    on-classic:\n      - ubuntu/!desktop", `on-classic in allow-connection in slot rule for interface "iface" contains an invalid element: "ubuntu/!desktop": invalid operating system constraint: invalid variant ID`},
 		{`iface:
   allow-connection:
     plug-snap-ids:

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -200,6 +200,9 @@ func snapDeclarationFormatAnalyze(headers map[string]any, body []byte) (formatnu
 		if rule.feature(publisherIDConstraintsFeature) {
 			setFormatNum(6)
 		}
+		if rule.feature(onClassicVariantConstraintsFeature) {
+			setFormatNum(7)
+		}
 	})
 	if err != nil {
 		return 0, err
@@ -224,6 +227,9 @@ func snapDeclarationFormatAnalyze(headers map[string]any, body []byte) (formatnu
 		}
 		if rule.feature(publisherIDConstraintsFeature) {
 			setFormatNum(6)
+		}
+		if rule.feature(onClassicVariantConstraintsFeature) {
+			setFormatNum(7)
 		}
 	})
 	if err != nil {

--- a/asserts/snap_asserts_test.go
+++ b/asserts/snap_asserts_test.go
@@ -734,6 +734,60 @@ func (sds *snapDeclSuite) TestSuggestedFormat(c *C) {
 			c.Check(fmtnum, Equals, 6)
 		}
 	}
+
+	headers = map[string]any{
+		"plugs": map[string]any{
+			"interface7": map[string]any{
+				"allow-installation": map[string]any{
+					"on-classic": []any{"ubuntu"},
+				},
+			},
+		},
+	}
+	fmtnum, err = asserts.SuggestFormat(asserts.SnapDeclarationType, headers, nil)
+	c.Assert(err, IsNil)
+	c.Check(fmtnum, Equals, 1)
+
+	for _, sidePrefix := range []string{"plug", "slot"} {
+		headers = map[string]any{
+			sidePrefix + "s": map[string]any{
+				"interface7": map[string]any{
+					"allow-installation": map[string]any{
+						"on-classic": []any{"ubuntu/touch"},
+					},
+				},
+			},
+		}
+		fmtnum, err = asserts.SuggestFormat(asserts.SnapDeclarationType, headers, nil)
+		c.Assert(err, IsNil)
+		c.Check(fmtnum, Equals, 7)
+
+		headers = map[string]any{
+			sidePrefix + "s": map[string]any{
+				"interface7": map[string]any{
+					"allow-installation": map[string]any{
+						"on-classic": []any{"ubuntu/*"},
+					},
+				},
+			},
+		}
+		fmtnum, err = asserts.SuggestFormat(asserts.SnapDeclarationType, headers, nil)
+		c.Assert(err, IsNil)
+		c.Check(fmtnum, Equals, 7)
+
+		headers = map[string]any{
+			sidePrefix + "s": map[string]any{
+				"interface7": map[string]any{
+					"allow-auto-connection": map[string]any{
+						"on-classic": []any{"ubuntu/"},
+					},
+				},
+			},
+		}
+		fmtnum, err = asserts.SuggestFormat(asserts.SnapDeclarationType, headers, nil)
+		c.Assert(err, IsNil)
+		c.Check(fmtnum, Equals, 7)
+	}
 }
 
 func prereqDevAccount(c *C, storeDB assertstest.SignerDB, db *asserts.Database) {

--- a/interfaces/builtin/README.md
+++ b/interfaces/builtin/README.md
@@ -491,6 +491,12 @@ Desktop means this idea is not always valid. A different approach is to
 deny-connection based on the type of slot carrying snap, e.g for
 `upower-observe` nowadays, we have:
 
+`on-classic` constraints can also be limited to specific classic operating
+systems. A plain operating system ID such as `ubuntu` matches any variant for
+compatibility. Starting with snap-declaration format 7, entries can also use
+`distro/variant` to match a specific VARIANT_ID, `distro/*` to match any
+variant, and `distro/` to match only when VARIANT_ID is unset.
+
     upower-observe:
       allow-installation:
         slot-snap-type:

--- a/interfaces/policy/helpers.go
+++ b/interfaces/policy/helpers.go
@@ -78,9 +78,24 @@ func checkOnClassic(c *asserts.OnClassicConstraint) error {
 		return fmt.Errorf("on-classic mismatch")
 	}
 	if c.Classic && len(c.SystemIDs) != 0 {
-		return checkID("operating system ID", release.ReleaseInfo.ID, c.SystemIDs, nil)
+		for _, systemID := range c.SystemIDs {
+			if checkOnClassicSystem(systemID, release.ReleaseInfo.ID, release.ReleaseInfo.VariantID) {
+				return nil
+			}
+		}
+		return fmt.Errorf("operating system does not match")
 	}
 	return nil
+}
+
+func checkOnClassicSystem(system asserts.OnClassicSystemConstraint, distroID, variantID string) bool {
+	if system.DistroID != distroID {
+		return false
+	}
+	if system.VariantAny {
+		return true
+	}
+	return system.VariantID == variantID
 }
 
 func checkOnCoreDesktop(c *asserts.OnCoreDesktopConstraint) error {

--- a/interfaces/policy/helpers.go
+++ b/interfaces/policy/helpers.go
@@ -89,13 +89,7 @@ func checkOnClassic(c *asserts.OnClassicConstraint) error {
 }
 
 func checkOnClassicSystem(system asserts.OnClassicSystemConstraint, distroID, variantID string) bool {
-	if system.DistroID != distroID {
-		return false
-	}
-	if system.VariantAny {
-		return true
-	}
-	return system.VariantID == variantID
+	return system.DistroID == distroID && (system.VariantID == variantID || system.VariantAny)
 }
 
 func checkOnCoreDesktop(c *asserts.OnCoreDesktopConstraint) error {

--- a/interfaces/policy/policy_test.go
+++ b/interfaces/policy/policy_test.go
@@ -108,6 +108,12 @@ plugs:
       on-classic:
         - ubuntu
         - debian
+  plug-on-classic-variants:
+    allow-connection:
+      on-classic:
+        - ubuntu/touch
+        - debian/*
+        - fedora/
   plug-on-classic-false:
     allow-connection:
       on-classic: false
@@ -171,6 +177,12 @@ plugs:
       on-classic:
         - ubuntu
         - debian
+  install-plug-on-classic-variants:
+    allow-installation:
+      on-classic:
+        - ubuntu/touch
+        - debian/*
+        - fedora/
   install-plug-device-scope:
     allow-installation: false
   install-plug-name-bound:
@@ -239,6 +251,12 @@ slots:
       on-classic:
         - ubuntu
         - debian
+  slot-on-classic-variants:
+    allow-connection:
+      on-classic:
+        - ubuntu/touch
+        - debian/*
+        - fedora/
   slot-on-classic-false:
     allow-connection:
       on-classic: false
@@ -309,6 +327,12 @@ slots:
       on-classic:
         - ubuntu
         - debian
+  install-slot-on-classic-variants:
+    allow-installation:
+      on-classic:
+        - ubuntu/touch
+        - debian/*
+        - fedora/
   install-slot-device-scope:
     allow-installation: false
   install-slot-name-bound:
@@ -508,10 +532,12 @@ plugs:
 
    slot-on-classic-true:
    slot-on-classic-distros:
+   slot-on-classic-variants:
    slot-on-classic-false:
 
    plug-on-classic-true:
    plug-on-classic-distros:
+   plug-on-classic-variants:
    plug-on-classic-false:
 
    slots-arity-default:
@@ -707,10 +733,12 @@ slots:
 
    slot-on-classic-true:
    slot-on-classic-distros:
+   slot-on-classic-variants:
    slot-on-classic-false:
 
    plug-on-classic-true:
    plug-on-classic-distros:
+   plug-on-classic-variants:
    plug-on-classic-false:
 
    slots-arity-default:
@@ -1785,27 +1813,38 @@ func (s *policySuite) TestPlugOnClassicCheckConnection(c *C) {
 	defer r2()
 
 	tests := []struct {
-		distro string // "" => not classic
-		iface  string
-		err    string // "" => no error
+		classic bool
+		distro  string
+		variant string
+		iface   string
+		err     string // "" => no error
 	}{
-		{"ubuntu", "plug-on-classic-true", ""},
-		{"", "plug-on-classic-true", `connection not allowed by plug rule of interface "plug-on-classic-true"`},
-		{"", "plug-on-classic-false", ""},
-		{"ubuntu", "plug-on-classic-false", "connection not allowed.*"},
-		{"ubuntu", "plug-on-classic-distros", ""},
-		{"debian", "plug-on-classic-distros", ""},
-		{"", "plug-on-classic-distros", "connection not allowed.*"},
-		{"other", "plug-on-classic-distros", "connection not allowed.*"},
+		{classic: true, distro: "ubuntu", iface: "plug-on-classic-true"},
+		{iface: "plug-on-classic-true", err: `connection not allowed by plug rule of interface "plug-on-classic-true"`},
+		{iface: "plug-on-classic-false"},
+		{classic: true, distro: "ubuntu", iface: "plug-on-classic-false", err: "connection not allowed.*"},
+		{classic: true, distro: "ubuntu", iface: "plug-on-classic-distros"},
+		{classic: true, distro: "ubuntu", variant: "server", iface: "plug-on-classic-distros"},
+		{classic: true, distro: "debian", iface: "plug-on-classic-distros"},
+		{iface: "plug-on-classic-distros", err: "connection not allowed.*"},
+		{classic: true, distro: "other", iface: "plug-on-classic-distros", err: "connection not allowed.*"},
+		{classic: true, distro: "ubuntu", variant: "touch", iface: "plug-on-classic-variants"},
+		{classic: true, distro: "ubuntu", variant: "server", iface: "plug-on-classic-variants", err: "connection not allowed.*"},
+		{classic: true, distro: "debian", variant: "sid", iface: "plug-on-classic-variants"},
+		{classic: true, distro: "fedora", iface: "plug-on-classic-variants"},
+		{classic: true, distro: "fedora", variant: "workstation", iface: "plug-on-classic-variants", err: "connection not allowed.*"},
+		{iface: "plug-on-classic-variants", err: "connection not allowed.*"},
 	}
 
 	for _, t := range tests {
-		if t.distro == "" {
+		if !t.classic {
 			release.OnClassic = false
+			release.ReleaseInfo = release.OS{}
 		} else {
 			release.OnClassic = true
 			release.ReleaseInfo = release.OS{
-				ID: t.distro,
+				ID:        t.distro,
+				VariantID: t.variant,
 			}
 		}
 		cand := policy.ConnectCandidate{
@@ -1829,27 +1868,38 @@ func (s *policySuite) TestSlotOnClassicCheckConnection(c *C) {
 	defer r2()
 
 	tests := []struct {
-		distro string // "" => not classic
-		iface  string
-		err    string // "" => no error
+		classic bool
+		distro  string
+		variant string
+		iface   string
+		err     string // "" => no error
 	}{
-		{"ubuntu", "slot-on-classic-true", ""},
-		{"", "slot-on-classic-true", `connection not allowed by slot rule of interface "slot-on-classic-true"`},
-		{"", "slot-on-classic-false", ""},
-		{"ubuntu", "slot-on-classic-false", "connection not allowed.*"},
-		{"ubuntu", "slot-on-classic-distros", ""},
-		{"debian", "slot-on-classic-distros", ""},
-		{"", "slot-on-classic-distros", "connection not allowed.*"},
-		{"other", "slot-on-classic-distros", "connection not allowed.*"},
+		{classic: true, distro: "ubuntu", iface: "slot-on-classic-true"},
+		{iface: "slot-on-classic-true", err: `connection not allowed by slot rule of interface "slot-on-classic-true"`},
+		{iface: "slot-on-classic-false"},
+		{classic: true, distro: "ubuntu", iface: "slot-on-classic-false", err: "connection not allowed.*"},
+		{classic: true, distro: "ubuntu", iface: "slot-on-classic-distros"},
+		{classic: true, distro: "ubuntu", variant: "server", iface: "slot-on-classic-distros"},
+		{classic: true, distro: "debian", iface: "slot-on-classic-distros"},
+		{iface: "slot-on-classic-distros", err: "connection not allowed.*"},
+		{classic: true, distro: "other", iface: "slot-on-classic-distros", err: "connection not allowed.*"},
+		{classic: true, distro: "ubuntu", variant: "touch", iface: "slot-on-classic-variants"},
+		{classic: true, distro: "ubuntu", variant: "server", iface: "slot-on-classic-variants", err: "connection not allowed.*"},
+		{classic: true, distro: "debian", variant: "sid", iface: "slot-on-classic-variants"},
+		{classic: true, distro: "fedora", iface: "slot-on-classic-variants"},
+		{classic: true, distro: "fedora", variant: "workstation", iface: "slot-on-classic-variants", err: "connection not allowed.*"},
+		{iface: "slot-on-classic-variants", err: "connection not allowed.*"},
 	}
 
 	for _, t := range tests {
-		if t.distro == "" {
+		if !t.classic {
 			release.OnClassic = false
+			release.ReleaseInfo = release.OS{}
 		} else {
 			release.OnClassic = true
 			release.ReleaseInfo = release.OS{
-				ID: t.distro,
+				ID:        t.distro,
+				VariantID: t.variant,
 			}
 		}
 		cand := policy.ConnectCandidate{
@@ -1873,35 +1923,63 @@ func (s *policySuite) TestOnClassicInstallation(c *C) {
 	defer r2()
 
 	tests := []struct {
-		distro      string // "" => not classic
+		classic     bool
+		distro      string
+		variant     string
 		installYaml string
 		err         string // "" => no error
 	}{
-		{"", `name: install-snap
+		{installYaml: `name: install-snap
 version: 0
 slots:
-  install-slot-on-classic-distros:`, `installation not allowed by "install-slot-on-classic-distros" slot rule.*`},
-		{"debian", `name: install-snap
+  install-slot-on-classic-distros:`, err: `installation not allowed by "install-slot-on-classic-distros" slot rule.*`},
+		{classic: true, distro: "debian", variant: "sid", installYaml: `name: install-snap
 version: 0
 slots:
-  install-slot-on-classic-distros:`, ""},
-		{"", `name: install-snap
+  install-slot-on-classic-distros:`, err: ""},
+		{installYaml: `name: install-snap
 version: 0
 plugs:
-  install-plug-on-classic-distros:`, `installation not allowed by "install-plug-on-classic-distros" plug rule.*`},
-		{"debian", `name: install-snap
+  install-plug-on-classic-distros:`, err: `installation not allowed by "install-plug-on-classic-distros" plug rule.*`},
+		{classic: true, distro: "debian", variant: "sid", installYaml: `name: install-snap
 version: 0
 plugs:
-  install-plug-on-classic-distros:`, ""},
+  install-plug-on-classic-distros:`, err: ""},
+		{classic: true, distro: "ubuntu", variant: "touch", installYaml: `name: install-snap
+version: 0
+slots:
+  install-slot-on-classic-variants:`, err: ""},
+		{classic: true, distro: "ubuntu", variant: "server", installYaml: `name: install-snap
+version: 0
+slots:
+  install-slot-on-classic-variants:`, err: `installation not allowed by "install-slot-on-classic-variants" slot rule.*`},
+		{classic: true, distro: "fedora", installYaml: `name: install-snap
+version: 0
+slots:
+  install-slot-on-classic-variants:`, err: ""},
+		{classic: true, distro: "fedora", variant: "workstation", installYaml: `name: install-snap
+version: 0
+slots:
+  install-slot-on-classic-variants:`, err: `installation not allowed by "install-slot-on-classic-variants" slot rule.*`},
+		{classic: true, distro: "debian", variant: "sid", installYaml: `name: install-snap
+version: 0
+plugs:
+  install-plug-on-classic-variants:`, err: ""},
+		{classic: true, distro: "ubuntu", variant: "server", installYaml: `name: install-snap
+version: 0
+plugs:
+  install-plug-on-classic-variants:`, err: `installation not allowed by "install-plug-on-classic-variants" plug rule.*`},
 	}
 
 	for _, t := range tests {
-		if t.distro == "" {
+		if !t.classic {
 			release.OnClassic = false
+			release.ReleaseInfo = release.OS{}
 		} else {
 			release.OnClassic = true
 			release.ReleaseInfo = release.OS{
-				ID: t.distro,
+				ID:        t.distro,
+				VariantID: t.variant,
 			}
 		}
 

--- a/release/release.go
+++ b/release/release.go
@@ -116,7 +116,7 @@ func readOSReleaseFromRoot(rootdir string) OS {
 			// This is like ID, except it's a space separated list... hooray?
 			osRelease.IDLike = strings.Fields(strings.ToLower(v))
 		case "VARIANT_ID":
-			osRelease.VariantID = v
+			osRelease.VariantID = strings.ToLower(v)
 		case "VERSION_ID":
 			osRelease.VersionID = v
 		}

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -124,6 +124,7 @@ func (s *ReleaseTestSuite) TestReadOSRelease(c *C) {
 
 	os := release.ReadOSReleaseFromRoot(root)
 	c.Check(os.ID, Equals, "ubuntu")
+	c.Check(os.VariantID, Equals, "")
 	c.Check(os.VersionID, Equals, "18.09")
 }
 

--- a/release/release_test.go
+++ b/release/release_test.go
@@ -229,7 +229,7 @@ func (s *ReleaseTestSuite) TestUbuntuCoreVariantRelease(c *C) {
 	dump := `NAME="Ubuntu Core Desktop"
 VERSION="22"
 ID="ubuntu-core"
-VARIANT_ID="desktop"
+VARIANT_ID="Desktop"
 VERSION_ID="22"
 "`
 


### PR DESCRIPTION
Extend on-classic constraints to accept "distro/variant",
"distro/*", and "distro/" under a new snap-declaration format 7.
These match a specific variant, any variant, and an unset VARIANT_ID;
plain "distro" remains the compatibility form that matches any variant.
Update policy matching and tests accordingly.