### PR TITLE
many: various fixes for hybrid-with-seed remodels

### DIFF
--- a/interfaces/builtin/gbm_driver_libs.go
+++ b/interfaces/builtin/gbm_driver_libs.go
@@ -133,6 +133,10 @@ func (iface *gbmDriverLibsInterface) SymlinksConnectedPlug(spec *symlinks.Specif
 		return fmt.Errorf("invalid client-driver: %w", err)
 	}
 	// Look for the driver library
+	// TODO: if all library-source paths refer to components that are not
+	// installed, this should be a no-op. currently filePathInLibDirs returns an
+	// error for a missing client-driver when all backing component paths were
+	// filtered out.
 	path, err := filePathInLibDirs(slot, clientDriver)
 	if err != nil {
 		return err

--- a/interfaces/builtin/gbm_driver_libs.go
+++ b/interfaces/builtin/gbm_driver_libs.go
@@ -143,6 +143,10 @@ func (iface *gbmDriverLibsInterface) SymlinksConnectedPlug(spec *symlinks.Specif
 		return fmt.Errorf("invalid client-driver: %w", err)
 	}
 	// Look for the driver library
+	// TODO: if all library-source paths refer to components that are not
+	// installed, this should be a no-op. currently filePathInLibDirs returns an
+	// error for a missing client-driver when all backing component paths were
+	// filtered out.
 	path, err := filePathInLibDirs(slot, clientDriver)
 	if err != nil {
 		return err

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -1830,9 +1830,6 @@ func (m *DeviceManager) appendTriedRecoverySystem(label string) error {
 }
 
 func (m *DeviceManager) ensureTriedRecoverySystem() error {
-	if release.OnClassic {
-		return nil
-	}
 	// nothing to do if not UC20 and run mode
 	if m.SystemMode(SysHasModeenv) != "run" {
 		return nil
@@ -1846,10 +1843,40 @@ func (m *DeviceManager) ensureTriedRecoverySystem() error {
 	m.state.Lock()
 	defer m.state.Unlock()
 
-	deviceCtx, err := DeviceCtx(m.state, nil, nil)
+	var seeded bool
+	err := m.state.Get("seeded", &seeded)
 	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
+	if !seeded {
+		return nil
+	}
+
+	deviceCtx, err := DeviceCtx(m.state, nil, nil)
+	if err != nil {
+		// if we're acting on a tried recovery system, we should have a device
+		// context. if we don't have one, just bail.
+		if errors.Is(err, state.ErrNoState) {
+			return nil
+		}
+		return err
+	}
+
+	// has to be core boot to have a recovery system that was tried
+	if !deviceCtx.IsCoreBoot() {
+		return nil
+	}
+
+	hasSystemSeed, err := checkForSystemSeed(m.state, deviceCtx)
+	if err != nil {
+		return fmt.Errorf("cannot find ubuntu seed role: %w", err)
+	}
+
+	// has to have a system seed to have a recovery system that was tried
+	if !hasSystemSeed {
+		return nil
+	}
+
 	outcome, label, err := boot.InspectTryRecoverySystemOutcome(deviceCtx)
 	if err != nil {
 		if !boot.IsInconsistentRecoverySystemState(err) {

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -1833,9 +1833,6 @@ func (m *DeviceManager) appendTriedRecoverySystem(label string) error {
 }
 
 func (m *DeviceManager) ensureTriedRecoverySystem() error {
-	if release.OnClassic {
-		return nil
-	}
 	// nothing to do if not UC20 and run mode
 	if m.SystemMode(SysHasModeenv) != "run" {
 		return nil
@@ -1849,10 +1846,40 @@ func (m *DeviceManager) ensureTriedRecoverySystem() error {
 	m.state.Lock()
 	defer m.state.Unlock()
 
-	deviceCtx, err := DeviceCtx(m.state, nil, nil)
+	var seeded bool
+	err := m.state.Get("seeded", &seeded)
 	if err != nil && !errors.Is(err, state.ErrNoState) {
 		return err
 	}
+	if !seeded {
+		return nil
+	}
+
+	deviceCtx, err := DeviceCtx(m.state, nil, nil)
+	if err != nil {
+		// if we're acting on a tried recovery system, we should have a device
+		// context. if we don't have one, just bail.
+		if errors.Is(err, state.ErrNoState) {
+			return nil
+		}
+		return err
+	}
+
+	// has to be core boot to have a recovery system that was tried
+	if !deviceCtx.IsCoreBoot() {
+		return nil
+	}
+
+	hasSystemSeed, err := checkForSystemSeed(m.state, deviceCtx)
+	if err != nil {
+		return fmt.Errorf("cannot find ubuntu seed role: %w", err)
+	}
+
+	// has to have a system seed to have a recovery system that was tried
+	if !hasSystemSeed {
+		return nil
+	}
+
 	outcome, label, err := boot.InspectTryRecoverySystemOutcome(deviceCtx)
 	if err != nil {
 		if !boot.IsInconsistentRecoverySystemState(err) {

--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -1640,6 +1640,97 @@ func (s *deviceMgrSystemsCreateSuite) mockStandardSnapsModeenvAndBootloaderState
 	c.Assert(err, IsNil)
 }
 
+func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerEnsureTriedRecoverySystemHybridClassic(c *C) {
+	restore := release.MockOnClassic(true)
+	defer restore()
+	restore = devicestate.SetBootOkRanForCurrentBootID(s.mgr, true)
+	defer restore()
+	devicestate.SetBootRevisionsUpdated(s.mgr, true)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	s.model = s.makeModelAssertionInState(c, "canonical", "pc-20-hybrid", map[string]any{
+		"architecture": "amd64",
+		"grade":        "dangerous",
+		"base":         "core20",
+		"classic":      "true",
+		"distribution": "ubuntu",
+		"snaps": []any{
+			map[string]any{
+				"name": "pc-kernel",
+				"id":   s.ss.AssertedSnapID("pc-kernel"),
+				"type": "kernel",
+			},
+			map[string]any{
+				"name": "pc",
+				"id":   s.ss.AssertedSnapID("pc"),
+				"type": "gadget",
+			},
+		},
+	})
+	c.Assert(s.model.HybridClassic(), Equals, true)
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand:  "canonical",
+		Model:  "pc-20-hybrid",
+		Serial: "serialserialserial",
+	})
+	s.mockStandardSnapsModeenvAndBootloaderState(c)
+	const gadgetYaml = `
+volumes:
+  pc:
+    bootloader: grub
+    structure:
+      - name: ubuntu-seed
+        role: system-seed
+        type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+        size: 1G
+      - name: ubuntu-boot
+        role: system-boot
+        type: 83,F9E14625-EF3E-4200-AFEF-AEBD407460C4
+        size: 1G
+      - name: ubuntu-data
+        role: system-data
+        type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
+        size: 2G
+`
+	gadgetPath := filepath.Join(snap.MinimalPlaceInfo("pc", snap.R(1)).MountDir(), "meta/gadget.yaml")
+	c.Assert(os.WriteFile(gadgetPath, []byte(gadgetYaml), 0644), IsNil)
+	deviceCtx, err := devicestate.DeviceCtx(s.state, nil, nil)
+	c.Assert(err, IsNil)
+	c.Check(deviceCtx.Classic(), Equals, true)
+	c.Check(deviceCtx.IsCoreBoot(), Equals, true)
+	gadgetData, err := devicestate.CurrentGadgetData(s.state, deviceCtx)
+	c.Assert(err, IsNil)
+	c.Assert(gadgetData.Info.HasRole(gadget.SystemSeed), Equals, true)
+
+	err = s.bootloader.SetBootVars(map[string]string{
+		"try_recovery_system":    "1234",
+		"recovery_system_status": "tried",
+	})
+	c.Assert(err, IsNil)
+	modeenv, err := boot.ReadModeenv("")
+	c.Assert(err, IsNil)
+	modeenv.CurrentRecoverySystems = append(modeenv.CurrentRecoverySystems, "1234")
+	c.Assert(modeenv.Write(), IsNil)
+
+	s.state.Unlock()
+	err = s.mgr.Ensure()
+	s.state.Lock()
+	c.Assert(err, IsNil)
+
+	var tried []string
+	err = s.state.Get("tried-systems", &tried)
+	c.Assert(err, IsNil)
+
+	c.Check(tried, DeepEquals, []string{"1234"})
+	c.Check(s.bootloader.BootVars, DeepEquals, map[string]string{
+		"snap_core":              "core20_3.snap",
+		"snap_kernel":            "pc-kernel_2.snap",
+		"try_recovery_system":    "",
+		"recovery_system_status": "",
+	})
+}
+
 func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemHappy(c *C) {
 	restore := devicestate.SetBootOkRanForCurrentBootID(s.mgr, true)
 	defer restore()

--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -1640,6 +1640,98 @@ func (s *deviceMgrSystemsCreateSuite) mockStandardSnapsModeenvAndBootloaderState
 	c.Assert(err, IsNil)
 }
 
+func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerEnsureTriedRecoverySystemHybridClassic(c *C) {
+	restore := release.MockOnClassic(true)
+	defer restore()
+	restore = devicestate.SetBootOkRanForCurrentBootID(s.mgr, true)
+	defer restore()
+	devicestate.SetBootRevisionsUpdated(s.mgr, true)
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	s.model = s.makeModelAssertionInState(c, "canonical", "pc-20-hybrid", map[string]any{
+		"architecture": "amd64",
+		"grade":        "dangerous",
+		"base":         "core20",
+		"classic":      "true",
+		"distribution": "ubuntu",
+		"snaps": []any{
+			map[string]any{
+				"name": "pc-kernel",
+				"id":   s.ss.AssertedSnapID("pc-kernel"),
+				"type": "kernel",
+			},
+			map[string]any{
+				"name": "pc",
+				"id":   s.ss.AssertedSnapID("pc"),
+				"type": "gadget",
+			},
+		},
+	})
+	c.Assert(s.model.HybridClassic(), Equals, true)
+	devicestatetest.SetDevice(s.state, &auth.DeviceState{
+		Brand:  "canonical",
+		Model:  "pc-20-hybrid",
+		Serial: "serialserialserial",
+	})
+	s.mockStandardSnapsModeenvAndBootloaderState(c)
+	const gadgetYaml = `
+volumes:
+  pc:
+    bootloader: grub
+    structure:
+      - name: ubuntu-seed
+        role: system-seed
+        type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+        size: 1G
+      - name: ubuntu-boot
+        role: system-boot
+        type: 83,F9E14625-EF3E-4200-AFEF-AEBD407460C4
+        size: 1G
+      - name: ubuntu-data
+        role: system-data
+        type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
+        size: 2G
+`
+	gadgetPath := filepath.Join(snap.MinimalPlaceInfo("pc", snap.R(1)).MountDir(), "meta/gadget.yaml")
+	c.Assert(os.WriteFile(gadgetPath, []byte(gadgetYaml), 0644), IsNil)
+	deviceCtx, err := devicestate.DeviceCtx(s.state, nil, nil)
+	c.Assert(err, IsNil)
+	c.Check(deviceCtx.Classic(), Equals, true)
+	c.Check(deviceCtx.IsCoreBoot(), Equals, true)
+	gadgetData, err := devicestate.CurrentGadgetData(s.state, deviceCtx)
+	c.Assert(err, IsNil)
+	c.Assert(gadgetData.Info.HasRole(gadget.SystemSeed), Equals, true)
+
+	err = s.bootloader.SetBootVars(map[string]string{
+		"try_recovery_system":    "1234",
+		"recovery_system_status": "tried",
+	})
+	c.Assert(err, IsNil)
+	modeenv, err := boot.ReadModeenv("")
+	c.Assert(err, IsNil)
+	modeenv.CurrentRecoverySystems = append(modeenv.CurrentRecoverySystems, "1234")
+	c.Assert(modeenv.Write(), IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(dirs.GlobalRootDir, "etc", "default"), 0755), IsNil)
+
+	s.state.Unlock()
+	err = s.mgr.Ensure()
+	s.state.Lock()
+	c.Assert(err, IsNil)
+
+	var tried []string
+	err = s.state.Get("tried-systems", &tried)
+	c.Assert(err, IsNil)
+
+	c.Check(tried, DeepEquals, []string{"1234"})
+	c.Check(s.bootloader.BootVars, DeepEquals, map[string]string{
+		"snap_core":              "core20_3.snap",
+		"snap_kernel":            "pc-kernel_2.snap",
+		"try_recovery_system":    "",
+		"recovery_system_status": "",
+	})
+}
+
 func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemHappy(c *C) {
 	restore := devicestate.SetBootOkRanForCurrentBootID(s.mgr, true)
 	defer restore()

--- a/seed/seedwriter/writer.go
+++ b/seed/seedwriter/writer.go
@@ -1751,13 +1751,13 @@ func (w *Writer) checkSnapsAccessor() error {
 
 // BootSnaps returns the seed snaps involved in the boot process.
 // It can be invoked only after Downloaded returns complete ==
-// true. It returns an error for classic models as for those no snaps
-// participate in boot before user space.
+// true. It returns an error for non-hybrid classic models as for those no
+// snaps participate in boot before user space.
 func (w *Writer) BootSnaps() ([]*SeedSnap, error) {
 	if err := w.checkSnapsAccessor(); err != nil {
 		return nil, err
 	}
-	if w.model.Classic() {
+	if w.model.Classic() && !w.model.HybridClassic() {
 		return nil, fmt.Errorf("no snaps participating in boot on classic")
 	}
 	var bootSnaps []*SeedSnap

--- a/seed/seedwriter/writer_test.go
+++ b/seed/seedwriter/writer_test.go
@@ -542,6 +542,72 @@ func (s *writerSuite) TestDownloadedCore18(c *C) {
 	c.Check(w.Warnings(), HasLen, 0)
 }
 
+func (s *writerSuite) TestDownloadedHybridClassic(c *C) {
+	s.opts.Label = "20260706"
+
+	model := s.Brands.Model("my-brand", "my-model", map[string]any{
+		"architecture": "amd64",
+		"base":         "core18",
+		"classic":      "true",
+		"distribution": "ubuntu",
+		"grade":        "dangerous",
+		"snaps": []any{
+			map[string]any{
+				"name": "pc",
+				"id":   s.AssertedSnapID("pc"),
+				"type": "gadget",
+			},
+			map[string]any{
+				"name": "pc-kernel",
+				"id":   s.AssertedSnapID("pc-kernel"),
+				"type": "kernel",
+			},
+			map[string]any{
+				"name": "core18",
+				"id":   s.AssertedSnapID("core18"),
+				"type": "base",
+			},
+			map[string]any{
+				"name": "snapd",
+				"id":   s.AssertedSnapID("snapd"),
+				"type": "snapd",
+			},
+		},
+	})
+	c.Assert(model.HybridClassic(), Equals, true)
+
+	s.makeSnap(c, "snapd", "")
+	s.makeSnap(c, "pc-kernel=18", "")
+	s.makeSnap(c, "core18", "")
+	s.makeSnap(c, "pc=18", "")
+
+	w, err := seedwriter.New(model, s.opts)
+	c.Assert(err, IsNil)
+
+	err = w.Start(s.db, s.rf)
+	c.Assert(err, IsNil)
+
+	snaps, err := w.SnapsToDownload()
+	c.Assert(err, IsNil)
+	c.Check(snaps, HasLen, 4)
+	c.Check(naming.SameSnap(snaps[0], naming.Snap("snapd")), Equals, true)
+	c.Check(naming.SameSnap(snaps[1], naming.Snap("pc-kernel")), Equals, true)
+	c.Check(naming.SameSnap(snaps[2], naming.Snap("core18")), Equals, true)
+	c.Check(naming.SameSnap(snaps[3], naming.Snap("pc")), Equals, true)
+
+	for _, sn := range snaps {
+		s.fillDownloadedSnap(c, w, sn)
+	}
+
+	complete, err := w.Downloaded(s.fetchAsserts(c))
+	c.Assert(err, IsNil)
+	c.Check(complete, Equals, true)
+
+	bootSnaps, err := w.BootSnaps()
+	c.Assert(err, IsNil)
+	c.Check(bootSnaps, DeepEquals, snaps)
+}
+
 func (s *writerSuite) TestSnapsToDownloadCore18IncompatibleTrack(c *C) {
 	model := s.Brands.Model("my-brand", "my-model", map[string]any{
 		"display-name":   "my model",

--- a/spread.yaml
+++ b/spread.yaml
@@ -729,7 +729,7 @@ backends:
                 PATH="${SPREAD_HOST_PATH}"
             fi
             # Spread does not expose any settings to ad-hoc backends.
-            export QEMU_MEM_OPTION="-m 3072"
+            export QEMU_MEM_OPTION="-m 6144"
             export QEMU_SMP_OPTION="-smp 4"
             exec image-garden allocate "$(.image-garden/remap-name snapd-to-garden "$SPREAD_SYSTEM")"
         discard: |

--- a/spread.yaml
+++ b/spread.yaml
@@ -733,7 +733,7 @@ backends:
                 PATH="${SPREAD_HOST_PATH}"
             fi
             # Spread does not expose any settings to ad-hoc backends.
-            export QEMU_MEM_OPTION="-m 3072"
+            export QEMU_MEM_OPTION="-m 6144"
             export QEMU_SMP_OPTION="-smp 4"
             exec image-garden allocate "$(.image-garden/remap-name snapd-to-garden "$SPREAD_SYSTEM")"
         discard: |

--- a/tests/lib/assertions/developer1-22-classic-dangerous-rev1.json
+++ b/tests/lib/assertions/developer1-22-classic-dangerous-rev1.json
@@ -40,9 +40,8 @@
             "type": "snapd"
         },
         {
-            "default-channel": "latest/edge",
-            "id": "vFTrGWyktbEDwuYJjdsZykV270mqcNz8",
-            "name": "jq-core22",
+            "default-channel": "latest/stable",
+            "name": "test-snapd-sh-core22",
             "type": "app"
         }
     ]

--- a/tests/lib/assertions/developer1-24-classic-dangerous-rev1.json
+++ b/tests/lib/assertions/developer1-24-classic-dangerous-rev1.json
@@ -41,8 +41,7 @@
         },
         {
             "default-channel": "latest/stable",
-            "id": "zBAzEImJzOAoGxmoG5o6Tl6ELZXMeUlt",
-            "name": "test-snapd-jq-core24",
+            "name": "test-snapd-sh-core24",
             "type": "app"
         }
     ]

--- a/tests/lib/assertions/developer1-26-classic-dangerous-rev1.json
+++ b/tests/lib/assertions/developer1-26-classic-dangerous-rev1.json
@@ -1,0 +1,48 @@
+{
+    "type": "model",
+    "authority-id": "developer1",
+    "series": "16",
+    "brand-id": "developer1",
+    "model": "developer1-26-classic-dangerous",
+    "architecture": "amd64",
+    "timestamp": "2024-04-09T22:00:00+00:00",
+    "grade": "dangerous",
+    "base": "core26",
+    "classic": "true",
+    "distribution": "ubuntu",
+    "revision": "1",
+    "serial-authority": [
+        "generic"
+    ],
+    "snaps": [
+        {
+            "default-channel": "26/edge",
+            "id": "UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH",
+            "name": "pc",
+            "type": "gadget"
+        },
+        {
+            "default-channel": "26-oem/stable",
+            "id": "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza",
+            "name": "pc-kernel",
+            "type": "kernel"
+        },
+        {
+            "default-channel": "latest/edge",
+            "id": "cUqM61hRuZAJYmIS898Ux66VY61gBbZf",
+            "name": "core26",
+            "type": "base"
+        },
+        {
+            "default-channel": "latest/stable",
+            "id": "PMrrV4ml8uWuEUDBT8dSGnKUYbevVhc4",
+            "name": "snapd",
+            "type": "snapd"
+        },
+        {
+            "default-channel": "latest/stable",
+            "name": "test-snapd-sh-core26",
+            "type": "app"
+        }
+    ]
+}

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -562,7 +562,7 @@ nested_is_generic_image() {
 }
 
 nested_get_extra_snaps_path() {
-    echo "${NESTED_EXTRA_SNAPS_PATH:-/tmp/extra-snaps}"
+    echo "${NESTED_WORK_DIR}/extra-snaps"
 }
 
 nested_get_assets_path() {

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -562,7 +562,7 @@ nested_is_generic_image() {
 }
 
 nested_get_extra_snaps_path() {
-    echo "/tmp/extra-snaps"
+    echo "${NESTED_EXTRA_SNAPS_PATH:-/tmp/extra-snaps}"
 }
 
 nested_get_assets_path() {

--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -575,7 +575,7 @@ nested_is_generic_image() {
 }
 
 nested_get_extra_snaps_path() {
-    echo "/tmp/extra-snaps"
+    echo "${NESTED_WORK_DIR}/extra-snaps"
 }
 
 nested_get_assets_path() {

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -1218,6 +1218,8 @@ uc24_build_initramfs_kernel_snap() {
 
     unsquashfs -d pc-kernel "$ORIG_SNAP"
     kernelver=$(find pc-kernel/modules/ -maxdepth 1 -mindepth 1 -printf "%f")
+
+    # TODO: update ubuntu-core-initramfs to use a disk-backed tmpdir by default
     TMPDIR=/var/tmp ubuntu-core-initramfs create-initrd --kernelver="$kernelver" --kerneldir pc-kernel/modules/"$kernelver" \
                           --firmwaredir pc-kernel/firmware --output initrd.img
 
@@ -1249,6 +1251,8 @@ uc24_build_initramfs_kernel_snap() {
     # Build signed uki image - snakeoil keys shipped by ubuntu-core-initramfs
     # are used by default
     objcopy -O binary -j .linux pc-kernel/kernel.efi linux-"$kernelver"
+
+    # TODO: update ubuntu-core-initramfs to use a disk-backed tmpdir by default
     TMPDIR=/var/tmp ubuntu-core-initramfs create-efi --kernelver="$kernelver" --initrd initrd.img --kernel linux --output kernel.efi
     cp kernel.efi-"$kernelver" pc-kernel/kernel.efi
 

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -1218,7 +1218,7 @@ uc24_build_initramfs_kernel_snap() {
 
     unsquashfs -d pc-kernel "$ORIG_SNAP"
     kernelver=$(find pc-kernel/modules/ -maxdepth 1 -mindepth 1 -printf "%f")
-    ubuntu-core-initramfs create-initrd --kernelver="$kernelver" --kerneldir pc-kernel/modules/"$kernelver" \
+    TMPDIR=/var/tmp ubuntu-core-initramfs create-initrd --kernelver="$kernelver" --kerneldir pc-kernel/modules/"$kernelver" \
                           --firmwaredir pc-kernel/firmware --output initrd.img
 
     # Check that manifest is generated
@@ -1249,7 +1249,7 @@ uc24_build_initramfs_kernel_snap() {
     # Build signed uki image - snakeoil keys shipped by ubuntu-core-initramfs
     # are used by default
     objcopy -O binary -j .linux pc-kernel/kernel.efi linux-"$kernelver"
-    ubuntu-core-initramfs create-efi --kernelver="$kernelver" --initrd initrd.img --kernel linux --output kernel.efi
+    TMPDIR=/var/tmp ubuntu-core-initramfs create-efi --kernelver="$kernelver" --initrd initrd.img --kernel linux --output kernel.efi
     cp kernel.efi-"$kernelver" pc-kernel/kernel.efi
 
     # copy any extra files that tests may need for the kernel

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -1228,7 +1228,9 @@ uc24_build_initramfs_kernel_snap() {
 
     unsquashfs -d pc-kernel "$ORIG_SNAP"
     kernelver=$(find pc-kernel/modules/ -maxdepth 1 -mindepth 1 -printf "%f")
-    ubuntu-core-initramfs create-initrd --kernelver="$kernelver" --kerneldir pc-kernel/modules/"$kernelver" \
+
+    # TODO: update ubuntu-core-initramfs to use a disk-backed tmpdir by default
+    TMPDIR=/var/tmp ubuntu-core-initramfs create-initrd --kernelver="$kernelver" --kerneldir pc-kernel/modules/"$kernelver" \
                           --firmwaredir pc-kernel/firmware --output initrd.img
 
     # Check that manifest is generated
@@ -1259,7 +1261,9 @@ uc24_build_initramfs_kernel_snap() {
     # Build signed uki image - snakeoil keys shipped by ubuntu-core-initramfs
     # are used by default
     objcopy -O binary -j .linux pc-kernel/kernel.efi linux-"$kernelver"
-    ubuntu-core-initramfs create-efi --kernelver="$kernelver" --initrd initrd.img --kernel linux --output kernel.efi
+
+    # TODO: update ubuntu-core-initramfs to use a disk-backed tmpdir by default
+    TMPDIR=/var/tmp ubuntu-core-initramfs create-efi --kernelver="$kernelver" --initrd initrd.img --kernel linux --output kernel.efi
     cp kernel.efi-"$kernelver" pc-kernel/kernel.efi
 
     # copy any extra files that tests may need for the kernel

--- a/tests/lib/tools/setup_nested_hybrid_system.sh
+++ b/tests/lib/tools/setup_nested_hybrid_system.sh
@@ -391,7 +391,7 @@ main() {
         # work on and attach to the VM
         if [ -z "${disk}" ]; then
             disk="${PWD}/disk.img"
-            truncate --size=6G "${disk}"
+            truncate --size=8G "${disk}"
         fi
 
         # if a gadget wasn't provided, download one we know should work for hybrid

--- a/tests/nested/manual/base-kernel-refresh-rollback/task.yaml
+++ b/tests/nested/manual/base-kernel-refresh-rollback/task.yaml
@@ -39,14 +39,15 @@ prepare: |
 
   tests.nested prepare-essential-snaps
 
-  snapd_snap="$(echo /tmp/extra-snaps/snapd_*.snap)"
+  extra_snaps="$(tests.nested get extra-snaps-path)"
+  snapd_snap="$(echo "${extra_snaps}"/snapd_*.snap)"
 
   export SNAPPY_FORCE_API_URL="${NESTED_UBUNTU_IMAGE_SNAPPY_FORCE_SAS_URL}"
   ubuntu-image snap --image-size 10G ./base-kernel-refresh.model \
-    --snap /tmp/extra-snaps/pc.snap \
-    --snap /tmp/extra-snaps/pc-kernel.snap \
+    --snap "${extra_snaps}/pc.snap" \
+    --snap "${extra_snaps}/pc-kernel.snap" \
     --snap "${snapd_snap}" \
-    --snap "/tmp/extra-snaps/${base_snap}.snap"
+    --snap "${extra_snaps}/${base_snap}.snap"
 
   image_dir=$(tests.nested get images-path)
   image_name=$(tests.nested get image-name core)

--- a/tests/nested/manual/hybrid-remodel/task.yaml
+++ b/tests/nested/manual/hybrid-remodel/task.yaml
@@ -20,24 +20,11 @@ prepare: |
 
   snap install --edge test-snapd-swtpm
 
-  # The rev1 model used by this test adds one application snap. Keep the
-  # selected snap name/id in sync with developer1-${VERSION}-classic-dangerous-rev1.json.
-  #
-  # On 22 we use jq-core22 (existing store snap), while on 24 we use the
-  # test-owned core24 equivalent test-snapd-jq-core24.
-  case "${VERSION}" in
-    22)
-      snap_app_name=jq-core22
-      snap_app_id="vFTrGWyktbEDwuYJjdsZykV270mqcNz8"
-      app_channel="latest/edge"
-    ;;
-    24)
-      snap_app_name=test-snapd-jq-core24
-      snap_app_id="zBAzEImJzOAoGxmoG5o6Tl6ELZXMeUlt"
-      app_channel="latest/stable"
-    ;;
-  esac
-  snap download --channel="${app_channel}" "${snap_app_name}" --basename="${snap_app_name}"
+  # The rev1 model used by this test adds one application snap. Keep the snap
+  # name in sync with developer1-${VERSION}-classic-dangerous-rev1.json.
+  snap_app_name="test-snapd-sh-core${VERSION}"
+  snap_app_id="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+  snap pack "${TESTSLIB}/snaps/${snap_app_name}" --filename="${snap_app_name}.snap"
 
   "${TESTSTOOLS}/store-state" setup-fake-store "${NESTED_FAKESTORE_BLOB_DIR}"
   for key in "${TESTSLIB}"/assertions/{testrootorg-store.account-key,developer1.account,developer1.account-key}; do
@@ -177,9 +164,8 @@ execute: |
   remote.exec snap watch "${change_id}"
   remote.exec 'snap changes' | MATCH "${change_id}\s+Done.+Refresh model assertion from revision 0 to 1"
 
-  # Verify remodel installed the app snap added in rev1 (jq-core22 on 22,
-  # test-snapd-jq-core24 on 24).
-  remote.exec "snap list" | MATCH "jq-core${VERSION}"
+  # Verify remodel installed the app snap added in rev1.
+  remote.exec "snap list" | MATCH "test-snapd-sh-core${VERSION}"
 
   case "$VERSION" in
     22|24)

--- a/tests/nested/manual/hybrid-remodel/task.yaml
+++ b/tests/nested/manual/hybrid-remodel/task.yaml
@@ -19,7 +19,6 @@ environment:
   # for the fake store
   NESTED_FAKESTORE_BLOB_DIR: $(pwd)/fake-store-blobdir
   NESTED_UBUNTU_IMAGE_SNAPPY_FORCE_SAS_URL: http://localhost:11028
-  NESTED_EXTRA_SNAPS_PATH: /var/tmp/work-dir/extra-snaps
 
 prepare: |
   VERSION="$(tests.nested show version)"

--- a/tests/nested/manual/hybrid-remodel/task.yaml
+++ b/tests/nested/manual/hybrid-remodel/task.yaml
@@ -4,16 +4,22 @@ details: |
   This test remodels on a hybrid system to install a new kernel snap and new
   application snaps.
 
-systems: [ubuntu-22.04-64, ubuntu-24.04-64]
+systems: [ubuntu-22.04-64, ubuntu-24.04-64, ubuntu-26.04-64]
 
 environment:
   NESTED_BUILD_SNAPD_FROM_CURRENT: true
   NESTED_REPACK_KERNEL_SNAP: true
+  # TODO: remove once component-backed driver-libs slots are ignored when the
+  # referenced components are not installed. The 26/beta pc-kernel advertises
+  # gbm-driver-libs via $SNAP_COMPONENT(...), but this test seeds only the main
+  # kernel snap.
+  NESTED_KERNEL_REMOVE_COMPONENTS: true
 
   NESTED_SIGN_SNAPS_FAKESTORE: true
   # for the fake store
   NESTED_FAKESTORE_BLOB_DIR: $(pwd)/fake-store-blobdir
   NESTED_UBUNTU_IMAGE_SNAPPY_FORCE_SAS_URL: http://localhost:11028
+  NESTED_EXTRA_SNAPS_PATH: /var/tmp/work-dir/extra-snaps
 
 prepare: |
   VERSION="$(tests.nested show version)"
@@ -65,23 +71,53 @@ prepare: |
   # Re-sign the kernel to force a reseal
   # shellcheck source=tests/lib/nested.sh
   . "$TESTSLIB/nested.sh"
-  KEY_NAME=$(nested_get_snakeoil_key)
   sha256sum pc-kernel/kernel.efi
-  SNAKEOIL_KEY="$PWD/$KEY_NAME.key"
-  SNAKEOIL_CERT="$PWD/$KEY_NAME.pem"
+  case "${VERSION}" in
+    26)
+      # ensure that refreshing the kernel triggers a reseal
+      quiet apt install -y systemd-boot-efi systemd-ukify
+      objcopy -O binary -j .initrd pc-kernel/kernel.efi initrd.img
+      objcopy -O binary -j .linux pc-kernel/kernel.efi linux
+      /usr/lib/systemd/ukify build \
+        --linux=linux \
+        --initrd=initrd.img \
+        --section=.spread:hybrid-remodel \
+        --output=pc-kernel/kernel.efi
+      objdump -h pc-kernel/kernel.efi | grep '[.]spread'
+      rm initrd.img linux
+
+      # we must use the test keys that are recognized by secboot. it seems that
+      # the test-snapd-ovmf keys do not work.
+      SNAKEOIL_KEY="${PROJECT_PATH}/core-initrd/26.10/snakeoil/PkKek-1-snakeoil.key"
+      SNAKEOIL_CERT="${PROJECT_PATH}/core-initrd/26.10/snakeoil/PkKek-1-snakeoil.pem"
+    ;;
+    *)
+      KEY_NAME=$(nested_get_snakeoil_key)
+      SNAKEOIL_KEY="$PWD/$KEY_NAME.key"
+      SNAKEOIL_CERT="$PWD/$KEY_NAME.pem"
+    ;;
+  esac
   nested_secboot_sign_kernel pc-kernel "${SNAKEOIL_KEY}" "${SNAKEOIL_CERT}"
   sha256sum pc-kernel/kernel.efi
 
   snap pack pc-kernel --filename="${extra_snaps}/pc-kernel-oem.snap"
 
   rm -rf pc-kernel
-  "${TESTSTOOLS}"/store-state make-snap-installable --noack --revision 3 "${NESTED_FAKESTORE_BLOB_DIR}" "${extra_snaps}/pc-kernel-oem.snap" "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza"
+  "${TESTSTOOLS}"/store-state make-snap-installable --noack --revision 3 \
+    --extra-decl-json "${TESTSLIB}/assertions/pc-kernel-snap-decl-extras.json" \
+    "${NESTED_FAKESTORE_BLOB_DIR}" "${extra_snaps}/pc-kernel-oem.snap" "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza"
 
-  if [ "$VERSION" == 22 ]; then
-    PC_VERSION="23.10"
-  else
-    PC_VERSION="${VERSION}.04"
-  fi
+  case "${VERSION}" in
+    22)
+      PC_VERSION="23.10"
+    ;;
+    24)
+      PC_VERSION="24.04"
+    ;;
+    26)
+      PC_VERSION="26.10"
+    ;;
+  esac
   snap download --basename=pc --channel="classic-${PC_VERSION}/stable" pc
 
   unsquashfs -d pc pc.snap
@@ -89,6 +125,9 @@ prepare: |
   case "${VERSION}" in
     24)
       sed -i 's/^base: core22$/base: core24/' pc/meta/snap.yaml
+    ;;
+    26)
+      sed -i 's/^base: core24$/base: core26/' pc/meta/snap.yaml
     ;;
   esac
   mkdir -p pc/meta/hooks/
@@ -153,6 +192,11 @@ execute: |
 
   remote.push "${TESTSLIB}/assertions/developer1-${VERSION}-classic-dangerous-rev1.model"
 
+  has_system_seed=false
+  if remote.exec "grep -qE '^[[:space:]]*role:[[:space:]]+system-seed[[:space:]]*$' /snap/pc/current/meta/gadget.yaml"; then
+    has_system_seed=true
+  fi
+
   # remodel and reboot. we need to reboot because we swapped the kernel snap
   change_id=$(remote.exec "sudo snap remodel --no-wait developer1-${VERSION}-classic-dangerous-rev1.model")
   retry -n 100 --wait 5 remote.exec "snap tasks ${change_id} | grep 'INFO Task set to wait until a system restart allows to continue'"
@@ -161,6 +205,16 @@ execute: |
   boot_id="$(tests.nested boot-id)"
   remote.exec 'sudo reboot' || true
   remote.wait-for reboot "${boot_id}"
+
+  if [ "${has_system_seed}" = true ]; then
+    # a remodel with a recovery system first tests it, then requests another
+    # reboot to start using the new kernel.
+    retry -n 100 --wait 5 remote.exec 'test -f /run/reboot-required'
+    boot_id="$(tests.nested boot-id)"
+    remote.exec 'sudo reboot' || true
+    remote.wait-for reboot "${boot_id}"
+  fi
+
   remote.exec snap watch "${change_id}"
   remote.exec 'snap changes' | MATCH "${change_id}\s+Done.+Refresh model assertion from revision 0 to 1"
 
@@ -168,10 +222,7 @@ execute: |
   remote.exec "snap list" | MATCH "test-snapd-sh-core${VERSION}"
 
   case "$VERSION" in
-    22|24)
+    22|24|26)
       remote.exec 'snap list pc-kernel' | awk 'NR != 1 { print $4 }' | MATCH "${VERSION}-oem/stable"
       ;;
   esac
-
-  # TODO: once we support installing recovery systems during the hybrid install,
-  # we should switch this test to use a gadget that does not use "system-seed-null"

--- a/tests/nested/manual/hybrid-remodel/task.yaml
+++ b/tests/nested/manual/hybrid-remodel/task.yaml
@@ -4,11 +4,16 @@ details: |
   This test remodels on a hybrid system to install a new kernel snap and new
   application snaps.
 
-systems: [ubuntu-22.04-64, ubuntu-24.04-64]
+systems: [ubuntu-22.04-64, ubuntu-24.04-64, ubuntu-26.04-64]
 
 environment:
   NESTED_BUILD_SNAPD_FROM_CURRENT: true
   NESTED_REPACK_KERNEL_SNAP: true
+  # TODO: remove once component-backed driver-libs slots are ignored when the
+  # referenced components are not installed. The 26/beta pc-kernel advertises
+  # gbm-driver-libs via $SNAP_COMPONENT(...), but this test seeds only the main
+  # kernel snap.
+  NESTED_KERNEL_REMOVE_COMPONENTS: true
 
   NESTED_SIGN_SNAPS_FAKESTORE: true
   # for the fake store
@@ -65,23 +70,53 @@ prepare: |
   # Re-sign the kernel to force a reseal
   # shellcheck source=tests/lib/nested.sh
   . "$TESTSLIB/nested.sh"
-  KEY_NAME=$(nested_get_snakeoil_key)
   sha256sum pc-kernel/kernel.efi
-  SNAKEOIL_KEY="$PWD/$KEY_NAME.key"
-  SNAKEOIL_CERT="$PWD/$KEY_NAME.pem"
+  case "${VERSION}" in
+    26)
+      # ensure that refreshing the kernel triggers a reseal
+      quiet apt install -y systemd-boot-efi systemd-ukify
+      objcopy -O binary -j .initrd pc-kernel/kernel.efi initrd.img
+      objcopy -O binary -j .linux pc-kernel/kernel.efi linux
+      /usr/lib/systemd/ukify build \
+        --linux=linux \
+        --initrd=initrd.img \
+        --section=.spread:hybrid-remodel \
+        --output=pc-kernel/kernel.efi
+      objdump -h pc-kernel/kernel.efi | grep '[.]spread'
+      rm initrd.img linux
+
+      # we must use the test keys that are recognized by secboot. it seems that
+      # the test-snapd-ovmf keys do not work.
+      SNAKEOIL_KEY="${PROJECT_PATH}/core-initrd/26.10/snakeoil/PkKek-1-snakeoil.key"
+      SNAKEOIL_CERT="${PROJECT_PATH}/core-initrd/26.10/snakeoil/PkKek-1-snakeoil.pem"
+    ;;
+    *)
+      KEY_NAME=$(nested_get_snakeoil_key)
+      SNAKEOIL_KEY="$PWD/$KEY_NAME.key"
+      SNAKEOIL_CERT="$PWD/$KEY_NAME.pem"
+    ;;
+  esac
   nested_secboot_sign_kernel pc-kernel "${SNAKEOIL_KEY}" "${SNAKEOIL_CERT}"
   sha256sum pc-kernel/kernel.efi
 
   snap pack pc-kernel --filename="${extra_snaps}/pc-kernel-oem.snap"
 
   rm -rf pc-kernel
-  "${TESTSTOOLS}"/store-state make-snap-installable --noack --revision 3 "${NESTED_FAKESTORE_BLOB_DIR}" "${extra_snaps}/pc-kernel-oem.snap" "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza"
+  "${TESTSTOOLS}"/store-state make-snap-installable --noack --revision 3 \
+    --extra-decl-json "${TESTSLIB}/assertions/pc-kernel-snap-decl-extras.json" \
+    "${NESTED_FAKESTORE_BLOB_DIR}" "${extra_snaps}/pc-kernel-oem.snap" "pYVQrBcKmBa0mZ4CCN7ExT6jH8rY1hza"
 
-  if [ "$VERSION" == 22 ]; then
-    PC_VERSION="23.10"
-  else
-    PC_VERSION="${VERSION}.04"
-  fi
+  case "${VERSION}" in
+    22)
+      PC_VERSION="23.10"
+    ;;
+    24)
+      PC_VERSION="24.04"
+    ;;
+    26)
+      PC_VERSION="26.10"
+    ;;
+  esac
   snap download --basename=pc --channel="classic-${PC_VERSION}/stable" pc
 
   unsquashfs -d pc pc.snap
@@ -89,6 +124,9 @@ prepare: |
   case "${VERSION}" in
     24)
       sed -i 's/^base: core22$/base: core24/' pc/meta/snap.yaml
+    ;;
+    26)
+      sed -i 's/^base: core24$/base: core26/' pc/meta/snap.yaml
     ;;
   esac
   mkdir -p pc/meta/hooks/
@@ -153,6 +191,11 @@ execute: |
 
   remote.push "${TESTSLIB}/assertions/developer1-${VERSION}-classic-dangerous-rev1.model"
 
+  has_system_seed=false
+  if remote.exec "grep -qE '^[[:space:]]*role:[[:space:]]+system-seed[[:space:]]*$' /snap/pc/current/meta/gadget.yaml"; then
+    has_system_seed=true
+  fi
+
   # remodel and reboot. we need to reboot because we swapped the kernel snap
   change_id=$(remote.exec "sudo snap remodel --no-wait developer1-${VERSION}-classic-dangerous-rev1.model")
   retry -n 100 --wait 5 remote.exec "snap tasks ${change_id} | grep 'INFO Task set to wait until a system restart allows to continue'"
@@ -161,6 +204,16 @@ execute: |
   boot_id="$(tests.nested boot-id)"
   remote.exec 'sudo reboot' || true
   remote.wait-for reboot "${boot_id}"
+
+  if [ "${has_system_seed}" = true ]; then
+    # a remodel with a recovery system first tests it, then requests another
+    # reboot to start using the new kernel.
+    retry -n 100 --wait 5 remote.exec 'test -f /run/reboot-required'
+    boot_id="$(tests.nested boot-id)"
+    remote.exec 'sudo reboot' || true
+    remote.wait-for reboot "${boot_id}"
+  fi
+
   remote.exec snap watch "${change_id}"
   remote.exec 'snap changes' | MATCH "${change_id}\s+Done.+Refresh model assertion from revision 0 to 1"
 
@@ -168,10 +221,7 @@ execute: |
   remote.exec "snap list" | MATCH "test-snapd-sh-core${VERSION}"
 
   case "$VERSION" in
-    22|24)
+    22|24|26)
       remote.exec 'snap list pc-kernel' | awk 'NR != 1 { print $4 }' | MATCH "${VERSION}-oem/stable"
       ;;
   esac
