### PR TITLE
interfaces/builtin: make driver-libs interfaces usable on Core

### DIFF
--- a/interfaces/builtin/cuda_driver_libs.go
+++ b/interfaces/builtin/cuda_driver_libs.go
@@ -32,10 +32,10 @@ import (
 
 const cudaDriverLibsSummary = `allows exposing CUDA driver libraries to the system`
 
-// Plugs only supported for the system on classic for the moment (note this is
-// checked on "system" snap installation even though this is an implicit plug
-// in that case) - in the future we will allow snaps having this as plug and
-// this declaration will have to change.
+// Plugs only supported for the system snap (note this is checked on "system"
+// snap installation even though this is an implicit plug in that case) - in
+// the future we will allow snaps having this as plug and this declaration will
+// have to change.
 const cudaDriverLibsBaseDeclarationPlugs = `
   cuda-driver-libs:
     allow-installation:
@@ -78,6 +78,11 @@ func (iface *cudaDriverLibsInterface) BeforePrepareSlot(slot *snap.SlotInfo) err
 
 func (iface *cudaDriverLibsInterface) LdconfigConnectedPlug(spec *ldconfig.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// The plug can only be the system plug for the time being
+	// ldconfig is only used on classic; on core the libraries are exported
+	// via /var/lib/snapd/export instead.
+	if !release.OnClassic {
+		return nil
+	}
 	return addLdconfigLibDirs(spec, slot)
 }
 
@@ -91,15 +96,7 @@ func (t *cudaDriverLibsInterface) PathPatterns() []string {
 
 func (iface *cudaDriverLibsInterface) ConfigfilesConnectedPlug(spec *configfiles.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// The plug can only be the system plug for the time being
-
-	// Files used by snap-confine on classic
-	if release.OnClassic {
-		if err := addConfigfilesForSystemLibrarySourcePaths(cudaDriverLibs, spec, slot); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return addConfigfilesForSystemLibrarySourcePaths(cudaDriverLibs, spec, slot)
 }
 
 func (iface *cudaDriverLibsInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
@@ -115,8 +112,8 @@ func init() {
 			summary:              cudaDriverLibsSummary,
 			baseDeclarationPlugs: cudaDriverLibsBaseDeclarationPlugs,
 			baseDeclarationSlots: cudaDriverLibsBaseDeclarationSlots,
-			// Not supported on core yet
-			implicitPlugOnCore:    false,
+			// Supported on core and classic
+			implicitPlugOnCore:    true,
 			implicitPlugOnClassic: true,
 		},
 	})

--- a/interfaces/builtin/cuda_driver_libs_test.go
+++ b/interfaces/builtin/cuda_driver_libs_test.go
@@ -279,6 +279,10 @@ func (s *CudaDriverLibsInterfaceSuite) TestSanitizePlug(c *C) {
 }
 
 func (s *CudaDriverLibsInterfaceSuite) TestLdconfigSpec(c *C) {
+	// ldconfig is only active on classic
+	restore := release.MockOnClassic(true)
+	defer restore()
+
 	spec := &ldconfig.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Check(spec.LibDirs(), DeepEquals, map[ldconfig.SnapSlot][]string{
@@ -291,8 +295,38 @@ func (s *CudaDriverLibsInterfaceSuite) TestLdconfigSpec(c *C) {
 		}})
 }
 
+func (s *CudaDriverLibsInterfaceSuite) TestLdconfigSpecOnCore(c *C) {
+	// ldconfig is skipped on core
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	spec := &ldconfig.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Check(spec.LibDirs(), HasLen, 0)
+}
+
 func (s *CudaDriverLibsInterfaceSuite) TestConfigfilesSpec(c *C) {
+	// configfiles export runs on classic
 	restore := release.MockOnClassic(true)
+	defer restore()
+
+	spec := &configfiles.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Check(spec.PathContent(), DeepEquals, map[string]osutil.FileState{
+		"/var/lib/snapd/export/system_cuda-provider_cuda-slot_cuda-driver-libs.library-source": &osutil.MemoryFileState{
+			Content: []byte(
+				filepath.Join(dirs.SnapMountDir, "cuda-provider/5/lib1") + "\n" +
+					filepath.Join(dirs.SnapMountDir, "cuda-provider/5/lib2") + "\n" +
+					filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "cuda-provider"), "lib1") + "\n" +
+					filepath.Join(snap.ComponentMountDir("comp2", snap.R(22), "cuda-provider"), "lib2") + "\n" +
+					snap.ComponentMountDir("comp2", snap.R(22), "cuda-provider") + "\n"),
+			Mode: 0644},
+	})
+}
+
+func (s *CudaDriverLibsInterfaceSuite) TestConfigfilesSpecOnCore(c *C) {
+	// configfiles export also runs on core
+	restore := release.MockOnClassic(false)
 	defer restore()
 
 	spec := &configfiles.Specification{}
@@ -313,7 +347,7 @@ func (s *CudaDriverLibsInterfaceSuite) TestStaticInfo(c *C) {
 	si := interfaces.StaticInfoOf(s.iface)
 	c.Assert(si.ImplicitOnCore, Equals, false)
 	c.Assert(si.ImplicitOnClassic, Equals, false)
-	c.Assert(si.ImplicitPlugOnCore, Equals, false)
+	c.Assert(si.ImplicitPlugOnCore, Equals, true)
 	c.Assert(si.ImplicitPlugOnClassic, Equals, true)
 	c.Assert(si.Summary, Equals, `allows exposing CUDA driver libraries to the system`)
 	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "cuda-driver-libs")

--- a/interfaces/builtin/egl_driver_libs.go
+++ b/interfaces/builtin/egl_driver_libs.go
@@ -35,10 +35,10 @@ import (
 
 const eglDriverLibsSummary = `allows exposing EGL driver libraries to the system`
 
-// Plugs only supported for the system on classic for the moment (note this is
-// checked on "system" snap installation even though this is an implicit plug
-// in that case) - in the future we will allow snaps having this as plug and
-// this declaration will have to change.
+// Plugs only supported for the system snap (note this is checked on "system"
+// snap installation even though this is an implicit plug in that case) - in
+// the future we will allow snaps having this as plug and this declaration will
+// have to change.
 const eglDriverLibsBaseDeclarationPlugs = `
   egl-driver-libs:
     allow-installation:
@@ -94,6 +94,11 @@ func (iface *eglDriverLibsInterface) BeforePrepareSlot(slot *snap.SlotInfo) erro
 
 func (iface *eglDriverLibsInterface) LdconfigConnectedPlug(spec *ldconfig.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// The plug can only be the system plug for the time being
+	// ldconfig is only used on classic; on core the libraries are exported
+	// via /var/lib/snapd/export instead.
+	if !release.OnClassic {
+		return nil
+	}
 	return addLdconfigLibDirs(spec, slot)
 }
 
@@ -132,6 +137,11 @@ func checkEglIcdFile(slot *interfaces.ConnectedSlot, icdContent []byte) error {
 }
 
 func (iface *eglDriverLibsInterface) SymlinksConnectedPlug(spec *symlinks.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	// Symlinks are only created on classic; on core the libraries are
+	// exported via /var/lib/snapd/export instead.
+	if !release.OnClassic {
+		return nil
+	}
 	const withPriority = true
 	return symlinksForSourceDir(spec, slot,
 		sourceDirAttr{attrName: "icd-source", isOptional: false}, eglVendorPath,
@@ -143,13 +153,8 @@ func (t *eglDriverLibsInterface) PathPatterns() []string {
 }
 
 func (iface *eglDriverLibsInterface) ConfigfilesConnectedPlug(spec *configfiles.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	// Files used by snap-confine on classic
-	if release.OnClassic {
-		if err := addConfigfilesForSystemLibrarySourcePaths(eglDriverLibs, spec, slot); err != nil {
-			return err
-		}
-	}
-	return nil
+	// Files used by snap-confine on classic and core
+	return addConfigfilesForSystemLibrarySourcePaths(eglDriverLibs, spec, slot)
 }
 
 func (iface *eglDriverLibsInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
@@ -165,8 +170,8 @@ func init() {
 			summary:              eglDriverLibsSummary,
 			baseDeclarationPlugs: eglDriverLibsBaseDeclarationPlugs,
 			baseDeclarationSlots: eglDriverLibsBaseDeclarationSlots,
-			// Not supported on core yet
-			implicitPlugOnCore:    false,
+			// Supported on core and classic
+			implicitPlugOnCore:    true,
 			implicitPlugOnClassic: true,
 		},
 	})

--- a/interfaces/builtin/egl_driver_libs_test.go
+++ b/interfaces/builtin/egl_driver_libs_test.go
@@ -254,6 +254,10 @@ func (s *EglDriverLibsInterfaceSuite) TestSanitizePlug(c *C) {
 }
 
 func (s *EglDriverLibsInterfaceSuite) TestLdconfigSpec(c *C) {
+	// ldconfig is only active on classic
+	restore := release.MockOnClassic(true)
+	defer restore()
+
 	spec := &ldconfig.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Check(spec.LibDirs(), DeepEquals, map[ldconfig.SnapSlot][]string{
@@ -263,6 +267,16 @@ func (s *EglDriverLibsInterfaceSuite) TestLdconfigSpec(c *C) {
 			filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "egl-provider"), "lib1"),
 			filepath.Join(snap.ComponentMountDir("comp2", snap.R(22), "egl-provider"), "lib2"),
 		}})
+}
+
+func (s *EglDriverLibsInterfaceSuite) TestLdconfigSpecOnCore(c *C) {
+	// ldconfig is skipped on core
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	spec := &ldconfig.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Check(spec.LibDirs(), HasLen, 0)
 }
 
 func (s *EglDriverLibsInterfaceSuite) TestSymlinksSpec(c *C) {
@@ -406,8 +420,36 @@ func (s *EglDriverLibsInterfaceSuite) TestSymlinksToComp2(c *C) {
 	})
 }
 
