### PR TITLE
cmd/snapctl: snapctl and snap-exec dispatch

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -337,7 +337,6 @@ parts:
             # being started from snap because of broken re-execution
             # and fixes that were not yet backported
             lib/snapd/snap-bootstrap
-            lib/snapd/snap-exec
             lib/snapd/snap-failure
             lib/snapd/snap-fde-keymgr
             lib/snapd/snap-preseed
@@ -358,7 +357,7 @@ parts:
            # FIXME: some binaries need to be run confined in apps. But
            # instead we should allow apps to access dynamic linkers
            # and libraries from snapd.
-           lib/snapd/snap-exec|lib/snapd/snapctl)
+           lib/snapd/snapctl)
              export CGO_ENABLED=0
              GO_LD_FLAGS=()
              CHECK_STATIC=1
@@ -459,6 +458,8 @@ parts:
       # link usr/bin/snap -> usr/lib/snapd/snapd
       mkdir -p "${CRAFT_PART_INSTALL}/usr/bin"
       ln -v -s -r "${CRAFT_PART_INSTALL}/usr/lib/snapd/snapd" "${CRAFT_PART_INSTALL}/usr/bin/snap"
+      # link usr/lib/snapd/snap-exec -> usr/lib/snapd/snapctl (multi-call binary)
+      ln -v -s snapctl "${CRAFT_PART_INSTALL}/usr/lib/snapd/snap-exec"
 
       if [ -f fips-build ]; then
         # Set up FIPS dispatch: replace each original binary with a symlink

--- a/cmd/snapctl/export_test.go
+++ b/cmd/snapctl/export_test.go
@@ -19,10 +19,17 @@
 
 package main
 
-import (
-	"github.com/snapcore/snapd/cmd/snapctl/tool/snap-exec"
-)
+import "github.com/snapcore/snapd/testutil"
 
-func main() {
-	snap_exec.Main()
+// Main exposes the unexported main() for testing.
+var Main = main
+
+// MockSnapExecMain replaces the snap-exec entry point for the duration of a test.
+func MockSnapExecMain(f func()) (restore func()) {
+	return testutil.Mock(&snapExecMain, f)
+}
+
+// MockSnapctlMain replaces the snapctl entry point for the duration of a test.
+func MockSnapctlMain(f func()) (restore func()) {
+	return testutil.Mock(&snapctlMain, f)
 }

--- a/cmd/snapctl/main.go
+++ b/cmd/snapctl/main.go
@@ -20,9 +20,26 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
+
+	"github.com/snapcore/snapd/cmd/snapctl/tool/snap-exec"
 	"github.com/snapcore/snapd/cmd/snapctl/tool/snapctl"
 )
 
+var (
+	snapExecMain = snap_exec.Main
+	snapctlMain  = snapctl.Main
+)
+
 func main() {
-	snapctl.Main()
+	argv0 := filepath.Base(os.Args[0])
+
+	// dispatch the binary multi entry point
+	switch argv0 {
+	case "snap-exec":
+		snapExecMain()
+	default: // "snapctl"
+		snapctlMain()
+	}
 }