-
-  # TODO: once we support installing recovery systems during the hybrid install,
-  # we should switch this test to use a gadget that does not use "system-seed-null"

--- a/tests/nested/manual/seed-refresh-back-to-revision/task.yaml
+++ b/tests/nested/manual/seed-refresh-back-to-revision/task.yaml
@@ -73,8 +73,9 @@ prepare: |
 
   tests.nested prepare-essential-snaps
 
-  mv "${test_snap_path}" "$(tests.nested get extra-snaps-path)/"
-  test_snap_path="$(tests.nested get extra-snaps-path)/$(basename "${test_snap_path}")"
+  extra_snaps="$(tests.nested get extra-snaps-path)"
+  mv "${test_snap_path}" "${extra_snaps}/"
+  test_snap_path="${extra_snaps}/$(basename "${test_snap_path}")"
 
   "${TESTSTOOLS}/store-state" make-snap-installable --noack \
     --revision 1 \
@@ -82,14 +83,14 @@ prepare: |
     "${test_snap_path}" \
     "${test_snap_id}"
 
-  snapd_snap="$(echo /tmp/extra-snaps/snapd_*.snap)"
+  snapd_snap="$(echo "${extra_snaps}"/snapd_*.snap)"
 
   export SNAPPY_FORCE_API_URL="${NESTED_UBUNTU_IMAGE_SNAPPY_FORCE_SAS_URL}"
   ubuntu-image snap --image-size 10G "$TESTSLIB/assertions/developer1-${version}-with-app-dangerous.model" \