+func (s *EglDriverLibsInterfaceSuite) TestSymlinksSpecOnCore(c *C) {
+	// Symlinks are skipped on core
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	spec := &symlinks.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Check(spec.Symlinks(), HasLen, 0)
+}
+
 func (s *EglDriverLibsInterfaceSuite) TestConfigfilesSpec(c *C) {
+	// configfiles export runs on classic
 	restore := release.MockOnClassic(true)
+	defer restore()
+
+	spec := &configfiles.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Check(spec.PathContent(), DeepEquals, map[string]osutil.FileState{
+		filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/export/system_egl-provider_egl-slot_egl-driver-libs.library-source"): &osutil.MemoryFileState{
+			Content: []byte(filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib1") + "\n" +
+				filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib2") + "\n" +
+				filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "egl-provider"), "lib1") + "\n" +
+				filepath.Join(snap.ComponentMountDir("comp2", snap.R(22), "egl-provider"), "lib2") + "\n"),
+			Mode: 0644},
+	})
+}
+
+func (s *EglDriverLibsInterfaceSuite) TestConfigfilesSpecOnCore(c *C) {
+	// configfiles export also runs on core
+	restore := release.MockOnClassic(false)
 	defer restore()
 
 	spec := &configfiles.Specification{}
@@ -464,7 +506,7 @@ func (s *EglDriverLibsInterfaceSuite) TestStaticInfo(c *C) {
 	si := interfaces.StaticInfoOf(s.iface)
 	c.Assert(si.ImplicitOnCore, Equals, false)
 	c.Assert(si.ImplicitOnClassic, Equals, false)
-	c.Assert(si.ImplicitPlugOnCore, Equals, false)
+	c.Assert(si.ImplicitPlugOnCore, Equals, true)
 	c.Assert(si.ImplicitPlugOnClassic, Equals, true)
 	c.Assert(si.Summary, Equals, `allows exposing EGL driver libraries to the system`)
 	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "egl-driver-libs")

--- a/interfaces/builtin/gbm_driver_libs.go
+++ b/interfaces/builtin/gbm_driver_libs.go
@@ -39,10 +39,10 @@ import (
 
 const gbmDriverLibsSummary = `allows exposing GBM driver libraries to the system`
 
-// Plugs only supported for the system on classic for the moment (note this is
-// checked on "system" snap installation even though this is an implicit plug
-// in that case) - in the future we will allow snaps having this as plug and
-// this declaration will have to change.
+// Plugs only supported for the system snap (note this is checked on "system"
+// snap installation even though this is an implicit plug in that case) - in
+// the future we will allow snaps having this as plug and this declaration will
+// have to change.
 const gbmDriverLibsBaseDeclarationPlugs = `
   gbm-driver-libs:
     allow-installation:
@@ -111,6 +111,11 @@ func (iface *gbmDriverLibsInterface) BeforePrepareSlot(slot *snap.SlotInfo) erro
 
 func (iface *gbmDriverLibsInterface) LdconfigConnectedPlug(spec *ldconfig.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// The plug can only be the system plug for the time being
+	// ldconfig is only used on classic; on core the libraries are exported
+	// via /var/lib/snapd/export instead.
+	if !release.OnClassic {
+		return nil
+	}
 	return addLdconfigLibDirs(spec, slot)
 }
 
@@ -128,6 +133,11 @@ func (iface *gbmDriverLibsInterface) TrackedDirectories() []string {
 }
 
 func (iface *gbmDriverLibsInterface) SymlinksConnectedPlug(spec *symlinks.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	// Symlinks are only created on classic; on core the libraries are
+	// exported via /var/lib/snapd/export instead.
+	if !release.OnClassic {
+		return nil
+	}
 	var clientDriver string
 	if err := slot.Attr("client-driver", &clientDriver); err != nil {
 		return fmt.Errorf("invalid client-driver: %w", err)
@@ -149,15 +159,8 @@ func (t *gbmDriverLibsInterface) PathPatterns() []string {
 
 func (iface *gbmDriverLibsInterface) ConfigfilesConnectedPlug(spec *configfiles.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// The plug can only be the system plug for the time being
-
-	// Files used by snap-confine on classic
-	if release.OnClassic {
-		if err := addConfigfilesForSystemLibrarySourcePaths(gbmDriverLibs, spec, slot); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	// Files used by snap-confine on classic and core
+	return addConfigfilesForSystemLibrarySourcePaths(gbmDriverLibs, spec, slot)
 }
 
 func (iface *gbmDriverLibsInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
@@ -173,8 +176,8 @@ func init() {
 			summary:              gbmDriverLibsSummary,
 			baseDeclarationPlugs: gbmDriverLibsBaseDeclarationPlugs,
 			baseDeclarationSlots: gbmDriverLibsBaseDeclarationSlots,
-			// Not supported on core yet
-			implicitPlugOnCore:    false,
+			// Supported on core and classic
+			implicitPlugOnCore:    true,
 			implicitPlugOnClassic: true,
 		},
 	})

--- a/interfaces/builtin/gbm_driver_libs_test.go
+++ b/interfaces/builtin/gbm_driver_libs_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/ldconfig"
 	"github.com/snapcore/snapd/interfaces/symlinks"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/testutil"
 )
@@ -249,6 +250,10 @@ func (s *GbmDriverLibsInterfaceSuite) TestSanitizePlug(c *C) {
 }
 
 func (s *GbmDriverLibsInterfaceSuite) TestLdconfigSpec(c *C) {
+	// ldconfig is only active on classic
+	restore := release.MockOnClassic(true)
+	defer restore()
+
 	spec := &ldconfig.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Check(spec.LibDirs(), DeepEquals, map[ldconfig.SnapSlot][]string{
@@ -257,7 +262,21 @@ func (s *GbmDriverLibsInterfaceSuite) TestLdconfigSpec(c *C) {
 			filepath.Join(dirs.SnapMountDir, "gbm-provider/5/lib2")}})
 }
 
+func (s *GbmDriverLibsInterfaceSuite) TestLdconfigSpecOnCore(c *C) {
+	// ldconfig is skipped on core
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	spec := &ldconfig.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Check(spec.LibDirs(), HasLen, 0)
+}
+
 func (s *GbmDriverLibsInterfaceSuite) TestSymlinksSpec(c *C) {
+	// Symlinks are only created on classic
+	restore := release.MockOnClassic(true)
+	defer restore()
+
 	spec := &symlinks.Specification{}
 	snapSourceDir := filepath.Join(s.testRoot, "snap/gbm-provider/5/lib2")
 	targetPath := filepath.Join(snapSourceDir, "nvidia-drm_gbm.so")
@@ -273,13 +292,31 @@ func (s *GbmDriverLibsInterfaceSuite) TestSymlinksSpec(c *C) {
 	})
 }
 
+func (s *GbmDriverLibsInterfaceSuite) TestSymlinksSpecOnCore(c *C) {
+	// Symlinks are skipped on core
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	spec := &symlinks.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Check(spec.Symlinks(), HasLen, 0)
+}
+
 func (s *GbmDriverLibsInterfaceSuite) TestSymlinksSpecNoClient(c *C) {
+	// This error path is only reachable on classic
+	restore := release.MockOnClassic(true)
+	defer restore()
+
 	spec := &symlinks.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), ErrorMatches,
 		`"nvidia-drm_gbm\.so" not found in the library-source directories`)
 }
 
 func (s *GbmDriverLibsInterfaceSuite) TestSymlinksSpecNoClientDriver(c *C) {
+	// This error path is only reachable on classic
+	restore := release.MockOnClassic(true)
+	defer restore()
+
 	spec := &symlinks.Specification{}
 	slot, _ := MockConnectedSlot(c, `name: gbm-provider
 version: 0
@@ -312,11 +349,27 @@ func (s *GbmDriverLibsInterfaceSuite) TestConfigfilesSpec(c *C) {
 	})
 }
 
