### PR TITLE
cmd/snap-confine,tests: discard stale ns when layout source changes

### DIFF
--- a/cmd/snap-confine/ns-support.c
+++ b/cmd/snap-confine/ns-support.c
@@ -24,6 +24,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <linux/magic.h>
+#include <mntent.h>
 #include <sched.h>
 #include <signal.h>
 #include <string.h>
@@ -318,6 +319,68 @@ static bool homedirs_are_mounted(sc_mountinfo *mi, char **homedirs, int num_home
     return all_seen;
 }
 
+// layout_data_mounts_are_consistent checks whether layout bind mounts whose
+// source is under the snap's data directory still refer to the same inode as
+// what is currently mounted at their destination inside the namespace.
+//
+// A layout bind mount becomes stale when its source directory is moved,
+// replaced, or deleted on the host (e.g. by snapshot restore, or by any snap
+// app, hook, or service): the bind mount at the layout destination keeps
+// referencing the original source inode, while the source path itself now
+// names a different inode on the host. Comparing the inode of the source path
+// against the inode seen at the destination detects this divergence.
+//
+// Must be called from inside the preserved namespace (after setns).
+static bool layout_data_mounts_are_consistent(const sc_invocation *inv) {
+    char fstab_path[PATH_MAX] = {0};
+    sc_must_snprintf(fstab_path, sizeof fstab_path, "/var/lib/snapd/mount/snap.%s.fstab", inv->snap_instance);
+
+    FILE *fstab SC_CLEANUP(sc_cleanup_file) = setmntent(fstab_path, "r");
+    if (fstab == NULL) {
+        if (errno == ENOENT) {
+            /* No mount profile means no layout mounts to check. */
+            return true;
+        }
+        die("cannot open mount profile %s", fstab_path);
+    }
+
+    /* Build the prefix for snap data paths: /var/snap/<snap_instance>/ */
+    char snap_data_prefix[PATH_MAX] = {0};
+    sc_must_snprintf(snap_data_prefix, sizeof snap_data_prefix, "/var/snap/%s/", inv->snap_instance);
+
+    struct mntent *entry;
+    while ((entry = getmntent(fstab)) != NULL) {
+        /* Only check layout bind mounts whose source is under the snap data
+         * dir. Tmpfs layout entries have "tmpfs" as the source and won't
+         * match the prefix. */
+        if (hasmntopt(entry, "x-snapd.origin=layout") == NULL) {
+            continue;
+        }
+        if (!sc_startswith(entry->mnt_fsname, snap_data_prefix)) {
+            continue;
+        }
+
+        struct stat src_st, dst_st;
+        if (stat(entry->mnt_fsname, &src_st) != 0) {
+            /* Source path no longer exists on the host side. */
+            debug("layout mount source %s is missing, namespace is stale", entry->mnt_fsname);
+            return false;
+        }
+        if (stat(entry->mnt_dir, &dst_st) != 0) {
+            /* Destination not accessible in the namespace. */
+            debug("layout mount destination %s is not accessible, namespace is stale", entry->mnt_dir);
+            return false;
+        }
+        if (src_st.st_dev != dst_st.st_dev || src_st.st_ino != dst_st.st_ino) {
+            debug("layout mount source %s and destination %s differ, namespace is stale", entry->mnt_fsname,
+                  entry->mnt_dir);
+            return false;
+        }
+    }
+
+    return true;
+}
+
 // Inspect the namespace and check if we should discard it.
 static bool should_discard_current_ns(const struct sc_invocation *inv, dev_t base_snap_dev) {
     sc_mountinfo *mi SC_CLEANUP(sc_cleanup_mountinfo) = NULL;
@@ -336,6 +399,13 @@ static bool should_discard_current_ns(const struct sc_invocation *inv, dev_t bas
     // changed: so this code will check that all homedirs are mounted in the
     // namespace.
     if (!homedirs_are_mounted(mi, inv->homedirs, inv->num_homedirs)) {
+        return true;
+    }
+    // A layout bind mount sourced from the snap's data directory becomes stale
+    // when the source directory is moved, replaced, or deleted on the host
+    // (e.g. by snapshot restore, or by any snap app, hook, or service). Check
+    // that the inode at each such destination still matches its source.
+    if (!layout_data_mounts_are_consistent(inv)) {
         return true;
     }
 

--- a/tests/main/layout-ns-stale-source/task.yaml
+++ b/tests/main/layout-ns-stale-source/task.yaml
@@ -1,0 +1,72 @@
+summary: Verify that a replaced layout mount source discards the preserved mount namespace
+
+details: |
+    Layout bind mounts sourced from $SNAP_DATA or $SNAP_COMMON bind the source
+    directory inode into the preserved mount namespace when the namespace is
+    first created. If the source directory is later replaced with a new inode —
+    either by a snapshot restore or by a snap app, hook, or service moving the
+    directory — the preserved namespace becomes stale: the layout destination
+    still references the original inode while the source path now resolves to a
+    different one.
+
+    This test verifies that in such a case the preserved mount namespace is
+    discarded and recreated.
+
+environment:
+    TRIGGER/v1: snapshot-restore
+    TRIGGER/v2: app-rename
+    LAYOUT_SRC/v1: /var/snap/test-snapd-layout-data/current/test-data
+    LAYOUT_SRC/v2: /var/snap/test-snapd-layout-data/common/test-data
+    LAYOUT_DEST/v1: /var/lib/test-snapd-layout-data
+    LAYOUT_DEST/v2: /var/lib/test-snapd-layout-common
+    # tar invoked when creating snapshots triggers OOM
+    SNAPD_NO_MEMORY_LIMIT: 1
+
+prepare: |
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-layout-data
+    tests.cleanup defer snap remove --purge test-snapd-layout-data
+
+execute: |
+    echo "Run the snap once to create the preserved mount namespace"
+    test-snapd-layout-data.sh -c "true"
+
+    echo "The layout destination is accessible inside the namespace"
+    test-snapd-layout-data.sh -c "test -d $LAYOUT_DEST"
+
+    echo "Confirm the namespace is being reused at this point"
+    SNAPD_DEBUG=1 test-snapd-layout-data.sh -c "true" 2>&1 | MATCH "preserved mount is not stale, reusing"
+
+    if [ "$TRIGGER" = snapshot-restore ]; then
+        echo "Drop a canary file via the layout destination"
+        test-snapd-layout-data.sh -c "echo hello > $LAYOUT_DEST/canary"
+        test -f "$LAYOUT_SRC/canary"
+
+        echo "Take a snapshot"
+        SET_ID=$(snap save test-snapd-layout-data | cut -d\  -f1 | tail -n1)
+        tests.cleanup defer snap forget "$SET_ID" || true
+
+        echo "Remove the canary so we can verify restore brings it back"
+        rm -f "$LAYOUT_SRC/canary"
+
+        echo "Restore the snapshot — this replaces the snap data directory inode"
+        snap restore "$SET_ID"
+        test -f "$LAYOUT_SRC/canary"
+    elif [ "$TRIGGER" = app-rename ]; then
+        echo "Simulate an app replacing the layout source dir (mv old new)"
+        test-snapd-layout-data.sh -c "mv \$SNAP_COMMON/test-data \$SNAP_COMMON/test-data-old && mkdir \$SNAP_COMMON/test-data"
+    fi
+
+    echo "Namespace must be discarded and rebuilt after the source dir was replaced"
+    SNAPD_DEBUG=1 test-snapd-layout-data.sh -c "true" &> output.log
+    MATCH "namespace is stale" < output.log
+    MATCH "discarding mount namespaces of snap test-snapd-layout-data" <output.log
+    echo "Layout destination must be accessible in the fresh namespace"
+    test-snapd-layout-data.sh -c "test -d $LAYOUT_DEST"
+
+    if [ "$TRIGGER" = snapshot-restore ]; then
+        echo "Canary must be visible through the layout destination in the new namespace"
+        test-snapd-layout-data.sh -c "test -f $LAYOUT_DEST/canary"
+    fi
+
+    echo "Confirm the namespace is now reused again"
+    SNAPD_DEBUG=1 test-snapd-layout-data.sh -c "true" 2>&1 | MATCH "preserved mount is not stale, reusing"

--- a/tests/main/layout-ns-stale-source/test-snapd-layout-data/bin/sh
+++ b/tests/main/layout-ns-stale-source/test-snapd-layout-data/bin/sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /bin/sh "$@"

--- a/tests/main/layout-ns-stale-source/test-snapd-layout-data/meta/snap.yaml
+++ b/tests/main/layout-ns-stale-source/test-snapd-layout-data/meta/snap.yaml
@@ -1,0 +1,19 @@
+name: test-snapd-layout-data
+version: 1.0
+summary: Test snap with SNAP_DATA and SNAP_COMMON layout bind mounts
+description: |
+  Used to reproduce the preserved namespace staleness bug triggered by
+  snapshot restore or directory rename replacing a snap data directory inode.
+base: core24
+confinement: strict
+grade: devel
+
+layout:
+  /var/lib/test-snapd-layout-data:
+    bind: $SNAP_DATA/test-data
+  /var/lib/test-snapd-layout-common:
+    bind: $SNAP_COMMON/test-data
+
+apps:
+  sh:
+    command: bin/sh


### PR DESCRIPTION
Layout bind mounts sourced from $SNAP_DATA or $SNAP_COMMON capture the source directory inode when the preserved mount namespace is first created. If that inode is later replaced — for example by a snapshot restore or by a snap app or service replacing the directory — the namespace becomes stale: the layout destination still references the original inode while the source path resolves to a different one.

Add layout_data_mounts_are_consistent() to ns-support.c. It opens the snap's mount profile, iterates entries tagged with x-snapd.origin=layout whose source is under /var/snap/<instance>/, and compares the (dev, ino) of the source path against the (dev, ino) seen at the destination inside the preserved namespace. A mismatch causes should_discard_current_ns() to return true, triggering a discard and rebuild.

Add a spread test (tests/main/layout-ns-stale-source) with two variants:
- v1: snap save / snap restore replaces the $SNAP_DATA inode
- v2: a snap app renames the $SNAP_COMMON source directory

TODO: add unit tests after an initial review of the proposed fix