-    --snap /tmp/extra-snaps/pc.snap \
-    --snap /tmp/extra-snaps/pc-kernel.snap \
+    --snap "${extra_snaps}/pc.snap" \
+    --snap "${extra_snaps}/pc-kernel.snap" \
     --snap "${snapd_snap}" \
-    --snap "/tmp/extra-snaps/${base_snap}.snap" \
+    --snap "${extra_snaps}/${base_snap}.snap" \
     --snap "${test_snap_path}"
 
   image_dir=$(tests.nested get images-path)

--- a/tests/nested/manual/seed-refresh-eviction/task.yaml
+++ b/tests/nested/manual/seed-refresh-eviction/task.yaml
@@ -48,8 +48,9 @@ prepare: |
 
   tests.nested prepare-essential-snaps
 
-  mv "${test_snap_path}" "$(tests.nested get extra-snaps-path)/"
-  test_snap_path="$(tests.nested get extra-snaps-path)/$(basename "${test_snap_path}")"
+  extra_snaps="$(tests.nested get extra-snaps-path)"
+  mv "${test_snap_path}" "${extra_snaps}/"
+  test_snap_path="${extra_snaps}/$(basename "${test_snap_path}")"
 
   "${TESTSTOOLS}/store-state" make-snap-installable --noack \
     --revision 1 \