--- a/cmd/snapctl/main_test.go
+++ b/cmd/snapctl/main_test.go
@@ -1,0 +1,101 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package main_test
+
+import (
+	"os"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	snapctlmain "github.com/snapcore/snapd/cmd/snapctl"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type dispatchSuite struct{}
+
+var _ = Suite(&dispatchSuite{})
+
+func runDispatch(args []string) (called string, argsAtCall []string) {
+	saved := os.Args
+	defer func() { os.Args = saved }()
+	os.Args = args
+
+	restoreSnapExec := snapctlmain.MockSnapExecMain(func() {
+		called = "snap-exec"
+		argsAtCall = append([]string(nil), os.Args...)
+	})
+	defer restoreSnapExec()
+
+	restoreSnapctl := snapctlmain.MockSnapctlMain(func() {
+		called = "snapctl"
+		argsAtCall = append([]string(nil), os.Args...)
+	})
+	defer restoreSnapctl()
+
+	snapctlmain.Main()
+	return called, argsAtCall
+}
+
+func (s *dispatchSuite) TestArgv0SnapExecDispatchesSnapExec(c *C) {
+	called, argsAtCall := runDispatch([]string{"snap-exec"})
+	c.Check(called, Equals, "snap-exec")
+	c.Check(argsAtCall, DeepEquals, []string{"snap-exec"})
+}
+
+func (s *dispatchSuite) TestArgv0SnapExecWithArgsPassesArgsThrough(c *C) {
+	called, argsAtCall := runDispatch([]string{"snap-exec", "mysnap.app", "--arg"})
+	c.Check(called, Equals, "snap-exec")
+	c.Check(argsAtCall, DeepEquals, []string{"snap-exec", "mysnap.app", "--arg"})
+}
+
+func (s *dispatchSuite) TestArgv0SnapExecFullPathDispatches(c *C) {
+	called, argsAtCall := runDispatch([]string{"/usr/lib/snapd/snap-exec", "mysnap.app"})
+	c.Check(called, Equals, "snap-exec")
+	c.Check(argsAtCall, DeepEquals, []string{"/usr/lib/snapd/snap-exec", "mysnap.app"})
+}
+
+func (s *dispatchSuite) TestArgv0SnapExecInSnapDispatches(c *C) {
+	// snap-exec invoked from within a snapd snap (re-exec scenario).
+	args := []string{"/snap/snapd/123/usr/lib/snapd/snap-exec", "mysnap.app"}
+	called, argsAtCall := runDispatch(args)
+	c.Check(called, Equals, "snap-exec")
+	c.Check(argsAtCall, DeepEquals, args)
+}
+
+func (s *dispatchSuite) TestArgv0SnapctlDispatchesSnapctl(c *C) {
+	called, argsAtCall := runDispatch([]string{"snapctl"})
+	c.Check(called, Equals, "snapctl")
+	c.Check(argsAtCall, DeepEquals, []string{"snapctl"})
+}
+
+func (s *dispatchSuite) TestArgv0SnapctlWithArgsPassesArgsThrough(c *C) {
+	called, argsAtCall := runDispatch([]string{"snapctl", "set", "key=value"})
+	c.Check(called, Equals, "snapctl")
+	c.Check(argsAtCall, DeepEquals, []string{"snapctl", "set", "key=value"})
+}
+
+func (s *dispatchSuite) TestArgv0UnknownDispatchesSnapctl(c *C) {
+	// Any argv[0] other than "snap-exec" falls through to snapctl.
+	called, argsAtCall := runDispatch([]string{"something-else", "an-arg"})
+	c.Check(called, Equals, "snapctl")
+	c.Check(argsAtCall, DeepEquals, []string{"something-else", "an-arg"})
+}

--- a/cmd/snapctl/tool/snap-exec/export_test.go
+++ b/cmd/snapctl/tool/snap-exec/export_test.go
@@ -32,6 +32,7 @@ var (
 	Run              = run
 	ExecApp          = execApp
 	ExecHook         = execHook
+	LateInit         = lateInit
 )
 
 func MockSyscallExec(f func(argv0 string, argv []string, envv []string) (err error)) func() {

--- a/cmd/snapctl/tool/snap-exec/main.go
+++ b/cmd/snapctl/tool/snap-exec/main.go
@@ -52,14 +52,17 @@ var opts struct {
 	Hook    string `long:"hook" description:"hook to run" hidden:"yes"`
 }
 
-func init() {
+func lateInit() {
 	// plug/slot sanitization not used nor possible from snap-exec, make it no-op
 	snap.SanitizePlugsSlots = func(snapInfo *snap.Info) {}
-	logger.SimpleSetup(nil)
 }
 
 // Main is the entry point for snap-exec. It exits the process on error.
 func Main() {
+	lateInit()
+
+	logger.SimpleSetup(nil)
+
 	if err := run(); err != nil {
 		fmt.Fprintf(os.Stderr, "cannot snap-exec: %s\n", err)
 		os.Exit(1)

--- a/cmd/snapctl/tool/snap-exec/main_test.go
+++ b/cmd/snapctl/tool/snap-exec/main_test.go
@@ -46,6 +46,10 @@ type snapExecSuite struct{}
 
 var _ = Suite(&snapExecSuite{})
 
+func (s *snapExecSuite) SetUpSuite(c *C) {
+	snap_exec.LateInit()
+}
+
 func (s *snapExecSuite) SetUpTest(c *C) {
 	// clean previous parse runs
 	snap_exec.SetOptsCommand("")

--- a/data/selinux/snappy.te
+++ b/data/selinux/snappy.te
@@ -792,11 +792,14 @@ gen_require(`
 allow snappy_confine_t unconfined_service_t:process { noatsecure rlimitinh siginh transition dyntransition };
 
 # for classic snaps, snap-confine executes snap-exec from the host (labeled as
-# snappy_exec_t)
+# snappy_exec_t, or snappy_cli_exec_t if merged with snapctl)
 can_exec(snappy_confine_t, snappy_exec_t)
-# allow snappy_exec_t to be an entrypoint to unconfined_service_t, only
-# snap-confine is allowed to transition this way
+can_exec(snappy_confine_t, snappy_cli_exec_t)
+# allow snappy_exec_t and snappy_cli_exec_t to be an entrypoint to
+# unconfined_service_t, only snap-confine is allowed to transition this way
+# (which still requires the source domain to allow such transition)
 domain_entry_file(unconfined_service_t, snappy_exec_t)
+domain_entry_file(unconfined_service_t, snappy_cli_exec_t)
 
 ########################################
 #

--- a/interfaces/apparmor/backend_test.go
+++ b/interfaces/apparmor/backend_test.go
@@ -1271,6 +1271,8 @@ profile "snap.samba.smbd" flags=(attach_disconnected,mediate_deleted) {
   # Same as above but accounting for the case when the
   # snapd snap is installed and executes the snap application.
   @{INSTALL_DIR}/snapd/*/usr/lib/snapd/snap-exec rm,
+  # Support for merged snapctl and snap-exec binaries
+  @{INSTALL_DIR}/snapd/*/usr/lib/snapd/snapctl rm,
 
 ` + mountInfoSnippet + `
 snippet

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -183,6 +183,8 @@ var templateCommon = `
 
   # For snappy reexec on 4.8+ kernels
   /usr/lib/snapd/snap-exec m,
+  # Support for merged snapctl and snap-exec binaries
+  /usr/lib/snapd/snapctl m,
 
   # For gdb support
   /usr/lib/snapd/snap-gdbserver-shim ixr,
@@ -931,6 +933,8 @@ var classicJailmodeSnippet = `
   # Same as above but accounting for the case when the
   # snapd snap is installed and executes the snap application.
   @{INSTALL_DIR}/snapd/*/usr/lib/snapd/snap-exec rm,
+  # Support for merged snapctl and snap-exec binaries
+  @{INSTALL_DIR}/snapd/*/usr/lib/snapd/snapctl rm,
 `
 
 var ptraceTraceDenySnippet = `

--- a/interfaces/apparmor/template.go
+++ b/interfaces/apparmor/template.go
@@ -168,6 +168,8 @@ var templateCommon = `
 
   # For snappy reexec on 4.8+ kernels
   /usr/lib/snapd/snap-exec m,
+  # Support for merged snapctl and snap-exec binaries
+  /usr/lib/snapd/snapctl m,
 
   # For gdb support
   /usr/lib/snapd/snap-gdbserver-shim ixr,
@@ -917,6 +919,8 @@ var classicJailmodeSnippet = `
   # Same as above but accounting for the case when the
   # snapd snap is installed and executes the snap application.
   @{INSTALL_DIR}/snapd/*/usr/lib/snapd/snap-exec rm,
+  # Support for merged snapctl and snap-exec binaries
+  @{INSTALL_DIR}/snapd/*/usr/lib/snapd/snapctl rm,
 `
 
 var ptraceTraceDenySnippet = `

--- a/packaging/debian-sid/rules
+++ b/packaging/debian-sid/rules
@@ -16,7 +16,6 @@ export DH_GOPKG := github.com/snapcore/snapd
 export DH_GOLANG_EXCLUDES=tests
 export DH_GOLANG_BUILDPKG = $(strip $(addprefix $(DH_GOPKG)/, \
     cmd/snapd \
-    cmd/snap-exec \
     cmd/snap-seccomp \
     cmd/snap-update-ns \
     cmd/snapctl \
@@ -176,10 +175,9 @@ override_dh_auto_build: snapd.defines.mk
 
 	# (static linking on powerpc with cgo is broken)
 ifneq ($(shell dpkg-architecture -qDEB_HOST_ARCH),powerpc)
-	# Generate static snap-exec, snapctl and snap-update-ns - it somehow includes CGO so
-	# we must force a static build here. We need a static snap-{exec,update-ns}
+	# Generate static snapctl and snap-update-ns - it somehow includes CGO so
+	# we must force a static build here. We need a static snap-update-ns and snapctl
 	# inside the core snap because not all bases will have a libc
-	(cd _build/bin && GO111MODULE=off GOPATH=$$(pwd)/.. CGO_ENABLED=0 go build -tags "$(TAGS)" $(GCCGOFLAGS) -pkgdir=$$(pwd)/std $(DH_GOPKG)/cmd/snap-exec)
 	(cd _build/bin && GO111MODULE=off GOPATH=$$(pwd)/.. CGO_ENABLED=0 go build -tags "$(TAGS)" $(GCCGOFLAGS) -pkgdir=$$(pwd)/std $(DH_GOPKG)/cmd/snapctl)
 	(cd _build/bin && GO111MODULE=off GOPATH=$$(pwd)/.. go build -tags "$(TAGS)" --ldflags '-extldflags "-static"' $(GCCGOFLAGS) -pkgdir=$$(pwd)/std $(DH_GOPKG)/cmd/snap-update-ns)
 

--- a/packaging/debian-sid/snapd.install
+++ b/packaging/debian-sid/snapd.install
@@ -11,7 +11,6 @@ data/info /usr/lib/snapd/
 # snap-confine stuff
 etc/apparmor.d/usr.lib.snapd.snap-confine.real
 usr/bin/snapd /usr/lib/snapd/
-usr/bin/snap-exec /usr/lib/snapd/
 usr/bin/snap-seccomp /usr/lib/snapd/
 usr/bin/snap-update-ns /usr/lib/snapd/
 usr/bin/snapctl /usr/lib/snapd/

--- a/packaging/debian-sid/snapd.links
+++ b/packaging/debian-sid/snapd.links
@@ -3,4 +3,5 @@
 #     https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=764678
 /usr/lib/systemd/user/snapd.session-agent.socket /usr/lib/systemd/user/sockets.target.wants/snapd.session-agent.socket
 usr/lib/snapd/snapctl usr/bin/snapctl
+usr/lib/snapd/snapctl usr/lib/snapd/snap-exec
 usr/lib/snapd/snapd usr/bin/snap

--- a/packaging/fedora/snapd.spec
+++ b/packaging/fedora/snapd.spec
@@ -797,7 +797,7 @@ sort -u -o devel.file-list devel.file-list
 %endif
 
 %check
-for binary in snap-exec snap-update-ns snapctl; do
+for binary in snap-update-ns snapctl; do
     ldd %{_builddir}/$binary 2>&1 | grep 'not a dynamic executable'
 done
 

--- a/packaging/snapd.mk
+++ b/packaging/snapd.mk
@@ -62,7 +62,7 @@ snap_mount_dir = /snap
 endif
 
 # The list of go binaries we are expected to build.
-go_binaries = $(addprefix $(builddir)/, snapd snapctl snap-seccomp snap-update-ns snap-exec snapd-apparmor)
+go_binaries = $(addprefix $(builddir)/, snapd snapctl snap-seccomp snap-update-ns snapd-apparmor)
 
 GO_TAGS = nosecboot
 ifeq ($(with_testkeys),1)
@@ -136,10 +136,10 @@ $(builddir)/snapd $(builddir)/snap-seccomp $(builddir)/snapd-apparmor:
 		$(EXTRA_GO_BUILD_FLAGS) \
 		$(import_path)/cmd/$(notdir $@)
 
-# Those three need to be built as static binaries. They run on the inside of a
+# The following binaries need to be built statically. They run on the inside of a
 # nearly-arbitrary mount namespace that does not contain anything we can depend
 # on (no standard library, for example).
-$(builddir)/snap-update-ns $(builddir)/snap-exec $(builddir)/snapctl:
+$(builddir)/snap-update-ns $(builddir)/snapctl:
 	go build -o $@ -buildmode=$(GO_STATIC_BUILDMODE) \
 		$(GO_MOD) \
 		$(if $(GO_TAGS),-tags "$(GO_TAGS)") \
@@ -154,7 +154,7 @@ $(builddir)/snap-update-ns $(builddir)/snap-exec $(builddir)/snapctl:
 .PHONY: check-static-binaries
 check-static-binaries:
 	@echo "Checking that critical binaries are statically linked..."
-	@for binary in snap-exec snap-update-ns snapctl; do \
+	@for binary in snap-update-ns snapctl; do \
 		if [ -f "$(builddir)/$$binary" ]; then \
 			if ! file "$(builddir)/$$binary" | grep -q -F static; then \
 				echo "ERROR: $$binary is dynamically linked, must be static"; \
@@ -199,11 +199,16 @@ $(addprefix $(DESTDIR),$(libexecdir)/snapd $(bindir) $(mandir)/man8 /$(sharedsta
 
 .PHONY: install
 
-# Install snapd, snapctl, snap-{exec,update-ns,seccomp} into /usr/lib/snapd/
-install:: $(addprefix $(builddir)/,snapd snapctl snap-exec snap-update-ns snap-seccomp snapd-apparmor) | $(DESTDIR)$(libexecdir)/snapd
+# Install snapd, snapctl, snap-{update-ns,seccomp} into /usr/lib/snapd/
+install:: $(addprefix $(builddir)/,snapd snapctl snap-update-ns snap-seccomp snapd-apparmor) | $(DESTDIR)$(libexecdir)/snapd
 	install -m 755 $^ $|
 
-# Ensure /usr/bin/snapctl is a relative symlink to /usr/lib/snapd/snapctl
+# Ensure $(libexecdir)/snapd/snap-exec is a symlink to snapctl
+# (snap-exec is part of the multi-call snapctl binary)
+install:: | $(DESTDIR)$(libexecdir)/snapd
+	ln -v -s snapctl $|/snap-exec
+
+# Ensure /usr/bin/snapctl is a symlink to /usr/lib/snapd/snapctl
 install:: | $(DESTDIR)$(bindir)
 	ln -v -s -r $(DESTDIR)$(libexecdir)/snapd/snapctl $|/snapctl
 

--- a/packaging/ubuntu-16.04/rules
+++ b/packaging/ubuntu-16.04/rules
@@ -260,10 +260,9 @@ endif
 
 	(cd _build/bin && GOPATH=$$(pwd)/.. go build -mod=vendor $(BUILDFLAGS) $(GCCGOFLAGS) $(SNAP_BOOTSTRAP_TAGS) $(DH_GOPKG)/cmd/snap-bootstrap)
 
-	# Generate static snap-exec, snapctl and snap-update-ns - it somehow includes CGO so
-	# we must force a static build here. We need a static snap-{exec,update-ns}/snapctl
+	# Generate static snapctl and snap-update-ns - it somehow includes CGO so
+	# we must force a static build here. We need a static snap-update-ns and snapctl
 	# inside the core snap because not all bases will have a libc
-	(cd _build/bin && GOPATH=$$(pwd)/.. CGO_ENABLED=0 go build -mod=vendor $(GCCGOFLAGS) $(DH_GOPKG)/cmd/snap-exec)
 	(cd _build/bin && GOPATH=$$(pwd)/.. CGO_ENABLED=0 go build -mod=vendor $(GCCGOFLAGS) $(DH_GOPKG)/cmd/snapctl)
 	(cd _build/bin && GOPATH=$$(pwd)/.. go build -mod=vendor --ldflags '-extldflags "-static"' $(GCCGOFLAGS) $(DH_GOPKG)/cmd/snap-update-ns)
 

--- a/packaging/ubuntu-16.04/snapd.install.in
+++ b/packaging/ubuntu-16.04/snapd.install.in
@@ -1,7 +1,6 @@
 usr/bin/snapd /usr/lib/snapd/
 usr/bin/snapctl /usr/lib/snapd/
 usr/lib/snapd/system-shutdown
-usr/bin/snap-exec /usr/lib/snapd/
 usr/bin/snap-repair /usr/lib/snapd/
 usr/bin/snap-failure /usr/lib/snapd/
 usr/bin/snap-update-ns /usr/lib/snapd/

--- a/packaging/ubuntu-16.04/snapd.links
+++ b/packaging/ubuntu-16.04/snapd.links
@@ -3,4 +3,5 @@
 #     https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=764678
 /usr/lib/systemd/user/snapd.session-agent.socket /usr/lib/systemd/user/sockets.target.wants/snapd.session-agent.socket
 usr/lib/snapd/snapctl usr/bin/snapctl
+usr/lib/snapd/snapctl usr/lib/snapd/snap-exec
 usr/lib/snapd/snapd usr/bin/snap

--- a/packaging/ubuntu-26.04/rules
+++ b/packaging/ubuntu-26.04/rules
@@ -224,10 +224,9 @@ endif
 
 	(cd _build/bin && GOPATH=$$(pwd)/.. go build -mod=vendor $(BUILDFLAGS) $(GCCGOFLAGS) $(SNAP_BOOTSTRAP_TAGS) $(DH_GOPKG)/cmd/snap-bootstrap)
 
-	# Generate static snap-exec, snapctl and snap-update-ns - it somehow includes CGO so
-	# we must force a static build here. We need a static snap-{exec,update-ns}/snapctl
+	# Generate static snapctl and snap-update-ns - it somehow includes CGO so
+	# we must force a static build here. We need a static snap-update-ns and snapctl
 	# inside the core snap because not all bases will have a libc
-	(cd _build/bin && GOPATH=$$(pwd)/.. CGO_ENABLED=0 go build -mod=vendor $(GCCGOFLAGS) $(DH_GOPKG)/cmd/snap-exec)
 	(cd _build/bin && GOPATH=$$(pwd)/.. CGO_ENABLED=0 go build -mod=vendor $(GCCGOFLAGS) $(DH_GOPKG)/cmd/snapctl)
 	(cd _build/bin && GOPATH=$$(pwd)/.. go build -mod=vendor --ldflags '-extldflags "-static"' $(GCCGOFLAGS) $(DH_GOPKG)/cmd/snap-update-ns)
 

--- a/packaging/ubuntu-26.04/rules
+++ b/packaging/ubuntu-26.04/rules
@@ -234,10 +234,9 @@ endif
 
 	(cd _build/bin && GOPATH=$$(pwd)/.. go build -mod=vendor $(BUILDFLAGS) $(GCCGOFLAGS) $(SNAP_BOOTSTRAP_TAGS) $(DH_GOPKG)/cmd/snap-bootstrap)
 
-	# Generate static snap-exec, snapctl and snap-update-ns - it somehow includes CGO so
-	# we must force a static build here. We need a static snap-{exec,update-ns}/snapctl
+	# Generate static snapctl and snap-update-ns - it somehow includes CGO so
+	# we must force a static build here. We need a static snap-update-ns and snapctl
 	# inside the core snap because not all bases will have a libc
-	(cd _build/bin && GOPATH=$$(pwd)/.. CGO_ENABLED=0 go build -mod=vendor $(GCCGOFLAGS) $(DH_GOPKG)/cmd/snap-exec)
 	(cd _build/bin && GOPATH=$$(pwd)/.. CGO_ENABLED=0 go build -mod=vendor $(GCCGOFLAGS) $(DH_GOPKG)/cmd/snapctl)
 	(cd _build/bin && GOPATH=$$(pwd)/.. go build -mod=vendor --ldflags '-extldflags "-static"' $(GCCGOFLAGS) $(DH_GOPKG)/cmd/snap-update-ns)
 

--- a/packaging/ubuntu-26.04/snapd.install.in
+++ b/packaging/ubuntu-26.04/snapd.install.in
@@ -1,6 +1,5 @@
 usr/bin/snapd /usr/lib/snapd/
 usr/bin/snapctl /usr/lib/snapd/
-usr/bin/snap-exec /usr/lib/snapd/
 usr/bin/snap-repair /usr/lib/snapd/
 usr/bin/snap-failure /usr/lib/snapd/
 usr/bin/snap-update-ns /usr/lib/snapd/

--- a/packaging/ubuntu-26.04/snapd.links
+++ b/packaging/ubuntu-26.04/snapd.links
@@ -1,3 +1,4 @@
 /usr/lib/snapd/snap-device-helper  /usr/lib/udev/snappy-app-dev
 usr/lib/snapd/snapctl usr/bin/snapctl
+usr/lib/snapd/snapctl usr/lib/snapd/snap-exec
 usr/lib/snapd/snapd usr/bin/snap


### PR DESCRIPTION
The branch introduces name based dispatch for `snapctl` and `snap-exec` commands which are executed within the snap's mount namespace.

The mode of operation is identical to to snap/snapd, or snapd/tools dispatch introduced in https://github.com/canonical/snapd/pull/17357. We check the `argv[0]` to identify the desired 'tool' name and run it passing all of its arguments unmodified. Although, differently from snapd tools, we do not need an extra trampoline binary as the dispatching based on program name is unambiguous.

Cherry picks from: #17145

Related: [SNAPDENG-37092](https://warthogs.atlassian.net/browse/SNAPDENG-37092)

[SNAPDENG-37092]: https://warthogs.atlassian.net/browse/SNAPDENG-37092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