+func (s *GbmDriverLibsInterfaceSuite) TestConfigfilesSpecOnCore(c *C) {
+	// configfiles export also runs on core
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	spec := &configfiles.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Check(spec.PathContent(), DeepEquals, map[string]osutil.FileState{
+		filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/export/system_gbm-provider_gbm-slot_gbm-driver-libs.library-source"): &osutil.MemoryFileState{
+			Content: []byte(
+				filepath.Join(dirs.SnapMountDir, "gbm-provider/5/lib1") + "\n" +
+					filepath.Join(dirs.SnapMountDir, "gbm-provider/5/lib2") + "\n"),
+			Mode: 0644},
+	})
+}
+
 func (s *GbmDriverLibsInterfaceSuite) TestStaticInfo(c *C) {
 	si := interfaces.StaticInfoOf(s.iface)
 	c.Assert(si.ImplicitOnCore, Equals, false)
 	c.Assert(si.ImplicitOnClassic, Equals, false)
-	c.Assert(si.ImplicitPlugOnCore, Equals, false)
+	c.Assert(si.ImplicitPlugOnCore, Equals, true)
 	c.Assert(si.ImplicitPlugOnClassic, Equals, true)
 	c.Assert(si.Summary, Equals, `allows exposing GBM driver libraries to the system`)
 	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "gbm-driver-libs")