@@ -57,14 +58,14 @@ prepare: |
     "${test_snap_path}" \
     "${test_snap_id}"
 
-  snapd_snap="$(echo /tmp/extra-snaps/snapd_*.snap)"
+  snapd_snap="$(echo "${extra_snaps}"/snapd_*.snap)"
 
   export SNAPPY_FORCE_API_URL="${NESTED_UBUNTU_IMAGE_SNAPPY_FORCE_SAS_URL}"
   ubuntu-image snap --image-size 10G "$TESTSLIB/assertions/developer1-${version}-with-app-dangerous.model" \
-    --snap /tmp/extra-snaps/pc.snap \
-    --snap /tmp/extra-snaps/pc-kernel.snap \
+    --snap "${extra_snaps}/pc.snap" \
+    --snap "${extra_snaps}/pc-kernel.snap" \
     --snap "${snapd_snap}" \
-    --snap "/tmp/extra-snaps/${base_snap}.snap" \
+    --snap "${extra_snaps}/${base_snap}.snap" \
     --snap "${test_snap_path}"
 
   image_dir=$(tests.nested get images-path)

--- a/tests/nested/manual/seed-refresh-no-space/task.yaml
+++ b/tests/nested/manual/seed-refresh-no-space/task.yaml
@@ -40,14 +40,15 @@ prepare: |
 
   tests.nested prepare-essential-snaps
 
