### PR TITLE
many: ListMountUnits allows listing installed units which includes unloaded ones

### DIFF
--- a/overlord/hookstate/ctlcmd/umount.go
+++ b/overlord/hookstate/ctlcmd/umount.go
@@ -52,9 +52,9 @@ func (m *umountCommand) Execute([]string) error {
 
 	snapName := context.InstanceName()
 
-	// Get the list of all our mount units, to find the matching one
+	// Get the list of all our mount units (including unloaded units), to find the matching one
 	sysd := systemd.New(systemd.SystemMode, nil)
-	mountPoints, err := sysd.ListMountUnits(snapName, "mount-control")
+	mountPoints, err := sysd.ListMountUnits(snapName, "mount-control", systemd.AllMountUnits)
 	if err != nil {
 		return fmt.Errorf("cannot retrieve list of mount units: %v", err)
 	}

--- a/overlord/hookstate/ctlcmd/umount.go
+++ b/overlord/hookstate/ctlcmd/umount.go
@@ -52,9 +52,9 @@ func (m *umountCommand) Execute([]string) error {
 
 	snapName := context.InstanceName()
 
-	// Get the list of all our mount units (including unloaded units), to find the matching one
+	// Get the list of installed mount units to find the matching one
 	sysd := systemd.New(systemd.SystemMode, nil)
-	mountPoints, err := sysd.ListMountUnits(snapName, "mount-control", systemd.AllMountUnits)
+	mountPoints, err := sysd.ListMountUnits(snapName, "mount-control", systemd.InstalledMountUnits)
 	if err != nil {
 		return fmt.Errorf("cannot retrieve list of mount units: %v", err)
 	}

--- a/overlord/hookstate/ctlcmd/umount.go
+++ b/overlord/hookstate/ctlcmd/umount.go
@@ -52,7 +52,11 @@ func (m *umountCommand) Execute([]string) error {
 
 	snapName := context.InstanceName()
 
-	// Get the list of installed mount units to find the matching one
+	// Get the list of installed mount units to find the matching one.
+	// mount-control mounts always create a mount unit file and using
+	// systemd.InstalledMountUnits here ensures that we get the
+	// corresponding mount unit even if it is not currently loaded in
+	// systemd's memory (e.g. if it was stopped and garbage-collected).
 	sysd := systemd.New(systemd.SystemMode, nil)
 	mountPoints, err := sysd.ListMountUnits(snapName, "mount-control", systemd.InstalledMountUnits)
 	if err != nil {

--- a/overlord/hookstate/ctlcmd/umount_test.go
+++ b/overlord/hookstate/ctlcmd/umount_test.go
@@ -86,7 +86,7 @@ func (s *umountSuite) TestListUnitFailure(c *C) {
 	_, _, _, err := ctlcmd.Run(s.mockContext, []string{"umount", "/dest"}, 0, nil)
 	c.Check(err, ErrorMatches, `cannot retrieve list of mount units: list error`)
 	c.Check(s.sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{
-		{SnapName: "snap1", Origin: "mount-control"},
+		{SnapName: "snap1", Origin: "mount-control", Filter: systemd.AllMountUnits},
 	})
 	c.Check(s.sysd.RemoveMountUnitFileCalls, HasLen, 0)
 }
@@ -100,7 +100,7 @@ func (s *umountSuite) TestUnitNotFound(c *C) {
 	_, _, _, err := ctlcmd.Run(s.mockContext, []string{"umount", "/dest"}, 0, nil)
 	c.Check(err, ErrorMatches, `cannot find the given mount`)
 	c.Check(s.sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{
-		{SnapName: "snap1", Origin: "mount-control"},
+		{SnapName: "snap1", Origin: "mount-control", Filter: systemd.AllMountUnits},
 	})
 	c.Check(s.sysd.RemoveMountUnitFileCalls, HasLen, 0)
 }
@@ -113,7 +113,7 @@ func (s *umountSuite) TestRemovalError(c *C) {
 	_, _, _, err := ctlcmd.Run(s.mockContext, []string{"umount", "/dest"}, 0, nil)
 	c.Check(err, ErrorMatches, `cannot remove mount unit: remove error`)
 	c.Check(s.sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{
-		{SnapName: "snap1", Origin: "mount-control"},
+		{SnapName: "snap1", Origin: "mount-control", Filter: systemd.AllMountUnits},
 	})
 	c.Check(s.sysd.RemoveMountUnitFileCalls, DeepEquals, []string{
 		"/dest",
@@ -126,7 +126,7 @@ func (s *umountSuite) TestHappy(c *C) {
 	_, _, _, err := ctlcmd.Run(s.mockContext, []string{"umount", "/dest"}, 0, nil)
 	c.Check(err, IsNil)
 	c.Check(s.sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{
-		{SnapName: "snap1", Origin: "mount-control"},
+		{SnapName: "snap1", Origin: "mount-control", Filter: systemd.AllMountUnits},
 	})
 	c.Check(s.sysd.RemoveMountUnitFileCalls, DeepEquals, []string{
 		"/dest",

--- a/overlord/hookstate/ctlcmd/umount_test.go
+++ b/overlord/hookstate/ctlcmd/umount_test.go
@@ -86,7 +86,7 @@ func (s *umountSuite) TestListUnitFailure(c *C) {
 	_, _, _, err := ctlcmd.Run(s.mockContext, []string{"umount", "/dest"}, 0, nil)
 	c.Check(err, ErrorMatches, `cannot retrieve list of mount units: list error`)
 	c.Check(s.sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{
-		{SnapName: "snap1", Origin: "mount-control", Filter: systemd.AllMountUnits},
+		{SnapName: "snap1", Origin: "mount-control", Filter: systemd.InstalledMountUnits},
 	})
 	c.Check(s.sysd.RemoveMountUnitFileCalls, HasLen, 0)
 }
@@ -100,7 +100,7 @@ func (s *umountSuite) TestUnitNotFound(c *C) {
 	_, _, _, err := ctlcmd.Run(s.mockContext, []string{"umount", "/dest"}, 0, nil)
 	c.Check(err, ErrorMatches, `cannot find the given mount`)
 	c.Check(s.sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{
-		{SnapName: "snap1", Origin: "mount-control", Filter: systemd.AllMountUnits},
+		{SnapName: "snap1", Origin: "mount-control", Filter: systemd.InstalledMountUnits},
 	})
 	c.Check(s.sysd.RemoveMountUnitFileCalls, HasLen, 0)
 }
@@ -113,7 +113,7 @@ func (s *umountSuite) TestRemovalError(c *C) {
 	_, _, _, err := ctlcmd.Run(s.mockContext, []string{"umount", "/dest"}, 0, nil)
 	c.Check(err, ErrorMatches, `cannot remove mount unit: remove error`)
 	c.Check(s.sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{
-		{SnapName: "snap1", Origin: "mount-control", Filter: systemd.AllMountUnits},
+		{SnapName: "snap1", Origin: "mount-control", Filter: systemd.InstalledMountUnits},
 	})
 	c.Check(s.sysd.RemoveMountUnitFileCalls, DeepEquals, []string{
 		"/dest",
@@ -126,7 +126,7 @@ func (s *umountSuite) TestHappy(c *C) {
 	_, _, _, err := ctlcmd.Run(s.mockContext, []string{"umount", "/dest"}, 0, nil)
 	c.Check(err, IsNil)
 	c.Check(s.sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{
-		{SnapName: "snap1", Origin: "mount-control", Filter: systemd.AllMountUnits},
+		{SnapName: "snap1", Origin: "mount-control", Filter: systemd.InstalledMountUnits},
 	})
 	c.Check(s.sysd.RemoveMountUnitFileCalls, DeepEquals, []string{
 		"/dest",

--- a/overlord/snapshotstate/backend/mounts.go
+++ b/overlord/snapshotstate/backend/mounts.go
@@ -34,7 +34,8 @@ import (
 func listMountsAtOrUnder(snapName, baseDir string) (snapctlMPs, nonSnapctlMPs []string, err error) {
 	sysd := systemd.New(systemd.SystemMode, nil)
 	// mounts created using snapctl have the "mount-control" origin
-	mcMountPoints, err := sysd.ListMountUnits(snapName, "mount-control")
+	// only loaded and active units are needed
+	mcMountPoints, err := sysd.ListMountUnits(snapName, "mount-control", systemd.LoadedMountUnits)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/overlord/snapshotstate/backend/mounts.go
+++ b/overlord/snapshotstate/backend/mounts.go
@@ -33,8 +33,11 @@ import (
 // divided into snapctl and non-snapctl mount groups.
 func listMountsAtOrUnder(snapName, baseDir string) (snapctlMPs, nonSnapctlMPs []string, err error) {
 	sysd := systemd.New(systemd.SystemMode, nil)
-	// mounts created using snapctl have the "mount-control" origin
-	// only loaded and active units are needed
+	// Mounts created using snapctl have the "mount-control" origin.
+	// Only active units are needed here but systemd.LoadedMountUnits
+	// lists loaded units which may be active or inactive. This is still
+	// fine because mcMountPoints is only used to filter the mountInfo
+	// list which only contains active mounts.
 	mcMountPoints, err := sysd.ListMountUnits(snapName, "mount-control", systemd.LoadedMountUnits)
 	if err != nil {
 		return nil, nil, err

--- a/overlord/snapshotstate/backend/mounts_test.go
+++ b/overlord/snapshotstate/backend/mounts_test.go
@@ -122,7 +122,7 @@ func (s *snapshotSuite) TestRestoreNoMountsAtDst(c *C) {
 	rs.Cleanup()
 
 	// one ListMountUnits call while processing each of {system common, system rev, user common, user rev}
-	expListMountUnitsParams := systemdtest.ParamsForListMountUnits{SnapName: "hello-snap", Origin: "mount-control"}
+	expListMountUnitsParams := systemdtest.ParamsForListMountUnits{SnapName: "hello-snap", Origin: "mount-control", Filter: systemd.LoadedMountUnits}
 	c.Check(s.sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{
 		expListMountUnitsParams, expListMountUnitsParams, expListMountUnitsParams, expListMountUnitsParams,
 	})
@@ -150,7 +150,7 @@ func (s *snapshotSuite) TestRestoreStopsAndRestartsSnapctlMounts(c *C) {
 	rs.Cleanup()
 
 	// one ListMountUnits call while processing each of {system common, system rev, user common, user rev}
-	expListMountUnitsParams := systemdtest.ParamsForListMountUnits{SnapName: "hello-snap", Origin: "mount-control"}
+	expListMountUnitsParams := systemdtest.ParamsForListMountUnits{SnapName: "hello-snap", Origin: "mount-control", Filter: systemd.LoadedMountUnits}
 	c.Check(s.sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{
 		expListMountUnitsParams, expListMountUnitsParams, expListMountUnitsParams, expListMountUnitsParams,
 	})
@@ -177,7 +177,7 @@ func (s *snapshotSuite) TestRestoreNonSnapctlMountReturnsError(c *C) {
 
 	// ListMountUnits called at least once
 	c.Assert(s.sysd.ListMountUnitsCalls, Not(HasLen), 0)
-	c.Check(s.sysd.ListMountUnitsCalls[0], DeepEquals, systemdtest.ParamsForListMountUnits{SnapName: "hello-snap", Origin: "mount-control"})
+	c.Check(s.sysd.ListMountUnitsCalls[0], DeepEquals, systemdtest.ParamsForListMountUnits{SnapName: "hello-snap", Origin: "mount-control", Filter: systemd.LoadedMountUnits})
 	c.Check(s.sysd.StopCalls, HasLen, 0)
 	c.Check(s.sysd.StartCalls, HasLen, 0)
 }
@@ -196,7 +196,7 @@ func (s *snapshotSuite) TestRestoreListMountErrorReturnsError(c *C) {
 	c.Assert(err, ErrorMatches, `.*cannot list mounts.*mock ListMountUnits error.*`)
 
 	c.Assert(s.sysd.ListMountUnitsCalls, HasLen, 1)
-	c.Check(s.sysd.ListMountUnitsCalls[0], DeepEquals, systemdtest.ParamsForListMountUnits{SnapName: "hello-snap", Origin: "mount-control"})
+	c.Check(s.sysd.ListMountUnitsCalls[0], DeepEquals, systemdtest.ParamsForListMountUnits{SnapName: "hello-snap", Origin: "mount-control", Filter: systemd.LoadedMountUnits})
 	c.Check(s.sysd.StopCalls, HasLen, 0)
 	c.Check(s.sysd.StartCalls, HasLen, 0)
 }
@@ -222,7 +222,7 @@ func (s *snapshotSuite) TestRestoreStopFailureReturnsError(c *C) {
 	c.Assert(err, ErrorMatches, `.*cannot stop mount unit.*systemd stop failed.*`)
 
 	c.Assert(s.sysd.ListMountUnitsCalls, Not(HasLen), 0)
-	c.Check(s.sysd.ListMountUnitsCalls[0], DeepEquals, systemdtest.ParamsForListMountUnits{SnapName: "hello-snap", Origin: "mount-control"})
+	c.Check(s.sysd.ListMountUnitsCalls[0], DeepEquals, systemdtest.ParamsForListMountUnits{SnapName: "hello-snap", Origin: "mount-control", Filter: systemd.LoadedMountUnits})
 	c.Check(s.sysd.StopCalls, HasLen, 1)
 	c.Check(s.sysd.StartCalls, HasLen, 0)
 }
@@ -251,7 +251,7 @@ func (s *snapshotSuite) TestRestoreRestartFailureIsLoggedNotReturned(c *C) {
 	rs.Cleanup()
 
 	// one ListMountUnits call while processing each of {system common, system rev, user common, user rev}
-	expListMountUnitsParams := systemdtest.ParamsForListMountUnits{SnapName: "hello-snap", Origin: "mount-control"}
+	expListMountUnitsParams := systemdtest.ParamsForListMountUnits{SnapName: "hello-snap", Origin: "mount-control", Filter: systemd.LoadedMountUnits}
 	c.Check(s.sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{
 		expListMountUnitsParams, expListMountUnitsParams, expListMountUnitsParams, expListMountUnitsParams,
 	})
@@ -303,7 +303,7 @@ func (s *snapshotSuite) TestRevertStopsAndRestartsSnapctlMounts(c *C) {
 	}
 	rs.Revert()
 
-	expListMountUnitsParams := systemdtest.ParamsForListMountUnits{SnapName: "mysnap", Origin: "mount-control"}
+	expListMountUnitsParams := systemdtest.ParamsForListMountUnits{SnapName: "mysnap", Origin: "mount-control", Filter: systemd.LoadedMountUnits}
 	c.Assert(s.sysd.ListMountUnitsCalls, HasLen, 1)
 	c.Check(s.sysd.ListMountUnitsCalls[0], DeepEquals, expListMountUnitsParams)
 
@@ -343,7 +343,7 @@ func (s *snapshotSuite) TestRevertLogsAndContinuesOnNonSnapctlMounts(c *C) {
 	rs.Revert()
 
 	// Both dirs must have been visited (loop continued past dir1).
-	expListMountUnitsParams := systemdtest.ParamsForListMountUnits{SnapName: "mysnap", Origin: "mount-control"}
+	expListMountUnitsParams := systemdtest.ParamsForListMountUnits{SnapName: "mysnap", Origin: "mount-control", Filter: systemd.LoadedMountUnits}
 	c.Assert(s.sysd.ListMountUnitsCalls, HasLen, 2)
 	c.Check(s.sysd.ListMountUnitsCalls[0], DeepEquals, expListMountUnitsParams)
 	c.Check(s.sysd.ListMountUnitsCalls[1], DeepEquals, expListMountUnitsParams)
@@ -386,7 +386,7 @@ func (s *snapshotSuite) TestRevertLogsAndContinuesOnStopFailure(c *C) {
 	rs.Revert()
 
 	// Both dirs must have been visited (loop continued past dir1).
-	expListMountUnitsParams := systemdtest.ParamsForListMountUnits{SnapName: "mysnap", Origin: "mount-control"}
+	expListMountUnitsParams := systemdtest.ParamsForListMountUnits{SnapName: "mysnap", Origin: "mount-control", Filter: systemd.LoadedMountUnits}
 	c.Assert(s.sysd.ListMountUnitsCalls, HasLen, 2)
 	c.Check(s.sysd.ListMountUnitsCalls[0], DeepEquals, expListMountUnitsParams)
 	c.Check(s.sysd.ListMountUnitsCalls[1], DeepEquals, expListMountUnitsParams)
@@ -427,7 +427,7 @@ func (s *snapshotSuite) TestRevertLogsAndContinuesOnStartFailure(c *C) {
 	}
 	rs.Revert()
 
-	expListMountUnitsParams := systemdtest.ParamsForListMountUnits{SnapName: "mysnap", Origin: "mount-control"}
+	expListMountUnitsParams := systemdtest.ParamsForListMountUnits{SnapName: "mysnap", Origin: "mount-control", Filter: systemd.LoadedMountUnits}
 	c.Assert(s.sysd.ListMountUnitsCalls, HasLen, 1)
 	c.Check(s.sysd.ListMountUnitsCalls[0], DeepEquals, expListMountUnitsParams)
 	c.Assert(s.sysd.StopCalls, HasLen, 1)
@@ -464,7 +464,7 @@ func (s *snapshotSuite) TestRevertLogsAndContinuesOnListMountError(c *C) {
 	rs.Revert()
 
 	// Both dirs must have been visited (loop continued past the first error).
-	expListMountUnitsParams := systemdtest.ParamsForListMountUnits{SnapName: "mysnap", Origin: "mount-control"}
+	expListMountUnitsParams := systemdtest.ParamsForListMountUnits{SnapName: "mysnap", Origin: "mount-control", Filter: systemd.LoadedMountUnits}
 	c.Assert(s.sysd.ListMountUnitsCalls, HasLen, 2)
 	c.Check(s.sysd.ListMountUnitsCalls[0], DeepEquals, expListMountUnitsParams)
 	c.Check(s.sysd.ListMountUnitsCalls[1], DeepEquals, expListMountUnitsParams)

--- a/overlord/snapstate/backend/mountunit.go
+++ b/overlord/snapstate/backend/mountunit.go
@@ -73,7 +73,8 @@ func removeMountUnit(mountDir string, meter progress.Meter) error {
 // if any unit cannot be removed.
 func (b Backend) RemoveContainerMountUnits(s snap.ContainerPlaceInfo, meter progress.Meter, origin string, baseDirs []string) error {
 	sysd := systemd.New(systemd.SystemMode, meter)
-	mountPoints, err := sysd.ListMountUnits(s.ContainerName(), origin)
+	// Get all mount units, including the unloaded ones
+	mountPoints, err := sysd.ListMountUnits(s.ContainerName(), origin, systemd.AllMountUnits)
 	if err != nil {
 		return err
 	}
@@ -142,7 +143,8 @@ func (b Backend) ListNonSnapctlMountsInSnapAllDataDirs(info *snap.Info, opts *di
 func listNonSnapctlMounts(info *snap.Info, baseDirs []string) ([]string, error) {
 	sysd := systemd.New(systemd.SystemMode, nil)
 	// mounts created using snapctl have the "mount-control" origin
-	mcMountPoints, err := sysd.ListMountUnits(info.ContainerName(), "mount-control")
+	// only loaded and active units are needed
+	mcMountPoints, err := sysd.ListMountUnits(info.ContainerName(), "mount-control", systemd.LoadedMountUnits)
 	if err != nil {
 		return nil, err
 	}

--- a/overlord/snapstate/backend/mountunit.go
+++ b/overlord/snapstate/backend/mountunit.go
@@ -73,8 +73,8 @@ func removeMountUnit(mountDir string, meter progress.Meter) error {
 // if any unit cannot be removed.
 func (b Backend) RemoveContainerMountUnits(s snap.ContainerPlaceInfo, meter progress.Meter, origin string, baseDirs []string) error {
 	sysd := systemd.New(systemd.SystemMode, meter)
-	// Get all mount units, including the unloaded ones
-	mountPoints, err := sysd.ListMountUnits(s.ContainerName(), origin, systemd.AllMountUnits)
+	// Get installed mount units which includes the unloaded units
+	mountPoints, err := sysd.ListMountUnits(s.ContainerName(), origin, systemd.InstalledMountUnits)
 	if err != nil {
 		return err
 	}

--- a/overlord/snapstate/backend/mountunit.go
+++ b/overlord/snapstate/backend/mountunit.go
@@ -73,7 +73,10 @@ func removeMountUnit(mountDir string, meter progress.Meter) error {
 // if any unit cannot be removed.
 func (b Backend) RemoveContainerMountUnits(s snap.ContainerPlaceInfo, meter progress.Meter, origin string, baseDirs []string) error {
 	sysd := systemd.New(systemd.SystemMode, meter)
-	// Get installed mount units which includes the unloaded units
+	// Get installed mount units which includes the unloaded units.
+	// Using systemd.InstalledMountUnits here ensures that we get the
+	// mount units even if they are not currently loaded in systemd's
+	// memory (e.g. if it was stopped and garbage-collected).
 	mountPoints, err := sysd.ListMountUnits(s.ContainerName(), origin, systemd.InstalledMountUnits)
 	if err != nil {
 		return err
@@ -142,8 +145,11 @@ func (b Backend) ListNonSnapctlMountsInSnapAllDataDirs(info *snap.Info, opts *di
 
 func listNonSnapctlMounts(info *snap.Info, baseDirs []string) ([]string, error) {
 	sysd := systemd.New(systemd.SystemMode, nil)
-	// mounts created using snapctl have the "mount-control" origin
-	// only loaded and active units are needed
+	// Mounts created using snapctl have the "mount-control" origin.
+	// Only active units are needed here but systemd.LoadedMountUnits
+	// lists loaded units which may be active or inactive. This is still
+	// fine because mcMountPoints is only used to filter the mountInfo
+	// list which only contains active mounts.
 	mcMountPoints, err := sysd.ListMountUnits(info.ContainerName(), "mount-control", systemd.LoadedMountUnits)
 	if err != nil {
 		return nil, err

--- a/overlord/snapstate/backend/mountunit_test.go
+++ b/overlord/snapstate/backend/mountunit_test.go
@@ -143,7 +143,7 @@ func (s *mountunitSuite) TestRemoveSnapMountUnitsFailOnList(c *C) {
 	c.Check(err, Equals, expectedErr)
 	c.Check(sysd.ListMountUnitsCalls, HasLen, 1)
 	c.Check(sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{
-		{SnapName: "foo", Origin: "", Filter: systemd.AllMountUnits},
+		{SnapName: "foo", Origin: "", Filter: systemd.InstalledMountUnits},
 	})
 	c.Check(sysd.RemoveMountUnitFileCalls, HasLen, 0)
 }
@@ -175,7 +175,7 @@ func (s *mountunitSuite) TestRemoveSnapMountUnitsFailOnRemoval(c *C) {
 	c.Check(err, Equals, expectedErr)
 	c.Check(sysd.ListMountUnitsCalls, HasLen, 1)
 	c.Check(sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{
-		{SnapName: "foo", Origin: "", Filter: systemd.AllMountUnits},
+		{SnapName: "foo", Origin: "", Filter: systemd.InstalledMountUnits},
 	})
 
 	c.Check(sysd.RemoveMountUnitFileCalls, HasLen, 1)
@@ -207,7 +207,7 @@ func (s *mountunitSuite) TestRemoveSnapMountUnitsHappy(c *C) {
 	c.Check(err, IsNil)
 	c.Check(sysd.ListMountUnitsCalls, HasLen, 1)
 	c.Check(sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{
-		{SnapName: "foo", Origin: "", Filter: systemd.AllMountUnits},
+		{SnapName: "foo", Origin: "", Filter: systemd.InstalledMountUnits},
 	})
 
 	c.Check(sysd.RemoveMountUnitFileCalls, HasLen, 3)
@@ -243,7 +243,7 @@ func (s *mountunitSuite) TestRemoveSnapMountUnitsFiltersBaseDirs(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Check(sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{
-		{SnapName: "some-snap", Origin: "mount-control", Filter: systemd.AllMountUnits},
+		{SnapName: "some-snap", Origin: "mount-control", Filter: systemd.InstalledMountUnits},
 	})
 	// Only the two matching mount points should have been removed.
 	c.Assert(sysd.RemoveMountUnitFileCalls, HasLen, 2)

--- a/overlord/snapstate/backend/mountunit_test.go
+++ b/overlord/snapstate/backend/mountunit_test.go
@@ -143,7 +143,7 @@ func (s *mountunitSuite) TestRemoveSnapMountUnitsFailOnList(c *C) {
 	c.Check(err, Equals, expectedErr)
 	c.Check(sysd.ListMountUnitsCalls, HasLen, 1)
 	c.Check(sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{
-		{SnapName: "foo", Origin: ""},
+		{SnapName: "foo", Origin: "", Filter: systemd.AllMountUnits},
 	})
 	c.Check(sysd.RemoveMountUnitFileCalls, HasLen, 0)
 }
@@ -175,7 +175,7 @@ func (s *mountunitSuite) TestRemoveSnapMountUnitsFailOnRemoval(c *C) {
 	c.Check(err, Equals, expectedErr)
 	c.Check(sysd.ListMountUnitsCalls, HasLen, 1)
 	c.Check(sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{
-		{SnapName: "foo", Origin: ""},
+		{SnapName: "foo", Origin: "", Filter: systemd.AllMountUnits},
 	})
 
 	c.Check(sysd.RemoveMountUnitFileCalls, HasLen, 1)
@@ -207,7 +207,7 @@ func (s *mountunitSuite) TestRemoveSnapMountUnitsHappy(c *C) {
 	c.Check(err, IsNil)
 	c.Check(sysd.ListMountUnitsCalls, HasLen, 1)
 	c.Check(sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{
-		{SnapName: "foo", Origin: ""},
+		{SnapName: "foo", Origin: "", Filter: systemd.AllMountUnits},
 	})
 
 	c.Check(sysd.RemoveMountUnitFileCalls, HasLen, 3)
@@ -243,7 +243,7 @@ func (s *mountunitSuite) TestRemoveSnapMountUnitsFiltersBaseDirs(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Check(sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{
-		{SnapName: "some-snap", Origin: "mount-control"},
+		{SnapName: "some-snap", Origin: "mount-control", Filter: systemd.AllMountUnits},
 	})
 	// Only the two matching mount points should have been removed.
 	c.Assert(sysd.RemoveMountUnitFileCalls, HasLen, 2)
@@ -331,7 +331,7 @@ func (s *mountunitSuite) testListNonSnapctlMountsNoMounts(c *C, variant scope) {
 	c.Assert(err, IsNil)
 	c.Check(mounts, HasLen, 0)
 	c.Check(sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{
-		{SnapName: "foo", Origin: "mount-control"},
+		{SnapName: "foo", Origin: "mount-control", Filter: systemd.LoadedMountUnits},
 	})
 }
 
@@ -368,7 +368,7 @@ func (s *mountunitSuite) testListNonSnapctlMountsAllSnapctl(c *C, variant scope)
 	// All mounts are snapctl mounts, so nothing is returned.
 	c.Check(mounts, HasLen, 0)
 	c.Check(sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{
-		{SnapName: "foo", Origin: "mount-control"},
+		{SnapName: "foo", Origin: "mount-control", Filter: systemd.LoadedMountUnits},
 	})
 }
 
@@ -411,7 +411,7 @@ func (s *mountunitSuite) testListNonSnapctlMountsReturnsNonSnapctl(c *C, variant
 	// Only the non-snapctl mount is returned.
 	c.Check(mounts, DeepEquals, []string{userMount})
 	c.Check(sysd.ListMountUnitsCalls, DeepEquals, []systemdtest.ParamsForListMountUnits{
-		{SnapName: "foo", Origin: "mount-control"},
+		{SnapName: "foo", Origin: "mount-control", Filter: systemd.LoadedMountUnits},
 	})
 }
 

--- a/systemd/emulation.go
+++ b/systemd/emulation.go
@@ -215,7 +215,7 @@ func (s *emulation) RemoveMountUnitFile(mountedDir string) error {
 	return nil
 }
 
-func (s *emulation) ListMountUnits(snapName, origin string) ([]string, error) {
+func (s *emulation) ListMountUnits(snapName, origin string, filter MountUnitFilter) ([]string, error) {
 	return nil, &notImplementedError{"ListMountUnits"}
 }
 

--- a/systemd/export_test.go
+++ b/systemd/export_test.go
@@ -63,6 +63,14 @@ func MockSystemdSysctlPath(p string) (restore func()) {
 	}
 }
 
+func MockMaxUnitsPerShow(n int) (restore func()) {
+	old := maxUnitsPerShow
+	maxUnitsPerShow = n
+	return func() {
+		maxUnitsPerShow = old
+	}
+}
+
 func (e *Error) SetExitCode(i int) {
 	e.exitCode = i
 }

--- a/systemd/export_test.go
+++ b/systemd/export_test.go
@@ -21,6 +21,8 @@ package systemd
 
 import (
 	"io"
+
+	"github.com/snapcore/snapd/testutil"
 )
 
 var (
@@ -28,47 +30,27 @@ var (
 )
 
 func MockOsGetenv(f func(string) string) func() {
-	oldOsGetenv := osGetenv
-	osGetenv = f
-	return func() { osGetenv = oldOsGetenv }
+	return testutil.Mock(&osGetenv, f)
 }
 
 func MockOsutilStreamCommand(f func(string, ...string) (io.ReadCloser, error)) func() {
-	old := osutilStreamCommand
-	osutilStreamCommand = f
-	return func() { osutilStreamCommand = old }
+	return testutil.Mock(&osutilStreamCommand, f)
 }
 
 func MockOsutilIsMounted(f func(path string) (bool, error)) func() {
-	old := osutilIsMounted
-	osutilIsMounted = f
-	return func() {
-		osutilIsMounted = old
-	}
+	return testutil.Mock(&osutilIsMounted, f)
 }
 
 func MockSquashFsType(f func() (string, []string)) func() {
-	old := squashfsFsType
-	squashfsFsType = f
-	return func() {
-		squashfsFsType = old
-	}
+	return testutil.Mock(&squashfsFsType, f)
 }
 
 func MockSystemdSysctlPath(p string) (restore func()) {
-	old := systemdSysctlPath
-	systemdSysctlPath = p
-	return func() {
-		systemdSysctlPath = old
-	}
+	return testutil.Mock(&systemdSysctlPath, p)
 }
 
 func MockMaxUnitsPerShow(n int) (restore func()) {
-	old := maxUnitsPerShow
-	maxUnitsPerShow = n
-	return func() {
-		maxUnitsPerShow = old
-	}
+	return testutil.Mock(&maxUnitsPerShow, n)
 }
 
 func (e *Error) SetExitCode(i int) {

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -1725,6 +1725,8 @@ func extractOriginModule(systemdUnitPath string) (string, error) {
 // systemd on disk by running "systemctl list-unit-files". This includes units
 // that are stopped and have been unloaded from memory.
 func (s *systemd) listInstalledMountUnitNames() ([]string, error) {
+	// TODO: Switch to using "--output=json" once the minimum required systemd
+	// version for "mount-control" interface is bumped up to 246.
 	listOut, err := s.systemctl("list-unit-files", "--no-legend", "*.mount")
 	if err != nil {
 		return nil, err

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -1721,8 +1721,7 @@ func extractOriginModule(systemdUnitPath string) (string, error) {
 
 // listMountUnitNames returns the names of all mount unit files known to
 // systemd on disk by running "systemctl list-unit-files". This includes units
-// that are stopped and have been unloaded from memory. The synthetic root mount
-// "-.mount" is excluded.
+// that are stopped and have been unloaded from memory.
 func (s *systemd) listMountUnitNames() ([]string, error) {
 	listOut, err := s.systemctl("list-unit-files", "--no-legend", "*.mount")
 	if err != nil {
@@ -1731,11 +1730,9 @@ func (s *systemd) listMountUnitNames() ([]string, error) {
 	var names []string
 	for _, line := range bytes.Split(bytes.TrimRight(listOut, "\n"), []byte("\n")) {
 		// Each line is: "<unit-name>  <state>  [<preset>]"
-		// Skip:
-		// * blank lines: they should not appear but we must not panic on them
-		// * "-.mount": systemd's synthetic root mount
+		// Skip blank lines: they should not appear but we must not panic on them.
 		fields := strings.Fields(string(line))
-		if len(fields) == 0 || fields[0] == "-.mount" {
+		if len(fields) == 0 {
 			continue
 		}
 		names = append(names, fields[0])
@@ -1743,18 +1740,18 @@ func (s *systemd) listMountUnitNames() ([]string, error) {
 	return names, nil
 }
 
-// showUnitProperties runs "systemctl show <propertyArg>" for the given
+// showUnitProperties runs "systemctl show <propertyOption>" for the given
 // unit names, chunking the calls to stay within ARG_MAX limits.
 // The returned byte slice is the concatenated output with "\n\n" record
 // separators preserved at chunk boundaries.
-func (s *systemd) showUnitProperties(propertyArg string, unitArgs []string) ([]byte, error) {
+func (s *systemd) showUnitProperties(propertyOption string, unitArgs []string) ([]byte, error) {
 	var out []byte
 	for len(unitArgs) > 0 {
 		chunk := unitArgs
 		if len(chunk) > maxUnitsPerShow {
 			chunk = chunk[:maxUnitsPerShow]
 		}
-		chunkOut, err := s.systemctl(append([]string{"show", propertyArg}, chunk...)...)
+		chunkOut, err := s.systemctl(append([]string{"show", propertyOption, "--"}, chunk...)...)
 		if err != nil {
 			return nil, err
 		}

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -77,6 +77,13 @@ var (
 
 	// allow replacing the systemd implementation with a mock one
 	newSystemd = newSystemdReal
+
+	// maxUnitsPerShow is the maximum number of unit names passed to a single
+	// "systemctl show" invocation by showUnitProperties. Kept as a var so
+	// tests can reduce it to exercise the chunk-boundary logic without
+	// creating hundreds of fake units. 64 units x NAME_MAX (255) bytes ~ 16 KB,
+	// which should be below the ARG_MAX limit also on constrained systems.
+	maxUnitsPerShow = 64
 )
 
 // mu is a sync.Mutex that also supports to check if the lock is taken
@@ -1712,43 +1719,62 @@ func extractOriginModule(systemdUnitPath string) (string, error) {
 	return originModule, nil
 }
 
-func (s *systemd) ListMountUnits(snapName, origin string, filter MountUnitFilter) ([]string, error) {
-	var unitArgs []string
-	switch filter {
-	case AllMountUnits:
-		// list-unit-files enumerates all unit files known to systemd on disk,
-		// including units that are stopped and have been unloaded from memory.
-		listOut, err := s.systemctl("list-unit-files", "--no-legend", "*.mount")
-		if err != nil {
-			return nil, err
-		}
-		for _, line := range bytes.Split(bytes.TrimRight(listOut, "\n"), []byte("\n")) {
-			// Each line is: "<unit-name>  <state>  [<preset>]"
-			// Skip:
-			// * blank lines: they should not appear but we must not panic on them
-			// * "-.mount": systemd's synthetic root mount
-			fields := strings.Fields(string(line))
-			if len(fields) == 0 || fields[0] == "-.mount" {
-				continue
-			}
-			unitArgs = append(unitArgs, fields[0])
-		}
-		if len(unitArgs) == 0 {
-			return nil, nil
-		}
-	case LoadedMountUnits:
-		// The *.mount glob is expanded by systemd against its in-memory units,
-		// so only loaded units are returned.
-		unitArgs = []string{"*.mount"}
-	default:
-		return nil, fmt.Errorf("internal error: unknown MountUnitFilter value %d", filter)
-	}
-
-	out, err := s.systemctl(append([]string{"show", "--property=Description,Where,FragmentPath"}, unitArgs...)...)
+// listMountUnitNames returns the names of all mount unit files known to
+// systemd on disk by running "systemctl list-unit-files". This includes units
+// that are stopped and have been unloaded from memory. The synthetic root mount
+// "-.mount" is excluded.
+func (s *systemd) listMountUnitNames() ([]string, error) {
+	listOut, err := s.systemctl("list-unit-files", "--no-legend", "*.mount")
 	if err != nil {
 		return nil, err
 	}
+	var names []string
+	for _, line := range bytes.Split(bytes.TrimRight(listOut, "\n"), []byte("\n")) {
+		// Each line is: "<unit-name>  <state>  [<preset>]"
+		// Skip:
+		// * blank lines: they should not appear but we must not panic on them
+		// * "-.mount": systemd's synthetic root mount
+		fields := strings.Fields(string(line))
+		if len(fields) == 0 || fields[0] == "-.mount" {
+			continue
+		}
+		names = append(names, fields[0])
+	}
+	return names, nil
+}
 
+// showUnitProperties runs "systemctl show <propertyArg>" for the given
+// unit names, chunking the calls to stay within ARG_MAX limits.
+// The returned byte slice is the concatenated output with "\n\n" record
+// separators preserved at chunk boundaries.
+func (s *systemd) showUnitProperties(propertyArg string, unitArgs []string) ([]byte, error) {
+	var out []byte
+	for len(unitArgs) > 0 {
+		chunk := unitArgs
+		if len(chunk) > maxUnitsPerShow {
+			chunk = chunk[:maxUnitsPerShow]
+		}
+		chunkOut, err := s.systemctl(append([]string{"show", propertyArg}, chunk...)...)
+		if err != nil {
+			return nil, err
+		}
+		// systemctl show ends each chunk with a single "\n". Insert an
+		// extra "\n" between chunks so that the boundary becomes "\n\n",
+		// which is the unit-record separator the parser below expects.
+		if len(out) > 0 {
+			out = append(out, '\n')
+		}
+		out = append(out, chunkOut...)
+		unitArgs = unitArgs[len(chunk):]
+	}
+	return out, nil
+}
+
+// parseMountUnitsOutput parses the concatenated "systemctl show" output and
+// returns the mount points of units belonging to snapName and (optionally)
+// created by the given origin module. The output must include the
+// Description, Where, and FragmentPath properties.
+func parseMountUnitsOutput(out []byte, snapName, origin string) ([]string, error) {
 	var mountPoints []string
 	if bytes.TrimSpace(out) == nil {
 		return mountPoints, nil
@@ -1805,6 +1831,36 @@ func (s *systemd) ListMountUnits(snapName, origin string, filter MountUnitFilter
 		mountPoints = append(mountPoints, where)
 	}
 	return mountPoints, nil
+}
+
+func (s *systemd) ListMountUnits(snapName, origin string, filter MountUnitFilter) ([]string, error) {
+	var unitArgs []string
+	switch filter {
+	case AllMountUnits:
+		// list-unit-files enumerates all unit files known to systemd on disk,
+		// including units that are stopped and have been unloaded from memory.
+		var err error
+		unitArgs, err = s.listMountUnitNames()
+		if err != nil {
+			return nil, err
+		}
+		if len(unitArgs) == 0 {
+			return nil, nil
+		}
+	case LoadedMountUnits:
+		// The *.mount glob is expanded by systemd against its in-memory units,
+		// so only loaded units are returned.
+		unitArgs = []string{"*.mount"}
+	default:
+		return nil, fmt.Errorf("internal error: unknown MountUnitFilter value %d", filter)
+	}
+
+	out, err := s.showUnitProperties("--property=Description,Where,FragmentPath", unitArgs)
+	if err != nil {
+		return nil, err
+	}
+
+	return parseMountUnitsOutput(out, snapName, origin)
 }
 
 func (s *systemd) ReloadOrRestart(serviceNames []string) error {

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -397,6 +397,19 @@ const (
 	MountCreated
 )
 
+// MountUnitFilter controls which mount units are returned by ListMountUnits.
+type MountUnitFilter int
+
+const (
+	// LoadedMountUnits returns only units currently loaded in systemd's memory.
+	// This is cheaper but may miss units that have been stopped and garbage-collected
+	// from systemd's memory.
+	LoadedMountUnits MountUnitFilter = iota
+	// AllMountUnits returns all units known to systemd, including those that
+	// are stopped and have been unloaded from memory but still exist on disk.
+	AllMountUnits
+)
+
 // Systemd exposes a minimal interface to manage systemd via the systemctl command.
 type Systemd interface {
 	// Backend returns the underlying implementation backend.
@@ -457,9 +470,11 @@ type Systemd interface {
 	EnsureMountUnitFile(unitOptions *MountUnitOptions) (string, error)
 	// RemoveMountUnitFile unmounts/stops/disables/removes a mount unit.
 	RemoveMountUnitFile(baseDir string) error
-	// ListMountUnits gets the list of targets of the mount units created by
-	// the `origin` module for the given snap
-	ListMountUnits(snapName, origin string) ([]string, error)
+	// ListMountUnits gets the list of mount points of the mount units created
+	// by the `origin` module for the given snap. filter controls whether only
+	// currently-loaded units are returned (LoadedMountUnits) or all units
+	// including those stopped and unloaded from systemd's memory (AllMountUnits).
+	ListMountUnits(snapName, origin string, filter MountUnitFilter) ([]string, error)
 	// Mask the given service.
 	Mask(service string) error
 	// Unmask the given service.
@@ -1697,8 +1712,39 @@ func extractOriginModule(systemdUnitPath string) (string, error) {
 	return originModule, nil
 }
 
-func (s *systemd) ListMountUnits(snapName, origin string) ([]string, error) {
-	out, err := s.systemctl("show", "--property=Description,Where,FragmentPath", "*.mount")
+func (s *systemd) ListMountUnits(snapName, origin string, filter MountUnitFilter) ([]string, error) {
+	var unitArgs []string
+	switch filter {
+	case AllMountUnits:
+		// list-unit-files enumerates all unit files known to systemd on disk,
+		// including units that are stopped and have been unloaded from memory.
+		listOut, err := s.systemctl("list-unit-files", "--no-legend", "*.mount")
+		if err != nil {
+			return nil, err
+		}
+		for _, line := range bytes.Split(bytes.TrimRight(listOut, "\n"), []byte("\n")) {
+			// Each line is: "<unit-name>  <state>  [<preset>]"
+			// Skip:
+			// * blank lines: they should not appear but we must not panic on them
+			// * "-.mount": systemd's synthetic root mount
+			fields := strings.Fields(string(line))
+			if len(fields) == 0 || fields[0] == "-.mount" {
+				continue
+			}
+			unitArgs = append(unitArgs, fields[0])
+		}
+		if len(unitArgs) == 0 {
+			return nil, nil
+		}
+	case LoadedMountUnits:
+		// The *.mount glob is expanded by systemd against its in-memory units,
+		// so only loaded units are returned.
+		unitArgs = []string{"*.mount"}
+	default:
+		return nil, fmt.Errorf("internal error: unknown MountUnitFilter value %d", filter)
+	}
+
+	out, err := s.systemctl(append([]string{"show", "--property=Description,Where,FragmentPath"}, unitArgs...)...)
 	if err != nil {
 		return nil, err
 	}

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -408,13 +408,15 @@ const (
 type MountUnitFilter int
 
 const (
-	// LoadedMountUnits returns only units currently loaded in systemd's memory.
+	// LoadedMountUnits returns units currently loaded in systemd's memory.
 	// This is cheaper but may miss units that have been stopped and garbage-collected
 	// from systemd's memory.
 	LoadedMountUnits MountUnitFilter = iota
-	// AllMountUnits returns all units known to systemd, including those that
-	// are stopped and have been unloaded from memory but still exist on disk.
-	AllMountUnits
+	// InstalledMountUnits returns units that have a backing unit file
+	// installed on the filesystem, as reported by "systemctl list-unit-files".
+	// This includes units that are stopped and have been unloaded from systemd's
+	// memory, but excludes purely transient units that have no backing file.
+	InstalledMountUnits
 )
 
 // Systemd exposes a minimal interface to manage systemd via the systemctl command.
@@ -479,8 +481,8 @@ type Systemd interface {
 	RemoveMountUnitFile(baseDir string) error
 	// ListMountUnits gets the list of mount points of the mount units created
 	// by the `origin` module for the given snap. filter controls whether only
-	// currently-loaded units are returned (LoadedMountUnits) or all units
-	// including those stopped and unloaded from systemd's memory (AllMountUnits).
+	// units currently loaded in systemd's memory are returned (LoadedMountUnits)
+	// or units that have an installed backing file (InstalledMountUnits).
 	ListMountUnits(snapName, origin string, filter MountUnitFilter) ([]string, error)
 	// Mask the given service.
 	Mask(service string) error
@@ -1719,10 +1721,10 @@ func extractOriginModule(systemdUnitPath string) (string, error) {
 	return originModule, nil
 }
 
-// listMountUnitNames returns the names of all mount unit files known to
+// listInstalledMountUnitNames returns the names of all mount unit files known to
 // systemd on disk by running "systemctl list-unit-files". This includes units
 // that are stopped and have been unloaded from memory.
-func (s *systemd) listMountUnitNames() ([]string, error) {
+func (s *systemd) listInstalledMountUnitNames() ([]string, error) {
 	listOut, err := s.systemctl("list-unit-files", "--no-legend", "*.mount")
 	if err != nil {
 		return nil, err
@@ -1833,11 +1835,11 @@ func parseMountUnitsOutput(out []byte, snapName, origin string) ([]string, error
 func (s *systemd) ListMountUnits(snapName, origin string, filter MountUnitFilter) ([]string, error) {
 	var unitArgs []string
 	switch filter {
-	case AllMountUnits:
-		// list-unit-files enumerates all unit files known to systemd on disk,
-		// including units that are stopped and have been unloaded from memory.
+	case InstalledMountUnits:
+		// listInstalledMountUnitNames enumerates all installed unit files known to
+		// systemd, including units that are stopped and have been unloaded from memory.
 		var err error
-		unitArgs, err = s.listMountUnitNames()
+		unitArgs, err = s.listInstalledMountUnitNames()
 		if err != nil {
 			return nil, err
 		}

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -415,7 +415,7 @@ const (
 	// InstalledMountUnits returns units that have a backing unit file
 	// installed on the filesystem, as reported by "systemctl list-unit-files".
 	// This includes units that are stopped and have been unloaded from systemd's
-	// memory, but excludes purely transient units that have no backing file.
+	// memory, but excludes units that have no backing file.
 	InstalledMountUnits
 )
 

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -408,9 +408,9 @@ const (
 type MountUnitFilter int
 
 const (
-	// LoadedMountUnits returns units currently loaded in systemd's memory.
-	// This is cheaper but may miss units that have been stopped and garbage-collected
-	// from systemd's memory.
+	// LoadedMountUnits returns units currently loaded in systemd's memory,
+	// as reported by "systemctl show *.mount". This is cheaper but may miss
+	// units that have been stopped and garbage-collected from systemd's memory.
 	LoadedMountUnits MountUnitFilter = iota
 	// InstalledMountUnits returns units that have a backing unit file
 	// installed on the filesystem, as reported by "systemctl list-unit-files".
@@ -1761,7 +1761,7 @@ func (s *systemd) showUnitProperties(propertyOption string, unitArgs []string) (
 		}
 		// systemctl show ends each chunk with a single "\n". Insert an
 		// extra "\n" between chunks so that the boundary becomes "\n\n",
-		// which is the unit-record separator the parser below expects.
+		// which is the unit-record separator parseMountUnitsOutput expects.
 		if len(out) > 0 {
 			out = append(out, '\n')
 		}

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -2879,7 +2879,7 @@ func (s *SystemdTestSuite) TestListMountUnitsLoadedHappy(c *C) {
 	createFakeUnit := func(fileName, snapName, where, origin string) error {
 		path := filepath.Join(tmpDir, fileName)
 		if len(systemctlOutput) > 0 {
-			systemctlOutput += "\n\n"
+			systemctlOutput += "\n"
 		}
 		systemctlOutput += fmt.Sprintf(`Description=Mount unit for %s, revision x1
 Where=%s
@@ -2966,11 +2966,12 @@ func (s *SystemdTestSuite) TestListMountUnitsAllHappy(c *C) {
 	c.Assert(err, IsNil)
 	defer os.RemoveAll(tmpDir)
 
-	var showOutput string
+	// "-.mount" is a generated root mount returned by list-unit-files
+	showOutput := "Description=Root Mount\nWhere=/\nFragmentPath=/run/systemd/generator/-.mount\n"
 	createFakeUnit := func(fileName, snapName, where, origin string) error {
 		path := filepath.Join(tmpDir, fileName)
 		if len(showOutput) > 0 {
-			showOutput += "\n\n"
+			showOutput += "\n"
 		}
 		showOutput += fmt.Sprintf(`Description=Mount unit for %s, revision x1
 Where=%s
@@ -2999,8 +3000,6 @@ X-SnapdOrigin=%s
 	err = createFakeUnit("somewhere-other.mount", "some-other-snap", "/somewhere/other", "module2")
 	c.Assert(err, IsNil)
 
-	// list-unit-files output: three real units plus the synthetic root mount
-	// "-.mount" which must be silently skipped.
 	listOut := "-.mount  static   -\nsomepath-somedir.mount  enabled  enabled\nsomewhere-there.mount  enabled  -\nsomewhere-other.mount  static   disabled\n"
 
 	s.outs = [][]byte{
@@ -3013,12 +3012,12 @@ X-SnapdOrigin=%s
 	c.Check(units, DeepEquals, []string{"/somepath/somedir", "/somewhere/there"})
 	c.Check(err, IsNil)
 
-	// Verify the two systemctl calls; "-.mount" must not appear in the show call.
+	// Verify the two systemctl calls
 	c.Assert(s.argses, HasLen, 2)
 	c.Check(s.argses[0], DeepEquals, []string{"list-unit-files", "--no-legend", "*.mount"})
 	c.Check(s.argses[1], DeepEquals, []string{
-		"show", "--property=Description,Where,FragmentPath",
-		"somepath-somedir.mount", "somewhere-there.mount", "somewhere-other.mount",
+		"show", "--property=Description,Where,FragmentPath", "--",
+		"-.mount", "somepath-somedir.mount", "somewhere-there.mount", "somewhere-other.mount",
 	})
 
 	// Repeat with origin filter
@@ -3045,7 +3044,7 @@ func (s *SystemdTestSuite) TestListMountUnitsAllListUnitFilesMalformed(c *C) {
 	c.Assert(s.argses, HasLen, 2)
 	c.Check(s.argses[0], DeepEquals, []string{"list-unit-files", "--no-legend", "*.mount"})
 	c.Check(s.argses[1], DeepEquals, []string{
-		"show", "--property=Description,Where,FragmentPath",
+		"show", "--property=Description,Where,FragmentPath", "--",
 		"foo.mount", "bar.mount",
 	})
 }
@@ -3121,8 +3120,8 @@ X-SnapdOrigin=snapstate
 	// Verify three systemctl calls: list-unit-files + two show calls
 	c.Assert(s.argses, HasLen, 3)
 	c.Check(s.argses[0], DeepEquals, []string{"list-unit-files", "--no-legend", "*.mount"})
-	c.Check(s.argses[1], DeepEquals, []string{"show", "--property=Description,Where,FragmentPath", "snap-foo-1.mount", "snap-foo-2.mount"})
-	c.Check(s.argses[2], DeepEquals, []string{"show", "--property=Description,Where,FragmentPath", "snap-foo-3.mount"})
+	c.Check(s.argses[1], DeepEquals, []string{"show", "--property=Description,Where,FragmentPath", "--", "snap-foo-1.mount", "snap-foo-2.mount"})
+	c.Check(s.argses[2], DeepEquals, []string{"show", "--property=Description,Where,FragmentPath", "--", "snap-foo-3.mount"})
 }
 
 func (s *SystemdTestSuite) TestListMountUnitsUnknownFilter(c *C) {

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -3063,6 +3063,68 @@ func (s *SystemdTestSuite) TestListMountUnitsAllListUnitFilesError(c *C) {
 	c.Check(s.argses[0], DeepEquals, []string{"list-unit-files", "--no-legend", "*.mount"})
 }
 
+func (s *SystemdTestSuite) TestListMountUnitsAllChunkBoundary(c *C) {
+	// Reduce the chunk size to 2 so that 3 units span two "show" calls
+	restore := MockMaxUnitsPerShow(2)
+	defer restore()
+
+	tmpDir, err := os.MkdirTemp("/tmp", "snapd-systemd-test-list-mounts-chunk-*")
+	c.Assert(err, IsNil)
+	defer os.RemoveAll(tmpDir)
+
+	// chunk 1 contains units 1 and 2, chunk 2 contains unit 3
+	createFakeUnit := func(fileName, where string) (string, error) {
+		path := filepath.Join(tmpDir, fileName)
+		showBlock := fmt.Sprintf(`Description=Mount unit for some-snap, revision x1
+Where=%s
+FragmentPath=%s
+`, where, path)
+		contents := fmt.Sprintf(`[Unit]
+Description=Mount unit for some-snap, revision x1
+
+[Mount]
+What=/does/not/matter
+Where=%s
+Type=doesntmatter
+Options=do,not,matter,either
+
+[Install]
+WantedBy=doesntmatter.target
+X-SnapdOrigin=snapstate
+`, where)
+		return showBlock, os.WriteFile(path, []byte(contents), 0644)
+	}
+
+	show1, err := createFakeUnit("snap-foo-1.mount", "/snap/foo/1")
+	c.Assert(err, IsNil)
+	show2, err := createFakeUnit("snap-foo-2.mount", "/snap/foo/2")
+	c.Assert(err, IsNil)
+	show3, err := createFakeUnit("snap-foo-3.mount", "/snap/foo/3")
+	c.Assert(err, IsNil)
+
+	showChunk1 := show1 + "\n" + show2
+	showChunk2 := show3
+
+	listOut := "snap-foo-1.mount  enabled  -\nsnap-foo-2.mount  enabled  -\nsnap-foo-3.mount  enabled  -\n"
+
+	s.outs = [][]byte{
+		[]byte(listOut),    // list-unit-files
+		[]byte(showChunk1), // show chunk 1 (units 1 and 2)
+		[]byte(showChunk2), // show chunk 2 (unit 3)
+	}
+
+	sysd := New(SystemMode, nil)
+	units, err := sysd.ListMountUnits("some-snap", "", AllMountUnits)
+	c.Check(err, IsNil)
+	c.Check(units, DeepEquals, []string{"/snap/foo/1", "/snap/foo/2", "/snap/foo/3"})
+
+	// Verify three systemctl calls: list-unit-files + two show calls
+	c.Assert(s.argses, HasLen, 3)
+	c.Check(s.argses[0], DeepEquals, []string{"list-unit-files", "--no-legend", "*.mount"})
+	c.Check(s.argses[1], DeepEquals, []string{"show", "--property=Description,Where,FragmentPath", "snap-foo-1.mount", "snap-foo-2.mount"})
+	c.Check(s.argses[2], DeepEquals, []string{"show", "--property=Description,Where,FragmentPath", "snap-foo-3.mount"})
+}
+
 func (s *SystemdTestSuite) TestListMountUnitsUnknownFilter(c *C) {
 	sysd := New(SystemMode, nil)
 	units, err := sysd.ListMountUnits("some-snap", "", MountUnitFilter(99))

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -2926,7 +2926,7 @@ X-SnapdOrigin=%s
 	c.Check(err, IsNil)
 }
 
-func (s *SystemdTestSuite) TestListMountUnitsAllEmpty(c *C) {
+func (s *SystemdTestSuite) TestListMountUnitsInstalledEmpty(c *C) {
 	// When list-unit-files returns no mount units, ListMountUnits must return
 	// nil without issuing a second systemctl call.
 	s.outs = [][]byte{
@@ -2934,7 +2934,7 @@ func (s *SystemdTestSuite) TestListMountUnitsAllEmpty(c *C) {
 	}
 
 	sysd := New(SystemMode, nil)
-	units, err := sysd.ListMountUnits("some-snap", "", AllMountUnits)
+	units, err := sysd.ListMountUnits("some-snap", "", InstalledMountUnits)
 	c.Check(units, IsNil)
 	c.Check(err, IsNil)
 
@@ -2943,7 +2943,7 @@ func (s *SystemdTestSuite) TestListMountUnitsAllEmpty(c *C) {
 	c.Check(s.argses[0], DeepEquals, []string{"list-unit-files", "--no-legend", "*.mount"})
 }
 
-func (s *SystemdTestSuite) TestListMountUnitsAllWhitespaceOnly(c *C) {
+func (s *SystemdTestSuite) TestListMountUnitsInstalledWhitespaceOnly(c *C) {
 	// When list-unit-files returns only whitespace (non-empty but no real
 	// unit names), ListMountUnits must return nil without issuing a second
 	// systemctl call.
@@ -2952,7 +2952,7 @@ func (s *SystemdTestSuite) TestListMountUnitsAllWhitespaceOnly(c *C) {
 	}
 
 	sysd := New(SystemMode, nil)
-	units, err := sysd.ListMountUnits("some-snap", "", AllMountUnits)
+	units, err := sysd.ListMountUnits("some-snap", "", InstalledMountUnits)
 	c.Check(units, IsNil)
 	c.Check(err, IsNil)
 
@@ -2961,7 +2961,7 @@ func (s *SystemdTestSuite) TestListMountUnitsAllWhitespaceOnly(c *C) {
 	c.Check(s.argses[0], DeepEquals, []string{"list-unit-files", "--no-legend", "*.mount"})
 }
 
-func (s *SystemdTestSuite) TestListMountUnitsAllHappy(c *C) {
+func (s *SystemdTestSuite) TestListMountUnitsInstalledHappy(c *C) {
 	tmpDir, err := os.MkdirTemp("/tmp", "snapd-systemd-test-list-mounts-all-*")
 	c.Assert(err, IsNil)
 	defer os.RemoveAll(tmpDir)
@@ -3008,7 +3008,7 @@ X-SnapdOrigin=%s
 	}
 
 	sysd := New(SystemMode, nil)
-	units, err := sysd.ListMountUnits("some-snap", "", AllMountUnits)
+	units, err := sysd.ListMountUnits("some-snap", "", InstalledMountUnits)
 	c.Check(units, DeepEquals, []string{"/somepath/somedir", "/somewhere/there"})
 	c.Check(err, IsNil)
 
@@ -3022,12 +3022,12 @@ X-SnapdOrigin=%s
 
 	// Repeat with origin filter
 	s.i = 0
-	units, err = sysd.ListMountUnits("some-snap", "module3", AllMountUnits)
+	units, err = sysd.ListMountUnits("some-snap", "module3", InstalledMountUnits)
 	c.Check(units, DeepEquals, []string{"/somewhere/there"})
 	c.Check(err, IsNil)
 }
 
-func (s *SystemdTestSuite) TestListMountUnitsAllListUnitFilesMalformed(c *C) {
+func (s *SystemdTestSuite) TestListMountUnitsInstalledListUnitFilesMalformed(c *C) {
 	// A blank line embedded in list-unit-files output is skipped rather
 	// than causing a panic
 	s.outs = [][]byte{
@@ -3036,7 +3036,7 @@ func (s *SystemdTestSuite) TestListMountUnitsAllListUnitFilesMalformed(c *C) {
 	}
 
 	sysd := New(SystemMode, nil)
-	units, err := sysd.ListMountUnits("some-snap", "", AllMountUnits)
+	units, err := sysd.ListMountUnits("some-snap", "", InstalledMountUnits)
 	c.Check(units, HasLen, 0)
 	c.Check(err, IsNil)
 
@@ -3049,11 +3049,11 @@ func (s *SystemdTestSuite) TestListMountUnitsAllListUnitFilesMalformed(c *C) {
 	})
 }
 
-func (s *SystemdTestSuite) TestListMountUnitsAllListUnitFilesError(c *C) {
+func (s *SystemdTestSuite) TestListMountUnitsInstalledListUnitFilesError(c *C) {
 	s.errors = []error{fmt.Errorf("list-unit-files failed")}
 
 	sysd := New(SystemMode, nil)
-	units, err := sysd.ListMountUnits("some-snap", "", AllMountUnits)
+	units, err := sysd.ListMountUnits("some-snap", "", InstalledMountUnits)
 	c.Check(units, IsNil)
 	c.Check(err, ErrorMatches, ".*list-unit-files failed.*")
 
@@ -3062,7 +3062,7 @@ func (s *SystemdTestSuite) TestListMountUnitsAllListUnitFilesError(c *C) {
 	c.Check(s.argses[0], DeepEquals, []string{"list-unit-files", "--no-legend", "*.mount"})
 }
 
-func (s *SystemdTestSuite) TestListMountUnitsAllChunkBoundary(c *C) {
+func (s *SystemdTestSuite) TestListMountUnitsInstalledChunkBoundary(c *C) {
 	// Reduce the chunk size to 2 so that 3 units span two "show" calls
 	restore := MockMaxUnitsPerShow(2)
 	defer restore()
@@ -3113,7 +3113,7 @@ X-SnapdOrigin=snapstate
 	}
 
 	sysd := New(SystemMode, nil)
-	units, err := sysd.ListMountUnits("some-snap", "", AllMountUnits)
+	units, err := sysd.ListMountUnits("some-snap", "", InstalledMountUnits)
 	c.Check(err, IsNil)
 	c.Check(units, DeepEquals, []string{"/snap/foo/1", "/snap/foo/2", "/snap/foo/3"})
 

--- a/systemd/systemd_test.go
+++ b/systemd/systemd_test.go
@@ -2844,18 +2844,18 @@ func (s *SystemdTestSuite) TestUnmaskInEmulationMode(c *C) {
 		{"--root", "/path", "unmask", "foo"}})
 }
 
-func (s *SystemdTestSuite) TestListMountUnitsEmpty(c *C) {
+func (s *SystemdTestSuite) TestListMountUnitsLoadedEmpty(c *C) {
 	s.outs = [][]byte{
 		[]byte("\n"),
 	}
 
 	sysd := New(SystemMode, nil)
-	units, err := sysd.ListMountUnits("some-snap", "")
+	units, err := sysd.ListMountUnits("some-snap", "", LoadedMountUnits)
 	c.Check(units, HasLen, 0)
 	c.Check(err, IsNil)
 }
 
-func (s *SystemdTestSuite) TestListMountUnitsMalformed(c *C) {
+func (s *SystemdTestSuite) TestListMountUnitsLoadedMalformed(c *C) {
 	s.outs = [][]byte{
 		[]byte(`Description=Mount unit for some-snap, revision x1
 Where=/somewhere/here
@@ -2865,12 +2865,12 @@ HereIsOneLineWithoutAnEqualSign
 	}
 
 	sysd := New(SystemMode, nil)
-	units, err := sysd.ListMountUnits("some-snap", "")
+	units, err := sysd.ListMountUnits("some-snap", "", LoadedMountUnits)
 	c.Check(units, HasLen, 0)
 	c.Check(err, ErrorMatches, "cannot parse systemctl output:.*")
 }
 
-func (s *SystemdTestSuite) TestListMountUnitsHappy(c *C) {
+func (s *SystemdTestSuite) TestListMountUnitsLoadedHappy(c *C) {
 	tmpDir, err := os.MkdirTemp("/tmp", "snapd-systemd-test-list-mounts-*")
 	c.Assert(err, IsNil)
 	defer os.RemoveAll(tmpDir)
@@ -2915,15 +2915,162 @@ X-SnapdOrigin=%s
 	sysd := New(SystemMode, nil)
 
 	// First, get all mount units for some-snap, without filter on the origin module
-	units, err := sysd.ListMountUnits("some-snap", "")
+	units, err := sysd.ListMountUnits("some-snap", "", LoadedMountUnits)
 	c.Check(units, DeepEquals, []string{"/somepath/somedir", "/somewhere/there"})
 	c.Check(err, IsNil)
 
 	// Now repeat the same, filtering on the origin module
 	s.i = 0 // this resets the systemctl output iterator back to the beginning
-	units, err = sysd.ListMountUnits("some-snap", "module3")
+	units, err = sysd.ListMountUnits("some-snap", "module3", LoadedMountUnits)
 	c.Check(units, DeepEquals, []string{"/somewhere/there"})
 	c.Check(err, IsNil)
+}
+
+func (s *SystemdTestSuite) TestListMountUnitsAllEmpty(c *C) {
+	// When list-unit-files returns no mount units, ListMountUnits must return
+	// nil without issuing a second systemctl call.
+	s.outs = [][]byte{
+		[]byte("\n"),
+	}
+
+	sysd := New(SystemMode, nil)
+	units, err := sysd.ListMountUnits("some-snap", "", AllMountUnits)
+	c.Check(units, IsNil)
+	c.Check(err, IsNil)
+
+	// Only one systemctl call (list-unit-files); no 'show' call.
+	c.Assert(s.argses, HasLen, 1)
+	c.Check(s.argses[0], DeepEquals, []string{"list-unit-files", "--no-legend", "*.mount"})
+}
+
+func (s *SystemdTestSuite) TestListMountUnitsAllWhitespaceOnly(c *C) {
+	// When list-unit-files returns only whitespace (non-empty but no real
+	// unit names), ListMountUnits must return nil without issuing a second
+	// systemctl call.
+	s.outs = [][]byte{
+		[]byte("   \n"),
+	}
+
+	sysd := New(SystemMode, nil)
+	units, err := sysd.ListMountUnits("some-snap", "", AllMountUnits)
+	c.Check(units, IsNil)
+	c.Check(err, IsNil)
+
+	// Only one systemctl call (list-unit-files); no 'show' call.
+	c.Assert(s.argses, HasLen, 1)
+	c.Check(s.argses[0], DeepEquals, []string{"list-unit-files", "--no-legend", "*.mount"})
+}
+
+func (s *SystemdTestSuite) TestListMountUnitsAllHappy(c *C) {
+	tmpDir, err := os.MkdirTemp("/tmp", "snapd-systemd-test-list-mounts-all-*")
+	c.Assert(err, IsNil)
+	defer os.RemoveAll(tmpDir)
+
+	var showOutput string
+	createFakeUnit := func(fileName, snapName, where, origin string) error {
+		path := filepath.Join(tmpDir, fileName)
+		if len(showOutput) > 0 {
+			showOutput += "\n\n"
+		}
+		showOutput += fmt.Sprintf(`Description=Mount unit for %s, revision x1
+Where=%s
+FragmentPath=%s
+`, snapName, where, path)
+		contents := fmt.Sprintf(`[Unit]
+Description=Mount unit for %s, revision x1
+
+[Mount]
+What=/does/not/matter
+Where=%s
+Type=doesntmatter
+Options=do,not,matter,either
+
+[Install]
+WantedBy=doesntmatter.target
+X-SnapdOrigin=%s
+`, snapName, where, origin)
+		return os.WriteFile(path, []byte(contents), 0644)
+	}
+
+	err = createFakeUnit("somepath-somedir.mount", "some-snap", "/somepath/somedir", "module1")
+	c.Assert(err, IsNil)
+	err = createFakeUnit("somewhere-there.mount", "some-snap", "/somewhere/there", "module3")
+	c.Assert(err, IsNil)
+	err = createFakeUnit("somewhere-other.mount", "some-other-snap", "/somewhere/other", "module2")
+	c.Assert(err, IsNil)
+
+	// list-unit-files output: three real units plus the synthetic root mount
+	// "-.mount" which must be silently skipped.
+	listOut := "-.mount  static   -\nsomepath-somedir.mount  enabled  enabled\nsomewhere-there.mount  enabled  -\nsomewhere-other.mount  static   disabled\n"
+
+	s.outs = [][]byte{
+		[]byte(listOut),    // first call: list-unit-files
+		[]byte(showOutput), // second call: show with explicit unit names
+	}
+
+	sysd := New(SystemMode, nil)
+	units, err := sysd.ListMountUnits("some-snap", "", AllMountUnits)
+	c.Check(units, DeepEquals, []string{"/somepath/somedir", "/somewhere/there"})
+	c.Check(err, IsNil)
+
+	// Verify the two systemctl calls; "-.mount" must not appear in the show call.
+	c.Assert(s.argses, HasLen, 2)
+	c.Check(s.argses[0], DeepEquals, []string{"list-unit-files", "--no-legend", "*.mount"})
+	c.Check(s.argses[1], DeepEquals, []string{
+		"show", "--property=Description,Where,FragmentPath",
+		"somepath-somedir.mount", "somewhere-there.mount", "somewhere-other.mount",
+	})
+
+	// Repeat with origin filter
+	s.i = 0
+	units, err = sysd.ListMountUnits("some-snap", "module3", AllMountUnits)
+	c.Check(units, DeepEquals, []string{"/somewhere/there"})
+	c.Check(err, IsNil)
+}
+
+func (s *SystemdTestSuite) TestListMountUnitsAllListUnitFilesMalformed(c *C) {
+	// A blank line embedded in list-unit-files output is skipped rather
+	// than causing a panic
+	s.outs = [][]byte{
+		[]byte("foo.mount  enabled  -\n\nbar.mount  static   disabled\n"),
+		{}, // show returns empty
+	}
+
+	sysd := New(SystemMode, nil)
+	units, err := sysd.ListMountUnits("some-snap", "", AllMountUnits)
+	c.Check(units, HasLen, 0)
+	c.Check(err, IsNil)
+
+	// The blank line is skipped; only the two valid unit names reach show.
+	c.Assert(s.argses, HasLen, 2)
+	c.Check(s.argses[0], DeepEquals, []string{"list-unit-files", "--no-legend", "*.mount"})
+	c.Check(s.argses[1], DeepEquals, []string{
+		"show", "--property=Description,Where,FragmentPath",
+		"foo.mount", "bar.mount",
+	})
+}
+
+func (s *SystemdTestSuite) TestListMountUnitsAllListUnitFilesError(c *C) {
+	s.errors = []error{fmt.Errorf("list-unit-files failed")}
+
+	sysd := New(SystemMode, nil)
+	units, err := sysd.ListMountUnits("some-snap", "", AllMountUnits)
+	c.Check(units, IsNil)
+	c.Check(err, ErrorMatches, ".*list-unit-files failed.*")
+
+	// Only the first systemctl call should have been made
+	c.Assert(s.argses, HasLen, 1)
+	c.Check(s.argses[0], DeepEquals, []string{"list-unit-files", "--no-legend", "*.mount"})
+}
+
+func (s *SystemdTestSuite) TestListMountUnitsUnknownFilter(c *C) {
+	sysd := New(SystemMode, nil)
+	units, err := sysd.ListMountUnits("some-snap", "", MountUnitFilter(99))
+	c.Check(units, IsNil)
+	c.Check(err, ErrorMatches, `internal error: unknown MountUnitFilter value 99`)
+
+	// No systemctl calls should have been made
+	c.Check(s.argses, HasLen, 0)
 }
 
 func (s *SystemdTestSuite) TestMountHappy(c *C) {

--- a/systemd/systemdtest/systemdtest.go
+++ b/systemd/systemdtest/systemdtest.go
@@ -142,6 +142,7 @@ type ResultForEnsureMountUnitFile struct {
 type ParamsForListMountUnits struct {
 	SnapName string
 	Origin   string
+	Filter   systemd.MountUnitFilter
 }
 
 type ResultForListMountUnits struct {
@@ -173,9 +174,9 @@ func (s *FakeSystemd) RemoveMountUnitFile(mountDir string) error {
 	return s.RemoveMountUnitFileResult
 }
 
-func (s *FakeSystemd) ListMountUnits(snapName, origin string) ([]string, error) {
+func (s *FakeSystemd) ListMountUnits(snapName, origin string, filter systemd.MountUnitFilter) ([]string, error) {
 	s.ListMountUnitsCalls = append(s.ListMountUnitsCalls,
-		ParamsForListMountUnits{SnapName: snapName, Origin: origin})
+		ParamsForListMountUnits{SnapName: snapName, Origin: origin, Filter: filter})
 	return s.ListMountUnitsResult.MountPoints, s.ListMountUnitsResult.Err
 }
 

--- a/tests/main/interfaces-mount-control/task.yaml
+++ b/tests/main/interfaces-mount-control/task.yaml
@@ -160,8 +160,21 @@ execute: |
         "${SNAP_NAME}".cmd grep "$MOUNT_DEST1" /proc/self/mountinfo
         "${SNAP_NAME}".cmd test -e "$MOUNT_DEST1/file1"
 
-        echo "Remove the persistent mount"
+        unit_name="$(systemd-escape -p "$MOUNT_DEST1").mount"
+
+        echo "Stop the unit and force systemd to unload it from memory"
+        systemctl stop "$unit_name"
+        systemctl daemon-reload
+
+        echo "Verify the unit is no longer visible via 'systemctl show *.mount'"
+        NOMATCH "$unit_name" < <(systemctl show --property=FragmentPath "*.mount")
+
+        echo "Verify snapctl umount still works even though the unit is unloaded"
         "${SNAP_NAME}".cmd snapctl umount "$MOUNT_DEST1"
+
+        echo "Verify that the mount unit file is removed"
+        test ! -e "/etc/systemd/system/$unit_name"
+        test ! -e "/run/systemd/system/$unit_name"
 
         echo "Verify that the mount is gone"
         "${SNAP_NAME}".cmd grep "$MOUNT_DEST1" /proc/self/mountinfo && exit 1

--- a/tests/main/remove-impacted-by-mounts/task.yaml
+++ b/tests/main/remove-impacted-by-mounts/task.yaml
@@ -38,6 +38,10 @@ environment:
     MOUNT_DEST/v6: $MOUNT_DEST_USER_DATA
     MOUNT_DEST/v7: $MOUNT_DEST_GLOBAL_COMMON
     MOUNT_DEST/v8: $MOUNT_DEST_GLOBAL_DATA
+    # controls if the mount unit should be stopped before removing the snap
+    # this ensures we remove the mount unit even if it was stopped
+    STOP_MOUNT/v3: true
+    STOP_MOUNT/v4: false
 
 execute: |
     setup_src_data() {
@@ -98,6 +102,14 @@ execute: |
         "${SNAP_NAME}".cmd grep "$mount_dest" /proc/self/mountinfo
         echo "Ensure that the mounted files are visible"
         test -e "$mount_dest/file1"
+        if [ "$STOP_MOUNT" = true ]; then
+            echo "Stop the unit and force systemd to unload it from memory"
+            UNIT_NAME="$(systemd-escape -p "$mount_dest").mount"
+            systemctl stop "$UNIT_NAME"
+            systemctl daemon-reload
+            echo "Verify the unit is no longer visible via 'systemctl show *.mount'"
+            NOMATCH "$UNIT_NAME" < <(systemctl show --property=FragmentPath "*.mount")
+        fi
     }
 
     then_remove_succeeds_mount_removed_src_data_intact() {


### PR DESCRIPTION
Callers of `systemd.ListMountUnits` decide if they want to list `InstalledMountUnits` or `LoadedMountUnits`.
[SNAPDENG-36921](https://warthogs.atlassian.net/browse/SNAPDENG-36921)


[SNAPDENG-36921]: https://warthogs.atlassian.net/browse/SNAPDENG-36921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