### PR TITLE
o/snapstate: properly merge prerequisites into pending seed refresh

### DIFF
--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -298,7 +298,7 @@ func delayedCrossMgrInit() {
 	snapstate.IsOnMeteredConnection = netutil.IsOnMeteredConnection
 	snapstate.DeviceCtx = DeviceCtx
 	snapstate.RemodelingChange = RemodelingChange
-	snapstate.SeedRefreshTasks = SeedRefreshTasks
+	snapstate.CreateSeedRefreshTasks = SeedRefreshTasks
 	snapstate.PendingSeedRefreshTasks = PendingSeedRefreshTasks
 	snapstate.UpdateSeedRefreshChange = UpdateSeedRefreshChange
 	snapstate.CheckSeedRefreshRemove = CheckSeedRefreshRemove
@@ -1727,8 +1727,8 @@ func removeRecoverySystemTask(st *state.State, label string) *state.Task {
 	return remove
 }
 
-// SeedRefreshTasks returns a [snapstate.SeedRefreshTaskSet] that carries the
-// tasks needed to refresh the seed managed by seed-refresh mode, plus the snap
+// SeedRefreshTasks returns [snapstate.SeedRefreshTasks], which carries the tasks
+// needed to refresh the seed managed by seed-refresh mode, plus the snap
 // names selected for that seed refresh. The selected setup task IDs are written
 // into the recovery-system setup payload so the new seed can consume the
 // refreshed snaps and components. Older seed-refresh systems are removed
@@ -1738,7 +1738,7 @@ func SeedRefreshTasks(
 	dctx snapstate.DeviceContext,
 	candidates []snapstate.SeedRefreshCandidate,
 	eviction snapstate.SeedRefreshEvictionPolicy,
-) (*snapstate.SeedRefreshTaskSet, map[string]bool, error) {
+) (*snapstate.SeedRefreshTasks, map[string]bool, error) {
 	// remodel creates its own seed creation tasks explicitly, seed-refresh
 	// should never create them.
 	if dctx.ForRemodeling() {
@@ -1807,7 +1807,7 @@ func SeedRefreshTasks(
 		removals = append(removals, remove)
 	}
 
-	return &snapstate.SeedRefreshTaskSet{
+	return &snapstate.SeedRefreshTasks{
 		Create:   create,
 		Finalize: finalize,
 		Remove:   removals,
@@ -1816,14 +1816,14 @@ func SeedRefreshTasks(
 
 // PendingSeedRefreshTasks returns the pending seed-refresh task set in the
 // provided task set, or nil when it has no pending seed refresh.
-func PendingSeedRefreshTasks(ts *state.TaskSet) (*snapstate.SeedRefreshTaskSet, error) {
+func PendingSeedRefreshTasks(ts *state.TaskSet) (*snapstate.SeedRefreshTasks, error) {
 	return findSeedRefreshTasks(ts)
 }
 
 // UpdateSeedRefreshChange adds a late candidate to an existing seed-refresh
 // task set when the snap should participate in the refreshed seed. Returns
 // whether the candidate was added to the seed refresh.
-func UpdateSeedRefreshChange(seedTS *snapstate.SeedRefreshTaskSet, dctx snapstate.DeviceContext, candidate snapstate.SeedRefreshCandidate) (bool, error) {
+func UpdateSeedRefreshChange(seedTS *snapstate.SeedRefreshTasks, dctx snapstate.DeviceContext, candidate snapstate.SeedRefreshCandidate) (added bool, err error) {
 	// remodel creates its own seed creation tasks explicitly, seed-refresh
 	// should never create them.
 	if dctx.ForRemodeling() {
@@ -1941,7 +1941,7 @@ func seedRefreshTriggers(st *state.State, dctx snapstate.DeviceContext) func(str
 	}
 }
 
-func findSeedRefreshTasks(ts *state.TaskSet) (*snapstate.SeedRefreshTaskSet, error) {
+func findSeedRefreshTasks(ts *state.TaskSet) (*snapstate.SeedRefreshTasks, error) {
 	var finalize *state.Task
 	var removals []*state.Task
 	for _, t := range ts.Tasks() {
@@ -1987,7 +1987,7 @@ func findSeedRefreshTasks(ts *state.TaskSet) (*snapstate.SeedRefreshTaskSet, err
 		return nil, fmt.Errorf("internal error: seed-refresh creation task has already started with status %s while finalization is still pending", create.Status())
 	}
 
-	return &snapstate.SeedRefreshTaskSet{
+	return &snapstate.SeedRefreshTasks{
 		Create:   create,
 		Finalize: finalize,
 		Remove:   removals,

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -299,6 +299,7 @@ func delayedCrossMgrInit() {
 	snapstate.DeviceCtx = DeviceCtx
 	snapstate.RemodelingChange = RemodelingChange
 	snapstate.SeedRefreshTasks = SeedRefreshTasks
+	snapstate.PendingSeedRefreshTasks = PendingSeedRefreshTasks
 	snapstate.UpdateSeedRefreshChange = UpdateSeedRefreshChange
 	snapstate.CheckSeedRefreshRemove = CheckSeedRefreshRemove
 }
@@ -1813,37 +1814,36 @@ func SeedRefreshTasks(
 	}, added, nil
 }
 
+// PendingSeedRefreshTasks returns the pending seed-refresh task set in the
+// provided task set, or nil when it has no pending seed refresh.
+func PendingSeedRefreshTasks(ts *state.TaskSet) (*snapstate.SeedRefreshTaskSet, error) {
+	return findSeedRefreshTasks(ts)
+}
+
 // UpdateSeedRefreshChange adds a late candidate to an existing seed-refresh
-// change when the snap should participate in the refreshed seed. Returns nil if
-// snap isn't part of the seed refresh, otherwise returns the seed refresh task
-// set.
-func UpdateSeedRefreshChange(chg *state.Change, dctx snapstate.DeviceContext, candidate snapstate.SeedRefreshCandidate) (*snapstate.SeedRefreshTaskSet, error) {
+// task set when the snap should participate in the refreshed seed. Returns
+// whether the candidate was added to the seed refresh.
+func UpdateSeedRefreshChange(seedTS *snapstate.SeedRefreshTaskSet, dctx snapstate.DeviceContext, candidate snapstate.SeedRefreshCandidate) (bool, error) {
 	// remodel creates its own seed creation tasks explicitly, seed-refresh
 	// should never create them.
 	if dctx.ForRemodeling() {
-		return nil, nil
+		return false, nil
 	}
 
-	triggers := seedRefreshTriggers(chg.State(), dctx)
-
+	triggers := seedRefreshTriggers(seedTS.Create.State(), dctx)
 	ok, err := triggers(candidate.InstanceName)
 	if err != nil {
-		return nil, err
+		return false, err
 	}
 	if !ok {
-		return nil, nil
-	}
-
-	seedTS, err := findSeedRefreshTasks(chg)
-	if err != nil {
-		return nil, err
+		return false, nil
 	}
 
 	if err := appendSeedRefreshCandidate(seedTS.Create, candidate.SnapSetupTaskIDs, candidate.ComponentSetupTaskIDs); err != nil {
-		return nil, err
+		return false, err
 	}
 
-	return seedTS, nil
+	return true, nil
 }
 
 func appendSeedRefreshCandidate(create *state.Task, snapSetupTasks, compSetupTasks []string) error {
@@ -1941,10 +1941,10 @@ func seedRefreshTriggers(st *state.State, dctx snapstate.DeviceContext) func(str
 	}
 }
 
-func findSeedRefreshTasks(chg *state.Change) (*snapstate.SeedRefreshTaskSet, error) {
+func findSeedRefreshTasks(ts *state.TaskSet) (*snapstate.SeedRefreshTaskSet, error) {
 	var finalize *state.Task
 	var removals []*state.Task
-	for _, t := range chg.Tasks() {
+	for _, t := range ts.Tasks() {
 		switch t.Kind() {
 		case "finalize-recovery-system":
 			if t.Status().Ready() {
@@ -1962,7 +1962,7 @@ func findSeedRefreshTasks(chg *state.Change) (*snapstate.SeedRefreshTaskSet, err
 	}
 
 	if finalize == nil {
-		return nil, errors.New("internal error: seed-refresh change is missing pending finalize-recovery-system task")
+		return nil, nil
 	}
 
 	var createID string
@@ -1970,9 +1970,21 @@ func findSeedRefreshTasks(chg *state.Change) (*snapstate.SeedRefreshTaskSet, err
 		return nil, err
 	}
 
-	create := chg.State().Task(createID)
-	if create == nil || create.Change().ID() != chg.ID() || create.Kind() != "create-recovery-system" {
+	var create *state.Task
+	for _, t := range ts.Tasks() {
+		if t.ID() == createID {
+			create = t
+			break
+		}
+	}
+	if create == nil || create.Kind() != "create-recovery-system" {
 		return nil, errors.New("internal error: seed-refresh change is missing paired create-recovery-system task")
+	}
+
+	// attempting to inspect seed refresh tasks after creation but before
+	// finalization is always a bug in the current design
+	if create.Status() != state.DoStatus {
+		return nil, fmt.Errorf("internal error: seed-refresh creation task has already started with status %s while finalization is still pending", create.Status())
 	}
 
 	return &snapstate.SeedRefreshTaskSet{

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -2501,7 +2501,6 @@ func (s *deviceMgrSuite) TestUpdateSeedRefreshChange(c *C) {
 		{"name": "snap-1"},
 		{"name": "snap-2", "presence": "optional"},
 	}, "snap-2", "snap-3")
-	chg := s.state.NewChange("seed-refresh", "...")
 	snap1Task := s.state.NewTask("fake-download", "...")
 	snap2Task := s.state.NewTask("fake-download", "...")
 	snap3Task := s.state.NewTask("fake-download", "...")
@@ -2516,36 +2515,38 @@ func (s *deviceMgrSuite) TestUpdateSeedRefreshChange(c *C) {
 	finalize.Set("recovery-system-setup-task", create.ID())
 	remove := s.state.NewTask("remove-recovery-system", "...")
 	remove.WaitFor(finalize)
-	chg.AddTask(create)
-	chg.AddTask(finalize)
-	chg.AddTask(remove)
+	seedRefreshTS := state.NewTaskSet(create, finalize, remove)
 
-	seedTS, err := devicestate.UpdateSeedRefreshChange(chg, dctx, snapstate.SeedRefreshCandidate{
+	seedTS, err := devicestate.PendingSeedRefreshTasks(seedRefreshTS)
+	c.Assert(err, IsNil)
+	c.Assert(seedTS, NotNil)
+
+	added, err := devicestate.UpdateSeedRefreshChange(seedTS, dctx, snapstate.SeedRefreshCandidate{
 		InstanceName:          "snap-2",
 		SnapSetupTaskIDs:      []string{snap2Task.ID()},
 		ComponentSetupTaskIDs: []string{"comp-2", "comp-1"},
 	})
 	c.Assert(err, IsNil)
-	c.Assert(seedTS, NotNil)
+	c.Assert(added, Equals, true)
 	c.Check(seedTS.Create, Equals, create)
 	c.Check(seedTS.Finalize, Equals, finalize)
 	c.Check(seedTS.Remove, DeepEquals, []*state.Task{remove})
 
-	seedTS, err = devicestate.UpdateSeedRefreshChange(chg, dctx, snapstate.SeedRefreshCandidate{
+	added, err = devicestate.UpdateSeedRefreshChange(seedTS, dctx, snapstate.SeedRefreshCandidate{
 		InstanceName:          "snap-1",
 		SnapSetupTaskIDs:      []string{snap1Task.ID()},
 		ComponentSetupTaskIDs: []string{"comp-3"},
 	})
 	c.Assert(err, IsNil)
-	c.Assert(seedTS, NotNil)
+	c.Assert(added, Equals, true)
 
-	seedTS, err = devicestate.UpdateSeedRefreshChange(chg, dctx, snapstate.SeedRefreshCandidate{
+	added, err = devicestate.UpdateSeedRefreshChange(seedTS, dctx, snapstate.SeedRefreshCandidate{
 		InstanceName:          "snap-3",
 		SnapSetupTaskIDs:      []string{snap3Task.ID()},
 		ComponentSetupTaskIDs: []string{"comp-4"},
 	})
 	c.Assert(err, IsNil)
-	c.Check(seedTS, IsNil)
+	c.Check(added, Equals, false)
 
 	var setup devicestate.RecoverySystemSetup
 	c.Assert(create.Get("recovery-system-setup", &setup), IsNil)
@@ -2580,12 +2581,16 @@ func (s *deviceMgrSuite) TestUpdateSeedRefreshChangeSkipsRemodeling(c *C) {
 	chg.AddTask(create)
 	chg.AddTask(finalize)
 
-	seedTS, err := devicestate.UpdateSeedRefreshChange(chg, dctx, snapstate.SeedRefreshCandidate{
+	seedTS, err := devicestate.PendingSeedRefreshTasks(state.NewTaskSet(chg.Tasks()...))
+	c.Assert(err, IsNil)
+	c.Assert(seedTS, NotNil)
+
+	added, err := devicestate.UpdateSeedRefreshChange(seedTS, dctx, snapstate.SeedRefreshCandidate{
 		InstanceName:     "snap-1",
 		SnapSetupTaskIDs: []string{newSnapTask.ID()},
 	})
 	c.Assert(err, IsNil)
-	c.Check(seedTS, IsNil)
+	c.Check(added, Equals, false)
 
 	var setup devicestate.RecoverySystemSetup
 	c.Assert(create.Get("recovery-system-setup", &setup), IsNil)
@@ -2604,7 +2609,6 @@ func (s *deviceMgrSuite) TestUpdateSeedRefreshChangeComponentExclusive(c *C) {
 		{"name": "snap-1"},
 		{"name": "snap-2", "presence": "optional"},
 	}, "snap-2")
-	chg := s.state.NewChange("seed-refresh", "...")
 	snap1Task := s.state.NewTask("fake-download", "...")
 	compTask1 := s.state.NewTask("fake-download-component", "...")
 	compTask2 := s.state.NewTask("fake-download-component", "...")
@@ -2617,15 +2621,17 @@ func (s *deviceMgrSuite) TestUpdateSeedRefreshChangeComponentExclusive(c *C) {
 	})
 	finalize := s.state.NewTask("finalize-recovery-system", "...")
 	finalize.Set("recovery-system-setup-task", create.ID())
-	chg.AddTask(create)
-	chg.AddTask(finalize)
+	seedRefreshTS := state.NewTaskSet(create, finalize)
 
-	seedTS, err := devicestate.UpdateSeedRefreshChange(chg, dctx, snapstate.SeedRefreshCandidate{
+	seedTS, err := devicestate.PendingSeedRefreshTasks(seedRefreshTS)
+	c.Assert(err, IsNil)
+	c.Assert(seedTS, NotNil)
+	added, err := devicestate.UpdateSeedRefreshChange(seedTS, dctx, snapstate.SeedRefreshCandidate{
 		InstanceName:          "snap-2",
 		ComponentSetupTaskIDs: []string{compTask2.ID(), compTask1.ID()},
 	})
 	c.Assert(err, IsNil)
-	c.Assert(seedTS, NotNil)
+	c.Assert(added, Equals, true)
 
 	var setup devicestate.RecoverySystemSetup
 	c.Assert(create.Get("recovery-system-setup", &setup), IsNil)
@@ -2668,7 +2674,6 @@ func (s *deviceMgrSuite) TestUpdateSeedRefreshChangeSkipsOptionalSnapNotInCurren
 		{"name": "snap-1"},
 		{"name": "snap-2", "presence": "optional"},
 	})
-	chg := s.state.NewChange("seed-refresh", "...")
 	snap1Task := s.state.NewTask("fake-download", "...")
 	snap2Task := s.state.NewTask("fake-download", "...")
 	create := s.state.NewTask("create-recovery-system", "...")
@@ -2679,15 +2684,17 @@ func (s *deviceMgrSuite) TestUpdateSeedRefreshChangeSkipsOptionalSnapNotInCurren
 	})
 	finalize := s.state.NewTask("finalize-recovery-system", "...")
 	finalize.Set("recovery-system-setup-task", create.ID())
-	chg.AddTask(create)
-	chg.AddTask(finalize)
+	seedRefreshTS := state.NewTaskSet(create, finalize)
 
-	seedTS, err := devicestate.UpdateSeedRefreshChange(chg, dctx, snapstate.SeedRefreshCandidate{
+	seedTS, err := devicestate.PendingSeedRefreshTasks(seedRefreshTS)
+	c.Assert(err, IsNil)
+	c.Assert(seedTS, NotNil)
+	added, err := devicestate.UpdateSeedRefreshChange(seedTS, dctx, snapstate.SeedRefreshCandidate{
 		InstanceName:     "snap-2",
 		SnapSetupTaskIDs: []string{snap2Task.ID()},
 	})
 	c.Assert(err, IsNil)
-	c.Check(seedTS, IsNil)
+	c.Check(added, Equals, false)
 
 	var setup devicestate.RecoverySystemSetup
 	c.Assert(create.Get("recovery-system-setup", &setup), IsNil)
@@ -2740,8 +2747,6 @@ func (s *deviceMgrSuite) TestUpdateSeedRefreshChangeUsesPendingSeedRefreshTasks(
 		{"name": "snap-1"},
 		{"name": "snap-2"},
 	})
-	chg := s.state.NewChange("seed-refresh", "...")
-
 	oldSnapTask := s.state.NewTask("fake-download", "...")
 	oldCreate := s.state.NewTask("create-recovery-system", "...")
 	oldCreate.Set("recovery-system-setup", &devicestate.RecoverySystemSetup{
@@ -2768,21 +2773,22 @@ func (s *deviceMgrSuite) TestUpdateSeedRefreshChangeUsesPendingSeedRefreshTasks(
 	currentFinalize.Set("recovery-system-setup-task", currentCreate.ID())
 	currentRemove := s.state.NewTask("remove-recovery-system", "...")
 	currentRemove.WaitFor(currentFinalize)
-
-	chg.AddTask(oldCreate)
-	chg.AddTask(oldFinalize)
-	chg.AddTask(oldRemove)
-	chg.AddTask(currentCreate)
-	chg.AddTask(currentFinalize)
-	chg.AddTask(currentRemove)
+	seedRefreshTS := state.NewTaskSet(oldCreate, oldFinalize, oldRemove, currentCreate, currentFinalize, currentRemove)
 
 	nextSnapTask := s.state.NewTask("fake-download", "...")
-	seedTS, err := devicestate.UpdateSeedRefreshChange(chg, dctx, snapstate.SeedRefreshCandidate{
+	seedTS, err := devicestate.PendingSeedRefreshTasks(seedRefreshTS)
+	c.Assert(err, IsNil)
+	c.Assert(seedTS, NotNil)
+	c.Check(seedTS.Create, Equals, currentCreate)
+	c.Check(seedTS.Finalize, Equals, currentFinalize)
+	c.Check(seedTS.Remove, DeepEquals, []*state.Task{currentRemove})
+
+	added, err := devicestate.UpdateSeedRefreshChange(seedTS, dctx, snapstate.SeedRefreshCandidate{
 		InstanceName:     "snap-2",
 		SnapSetupTaskIDs: []string{nextSnapTask.ID()},
 	})
 	c.Assert(err, IsNil)
-	c.Assert(seedTS, NotNil)
+	c.Assert(added, Equals, true)
 	c.Check(seedTS.Create, Equals, currentCreate)
 	c.Check(seedTS.Finalize, Equals, currentFinalize)
 	c.Check(seedTS.Remove, DeepEquals, []*state.Task{currentRemove})
@@ -2794,6 +2800,19 @@ func (s *deviceMgrSuite) TestUpdateSeedRefreshChangeUsesPendingSeedRefreshTasks(
 	var currentSetup devicestate.RecoverySystemSetup
 	c.Assert(currentCreate.Get("recovery-system-setup", &currentSetup), IsNil)
 	c.Check(currentSetup.SnapSetupTasks, DeepEquals, []string{currentSnapTask.ID(), nextSnapTask.ID()})
+}
+
+func (s *deviceMgrSuite) TestPendingSeedRefreshTasksErrorsWhenCreateStartedAndFinalizePending(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	create := s.state.NewTask("create-recovery-system", "...")
+	finalize := s.state.NewTask("finalize-recovery-system", "...")
+	finalize.Set("recovery-system-setup-task", create.ID())
+	create.SetToWait(state.DoneStatus)
+
+	_, err := devicestate.PendingSeedRefreshTasks(state.NewTaskSet(create, finalize))
+	c.Check(err, ErrorMatches, "internal error: seed-refresh creation task has already started with status Wait while finalization is still pending")
 }
 
 func seedRefreshSnapYAML(name, snapType string) string {

--- a/overlord/snapstate/handlers_prereq.go
+++ b/overlord/snapstate/handlers_prereq.go
@@ -159,7 +159,7 @@ func defaultPrereqSnapsChannel() string {
 func installPrereqs(t *state.Task, base string, prereq map[string][]string, tm timings.Measurer, opts Options) error {
 	st := t.State()
 
-	var seedTS *SeedRefreshTaskSet
+	var seedTS *SeedRefreshTasks
 	trackSeedTS := func(ts *state.TaskSet) error {
 		if seedTS != nil {
 			return nil

--- a/overlord/snapstate/handlers_prereq.go
+++ b/overlord/snapstate/handlers_prereq.go
@@ -82,54 +82,7 @@ func (m *SnapManager) doPrerequisites(t *state.Task, _ *tomb.Tomb) error {
 		}
 	}
 
-	// If transactional, use a single lane for all tasks, so when one fails the
-	// changes for all affected snaps will be undone. Otherwise, have different
-	// lanes per snap so failures only affect the culprit snap.
-	flags := Flags{
-		Transaction: snapsup.Transaction,
-
-		// TODO: as a temporary workaround for a bug that occurs when a snap updates
-		// a prereq, we disable rerefreshes.
-		//
-		// specifically, if the snap that pulls in the prereq contains a configure
-		// hook that creates some tasks via snapctl, then those tasks will end up
-		// waiting on the check-rerefresh task for the updated prereq. the
-		// check-rerefresh task panics if any tasks are found to be waiting on it.
-		NoReRefresh: true,
-
-		// we're calling an API facing call which would otherwise be normally
-		// expected to produce a delayed effects taskset, but since the desire
-		// is to inject the tasksets into the current change, set the flag to
-		// avoid generating one
-		NoDelayedSideEffects: true,
-	}
-	if flags.Transaction == client.TransactionAllSnaps {
-		lanes := t.Lanes()
-		if len(lanes) != 1 {
-			return fmt.Errorf("internal error: more than one lane (%d) on a transactional action", len(lanes))
-		}
-
-		flags.Lane = lanes[0]
-	} else {
-		flags.Transaction = client.TransactionPerSnap
-	}
-
-	base := defaultCoreSnapName
-	if snapsup.Base != "" {
-		base = snapsup.Base
-	}
-
-	return installPrereqs(t, base, snapsup.PrereqContentAttrs, tm, Options{
-		Flags:     flags,
-		UserID:    snapsup.UserID,
-		DeviceCtx: dctx,
-		ConflictOptions: ConflictOptions{
-			FromChange: t.Change().ID(),
-			// setting this lets us use snap update conflict detection, even
-			// though we're passing in the change ID
-			DoNotIgnoreFromChangeInTaskConflictCheck: true,
-		},
-	})
+	return installPrereqs(t, snapsup, dctx, tm)
 }
 
 func defaultBaseSnapsChannel() string {
@@ -156,46 +109,91 @@ func defaultPrereqSnapsChannel() string {
 	return channel
 }
 
-func installPrereqs(t *state.Task, base string, prereq map[string][]string, tm timings.Measurer, opts Options) error {
+func installPrereqs(t *state.Task, snapsup *SnapSetup, dctx DeviceContext, tm timings.Measurer) error {
 	st := t.State()
 
-	var seedTS *SeedRefreshTasks
-	trackSeedTS := func(ts *state.TaskSet) error {
-		if seedTS != nil {
-			return nil
+	// If transactional, use a single lane for all tasks, so when one fails the
+	// changes for all affected snaps will be undone. Otherwise, have different
+	// lanes per snap so failures only affect the culprit snap.
+	transaction := snapsup.Transaction
+	var lane int
+	if transaction == client.TransactionAllSnaps {
+		lanes := t.Lanes()
+		if len(lanes) != 1 {
+			return fmt.Errorf("internal error: more than one lane (%d) on a transactional action", len(lanes))
 		}
 
-		enabled, err := seedRefreshEnabled(st)
-		if err != nil {
-			return err
-		}
-
-		if !enabled || ts == nil || t.Has("prerequisites-sync") {
-			return nil
-		}
-
-		seedTS, err = PendingSeedRefreshTasks(ts)
-		if err != nil {
-			return err
-		}
-
-		// ensure that future snap refreshes don't trigger more seed refreshes
-		opts.NoSeedRefresh = seedTS != nil
-
-		return nil
+		lane = lanes[0]
+	} else {
+		transaction = client.TransactionPerSnap
 	}
 
-	if err := trackSeedTS(state.NewTaskSet(t.Change().Tasks()...)); err != nil {
-		return err
+	base := defaultCoreSnapName
+	if snapsup.Base != "" {
+		base = snapsup.Base
 	}
 
 	// We try to install all wanted snaps. If one snap cannot be installed
 	// because of change conflicts or similar we retry. Only if all snaps can be
 	// installed together we add the tasks to the change.
-	var tss []*state.TaskSet
-	for prereqName, contentAttrs := range prereq {
+	var (
+		tss     []*state.TaskSet
+		baseTS  *state.TaskSet
+		snapdTS *state.TaskSet
+	)
+
+	findPendingSeedRefresh, err := newPrereqSeedRefreshFinder(t)
+	if err != nil {
+		return err
+	}
+
+	prereqOptions := func(prereqName string) (Options, error) {
+		seedTS, err := findPendingSeedRefresh(tss)
+		if err != nil {
+			return Options{}, err
+		}
+
+		return Options{
+			Flags: Flags{
+				Transaction:     transaction,
+				Lane:            lane,
+				RequireTypeBase: prereqName == base,
+
+				// TODO: as a temporary workaround for a bug that occurs when a
+				// snap updates a prereq, we disable rerefreshes.
+				//
+				// specifically, if the snap that pulls in the prereq contains a
+				// configure hook that creates some tasks via snapctl, then
+				// those tasks will end up waiting on the check-rerefresh task
+				// for the updated prereq. the check-rerefresh task panics if
+				// any tasks are found to be waiting on it.
+				NoReRefresh: true,
+
+				// we're calling an API facing call which would otherwise be
+				// normally expected to produce a delayed effects taskset, but
+				// since the desire is to inject the tasksets into the current
+				// change, set the flag to avoid generating one
+				NoDelayedSideEffects: true,
+			},
+			UserID:        snapsup.UserID,
+			DeviceCtx:     dctx,
+			NoSeedRefresh: seedTS != nil,
+			ConflictOptions: ConflictOptions{
+				FromChange: t.Change().ID(),
+				// setting this lets us use snap update conflict detection, even
+				// though we're passing in the change ID
+				DoNotIgnoreFromChangeInTaskConflictCheck: true,
+			},
+		}, nil
+	}
+
+	for prereqName, contentAttrs := range snapsup.PrereqContentAttrs {
+		opts, err := prereqOptions(prereqName)
+		if err != nil {
+			return err
+		}
+
 		var ts *state.TaskSet
-		var err error
 		timings.Run(tm, "install-prereq", fmt.Sprintf("install %q", prereqName), func(timings.Measurer) {
 			ts, err = ensurePrerequisite(t, contentAttrs, StoreSnap{
 				InstanceName: prereqName,
@@ -210,22 +208,16 @@ func installPrereqs(t *state.Task, base string, prereq map[string][]string, tm t
 		if ts == nil {
 			continue
 		}
-		if err := trackSeedTS(ts); err != nil {
-			return err
-		}
 		tss = append(tss, ts)
 	}
 
-	var baseTS *state.TaskSet
 	if base != "none" {
-		var err error
-		timings.Run(tm, "install-prereq", fmt.Sprintf("install base %q", base), func(timings.Measurer) {
-			// base prerequisites are installed with the same options as other
-			// prerequisites, except that they must be verified to have type
-			// base.
-			opts := opts
-			opts.Flags.RequireTypeBase = true
+		opts, err := prereqOptions(base)
+		if err != nil {
+			return err
+		}
 
+		timings.Run(tm, "install-prereq", fmt.Sprintf("install base %q", base), func(timings.Measurer) {
 			baseTS, err = ensurePrerequisite(t, nil, StoreSnap{
 				InstanceName: base,
 				RevOpts: RevisionOptions{
@@ -236,8 +228,8 @@ func installPrereqs(t *state.Task, base string, prereq map[string][]string, tm t
 		if err != nil {
 			return prereqError("snap base", base, err)
 		}
-		if err := trackSeedTS(baseTS); err != nil {
-			return err
+		if baseTS != nil {
+			tss = append(tss, baseTS)
 		}
 	}
 
@@ -246,8 +238,12 @@ func installPrereqs(t *state.Task, base string, prereq map[string][]string, tm t
 		return err
 	}
 
-	var snapdTS *state.TaskSet
 	if installSnapd {
+		opts, err := prereqOptions("snapd")
+		if err != nil {
+			return err
+		}
+
 		timings.Run(tm, "install-prereq", "install snapd", func(timings.Measurer) {
 			snapdTS, err = ensurePrerequisite(t, nil, StoreSnap{
 				InstanceName: "snapd",
@@ -259,34 +255,43 @@ func installPrereqs(t *state.Task, base string, prereq map[string][]string, tm t
 		if err != nil {
 			return prereqError("system snap", "snapd", err)
 		}
-		if err := trackSeedTS(snapdTS); err != nil {
-			return err
+		if snapdTS != nil {
+			tss = append(tss, snapdTS)
 		}
+	}
+
+	seedTS, err := findPendingSeedRefresh(tss)
+	if err != nil {
+		return err
 	}
 
 	// ensure that all prerequisites installs/updates are properly ordered in
 	// relation to seed-refresh tasks, if they exist
-	for _, ts := range append([]*state.TaskSet{snapdTS, baseTS}, tss...) {
-		if seedTS == nil || ts == nil {
-			continue
-		}
-
-		if err := maybeMergeLateSeedRefreshPrereq(seedTS, opts.DeviceCtx, ts); err != nil {
-			return err
+	if seedTS != nil {
+		for _, ts := range tss {
+			if err := maybeMergeLateSeedRefreshPrereq(seedTS, dctx, ts); err != nil {
+				return err
+			}
 		}
 	}
 
 	chg := t.Change()
-	// add all required snaps, no ordering, this will be done in the
+
+	// add all content providers, no ordering, this will be done in the
 	// auto-connect task handler
 	for _, ts := range tss {
+		if ts == baseTS || ts == snapdTS {
+			continue
+		}
 		chg.AddAll(ts)
 	}
+
 	// add the base if needed, prereqs else must wait on this
 	if baseTS != nil {
 		serializeTaskSetBeforeInProgressChange(baseTS, chg)
 		chg.AddAll(baseTS)
 	}
+
 	// add snapd if needed, everything must wait on this
 	if snapdTS != nil {
 		serializeTaskSetBeforeInProgressChange(snapdTS, chg)
@@ -298,6 +303,62 @@ func installPrereqs(t *state.Task, base string, prereq map[string][]string, tm t
 	t.SetStatus(state.DoneStatus)
 
 	return nil
+}
+
+// newPrereqSeedRefreshFinder returns a function that finds pending seed refresh
+// tasks in the given task's change, or in any task sets that are provided to
+// the returned function. Note that the returned closure caches the result per
+// *state.TaskSet, so duplicate queries should quick, but the task set will not
+// be re-evaluated if the contents have changed.
+//
+// To be used during prerequisite resolution.
+func newPrereqSeedRefreshFinder(t *state.Task) (func([]*state.TaskSet) (*SeedRefreshTasks, error), error) {
+	st := t.State()
+
+	enabled, err := seedRefreshEnabled(st)
+	if err != nil {
+		return nil, err
+	}
+
+	if !enabled || t.Has("prerequisites-sync") {
+		return func([]*state.TaskSet) (*SeedRefreshTasks, error) {
+			return nil, nil
+		}, nil
+	}
+
+	seedTS, err := PendingSeedRefreshTasks(state.NewTaskSet(t.Change().Tasks()...))
+	if err != nil {
+		return nil, err
+	}
+
+	// keep track of what task sets we've already seen. not required, but this
+	// prevents us from doing some duplicate task introspection.
+	seen := make(map[*state.TaskSet]bool)
+
+	return func(tss []*state.TaskSet) (*SeedRefreshTasks, error) {
+		if seedTS != nil {
+			return seedTS, nil
+		}
+
+		for _, ts := range tss {
+			if seen[ts] {
+				continue
+			}
+
+			found, err := PendingSeedRefreshTasks(ts)
+			if err != nil {
+				return nil, err
+			}
+			seen[ts] = true
+
+			if found != nil {
+				seedTS = found
+				return seedTS, nil
+			}
+		}
+
+		return nil, nil
+	}, nil
 }
 
 // considerSnapdAsPrereq returns true if we should install snapd as a

--- a/overlord/snapstate/handlers_prereq.go
+++ b/overlord/snapstate/handlers_prereq.go
@@ -159,6 +159,36 @@ func defaultPrereqSnapsChannel() string {
 func installPrereqs(t *state.Task, base string, prereq map[string][]string, tm timings.Measurer, opts Options) error {
 	st := t.State()
 
+	var seedTS *SeedRefreshTaskSet
+	trackSeedTS := func(ts *state.TaskSet) error {
+		if seedTS != nil {
+			return nil
+		}
+
+		enabled, err := seedRefreshEnabled(st)
+		if err != nil {
+			return err
+		}
+
+		if !enabled || ts == nil || t.Has("prerequisites-sync") {
+			return nil
+		}
+
+		seedTS, err = PendingSeedRefreshTasks(ts)
+		if err != nil {
+			return err
+		}
+
+		// ensure that future snap refreshes don't trigger more seed refreshes
+		opts.NoSeedRefresh = seedTS != nil
+
+		return nil
+	}
+
+	if err := trackSeedTS(state.NewTaskSet(t.Change().Tasks()...)); err != nil {
+		return err
+	}
+
 	// We try to install all wanted snaps. If one snap cannot be installed
 	// because of change conflicts or similar we retry. Only if all snaps can be
 	// installed together we add the tasks to the change.
@@ -179,6 +209,9 @@ func installPrereqs(t *state.Task, base string, prereq map[string][]string, tm t
 		}
 		if ts == nil {
 			continue
+		}
+		if err := trackSeedTS(ts); err != nil {
+			return err
 		}
 		tss = append(tss, ts)
 	}
@@ -203,6 +236,9 @@ func installPrereqs(t *state.Task, base string, prereq map[string][]string, tm t
 		if err != nil {
 			return prereqError("snap base", base, err)
 		}
+		if err := trackSeedTS(baseTS); err != nil {
+			return err
+		}
 	}
 
 	installSnapd, err := considerSnapdAsPrereq(st)
@@ -222,6 +258,19 @@ func installPrereqs(t *state.Task, base string, prereq map[string][]string, tm t
 		})
 		if err != nil {
 			return prereqError("system snap", "snapd", err)
+		}
+		if err := trackSeedTS(snapdTS); err != nil {
+			return err
+		}
+	}
+
+	for _, ts := range append([]*state.TaskSet{snapdTS, baseTS}, tss...) {
+		if seedTS == nil || ts == nil {
+			continue
+		}
+
+		if err := maybeMergeLateSeedRefreshPrereq(t.Change(), seedTS, opts.DeviceCtx, ts); err != nil {
+			return err
 		}
 	}
 
@@ -410,7 +459,6 @@ func ensurePrerequisite(t *state.Task, contentAttrs []string, sn StoreSnap, opts
 		}
 		return nil, err
 	}
-
 	return ts, nil
 }
 
@@ -447,9 +495,6 @@ func maybeUpdateContentProvider(t *state.Task, snapName string, contentAttrs []s
 		return nil, nil
 	}
 
-	if err := maybeMergeLateSeedRefreshPrereq(t.Change(), opts.DeviceCtx, ts); err != nil {
-		return nil, err
-	}
 	return ts, nil
 }
 

--- a/overlord/snapstate/handlers_prereq.go
+++ b/overlord/snapstate/handlers_prereq.go
@@ -269,7 +269,7 @@ func installPrereqs(t *state.Task, base string, prereq map[string][]string, tm t
 			continue
 		}
 
-		if err := maybeMergeLateSeedRefreshPrereq(t.Change(), seedTS, opts.DeviceCtx, ts); err != nil {
+		if err := maybeMergeLateSeedRefreshPrereq(seedTS, opts.DeviceCtx, ts); err != nil {
 			return err
 		}
 	}

--- a/overlord/snapstate/handlers_prereq.go
+++ b/overlord/snapstate/handlers_prereq.go
@@ -264,6 +264,8 @@ func installPrereqs(t *state.Task, base string, prereq map[string][]string, tm t
 		}
 	}
 
+	// ensure that all prerequisites installs/updates are properly ordered in
+	// relation to seed-refresh tasks, if they exist
 	for _, ts := range append([]*state.TaskSet{snapdTS, baseTS}, tss...) {
 		if seedTS == nil || ts == nil {
 			continue

--- a/overlord/snapstate/reboot.go
+++ b/overlord/snapstate/reboot.go
@@ -523,7 +523,7 @@ func arrangeRebootAndUpdateSeed(
 // share transactional lanes, and adds the given seed-refresh tasks to those
 // lanes as well.
 func mergeEssentialAndSeedLanes(
-	essentials map[snap.Type]snapInstallTaskSet, seedUpdates map[string]snapInstallTaskSet, seedTS *SeedRefreshTaskSet,
+	essentials map[snap.Type]snapInstallTaskSet, seedUpdates map[string]snapInstallTaskSet, seedTS *SeedRefreshTasks,
 ) {
 	merge := make(map[string]snapInstallTaskSet)
 	for _, sts := range seedUpdates {

--- a/overlord/snapstate/seed.go
+++ b/overlord/snapstate/seed.go
@@ -21,7 +21,6 @@ package snapstate
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/overlord/configstate/config"
@@ -177,7 +176,7 @@ func seedRefreshAndSeedSnapTaskSets(st *state.State, stss []snapInstallTaskSet, 
 // creation even when the snap is not part of the seed refresh. If the snap is
 // part of the seed refresh, then the before-local-modification tasks for that
 // snap will be ordered before seed creation.
-func maybeMergeLateSeedRefreshPrereq(chg *state.Change, seedTS *SeedRefreshTaskSet, dctx DeviceContext, ts *state.TaskSet) error {
+func maybeMergeLateSeedRefreshPrereq(seedTS *SeedRefreshTaskSet, dctx DeviceContext, ts *state.TaskSet) error {
 	// if this task set already carries the seed creation tasks, then there
 	// isn't anything more to do
 	for _, t := range ts.Tasks() {
@@ -226,50 +225,7 @@ func maybeMergeLateSeedRefreshPrereq(chg *state.Change, seedTS *SeedRefreshTaskS
 	// early failure here would be nice, but we'd have to open the seed. a
 	// seed-refresh that hits this case will fail during seed creation.
 
-	if err := errorIfPrereqNeedsInFlightBaseBlockedBySeedCreation(chg, seedTS, ts); err != nil {
-		return err
-	}
-
 	return mergeLateSeedRefreshPrereq(seedTS, ts)
-}
-
-// errorIfPrereqNeedsInFlightBaseBlockedBySeedCreation rejects the currently
-// unsupported case where a prerequisite refresh depends on a base refresh whose
-// link-snap is ordered after create-recovery-system. Without extra
-// synchronization, the prerequisite refresh would wait forever on that base.
-func errorIfPrereqNeedsInFlightBaseBlockedBySeedCreation(chg *state.Change, seedTS *SeedRefreshTaskSet, providerTS *state.TaskSet) error {
-	snapsupTask, err := providerTS.Edge(SnapSetupEdge)
-	if err != nil {
-		return errors.New("internal error: seed-refresh provider task set is missing required edge")
-	}
-
-	snapsup, err := TaskSnapSetup(snapsupTask)
-	if err != nil {
-		return err
-	}
-
-	base := snapsup.Base
-	if base == "none" {
-		return nil
-	}
-	if base == "" {
-		base = defaultCoreSnapName
-	}
-
-	baseLink, err := maybeFindTaskInChangeForSnap(chg, "link-snap", base)
-	if err != nil {
-		return err
-	}
-	if baseLink == nil || !willWaitOn(baseLink, seedTS.Create) {
-		return nil
-	}
-
-	// TODO:SEEDREFRESH: introduce new form of prerequisite synchronization that
-	// lets a late prerequisite refresh account for a base refresh whose
-	// link-snap is ordered after create-recovery-system. without that extra
-	// ordering, the prerequisite task keeps retrying forever on the in-flight
-	// base link-snap.
-	return fmt.Errorf("cannot automatically update prerequisite %q during seed-refresh while base %q waits for create-recovery-system", snapsup.InstanceName(), base)
 }
 
 // mergeLateSeedRefreshPrereq folds a prerequisite refresh selected by

--- a/overlord/snapstate/seed.go
+++ b/overlord/snapstate/seed.go
@@ -65,9 +65,15 @@ var SeedRefreshTasks = func(st *state.State, dctx DeviceContext, candidates []Se
 	panic("internal error: snapstate.SeedRefreshTasks is unset")
 }
 
+// PendingSeedRefreshTasks is set by devicestate to avoid an import cycle. See
+// devicestate.PendingSeedRefreshTasks.
+var PendingSeedRefreshTasks = func(ts *state.TaskSet) (*SeedRefreshTaskSet, error) {
+	panic("internal error: snapstate.PendingSeedRefreshTasks is unset")
+}
+
 // UpdateSeedRefreshChange is set by devicestate to avoid an import cycle. See
 // devicestate.UpdateSeedRefreshChange.
-var UpdateSeedRefreshChange = func(chg *state.Change, dctx DeviceContext, candidate SeedRefreshCandidate) (*SeedRefreshTaskSet, error) {
+var UpdateSeedRefreshChange = func(seedTS *SeedRefreshTaskSet, dctx DeviceContext, candidate SeedRefreshCandidate) (bool, error) {
 	panic("internal error: snapstate.UpdateSeedRefreshChange is unset")
 }
 
@@ -193,18 +199,25 @@ func maybeMergeLateSeedRefreshPrereq(chg *state.Change, dctx DeviceContext, prov
 		return nil
 	}
 
+	seedTS, err := PendingSeedRefreshTasks(state.NewTaskSet(chg.Tasks()...))
+	if err != nil {
+		return err
+	}
+	if seedTS == nil {
+		return nil
+	}
+
 	candidate, err := seedRefreshCandidateForTaskSet(providerTS)
 	if err != nil {
 		return err
 	}
 
-	seedTS, err := UpdateSeedRefreshChange(chg, dctx, candidate)
+	added, err := UpdateSeedRefreshChange(seedTS, dctx, candidate)
 	if err != nil {
 		return err
 	}
 
-	// snap didn't trigger a seed refresh
-	if seedTS == nil {
+	if !added {
 		return nil
 	}
 

--- a/overlord/snapstate/seed.go
+++ b/overlord/snapstate/seed.go
@@ -122,19 +122,6 @@ func seedRefreshEnabled(st *state.State) (bool, error) {
 	return seedRefresh, nil
 }
 
-func changeHasPendingSeedRefresh(chg *state.Change) bool {
-	for _, t := range chg.Tasks() {
-		switch t.Kind() {
-		case "create-recovery-system", "finalize-recovery-system":
-			if !t.Status().Ready() {
-				return true
-			}
-		}
-	}
-
-	return false
-}
-
 // seedRefreshAndSeedSnapTaskSets returns the seed-refresh tasks and the task
 // sets for snaps that are involved in the seed refresh.
 func seedRefreshAndSeedSnapTaskSets(st *state.State, stss []snapInstallTaskSet, eviction SeedRefreshEvictionPolicy, opts Options) (*SeedRefreshTaskSet, map[string]snapInstallTaskSet, error) {
@@ -150,12 +137,6 @@ func seedRefreshAndSeedSnapTaskSets(st *state.State, stss []snapInstallTaskSet, 
 	}
 
 	if !enabled {
-		return nil, nil, nil
-	}
-
-	// if the tasks here are being created from within a change that is still
-	// performing a seed refresh, then we don't want to create another one.
-	if chg := st.Change(opts.FromChange); chg != nil && changeHasPendingSeedRefresh(chg) {
 		return nil, nil, nil
 	}
 
@@ -191,23 +172,32 @@ func seedRefreshAndSeedSnapTaskSets(st *state.State, stss []snapInstallTaskSet, 
 	return seedTS, seedSnapTaskSets, nil
 }
 
-// maybeMergeLateSeedRefreshPrereq folds a prerequisite refresh into an
-// in-flight seed refresh when the current change still has pending
-// recovery-system tasks and the prerequisite snap is part of the model.
-func maybeMergeLateSeedRefreshPrereq(chg *state.Change, dctx DeviceContext, providerTS *state.TaskSet) error {
-	if !changeHasPendingSeedRefresh(chg) {
-		return nil
+// maybeMergeLateSeedRefreshPrereq orders a late prerequisite refresh against an
+// in-flight seed refresh. The initial prerequisites task must run before seed
+// creation even when the snap is not part of the seed refresh. If the snap is
+// part of the seed refresh, then the before-local-modification tasks for that
+// snap will be ordered before seed creation.
+func maybeMergeLateSeedRefreshPrereq(chg *state.Change, seedTS *SeedRefreshTaskSet, dctx DeviceContext, ts *state.TaskSet) error {
+	// if this task set already carries the seed creation tasks, then there
+	// isn't anything more to do
+	for _, t := range ts.Tasks() {
+		if t.ID() == seedTS.Create.ID() {
+			return nil
+		}
 	}
 
-	seedTS, err := PendingSeedRefreshTasks(state.NewTaskSet(chg.Tasks()...))
-	if err != nil {
-		return err
+	var prereq *state.Task
+	for _, t := range ts.Tasks() {
+		if t.Kind() == "prerequisites" && !t.Has("prerequisites-sync") {
+			prereq = t
+			break
+		}
 	}
-	if seedTS == nil {
-		return nil
+	if prereq == nil {
+		return errors.New("internal error: seed-refresh provider task set is missing initial prerequisites task")
 	}
 
-	candidate, err := seedRefreshCandidateForTaskSet(providerTS)
+	candidate, err := seedRefreshCandidateForTaskSet(ts)
 	if err != nil {
 		return err
 	}
@@ -218,15 +208,29 @@ func maybeMergeLateSeedRefreshPrereq(chg *state.Change, dctx DeviceContext, prov
 	}
 
 	if !added {
+		// seed creation must wait on all prerequisite tasks spawned by a refresh.
+		// this ensures that we've recursively resolved all prerequisites prior to
+		// seed creation.
+		for _, lane := range seedTS.Create.Lanes() {
+			prereq.JoinLane(lane)
+		}
+		seedTS.Create.WaitFor(prereq)
+
 		return nil
 	}
 
-	// TODO:SEEDREFRESH: drop this check
-	if err := errorIfPrereqNeedsInFlightBaseBlockedBySeedCreation(chg, seedTS, providerTS); err != nil {
+	// TODO:SEEDREFRESH: if a snap going into the refreshed seed starts
+	// requiring a base or content provider that was not in the existing
+	// seed, supporting it would require the refreshed seed to gain this
+	// prerequisite snap. this is intentionally unsupported for now. adding an
+	// early failure here would be nice, but we'd have to open the seed. a
+	// seed-refresh that hits this case will fail during seed creation.
+
+	if err := errorIfPrereqNeedsInFlightBaseBlockedBySeedCreation(chg, seedTS, ts); err != nil {
 		return err
 	}
 
-	return mergeLateSeedRefreshPrereq(seedTS, providerTS)
+	return mergeLateSeedRefreshPrereq(seedTS, ts)
 }
 
 // errorIfPrereqNeedsInFlightBaseBlockedBySeedCreation rejects the currently
@@ -274,15 +278,6 @@ func errorIfPrereqNeedsInFlightBaseBlockedBySeedCreation(chg *state.Change, seed
 // setup payload. this function only joins lanes and adds the ordering
 // dependencies needed by seed refresh.
 func mergeLateSeedRefreshPrereq(seedTS *SeedRefreshTaskSet, providerTS *state.TaskSet) error {
-	_, err := providerTS.Edge(SnapSetupEdge)
-	if err != nil {
-		return errors.New("internal error: seed-refresh provider task set is missing required edge")
-	}
-
-	for _, lane := range seedTS.Create.Lanes() {
-		providerTS.JoinLane(lane)
-	}
-
 	end, err := providerTS.Edge(EndEdge)
 	if err != nil {
 		return errors.New("internal error: seed-refresh provider task set is missing required edge")
@@ -291,6 +286,14 @@ func mergeLateSeedRefreshPrereq(seedTS *SeedRefreshTaskSet, providerTS *state.Ta
 	lastBeforeLocal, err := providerTS.Edge(LastBeforeLocalModificationsEdge)
 	if err != nil {
 		return errors.New("internal error: seed-refresh provider task set is missing required edge")
+	}
+
+	// joining the full task set to the seed lanes ensures that undoing the snap
+	// also undoes the seed refresh.
+	for _, lane := range seedTS.Create.Lanes() {
+		for _, t := range providerTS.Tasks() {
+			t.JoinLane(lane)
+		}
 	}
 
 	// TODO:SEEDREFRESH: what about content-providers that are essential snaps?

--- a/overlord/snapstate/seed.go
+++ b/overlord/snapstate/seed.go
@@ -28,8 +28,8 @@ import (
 	"github.com/snapcore/snapd/snap"
 )
 
-// SeedRefreshTaskSet carries the tasks needed to perform a seed refresh.
-type SeedRefreshTaskSet struct {
+// SeedRefreshTasks carries the tasks needed to perform a seed refresh.
+type SeedRefreshTasks struct {
 	Create   *state.Task
 	Finalize *state.Task
 	Remove   []*state.Task
@@ -58,21 +58,21 @@ type SeedRefreshCandidate struct {
 	ComponentSetupTaskIDs []string
 }
 
-// SeedRefreshTasks is set by devicestate to avoid an import cycle. See
+// CreateSeedRefreshTasks is set by devicestate to avoid an import cycle. See
 // devicestate.SeedRefreshTasks.
-var SeedRefreshTasks = func(st *state.State, dctx DeviceContext, candidates []SeedRefreshCandidate, eviction SeedRefreshEvictionPolicy) (*SeedRefreshTaskSet, map[string]bool, error) {
-	panic("internal error: snapstate.SeedRefreshTasks is unset")
+var CreateSeedRefreshTasks = func(st *state.State, dctx DeviceContext, candidates []SeedRefreshCandidate, eviction SeedRefreshEvictionPolicy) (*SeedRefreshTasks, map[string]bool, error) {
+	panic("internal error: snapstate.CreateSeedRefreshTasks is unset")
 }
 
 // PendingSeedRefreshTasks is set by devicestate to avoid an import cycle. See
 // devicestate.PendingSeedRefreshTasks.
-var PendingSeedRefreshTasks = func(ts *state.TaskSet) (*SeedRefreshTaskSet, error) {
+var PendingSeedRefreshTasks = func(ts *state.TaskSet) (*SeedRefreshTasks, error) {
 	panic("internal error: snapstate.PendingSeedRefreshTasks is unset")
 }
 
 // UpdateSeedRefreshChange is set by devicestate to avoid an import cycle. See
 // devicestate.UpdateSeedRefreshChange.
-var UpdateSeedRefreshChange = func(seedTS *SeedRefreshTaskSet, dctx DeviceContext, candidate SeedRefreshCandidate) (bool, error) {
+var UpdateSeedRefreshChange = func(seedTS *SeedRefreshTasks, dctx DeviceContext, candidate SeedRefreshCandidate) (added bool, err error) {
 	panic("internal error: snapstate.UpdateSeedRefreshChange is unset")
 }
 
@@ -123,7 +123,7 @@ func seedRefreshEnabled(st *state.State) (bool, error) {
 
 // seedRefreshAndSeedSnapTaskSets returns the seed-refresh tasks and the task
 // sets for snaps that are involved in the seed refresh.
-func seedRefreshAndSeedSnapTaskSets(st *state.State, stss []snapInstallTaskSet, eviction SeedRefreshEvictionPolicy, opts Options) (*SeedRefreshTaskSet, map[string]snapInstallTaskSet, error) {
+func seedRefreshAndSeedSnapTaskSets(st *state.State, stss []snapInstallTaskSet, eviction SeedRefreshEvictionPolicy, opts Options) (*SeedRefreshTasks, map[string]snapInstallTaskSet, error) {
 	// try mode doesn't actually install the snap, should never trigger a
 	// seed-refresh
 	if opts.Flags.TryMode || opts.NoSeedRefresh {
@@ -153,7 +153,7 @@ func seedRefreshAndSeedSnapTaskSets(st *state.State, stss []snapInstallTaskSet, 
 		candidates = append(candidates, candidate)
 	}
 
-	seedTS, added, err := SeedRefreshTasks(st, deviceCtx, candidates, eviction)
+	seedTS, added, err := CreateSeedRefreshTasks(st, deviceCtx, candidates, eviction)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -176,7 +176,7 @@ func seedRefreshAndSeedSnapTaskSets(st *state.State, stss []snapInstallTaskSet, 
 // creation even when the snap is not part of the seed refresh. If the snap is
 // part of the seed refresh, then the before-local-modification tasks for that
 // snap will be ordered before seed creation.
-func maybeMergeLateSeedRefreshPrereq(seedTS *SeedRefreshTaskSet, dctx DeviceContext, ts *state.TaskSet) error {
+func maybeMergeLateSeedRefreshPrereq(seedTS *SeedRefreshTasks, dctx DeviceContext, ts *state.TaskSet) error {
 	// if this task set already carries the seed creation tasks, then there
 	// isn't anything more to do
 	for _, t := range ts.Tasks() {
@@ -233,7 +233,7 @@ func maybeMergeLateSeedRefreshPrereq(seedTS *SeedRefreshTaskSet, dctx DeviceCont
 // graph. At this point, devicestate has already updated the recovery-system
 // setup payload. this function only joins lanes and adds the ordering
 // dependencies needed by seed refresh.
-func mergeLateSeedRefreshPrereq(seedTS *SeedRefreshTaskSet, providerTS *state.TaskSet) error {
+func mergeLateSeedRefreshPrereq(seedTS *SeedRefreshTasks, providerTS *state.TaskSet) error {
 	end, err := providerTS.Edge(EndEdge)
 	if err != nil {
 		return errors.New("internal error: seed-refresh provider task set is missing required edge")

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -88,6 +88,7 @@ type observedSeedRefreshCandidates struct {
 
 func mockSeedRefreshHooks(triggers []string) (*observedSeedRefreshCandidates, func()) {
 	oldSeedRefreshTasks := snapstate.SeedRefreshTasks
+	oldPendingSeedRefreshTasks := snapstate.PendingSeedRefreshTasks
 	oldUpdateSeedRefreshChange := snapstate.UpdateSeedRefreshChange
 	triggered := make(map[string]bool, len(triggers))
 	for _, instanceName := range triggers {
@@ -127,22 +128,27 @@ func mockSeedRefreshHooks(triggers []string) (*observedSeedRefreshCandidates, fu
 		return currentSeedTS, added, nil
 	}
 
-	snapstate.UpdateSeedRefreshChange = func(chg *state.Change, _ snapstate.DeviceContext, candidate snapstate.SeedRefreshCandidate) (*snapstate.SeedRefreshTaskSet, error) {
+	snapstate.PendingSeedRefreshTasks = func(*state.TaskSet) (*snapstate.SeedRefreshTaskSet, error) {
+		return currentSeedTS, nil
+	}
+
+	snapstate.UpdateSeedRefreshChange = func(seedTS *snapstate.SeedRefreshTaskSet, _ snapstate.DeviceContext, candidate snapstate.SeedRefreshCandidate) (bool, error) {
 		observed.prerequisites = append(observed.prerequisites, candidate)
 
 		if !triggered[candidate.InstanceName] {
-			return nil, nil
+			return false, nil
 		}
 
-		if currentSeedTS == nil {
-			return nil, fmt.Errorf("missing recovery-system tasks")
+		if seedTS == nil {
+			return false, fmt.Errorf("missing recovery-system tasks")
 		}
 
-		return currentSeedTS, nil
+		return true, nil
 	}
 
 	return &observed, func() {
 		snapstate.SeedRefreshTasks = oldSeedRefreshTasks
+		snapstate.PendingSeedRefreshTasks = oldPendingSeedRefreshTasks
 		snapstate.UpdateSeedRefreshChange = oldUpdateSeedRefreshChange
 	}
 }

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -128,8 +128,23 @@ func mockSeedRefreshHooks(triggers []string) (*observedSeedRefreshCandidates, fu
 		return currentSeedTS, added, nil
 	}
 
-	snapstate.PendingSeedRefreshTasks = func(*state.TaskSet) (*snapstate.SeedRefreshTaskSet, error) {
-		return currentSeedTS, nil
+	snapstate.PendingSeedRefreshTasks = func(ts *state.TaskSet) (*snapstate.SeedRefreshTaskSet, error) {
+		if currentSeedTS == nil {
+			return nil, nil
+		}
+
+		for _, t := range ts.Tasks() {
+			if t.ID() != currentSeedTS.Finalize.ID() || t.Status().Ready() {
+				continue
+			}
+
+			if currentSeedTS.Create.Status() != state.DoStatus {
+				return nil, fmt.Errorf("internal error: seed-refresh creation task has already started with status %s while finalization is still pending", currentSeedTS.Create.Status())
+			}
+			return currentSeedTS, nil
+		}
+
+		return nil, nil
 	}
 
 	snapstate.UpdateSeedRefreshChange = func(seedTS *snapstate.SeedRefreshTaskSet, _ snapstate.DeviceContext, candidate snapstate.SeedRefreshCandidate) (bool, error) {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -87,7 +87,7 @@ type observedSeedRefreshCandidates struct {
 }
 
 func mockSeedRefreshHooks(triggers []string) (*observedSeedRefreshCandidates, func()) {
-	oldSeedRefreshTasks := snapstate.SeedRefreshTasks
+	oldCreateSeedRefreshTasks := snapstate.CreateSeedRefreshTasks
 	oldPendingSeedRefreshTasks := snapstate.PendingSeedRefreshTasks
 	oldUpdateSeedRefreshChange := snapstate.UpdateSeedRefreshChange
 	triggered := make(map[string]bool, len(triggers))
@@ -96,9 +96,9 @@ func mockSeedRefreshHooks(triggers []string) (*observedSeedRefreshCandidates, fu
 	}
 
 	var observed observedSeedRefreshCandidates
-	var currentSeedTS *snapstate.SeedRefreshTaskSet
+	var currentSeedTS *snapstate.SeedRefreshTasks
 
-	snapstate.SeedRefreshTasks = func(st *state.State, _ snapstate.DeviceContext, candidates []snapstate.SeedRefreshCandidate, eviction snapstate.SeedRefreshEvictionPolicy) (*snapstate.SeedRefreshTaskSet, map[string]bool, error) {
+	snapstate.CreateSeedRefreshTasks = func(st *state.State, _ snapstate.DeviceContext, candidates []snapstate.SeedRefreshCandidate, eviction snapstate.SeedRefreshEvictionPolicy) (*snapstate.SeedRefreshTasks, map[string]bool, error) {
 		observed.initial = append(observed.initial, candidates)
 		observed.evictions = append(observed.evictions, eviction)
 
@@ -121,14 +121,14 @@ func mockSeedRefreshHooks(triggers []string) (*observedSeedRefreshCandidates, fu
 		finalize.WaitFor(create)
 		finalize.Set("recovery-system-setup-task", create.ID())
 
-		currentSeedTS = &snapstate.SeedRefreshTaskSet{
+		currentSeedTS = &snapstate.SeedRefreshTasks{
 			Create:   create,
 			Finalize: finalize,
 		}
 		return currentSeedTS, added, nil
 	}
 
-	snapstate.PendingSeedRefreshTasks = func(ts *state.TaskSet) (*snapstate.SeedRefreshTaskSet, error) {
+	snapstate.PendingSeedRefreshTasks = func(ts *state.TaskSet) (*snapstate.SeedRefreshTasks, error) {
 		if currentSeedTS == nil {
 			return nil, nil
 		}
@@ -147,7 +147,7 @@ func mockSeedRefreshHooks(triggers []string) (*observedSeedRefreshCandidates, fu
 		return nil, nil
 	}
 
-	snapstate.UpdateSeedRefreshChange = func(seedTS *snapstate.SeedRefreshTaskSet, _ snapstate.DeviceContext, candidate snapstate.SeedRefreshCandidate) (bool, error) {
+	snapstate.UpdateSeedRefreshChange = func(seedTS *snapstate.SeedRefreshTasks, _ snapstate.DeviceContext, candidate snapstate.SeedRefreshCandidate) (added bool, err error) {
 		observed.prerequisites = append(observed.prerequisites, candidate)
 
 		if !triggered[candidate.InstanceName] {
@@ -162,7 +162,7 @@ func mockSeedRefreshHooks(triggers []string) (*observedSeedRefreshCandidates, fu
 	}
 
 	return &observed, func() {
-		snapstate.SeedRefreshTasks = oldSeedRefreshTasks
+		snapstate.CreateSeedRefreshTasks = oldCreateSeedRefreshTasks
 		snapstate.PendingSeedRefreshTasks = oldPendingSeedRefreshTasks
 		snapstate.UpdateSeedRefreshChange = oldUpdateSeedRefreshChange
 	}

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -20398,6 +20398,361 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshPrerequisitesUpdatesMode
 	c.Assert(chg.IsReady(), Equals, true)
 }
 
+func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshRecursivePrerequisitesBeforeCreate(c *C) {
+	observed, restore := s.setupSeedRefreshUpdateTest(c, false, true, map[string]any{
+		"kernel":         "kernel",
+		"base":           "core18",
+		"required-snaps": []any{"content-provider", "some-app"},
+	}, []string{"content-provider", "some-app"})
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	ifacerepo.Replace(s.state, interfaces.NewRepository())
+	s.fakeStore.mutateSnapInfo = func(info *snap.Info) error {
+		switch info.InstanceName() {
+		case "some-app":
+			info.Plugs = map[string]*snap.PlugInfo{
+				"shared-content": {
+					Snap:      info,
+					Name:      "shared-content",
+					Interface: "content",
+					Attrs: map[string]any{
+						"default-provider": "content-provider",
+						"content":          "shared-content",
+					},
+				},
+			}
+		case "content-provider":
+			info.Plugs = map[string]*snap.PlugInfo{
+				"nested-content": {
+					Snap:      info,
+					Name:      "nested-content",
+					Interface: "content",
+					Attrs: map[string]any{
+						"default-provider": "nested-provider",
+						"content":          "nested-content",
+					},
+				},
+			}
+		}
+
+		return nil
+	}
+
+	mockSeedRefreshRebootHandlers(s, c, nil)
+
+	s.installSeedRefreshSnaps(c,
+		seedRefreshSnap{name: "kernel", snapID: "kernel-id", snapType: "kernel"},
+		seedRefreshSnap{name: "core18", snapID: "core18-snap-id", snapType: "base"},
+		seedRefreshSnap{name: "content-provider", snapID: "content-provider-id", snapType: "app", base: "core18"},
+		seedRefreshSnap{name: "nested-provider", snapID: "nested-provider-id", snapType: "app", base: "core18"},
+		seedRefreshSnap{name: "some-app", snapID: "some-app-id", snapType: "app", base: "core18"},
+	)
+
+	uts, chg := runSeedRefreshUpdate(c, s.state, s.user.ID, []snapstate.StoreUpdate{{InstanceName: "some-app"}})
+	_, seedTS := parseSeedRefreshTaskSets(uts)
+	c.Assert(seedTS, NotNil)
+
+	s.settle(c)
+
+	seedCreate, seedFinalize, _ := splitSeedRefreshTasks(c, seedTS)
+	c.Assert(observed.prerequisites, HasLen, 2)
+	c.Assert(observed.prerequisites[0].SnapSetupTaskIDs, HasLen, 1)
+	c.Assert(observed.prerequisites[1].SnapSetupTaskIDs, HasLen, 1)
+
+	providerSnapSetupTask := s.state.Task(observed.prerequisites[0].SnapSetupTaskIDs[0])
+	c.Assert(providerSnapSetupTask, NotNil)
+	providerSnapsup, err := snapstate.TaskSnapSetup(providerSnapSetupTask)
+	c.Assert(err, IsNil)
+	c.Check(providerSnapsup.InstanceName(), Equals, "content-provider")
+
+	nestedSnapSetupTask := s.state.Task(observed.prerequisites[1].SnapSetupTaskIDs[0])
+	c.Assert(nestedSnapSetupTask, NotNil)
+	nestedSnapsup, err := snapstate.TaskSnapSetup(nestedSnapSetupTask)
+	c.Assert(err, IsNil)
+	c.Check(nestedSnapsup.InstanceName(), Equals, "nested-provider")
+
+	// both prerequisite task sets are observed, but only content-provider is
+	// seed-relevant. nested-provider is intentionally outside the seed refresh.
+	c.Check(observed.prerequisites, testutil.DeepUnsortedMatches, []snapstate.SeedRefreshCandidate{
+		{
+			InstanceName:     providerSnapsup.InstanceName(),
+			SnapSetupTaskIDs: []string{providerSnapSetupTask.ID()},
+		},
+		{
+			InstanceName:     nestedSnapsup.InstanceName(),
+			SnapSetupTaskIDs: []string{nestedSnapSetupTask.ID()},
+		},
+	})
+
+	// find nested-provider's initial prerequisites task. this is the recursive
+	// prerequisite task that must complete before seed creation.
+	var nestedPrereq *state.Task
+	for _, task := range chg.Tasks() {
+		if task.Kind() != "prerequisites" || task.Has("prerequisites-sync") {
+			continue
+		}
+
+		snapsup, err := snapstate.TaskSnapSetup(task)
+		c.Assert(err, IsNil)
+		if snapsup.InstanceName() == "nested-provider" {
+			nestedPrereq = task
+			break
+		}
+	}
+	c.Assert(nestedPrereq, NotNil)
+
+	// create-recovery-system must not run until recursive initial prerequisites
+	// have had a chance to inject their own prerequisites.
+	c.Check(waitsOnTransitively(seedCreate, nestedPrereq), Equals, true)
+
+	// the dependency from nested-provider's initial prerequisites to seed creation
+	// must not let a later nested-provider failure undo the seed refresh, so the
+	// initial prerequisites task joins the seed lane.
+	sharesLane := false
+	for _, lane := range seedCreate.Lanes() {
+		for _, otherLane := range nestedPrereq.Lanes() {
+			if lane == otherLane {
+				sharesLane = true
+			}
+		}
+	}
+	c.Check(sharesLane, Equals, true)
+
+	// nested-provider is not seed-relevant, so finalization must not wait for
+	// the full nested-provider refresh to complete.
+	c.Check(waitTasksContainKindForSnap(c, seedFinalize, "nested-provider", "run-hook"), Equals, false)
+
+	s.mockRestartAndSettle(c, chg)
+
+	c.Assert(chg.Err(), IsNil)
+	c.Assert(chg.IsReady(), Equals, true)
+}
+
+func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshPrerequisitesCreatedFirstWaitOnSiblingPrerequisites(c *C) {
+	_, restore := s.setupSeedRefreshUpdateTest(c, false, true, map[string]any{
+		"kernel":         "kernel",
+		"base":           "core18",
+		"required-snaps": []any{"content-provider"},
+	}, []string{"content-provider"})
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	ifacerepo.Replace(s.state, interfaces.NewRepository())
+	s.fakeStore.mutateSnapInfo = func(info *snap.Info) error {
+		if info.InstanceName() != "some-app" {
+			return nil
+		}
+
+		info.Plugs = map[string]*snap.PlugInfo{
+			"shared-content": {
+				Snap:      info,
+				Name:      "shared-content",
+				Interface: "content",
+				Attrs: map[string]any{
+					"default-provider": "content-provider",
+					"content":          "shared-content",
+				},
+			},
+			"sibling-content": {
+				Snap:      info,
+				Name:      "sibling-content",
+				Interface: "content",
+				Attrs: map[string]any{
+					"default-provider": "sibling-provider",
+					"content":          "sibling-content",
+				},
+			},
+		}
+
+		return nil
+	}
+
+	mockSeedRefreshRebootHandlers(s, c, nil)
+
+	s.installSeedRefreshSnaps(c,
+		seedRefreshSnap{name: "kernel", snapID: "kernel-id", snapType: "kernel"},
+		seedRefreshSnap{name: "core18", snapID: "core18-snap-id", snapType: "base"},
+		seedRefreshSnap{name: "content-provider", snapID: "content-provider-id", snapType: "app", base: "core18"},
+		seedRefreshSnap{name: "sibling-provider", snapID: "sibling-provider-id", snapType: "app", base: "core18"},
+		seedRefreshSnap{name: "some-app", snapID: "some-app-id", snapType: "app", base: "core18"},
+	)
+
+	uts, chg := runSeedRefreshUpdate(c, s.state, s.user.ID, []snapstate.StoreUpdate{{InstanceName: "some-app"}})
+	_, seedTS := parseSeedRefreshTaskSets(uts)
+	c.Assert(seedTS, IsNil)
+	c.Assert(countTasksOfKind(chg.Tasks(), "create-recovery-system"), Equals, 0)
+	c.Assert(countTasksOfKind(chg.Tasks(), "finalize-recovery-system"), Equals, 0)
+
+	s.settle(c)
+
+	c.Assert(countTasksOfKind(chg.Tasks(), "create-recovery-system"), Equals, 1)
+	c.Assert(countTasksOfKind(chg.Tasks(), "finalize-recovery-system"), Equals, 1)
+
+	var seedCreate, seedFinalize *state.Task
+	for _, task := range chg.Tasks() {
+		switch task.Kind() {
+		case "create-recovery-system":
+			seedCreate = task
+		case "finalize-recovery-system":
+			seedFinalize = task
+		}
+	}
+	c.Assert(seedCreate, NotNil)
+	c.Assert(seedFinalize, NotNil)
+
+	var providerPrereq, siblingPrereq *state.Task
+	for _, task := range chg.Tasks() {
+		if task.Kind() != "prerequisites" || task.Has("prerequisites-sync") {
+			continue
+		}
+
+		snapsup, err := snapstate.TaskSnapSetup(task)
+		c.Assert(err, IsNil)
+		switch snapsup.InstanceName() {
+		case "content-provider":
+			providerPrereq = task
+		case "sibling-provider":
+			siblingPrereq = task
+		}
+	}
+	c.Assert(providerPrereq, NotNil)
+	c.Assert(siblingPrereq, NotNil)
+
+	// create-recovery-system must not run until all same-pass initial
+	// prerequisites have had a chance to inject their own prerequisites.
+	c.Check(waitsOnTransitively(seedCreate, providerPrereq), Equals, true)
+	c.Check(waitsOnTransitively(seedCreate, siblingPrereq), Equals, true)
+
+	// the dependency from sibling-provider's initial prerequisites to seed creation
+	// must not let a later sibling-provider failure undo the seed refresh, so the
+	// initial prerequisites task joins the seed lane.
+	sharesLane := false
+	for _, lane := range seedCreate.Lanes() {
+		for _, otherLane := range siblingPrereq.Lanes() {
+			if lane == otherLane {
+				sharesLane = true
+			}
+		}
+	}
+	c.Check(sharesLane, Equals, true)
+
+	// sibling-provider is not seed-relevant, so finalization must not wait for
+	// the full sibling-provider refresh to complete.
+	c.Check(waitTasksContainKindForSnap(c, seedFinalize, "content-provider", "run-hook"), Equals, true)
+	c.Check(waitTasksContainKindForSnap(c, seedFinalize, "sibling-provider", "run-hook"), Equals, false)
+
+	s.mockRestartAndSettle(c, chg)
+
+	c.Assert(chg.Err(), IsNil)
+	c.Assert(chg.IsReady(), Equals, true)
+}
+
+func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshPrerequisitesCreatedFirstDoesNotCreateDuplicateSeedRefresh(c *C) {
+	_, restore := s.setupSeedRefreshUpdateTest(c, false, true, map[string]any{
+		"kernel":         "kernel",
+		"base":           "core18",
+		"required-snaps": []any{"content-provider", "sibling-provider"},
+	}, []string{"content-provider", "sibling-provider"})
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	ifacerepo.Replace(s.state, interfaces.NewRepository())
+	s.fakeStore.mutateSnapInfo = func(info *snap.Info) error {
+		if info.InstanceName() != "some-app" {
+			return nil
+		}
+
+		info.Plugs = map[string]*snap.PlugInfo{
+			"shared-content": {
+				Snap:      info,
+				Name:      "shared-content",
+				Interface: "content",
+				Attrs: map[string]any{
+					"default-provider": "content-provider",
+					"content":          "shared-content",
+				},
+			},
+			"sibling-content": {
+				Snap:      info,
+				Name:      "sibling-content",
+				Interface: "content",
+				Attrs: map[string]any{
+					"default-provider": "sibling-provider",
+					"content":          "sibling-content",
+				},
+			},
+		}
+
+		return nil
+	}
+
+	mockSeedRefreshRebootHandlers(s, c, nil)
+
+	s.installSeedRefreshSnaps(c,
+		seedRefreshSnap{name: "kernel", snapID: "kernel-id", snapType: "kernel"},
+		seedRefreshSnap{name: "core18", snapID: "core18-snap-id", snapType: "base"},
+		seedRefreshSnap{name: "content-provider", snapID: "content-provider-id", snapType: "app", base: "core18"},
+		seedRefreshSnap{name: "sibling-provider", snapID: "sibling-provider-id", snapType: "app", base: "core18"},
+		seedRefreshSnap{name: "some-app", snapID: "some-app-id", snapType: "app", base: "core18"},
+	)
+
+	uts, chg := runSeedRefreshUpdate(c, s.state, s.user.ID, []snapstate.StoreUpdate{{InstanceName: "some-app"}})
+	_, seedTS := parseSeedRefreshTaskSets(uts)
+	c.Assert(seedTS, IsNil)
+
+	s.settle(c)
+
+	c.Assert(countTasksOfKind(chg.Tasks(), "create-recovery-system"), Equals, 1)
+	c.Assert(countTasksOfKind(chg.Tasks(), "finalize-recovery-system"), Equals, 1)
+
+	var seedCreate, seedFinalize *state.Task
+	for _, task := range chg.Tasks() {
+		switch task.Kind() {
+		case "create-recovery-system":
+			seedCreate = task
+		case "finalize-recovery-system":
+			seedFinalize = task
+		}
+	}
+	c.Assert(seedCreate, NotNil)
+	c.Assert(seedFinalize, NotNil)
+
+	var providerPrereq, siblingPrereq *state.Task
+	for _, task := range chg.Tasks() {
+		if task.Kind() != "prerequisites" || task.Has("prerequisites-sync") {
+			continue
+		}
+
+		snapsup, err := snapstate.TaskSnapSetup(task)
+		c.Assert(err, IsNil)
+		switch snapsup.InstanceName() {
+		case "content-provider":
+			providerPrereq = task
+		case "sibling-provider":
+			siblingPrereq = task
+		}
+	}
+	c.Assert(providerPrereq, NotNil)
+	c.Assert(siblingPrereq, NotNil)
+
+	c.Check(waitsOnTransitively(seedCreate, providerPrereq), Equals, true)
+	c.Check(waitsOnTransitively(seedCreate, siblingPrereq), Equals, true)
+	c.Check(waitTasksContainKindForSnap(c, seedFinalize, "content-provider", "run-hook"), Equals, true)
+	c.Check(waitTasksContainKindForSnap(c, seedFinalize, "sibling-provider", "run-hook"), Equals, true)
+
+	s.mockRestartAndSettle(c, chg)
+
+	c.Assert(chg.Err(), IsNil)
+	c.Assert(chg.IsReady(), Equals, true)
+}
+
 func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshPrerequisitesDoNotMergeWhenSeedRefreshAlreadyReady(c *C) {
 	observed, restore := s.setupSeedRefreshUpdateTest(c, false, true, map[string]any{
 		"kernel":         "kernel",
@@ -20526,9 +20881,7 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshPrerequisitesFailsForPro
 	c.Assert(err, IsNil)
 
 	c.Assert(prereqs.Status(), Equals, state.ErrorStatus)
-
-	c.Assert(prereqs.Status(), Equals, state.ErrorStatus)
-	c.Assert(strings.Join(prereqs.Log(), "\n"), Matches, `(?s).*cannot install prerequisite "content-provider": cannot automatically update prerequisite "content-provider" during seed-refresh while base "some-base" waits for create-recovery-system.*`)
+	c.Assert(strings.Join(prereqs.Log(), "\n"), Matches, `(?s).*cannot automatically update prerequisite "content-provider" during seed-refresh while base "some-base" waits for create-recovery-system.*`)
 }
 
 func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshAllowsRequestedModelContentProviderRefresh(c *C) {
@@ -21635,74 +21988,6 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshNoEssentialsWithAddition
 	appEndTask, err := appTS.Edge(snapstate.EndEdge)
 	c.Assert(err, IsNil)
 	c.Check(waitsOnTransitively(seedEnd, appEndTask), Equals, true)
-}
-
-func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshSkippedWhileParentSeedRefreshNotReady(c *C) {
-	_, restore := s.setupSeedRefreshUpdateTest(c, false, true, map[string]any{
-		"kernel":         "kernel",
-		"base":           "core18",
-		"required-snaps": []any{"some-app", "content-provider"},
-	}, []string{"some-app"})
-	defer restore()
-
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	s.installSeedRefreshSnaps(c,
-		seedRefreshSnap{name: "kernel", snapID: "kernel-id", snapType: "kernel"},
-		seedRefreshSnap{name: "core18", snapID: "core18-snap-id", snapType: "base"},
-		seedRefreshSnap{name: "some-app", snapID: "some-app-id", snapType: "app", base: "core18"},
-		seedRefreshSnap{name: "content-provider", snapID: "content-provider-id", snapType: "app", base: "core18"},
-	)
-
-	uts, chg := runSeedRefreshUpdate(c, s.state, s.user.ID, []snapstate.StoreUpdate{{InstanceName: "some-app"}})
-	c.Assert(findSeedRefreshTaskSet(uts.Refresh), NotNil)
-	c.Assert(countTasksOfKind(chg.Tasks(), "create-recovery-system"), Equals, 1)
-	c.Assert(countTasksOfKind(chg.Tasks(), "finalize-recovery-system"), Equals, 1)
-
-	goal := snapstate.StoreUpdateGoal(snapstate.StoreUpdate{InstanceName: "content-provider"})
-	ts, err := snapstate.UpdateOne(context.Background(), s.state, goal, nil, snapstate.Options{
-		UserID:          s.user.ID,
-		ConflictOptions: snapstate.ConflictOptions{FromChange: chg.ID()},
-	})
-	c.Assert(err, IsNil)
-
-	c.Check(countTasksOfKind(ts.Tasks(), "create-recovery-system"), Equals, 0)
-	c.Check(countTasksOfKind(ts.Tasks(), "finalize-recovery-system"), Equals, 0)
-}
-
-func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshAllowedOnceParentSeedRefreshReady(c *C) {
-	_, restore := s.setupSeedRefreshUpdateTest(c, false, true, map[string]any{
-		"kernel": "kernel",
-		"base":   "core18",
-	}, []string{"core18"})
-	defer restore()
-
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	s.installSeedRefreshSnaps(c,
-		seedRefreshSnap{name: "kernel", snapID: "kernel-id", snapType: "kernel"},
-		seedRefreshSnap{name: "core18", snapID: "core18-snap-id", snapType: "base"},
-	)
-
-	uts, chg := runSeedRefreshUpdate(c, s.state, s.user.ID, []snapstate.StoreUpdate{{InstanceName: "core18"}})
-	seedTS := findSeedRefreshTaskSet(uts.Refresh)
-	c.Assert(seedTS, NotNil)
-
-	seedCreate, seedFinalize, _ := splitSeedRefreshTasks(c, seedTS)
-	seedCreate.SetStatus(state.DoneStatus)
-	seedFinalize.SetStatus(state.DoneStatus)
-
-	goal := snapstate.StoreUpdateGoal(snapstate.StoreUpdate{InstanceName: "core18"})
-	ts, err := snapstate.UpdateOne(context.Background(), s.state, goal, nil, snapstate.Options{
-		UserID:          s.user.ID,
-		ConflictOptions: snapstate.ConflictOptions{FromChange: chg.ID()},
-	})
-	c.Assert(err, IsNil)
-
-	c.Check(countTasksOfKind(ts.Tasks(), "create-recovery-system"), Equals, 1)
-	c.Check(countTasksOfKind(ts.Tasks(), "finalize-recovery-system"), Equals, 1)
 }
 
 func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshReRefreshCreatesSecondSeed(c *C) {

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -20398,6 +20398,101 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshPrerequisitesUpdatesMode
 	c.Assert(chg.IsReady(), Equals, true)
 }
 
+func (s *snapmgrTestSuite) testUpdateWithGoalSeedRefreshLatePrerequisiteFailure(c *C, providerInSeed bool) {
+	requiredSnaps := []any{"some-app"}
+	seedRefreshTriggers := []string{"some-app"}
+	if providerInSeed {
+		requiredSnaps = []any{"content-provider", "some-app"}
+		seedRefreshTriggers = []string{"content-provider", "some-app"}
+	}
+
+	_, restore := s.setupSeedRefreshUpdateTest(c, false, true, map[string]any{
+		"kernel":         "kernel",
+		"base":           "core18",
+		"required-snaps": requiredSnaps,
+	}, seedRefreshTriggers)
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	ifacerepo.Replace(s.state, interfaces.NewRepository())
+	s.fakeStore.mutateSnapInfo = func(info *snap.Info) error {
+		if info.InstanceName() != "some-app" {
+			return nil
+		}
+
+		info.Plugs = map[string]*snap.PlugInfo{
+			"shared-content": {
+				Snap:      info,
+				Name:      "shared-content",
+				Interface: "content",
+				Attrs: map[string]any{
+					"default-provider": "content-provider",
+					"content":          "shared-content",
+				},
+			},
+		}
+
+		return nil
+	}
+
+	mockSeedRefreshRebootHandlers(s, c, nil)
+
+	s.installSeedRefreshSnaps(c,
+		seedRefreshSnap{name: "kernel", snapID: "kernel-id", snapType: "kernel"},
+		seedRefreshSnap{name: "core18", snapID: "core18-snap-id", snapType: "base"},
+		seedRefreshSnap{name: "content-provider", snapID: "content-provider-id", snapType: "app", base: "core18"},
+		seedRefreshSnap{name: "some-app", snapID: "some-app-id", snapType: "app", base: "core18"},
+	)
+
+	uts, chg := runSeedRefreshUpdate(c, s.state, s.user.ID, []snapstate.StoreUpdate{{InstanceName: "some-app"}})
+	_, seedTS := parseSeedRefreshTaskSets(uts)
+	c.Assert(seedTS, NotNil)
+	seedCreate, seedFinalize, _ := splitSeedRefreshTasks(c, seedTS)
+
+	errInjected := 0
+	s.fakeBackend.maybeInjectErr = func(op *fakeOp) error {
+		if op.op == "auto-connect:Doing" && op.name == "content-provider" {
+			errInjected++
+			return errors.New("late prerequisite mock error")
+		}
+		return nil
+	}
+
+	// run until seed creation requests a reboot, after the late prerequisite
+	// has been added to the change and joined to the seed lanes.
+	s.settle(c)
+	providerLink := findTaskForSnap(c, chg, "link-snap", "content-provider")
+	c.Check(waitTasksContainKindForSnap(c, seedFinalize, "content-provider", "run-hook"), Equals, providerInSeed)
+
+	// resume into the provider failure.
+	s.mockRestartAndSettle(c, chg)
+	if providerInSeed {
+		// let the seed cohort finish undoing across its restart boundary.
+		s.mockRestartAndSettle(c, chg)
+	}
+
+	c.Check(providerLink.Status(), Equals, state.UndoneStatus)
+	if providerInSeed {
+		c.Check(seedCreate.Status(), Equals, state.UndoneStatus)
+	} else {
+		c.Check(seedCreate.Status(), Equals, state.DoneStatus)
+		c.Check(seedFinalize.Status(), Equals, state.DoneStatus)
+	}
+	c.Check(chg.Status(), Equals, state.ErrorStatus)
+	c.Check(chg.Err(), ErrorMatches, `(?s).*\(late prerequisite mock error\)`)
+	c.Check(errInjected, Equals, 1)
+}
+
+func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshLatePrerequisiteFailureUndoesSeed(c *C) {
+	s.testUpdateWithGoalSeedRefreshLatePrerequisiteFailure(c, true)
+}
+
+func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshLateNonSeedPrerequisiteFailureDoesNotUndoSeed(c *C) {
+	s.testUpdateWithGoalSeedRefreshLatePrerequisiteFailure(c, false)
+}
+
 func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshRecursivePrerequisitesBeforeCreate(c *C) {
 	observed, restore := s.setupSeedRefreshUpdateTest(c, false, true, map[string]any{
 		"kernel":         "kernel",

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -20822,13 +20822,15 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshPrerequisitesDoNotMergeW
 	c.Assert(chg.IsReady(), Equals, false)
 }
 
-// TODO:SEEDREFRESH: update this test once this scenario is supported
-func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshPrerequisitesFailsForProviderSwitchingToInFlightNonEssentialBase(c *C) {
-	_, restore := s.setupSeedRefreshUpdateTest(c, false, true, map[string]any{
+func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshPrerequisitesProviderSwitchingToInFlightNonEssentialBaseRunThrough(c *C) {
+	restore := snapstate.MockPrerequisitesRetryTimeout(time.Millisecond)
+	defer restore()
+
+	_, restore = s.setupSeedRefreshUpdateTest(c, false, true, map[string]any{
 		"kernel":         "kernel",
 		"base":           "core18",
-		"required-snaps": []any{"content-provider", "some-app"},
-	}, []string{"content-provider", "some-app"})
+		"required-snaps": []any{"some-base", "content-provider", "some-app"},
+	}, []string{"some-base", "content-provider", "some-app"})
 	defer restore()
 
 	s.state.Lock()
@@ -20864,24 +20866,45 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshPrerequisitesFailsForPro
 		seedRefreshSnap{name: "some-app", snapID: "some-app-id", snapType: "app", base: "core18"},
 	)
 
-	uts, _ := runSeedRefreshUpdate(c, s.state, s.user.ID, []snapstate.StoreUpdate{{InstanceName: "some-app"}, {InstanceName: "some-base"}})
-	taskSetsBySnap, _ := parseSeedRefreshTaskSets(uts)
-	appTS := mustTaskSetForSnap(c, taskSetsBySnap, "some-app")
+	mockSeedRefreshRebootHandlers(s, c, nil)
 
-	prereqs := findKindInTaskSet(appTS, "prerequisites")
-	c.Assert(prereqs, NotNil)
+	uts, chg := runSeedRefreshUpdate(c, s.state, s.user.ID, []snapstate.StoreUpdate{{InstanceName: "some-app"}, {InstanceName: "some-base"}})
+	taskSetsBySnap, seedTS := parseSeedRefreshTaskSets(uts)
+	c.Assert(seedTS, NotNil)
+	seedCreate, seedFinalize, _ := splitSeedRefreshTasks(c, seedTS)
+	baseTS := mustTaskSetForSnap(c, taskSetsBySnap, "some-base")
 
 	s.state.Unlock()
 	err := s.o.SettleWithBreakCondition(testutil.HostScaledTimeout(10*time.Second), func() bool {
 		s.state.Lock()
 		defer s.state.Unlock()
-		return prereqs.Status().Ready()
+		return seedCreate.Status() == state.WaitStatus
 	})
 	s.state.Lock()
 	c.Assert(err, IsNil)
 
-	c.Assert(prereqs.Status(), Equals, state.ErrorStatus)
-	c.Assert(strings.Join(prereqs.Log(), "\n"), Matches, `(?s).*cannot automatically update prerequisite "content-provider" during seed-refresh while base "some-base" waits for create-recovery-system.*`)
+	providerPrereq, providerPrereqSync := findPrereqTasksForSnap(c, chg, "content-provider")
+
+	// base goes into the seed, but it isn't linked until after seed creation,
+	// since it isn't the boot base.
+	baseLink := findKindInTaskSet(baseTS, "link-snap")
+	c.Assert(baseLink, NotNil)
+	c.Check(waitTasksContainKindForSnap(c, seedCreate, "some-base", "validate-snap"), Equals, true)
+	c.Check(waitsOnTransitively(seedCreate, baseLink), Equals, false)
+
+	// initial prerequisites task goes before the seed is created
+	c.Check(waitsOnTransitively(seedCreate, providerPrereq), Equals, true)
+
+	// but preprequisites sync task runs after. this is important, since this
+	// task retries until the base's link-snap is done.
+	c.Check(waitsOnTransitively(seedCreate, providerPrereqSync), Equals, false)
+	c.Check(waitTasksContainKindForSnap(c, seedCreate, "content-provider", "validate-snap"), Equals, true)
+	c.Check(waitTasksContainKindForSnap(c, seedFinalize, "content-provider", "run-hook"), Equals, true)
+
+	s.mockRestartAndSettle(c, chg)
+
+	c.Assert(chg.Err(), IsNil)
+	c.Assert(chg.IsReady(), Equals, true)
 }
 
 func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshAllowsRequestedModelContentProviderRefresh(c *C) {

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -21309,8 +21309,8 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshRemoveSystemFailureDoesN
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	oldSeedRefreshTasks := snapstate.SeedRefreshTasks
-	snapstate.SeedRefreshTasks = func(st *state.State, _ snapstate.DeviceContext, candidates []snapstate.SeedRefreshCandidate, _ snapstate.SeedRefreshEvictionPolicy) (*snapstate.SeedRefreshTaskSet, map[string]bool, error) {
+	oldCreateSeedRefreshTasks := snapstate.CreateSeedRefreshTasks
+	snapstate.CreateSeedRefreshTasks = func(st *state.State, _ snapstate.DeviceContext, candidates []snapstate.SeedRefreshCandidate, _ snapstate.SeedRefreshEvictionPolicy) (*snapstate.SeedRefreshTasks, map[string]bool, error) {
 		added := make(map[string]bool, len(candidates))
 		for _, candidate := range candidates {
 			if candidate.InstanceName != "kernel" && candidate.InstanceName != "core18" && candidate.InstanceName != "some-app" {
@@ -21334,14 +21334,14 @@ func (s *snapmgrTestSuite) TestUpdateWithGoalSeedRefreshRemoveSystemFailureDoesN
 		remove2 := st.NewTask("remove-recovery-system", "Remove old recovery system 2")
 		remove2.WaitFor(finalize)
 
-		return &snapstate.SeedRefreshTaskSet{
+		return &snapstate.SeedRefreshTasks{
 			Create:   create,
 			Finalize: finalize,
 			Remove:   []*state.Task{remove1, remove2},
 		}, added, nil
 	}
 	defer func() {
-		snapstate.SeedRefreshTasks = oldSeedRefreshTasks
+		snapstate.CreateSeedRefreshTasks = oldCreateSeedRefreshTasks
 	}()
 
 	restartRequested := mockSeedRefreshRebootHandlers(s, c, nil)


### PR DESCRIPTION
This improves the robustness of prerequisites that either trigger a seed refresh or must join a seed refresh. Specifically, we are able to handle a scenario that would have previously lead to a deadlocked change.

This also updates `prerequisites` so that multiple prerequisites that are installed by one task all join the same seed-refresh, rather than creating multiple new ones.