-  snapd_snap="$(echo /tmp/extra-snaps/snapd_*.snap)"
+  extra_snaps="$(tests.nested get extra-snaps-path)"
+  snapd_snap="$(echo "${extra_snaps}"/snapd_*.snap)"
 
   export SNAPPY_FORCE_API_URL="${NESTED_UBUNTU_IMAGE_SNAPPY_FORCE_SAS_URL}"
   ubuntu-image snap --image-size 10G "$TESTSLIB/assertions/developer1-${version}-dangerous.model" \
-    --snap /tmp/extra-snaps/pc.snap \
-    --snap /tmp/extra-snaps/pc-kernel.snap \
+    --snap "${extra_snaps}/pc.snap" \
+    --snap "${extra_snaps}/pc-kernel.snap" \
     --snap "${snapd_snap}" \
-    --snap "/tmp/extra-snaps/${base_snap}.snap"
+    --snap "${extra_snaps}/${base_snap}.snap"
 
   image_dir=$(tests.nested get images-path)
   image_name=$(tests.nested get image-name core)

--- a/tests/nested/manual/seed-refresh-rollback/task.yaml
+++ b/tests/nested/manual/seed-refresh-rollback/task.yaml
@@ -45,14 +45,15 @@ prepare: |
 
   tests.nested prepare-essential-snaps
 