--- a/interfaces/builtin/opengl_driver_libs.go
+++ b/interfaces/builtin/opengl_driver_libs.go
@@ -32,10 +32,10 @@ import (
 
 const openglDriverLibsSummary = `allows exposing OpenGL driver libraries to the system`
 
-// Plugs only supported for the system on classic for the moment (note this is
-// checked on "system" snap installation even though this is an implicit plug
-// in that case) - in the future we will allow snaps having this as plug and
-// this declaration will have to change.
+// Plugs only supported for the system snap (note this is checked on "system"
+// snap installation even though this is an implicit plug in that case) - in
+// the future we will allow snaps having this as plug and this declaration will
+// have to change.
 const openglDriverLibsBaseDeclarationPlugs = `
   opengl-driver-libs:
     allow-installation:
@@ -80,6 +80,11 @@ func (iface *openglDriverLibsInterface) BeforePrepareSlot(slot *snap.SlotInfo) e
 
 func (iface *openglDriverLibsInterface) LdconfigConnectedPlug(spec *ldconfig.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// The plug can only be the system plug for the time being
+	// ldconfig is only used on classic; on core the libraries are exported
+	// via /var/lib/snapd/export instead.
+	if !release.OnClassic {
+		return nil
+	}
 	return addLdconfigLibDirs(spec, slot)
 }
 
@@ -91,15 +96,7 @@ func (t *openglDriverLibsInterface) PathPatterns() []string {
 
 func (iface *openglDriverLibsInterface) ConfigfilesConnectedPlug(spec *configfiles.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// The plug can only be the system plug for the time being
-
-	// Files used by snap-confine on classic
-	if release.OnClassic {
-		if err := addConfigfilesForSystemLibrarySourcePaths(openglDriverLibs, spec, slot); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return addConfigfilesForSystemLibrarySourcePaths(openglDriverLibs, spec, slot)
 }
 
 func (iface *openglDriverLibsInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
@@ -115,8 +112,8 @@ func init() {
 			summary:              openglDriverLibsSummary,
 			baseDeclarationPlugs: openglDriverLibsBaseDeclarationPlugs,
 			baseDeclarationSlots: openglDriverLibsBaseDeclarationSlots,
-			// Not supported on core yet
-			implicitPlugOnCore:    false,
+			// Supported on core and classic
+			implicitPlugOnCore:    true,
 			implicitPlugOnClassic: true,
 		},
 	})

--- a/interfaces/builtin/opengl_driver_libs_test.go
+++ b/interfaces/builtin/opengl_driver_libs_test.go
@@ -162,6 +162,10 @@ func (s *OpenglDriverLibsInterfaceSuite) TestSanitizePlug(c *C) {
 }
 
 func (s *OpenglDriverLibsInterfaceSuite) TestLdconfigSpec(c *C) {
+	// ldconfig is only active on classic
+	restore := release.MockOnClassic(true)
+	defer restore()
+
 	spec := &ldconfig.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Check(spec.LibDirs(), DeepEquals, map[ldconfig.SnapSlot][]string{
@@ -170,8 +174,35 @@ func (s *OpenglDriverLibsInterfaceSuite) TestLdconfigSpec(c *C) {
 			filepath.Join(dirs.SnapMountDir, "opengl-provider/5/lib2")}})
 }
 
+func (s *OpenglDriverLibsInterfaceSuite) TestLdconfigSpecOnCore(c *C) {
+	// ldconfig is skipped on core
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	spec := &ldconfig.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Check(spec.LibDirs(), HasLen, 0)
+}
+
 func (s *OpenglDriverLibsInterfaceSuite) TestConfigfilesSpec(c *C) {
+	// configfiles export runs on classic
 	restore := release.MockOnClassic(true)
+	defer restore()
+
+	spec := &configfiles.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Check(spec.PathContent(), DeepEquals, map[string]osutil.FileState{
+		filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/export/system_opengl-provider_opengl-slot_opengl-driver-libs.library-source"): &osutil.MemoryFileState{
+			Content: []byte(
+				filepath.Join(dirs.SnapMountDir, "opengl-provider/5/lib1") + "\n" +
+					filepath.Join(dirs.SnapMountDir, "opengl-provider/5/lib2") + "\n"),
+			Mode: 0644},
+	})
+}
+
+func (s *OpenglDriverLibsInterfaceSuite) TestConfigfilesSpecOnCore(c *C) {
+	// configfiles export also runs on core
+	restore := release.MockOnClassic(false)
 	defer restore()
 
 	spec := &configfiles.Specification{}
@@ -189,7 +220,7 @@ func (s *OpenglDriverLibsInterfaceSuite) TestStaticInfo(c *C) {
 	si := interfaces.StaticInfoOf(s.iface)
 	c.Assert(si.ImplicitOnCore, Equals, false)
 	c.Assert(si.ImplicitOnClassic, Equals, false)
-	c.Assert(si.ImplicitPlugOnCore, Equals, false)
+	c.Assert(si.ImplicitPlugOnCore, Equals, true)
 	c.Assert(si.ImplicitPlugOnClassic, Equals, true)
 	c.Assert(si.Summary, Equals, `allows exposing OpenGL driver libraries to the system`)
 	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "opengl-driver-libs")

--- a/interfaces/builtin/opengles_driver_libs.go
+++ b/interfaces/builtin/opengles_driver_libs.go
@@ -33,10 +33,10 @@ import (
 
 const openglesDriverLibsSummary = `allows exposing OpenGLES driver libraries to the system`
 
-// Plugs only supported for the system on classic for the moment (note this is
-// checked on "system" snap installation even though this is an implicit plug
-// in that case) - in the future we will allow snaps having this as plug and
-// this declaration will have to change.
+// Plugs only supported for the system snap (note this is checked on "system"
+// snap installation even though this is an implicit plug in that case) - in
+// the future we will allow snaps having this as plug and this declaration will
+// have to change.
 const openglesDriverLibsBaseDeclarationPlugs = `
   opengles-driver-libs:
     allow-installation:
@@ -81,6 +81,11 @@ func (iface *openglesDriverLibsInterface) BeforePrepareSlot(slot *snap.SlotInfo)
 
 func (iface *openglesDriverLibsInterface) LdconfigConnectedPlug(spec *ldconfig.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// The plug can only be the system plug for the time being
+	// ldconfig is only used on classic; on core the libraries are exported
+	// via /var/lib/snapd/export instead.
+	if !release.OnClassic {
+		return nil
+	}
 	return addLdconfigLibDirs(spec, slot)
 }
 
@@ -92,15 +97,7 @@ func (t *openglesDriverLibsInterface) PathPatterns() []string {
 
 func (iface *openglesDriverLibsInterface) ConfigfilesConnectedPlug(spec *configfiles.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// The plug can only be the system plug for the time being
-
-	// Files used by snap-confine on classic
-	if release.OnClassic {
-		if err := addConfigfilesForSystemLibrarySourcePaths(openglesDriverLibs, spec, slot); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return addConfigfilesForSystemLibrarySourcePaths(openglesDriverLibs, spec, slot)
 }
 
 func (iface *openglesDriverLibsInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
@@ -116,8 +113,8 @@ func init() {
 			summary:              openglesDriverLibsSummary,
 			baseDeclarationPlugs: openglesDriverLibsBaseDeclarationPlugs,
 			baseDeclarationSlots: openglesDriverLibsBaseDeclarationSlots,
-			// Not supported on core yet
-			implicitPlugOnCore:    false,
+			// Supported on core and classic
+			implicitPlugOnCore:    true,
 			implicitPlugOnClassic: true,
 		},
 	})

--- a/interfaces/builtin/opengles_driver_libs_test.go
+++ b/interfaces/builtin/opengles_driver_libs_test.go
@@ -163,6 +163,10 @@ func (s *OpenglesDriverLibsInterfaceSuite) TestSanitizePlug(c *C) {
 }
 
 func (s *OpenglesDriverLibsInterfaceSuite) TestLdconfigSpec(c *C) {
+	// ldconfig is only active on classic
+	restore := release.MockOnClassic(true)
+	defer restore()
+
 	spec := &ldconfig.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Check(spec.LibDirs(), DeepEquals, map[ldconfig.SnapSlot][]string{
@@ -171,8 +175,35 @@ func (s *OpenglesDriverLibsInterfaceSuite) TestLdconfigSpec(c *C) {
 			filepath.Join(dirs.SnapMountDir, "opengles-provider/5/lib2")}})
 }
 
+func (s *OpenglesDriverLibsInterfaceSuite) TestLdconfigSpecOnCore(c *C) {
+	// ldconfig is skipped on core
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	spec := &ldconfig.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Check(spec.LibDirs(), HasLen, 0)
+}
+
 func (s *OpenglesDriverLibsInterfaceSuite) TestConfigfilesSpec(c *C) {
+	// configfiles export runs on classic
 	restore := release.MockOnClassic(true)
+	defer restore()
+
+	spec := &configfiles.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Check(spec.PathContent(), DeepEquals, map[string]osutil.FileState{
+		filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/export/system_opengles-provider_opengles-slot_opengles-driver-libs.library-source"): &osutil.MemoryFileState{
+			Content: []byte(
+				filepath.Join(dirs.SnapMountDir, "opengles-provider/5/lib1") + "\n" +
+					filepath.Join(dirs.SnapMountDir, "opengles-provider/5/lib2") + "\n"),
+			Mode: 0644},
+	})
+}
+
+func (s *OpenglesDriverLibsInterfaceSuite) TestConfigfilesSpecOnCore(c *C) {
+	// configfiles export also runs on core
+	restore := release.MockOnClassic(false)
 	defer restore()
 
 	spec := &configfiles.Specification{}
@@ -190,7 +221,7 @@ func (s *OpenglesDriverLibsInterfaceSuite) TestStaticInfo(c *C) {
 	si := interfaces.StaticInfoOf(s.iface)
 	c.Assert(si.ImplicitOnCore, Equals, false)
 	c.Assert(si.ImplicitOnClassic, Equals, false)
-	c.Assert(si.ImplicitPlugOnCore, Equals, false)
+	c.Assert(si.ImplicitPlugOnCore, Equals, true)
 	c.Assert(si.ImplicitPlugOnClassic, Equals, true)
 	c.Assert(si.Summary, Equals, `allows exposing OpenGLES driver libraries to the system`)
 	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "opengles-driver-libs")

--- a/interfaces/builtin/vulkan_driver_libs.go
+++ b/interfaces/builtin/vulkan_driver_libs.go
@@ -38,10 +38,10 @@ import (
 
 const vulkanDriverLibsSummary = `allows exposing vulkan driver libraries to the system`
 
-// Plugs only supported for the system on classic for the moment (note this is
-// checked on "system" snap installation even though this is an implicit plug
-// in that case) - in the future we will allow snaps having this as plug and
-// this declaration will have to change.
+// Plugs only supported for the system snap (note this is checked on "system"
+// snap installation even though this is an implicit plug in that case) - in
+// the future we will allow snaps having this as plug and this declaration will
+// have to change.
 const vulkanDriverLibsBaseDeclarationPlugs = `
   vulkan-driver-libs:
     allow-installation:
@@ -97,6 +97,11 @@ func (iface *vulkanDriverLibsInterface) BeforePrepareSlot(slot *snap.SlotInfo) e
 
 func (iface *vulkanDriverLibsInterface) LdconfigConnectedPlug(spec *ldconfig.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// The plug can only be the system plug for the time being
+	// ldconfig is only used on classic; on core the libraries are exported
+	// via /var/lib/snapd/export instead.
+	if !release.OnClassic {
+		return nil
+	}
 	return addLdconfigLibDirs(spec, slot)
 }
 
@@ -238,6 +243,11 @@ func checkLayer(slot *interfaces.ConnectedSlot, layer vulkanLayer) error {
 }
 
 func (iface *vulkanDriverLibsInterface) SymlinksConnectedPlug(spec *symlinks.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	// Symlinks are only created on classic; on core the libraries are
+	// exported via /var/lib/snapd/export instead.
+	if !release.OnClassic {
+		return nil
+	}
 	for _, sourceAttr := range []struct {
 		sda       sourceDirAttr
 		targetDir string
@@ -265,13 +275,8 @@ func (t *vulkanDriverLibsInterface) PathPatterns() []string {
 }
 
 func (iface *vulkanDriverLibsInterface) ConfigfilesConnectedPlug(spec *configfiles.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	// Files used by snap-confine on classic
-	if release.OnClassic {
-		if err := addConfigfilesForSystemLibrarySourcePaths(vulkanDriverLibs, spec, slot); err != nil {
-			return err
-		}
-	}
-	return nil
+	// Files used by snap-confine on classic and core
+	return addConfigfilesForSystemLibrarySourcePaths(vulkanDriverLibs, spec, slot)
 }
 
 func (iface *vulkanDriverLibsInterface) AutoConnect(*snap.PlugInfo, *snap.SlotInfo) bool {
@@ -287,8 +292,8 @@ func init() {
 			summary:              vulkanDriverLibsSummary,
 			baseDeclarationPlugs: vulkanDriverLibsBaseDeclarationPlugs,
 			baseDeclarationSlots: vulkanDriverLibsBaseDeclarationSlots,
-			// Not supported on core yet
-			implicitPlugOnCore:    false,
+			// Supported on core and classic
+			implicitPlugOnCore:    true,
 			implicitPlugOnClassic: true,
 		},
 	})

--- a/interfaces/builtin/vulkan_driver_libs_test.go
+++ b/interfaces/builtin/vulkan_driver_libs_test.go
@@ -99,6 +99,9 @@ func (s *VulkanDriverLibsInterfaceSuite) SetUpTest(c *C) {
 	os.MkdirAll(filepath.Join(s.testRoot, dirs.DefaultSnapMountDir), 0755)
 	dirs.SetRootDir(s.testRoot)
 	s.AddCleanup(func() { dirs.SetRootDir("/") })
+	// Most tests in this suite exercise classic-only code paths (ldconfig,
+	// symlinks). Default to classic so tests don't need per-test mocking.
+	s.AddCleanup(release.MockOnClassic(true))
 
 	s.plug, s.plugInfo = MockConnectedPlug(c, vulkanDriverLibsConsumerYaml,
 		&snap.SideInfo{Revision: snap.R(3)}, "vulkan")
@@ -239,6 +242,16 @@ func (s *VulkanDriverLibsInterfaceSuite) TestLdconfigSpec(c *C) {
 			filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5/lib2"),
 			filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "vulkan-provider"), "lib1"),
 		}})
+}
+
+func (s *VulkanDriverLibsInterfaceSuite) TestLdconfigSpecOnCore(c *C) {
+	// ldconfig is skipped on core
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	spec := &ldconfig.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Check(spec.LibDirs(), HasLen, 0)
 }
 
 func (s *VulkanDriverLibsInterfaceSuite) TestSymlinksSpec(c *C) {
@@ -674,7 +687,20 @@ func (s *VulkanDriverLibsInterfaceSuite) TestSymlinksSpecBothLibraryAndCompsInLa
 }
 
 func (s *VulkanDriverLibsInterfaceSuite) TestConfigfilesSpec(c *C) {
-	restore := release.MockOnClassic(true)
+	spec := &configfiles.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Check(spec.PathContent(), DeepEquals, map[string]osutil.FileState{
+		filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/export/system_vulkan-provider_vulkan-slot_vulkan-driver-libs.library-source"): &osutil.MemoryFileState{
+			Content: []byte(filepath.Join(dirs.SnapMountDir, "vulkan-provider/5/lib1") + "\n" +
+				filepath.Join(dirs.SnapMountDir, "vulkan-provider/5/lib2") + "\n" +
+				filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "vulkan-provider"), "lib1") + "\n",
+			), Mode: 0644},
+	})
+}
+
+func (s *VulkanDriverLibsInterfaceSuite) TestConfigfilesSpecOnCore(c *C) {
+	// configfiles export also runs on core
+	restore := release.MockOnClassic(false)
 	defer restore()
 
 	spec := &configfiles.Specification{}
@@ -688,11 +714,21 @@ func (s *VulkanDriverLibsInterfaceSuite) TestConfigfilesSpec(c *C) {
 	})
 }
 
+func (s *VulkanDriverLibsInterfaceSuite) TestSymlinksSpecOnCore(c *C) {
+	// Symlinks are skipped on core
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	spec := &symlinks.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Check(spec.Symlinks(), HasLen, 0)
+}
+
 func (s *VulkanDriverLibsInterfaceSuite) TestStaticInfo(c *C) {
 	si := interfaces.StaticInfoOf(s.iface)
 	c.Assert(si.ImplicitOnCore, Equals, false)
 	c.Assert(si.ImplicitOnClassic, Equals, false)
-	c.Assert(si.ImplicitPlugOnCore, Equals, false)
+	c.Assert(si.ImplicitPlugOnCore, Equals, true)
 	c.Assert(si.ImplicitPlugOnClassic, Equals, true)
 	c.Assert(si.Summary, Equals, `allows exposing vulkan driver libraries to the system`)
 	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "vulkan-driver-libs")

--- a/tests/core/interfaces-driver-libs/comp1/egl.d/vendor.json
+++ b/tests/core/interfaces-driver-libs/comp1/egl.d/vendor.json
@@ -1,0 +1,6 @@
+{
+    "file_format_version" : "1.0.0",
+    "ICD" : {
+        "library_path" : "libsquare.so"
+    }
+}

--- a/tests/core/interfaces-driver-libs/comp1/meta/component.yaml
+++ b/tests/core/interfaces-driver-libs/comp1/meta/component.yaml
@@ -1,0 +1,5 @@
+component: libs-provider-core26+comp1
+type: standard
+version: 1.0
+summary: Component 1
+description: First component for libs-provider-core26

--- a/tests/core/interfaces-driver-libs/comp2/egl.d/vendor.json
+++ b/tests/core/interfaces-driver-libs/comp2/egl.d/vendor.json
@@ -1,0 +1,6 @@
+{
+    "file_format_version" : "1.0.0",
+    "ICD" : {
+        "library_path" : "libmultiply.so"
+    }
+}

--- a/tests/core/interfaces-driver-libs/comp2/meta/component.yaml
+++ b/tests/core/interfaces-driver-libs/comp2/meta/component.yaml
@@ -1,0 +1,5 @@
+component: libs-provider-core26+comp2
+type: standard
+version: 1.0
+summary: Component 2
+description: Second component for libs-provider-core26

--- a/tests/core/interfaces-driver-libs/libs-provider-core26/meta/snap.yaml
+++ b/tests/core/interfaces-driver-libs/libs-provider-core26/meta/snap.yaml
@@ -1,0 +1,26 @@
+name: libs-provider-core26
+version: 1.0
+base: core26
+slots:
+  cuda-driver-libs:
+    compatibility: cuda-(9..12)-ubuntu-2604
+    library-source:
+      - $SNAP/libs
+      - $SNAP_COMPONENT(comp1)/libs
+      - $SNAP_COMPONENT(comp2)/libs
+  egl-driver-libs:
+    priority: 15
+    compatibility: egl-1-5-ubuntu-2604
+    icd-source:
+      - $SNAP/egl.d
+      - $SNAP_COMPONENT(comp1)/egl.d
+      - $SNAP_COMPONENT(comp2)/egl.d
+    library-source:
+      - $SNAP/libs
+      - $SNAP_COMPONENT(comp1)/libs
+      - $SNAP_COMPONENT(comp2)/libs
+components:
+  comp1:
+    type: standard
+  comp2:
+    type: standard

--- a/tests/core/interfaces-driver-libs/task.yaml
+++ b/tests/core/interfaces-driver-libs/task.yaml
@@ -1,0 +1,62 @@
+summary: Test driver-libs interfaces on Ubuntu Core
+
+details: |
+    Verify that egl-driver-libs and cuda-driver-libs connections can be
+    established on Ubuntu Core 26, that the correct .library-source export
+    files are written to /var/lib/snapd/export/, that classic-specific
+    backends (ldconfig, EGL symlinks) are not activated, and that cleanup
+    works on disconnect and snap remove.
+
+systems: [ubuntu-core-26-64]
+
+environment:
+  PROVIDER_SNAP: libs-provider-core26
+  COMP1: comp1
+  COMP2: comp2
+
+prepare: |
+  snap pack "$PROVIDER_SNAP"
+  snap pack "$COMP1"
+  snap pack "$COMP2"
+
+restore: |
+  snap remove --purge "$PROVIDER_SNAP" || true
+
+execute: |
+  SNAP_MNT=/snap/"$PROVIDER_SNAP"
+  COMPS_MNT="$SNAP_MNT"/components/mnt
+  export_egl=/var/lib/snapd/export/system_"$PROVIDER_SNAP"_egl-driver-libs_egl-driver-libs.library-source
+  export_cuda=/var/lib/snapd/export/system_"$PROVIDER_SNAP"_cuda-driver-libs_cuda-driver-libs.library-source
+
+  snap install --dangerous "$PROVIDER_SNAP"_*.snap
+  snap install --dangerous \
+      "$PROVIDER_SNAP"+"$COMP1"_*.comp \
+      "$PROVIDER_SNAP"+"$COMP2"_*.comp
+
+  snap connect system:cuda-driver-libs "$PROVIDER_SNAP":cuda-driver-libs
+  snap connect system:egl-driver-libs "$PROVIDER_SNAP":egl-driver-libs
+
+  # .library-source export files must exist and contain component mount paths
+  MATCH "$COMPS_MNT"/"$COMP1"/x1/libs < "$export_cuda"
+  MATCH "$COMPS_MNT"/"$COMP2"/x1/libs < "$export_cuda"
+  MATCH "$COMPS_MNT"/"$COMP1"/x1/libs < "$export_egl"
+  MATCH "$COMPS_MNT"/"$COMP2"/x1/libs < "$export_egl"
+
+  # Classic-specific backends must NOT be active on Core
+  not test -f /etc/ld.so.conf.d/snap.system.conf
+  not ls /etc/glvnd/egl_vendor.d/*snap* 2>/dev/null
+
+  # TODO: verify export/data/ ICD files once the support is added
+
+  # Disconnect both interfaces and verify .library-source files are cleaned up
+  snap disconnect system:egl-driver-libs "$PROVIDER_SNAP":egl-driver-libs
+  snap disconnect system:cuda-driver-libs "$PROVIDER_SNAP":cuda-driver-libs
+  not test -f "$export_egl"
+  not test -f "$export_cuda"
+
+  # Reconnect, then remove the snap and verify cleanup
+  snap connect system:cuda-driver-libs "$PROVIDER_SNAP":cuda-driver-libs
+  snap connect system:egl-driver-libs "$PROVIDER_SNAP":egl-driver-libs
+  snap remove "$PROVIDER_SNAP"
+  not test -f "$export_egl"
+  not test -f "$export_cuda"


### PR DESCRIPTION
Make various driver-libs interfaces usable on Ubuntu Core. The change
only allows implicit plug on Core, but skips ldconfig or symlinks into
the host system. However, we still export the library paths under
/var/lib/snapd/export, such that snap-confine, at runtime, may consume
the relevant libraries.

Related: SNAPDENG-37199

Extracted form #17338 