-  snapd_snap="$(echo /tmp/extra-snaps/snapd_*.snap)"
+  extra_snaps="$(tests.nested get extra-snaps-path)"
+  snapd_snap="$(echo "${extra_snaps}"/snapd_*.snap)"
 
   export SNAPPY_FORCE_API_URL="${NESTED_UBUNTU_IMAGE_SNAPPY_FORCE_SAS_URL}"
   ubuntu-image snap --image-size 10G "$TESTSLIB/assertions/developer1-${version}-dangerous.model" \
-    --snap /tmp/extra-snaps/pc.snap \
-    --snap /tmp/extra-snaps/pc-kernel.snap \
+    --snap "${extra_snaps}/pc.snap" \
+    --snap "${extra_snaps}/pc-kernel.snap" \
     --snap "${snapd_snap}" \
-    --snap "/tmp/extra-snaps/${base_snap}.snap"
+    --snap "${extra_snaps}/${base_snap}.snap"
 
   image_dir=$(tests.nested get images-path)
   image_name=$(tests.nested get image-name core)

--- a/tests/nested/manual/seed-refresh/task.yaml
+++ b/tests/nested/manual/seed-refresh/task.yaml
@@ -49,8 +49,9 @@ prepare: |
 
   tests.nested prepare-essential-snaps
 
-  mv "${test_snap_path}" "$(tests.nested get extra-snaps-path)/"
-  test_snap_path="$(tests.nested get extra-snaps-path)/$(basename "${test_snap_path}")"
+  extra_snaps="$(tests.nested get extra-snaps-path)"
+  mv "${test_snap_path}" "${extra_snaps}/"
+  test_snap_path="${extra_snaps}/$(basename "${test_snap_path}")"
 
   "${TESTSTOOLS}/store-state" make-snap-installable --noack \
     --revision 1 \
@@ -58,14 +59,14 @@ prepare: |
     "${test_snap_path}" \
     "${test_snap_id}"
 
-  snapd_snap="$(echo /tmp/extra-snaps/snapd_*.snap)"
+  snapd_snap="$(echo "${extra_snaps}"/snapd_*.snap)"
 
   export SNAPPY_FORCE_API_URL="${NESTED_UBUNTU_IMAGE_SNAPPY_FORCE_SAS_URL}"
   ubuntu-image snap --image-size 10G "$TESTSLIB/assertions/developer1-${version}-with-app-dangerous.model" \
-    --snap /tmp/extra-snaps/pc.snap \
-    --snap /tmp/extra-snaps/pc-kernel.snap \
+    --snap "${extra_snaps}/pc.snap" \
+    --snap "${extra_snaps}/pc-kernel.snap" \
     --snap "${snapd_snap}" \
-    --snap "/tmp/extra-snaps/${base_snap}.snap" \
+    --snap "${extra_snaps}/${base_snap}.snap" \
     --snap "${test_snap_path}"
 
   image_dir=$(tests.nested get images-path)


### PR DESCRIPTION
There were a couple bugs that impacted hybrid remodeling when the gadget defines a partition with a `system-seed` role.

Changes in `seedwriter` are pretty simple, some guards were improperly assuming that a classic system couldn't have snap boot participants.

Changes in `devicestate` ensure that we properly mark recovery systems as tried. Previously, we bailed out early on classic systems, but that can't always be done on hybrid systems that have a `system-seed`.