### PR TITLE
o/snapstate/backend, snap, tests: check user before deleting snap user data

### DIFF
--- a/overlord/snapstate/backend/copydata_test.go
+++ b/overlord/snapstate/backend/copydata_test.go
@@ -83,9 +83,7 @@ func (s *copydataSuite) TestCopyData(c *C) {
 
 func (s *copydataSuite) testCopyData(c *C, snapDir string, opts *dirs.SnapDirOptions) {
 	{
-		usr, err := user.Current()
-		c.Assert(err, IsNil)
-		usr.HomeDir = filepath.Join(dirs.GlobalRootDir, "home", "user1")
+		usr := &user.User{Uid: "1000", Gid: "1000", HomeDir: filepath.Join(dirs.GlobalRootDir, "home", "user1")}
 		restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
 			return []*user.User{usr}, nil
 		})
@@ -330,9 +328,7 @@ func (s *copydataSuite) testCopyDataUndo(c *C, snapDir string, opts *dirs.SnapDi
 	homedir := s.populateHomeDataWithSnapDir(c, "user1", snapDir, snap.R(10))
 
 	{
-		usr, err := user.Current()
-		c.Assert(err, IsNil)
-		usr.HomeDir = filepath.Join(dirs.GlobalRootDir, "home", "user1")
+		usr := &user.User{Uid: "1000", Gid: "1000", HomeDir: filepath.Join(dirs.GlobalRootDir, "home", "user1")}
 		restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
 			return []*user.User{usr}, nil
 		})
@@ -474,9 +470,7 @@ func (s *copydataSuite) TestCopyDataDoIdempotent(c *C) {
 	homedir := s.populateHomeData(c, "user1", snap.R(10))
 
 	{
-		usr, err := user.Current()
-		c.Assert(err, IsNil)
-		usr.HomeDir = filepath.Join(dirs.GlobalRootDir, "home", "user1")
+		usr := &user.User{Uid: "1000", Gid: "1000", HomeDir: filepath.Join(dirs.GlobalRootDir, "home", "user1")}
 		restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
 			return []*user.User{usr}, nil
 		})
@@ -511,9 +505,7 @@ func (s *copydataSuite) TestCopyDataUndoIdempotent(c *C) {
 	homedir := s.populateHomeData(c, "user1", snap.R(10))
 
 	{
-		usr, err := user.Current()
-		c.Assert(err, IsNil)
-		usr.HomeDir = filepath.Join(dirs.GlobalRootDir, "home", "user1")
+		usr := &user.User{Uid: "1000", Gid: "1000", HomeDir: filepath.Join(dirs.GlobalRootDir, "home", "user1")}
 		restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
 			return []*user.User{usr}, nil
 		})
@@ -615,12 +607,8 @@ func (s *copydataSuite) TestCopyDataPartialFailure(c *C) {
 	homedir2 := s.populateHomeData(c, "user2", snap.R(10))
 
 	{
-		usr1, err := user.Current()
-		c.Assert(err, IsNil)
-		usr1.HomeDir = filepath.Join(dirs.GlobalRootDir, "home", "user1")
-		usr2, err := user.Current()
-		c.Assert(err, IsNil)
-		usr2.HomeDir = filepath.Join(dirs.GlobalRootDir, "home", "user2")
+		usr1 := &user.User{Uid: "1000", Gid: "1000", HomeDir: filepath.Join(dirs.GlobalRootDir, "home", "user1")}
+		usr2 := &user.User{Uid: "1001", Gid: "1001", HomeDir: filepath.Join(dirs.GlobalRootDir, "home", "user2")}
 		restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
 			return []*user.User{usr1, usr2}, nil
 		})

--- a/overlord/snapstate/backend/copydata_test.go
+++ b/overlord/snapstate/backend/copydata_test.go
@@ -26,7 +26,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
-	"strings"
 
 	. "gopkg.in/check.v1"
 
@@ -83,7 +82,16 @@ func (s *copydataSuite) TestCopyData(c *C) {
 }
 
 func (s *copydataSuite) testCopyData(c *C, snapDir string, opts *dirs.SnapDirOptions) {
-	dirs.SetSnapHomeDirs("/home")
+	{
+		usr, err := user.Current()
+		c.Assert(err, IsNil)
+		usr.HomeDir = filepath.Join(dirs.GlobalRootDir, "home", "user1")
+		restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+			return []*user.User{usr}, nil
+		})
+		defer restore()
+	}
+
 	homedir := filepath.Join(dirs.GlobalRootDir, "home", "user1", snapDir)
 	homeData := filepath.Join(homedir, "hello/10")
 	err := os.MkdirAll(homeData, 0755)
@@ -150,7 +158,19 @@ func (s *copydataSuite) testCopyDataMulti(c *C, snapDir string, opts *dirs.SnapD
 		filepath.Join(dirs.GlobalRootDir, "home", "company"),
 		filepath.Join(dirs.GlobalRootDir, "home", "department"),
 		filepath.Join(dirs.GlobalRootDir, "office")}
-	dirs.SetSnapHomeDirs(strings.Join(homeDirs, ","))
+
+	var mockUsers []*user.User
+	for i, homeBase := range homeDirs {
+		usr, err := user.Current()
+		c.Assert(err, IsNil)
+		usr.HomeDir = filepath.Join(homeBase, "user1")
+		usr.Uid = fmt.Sprintf("%d", 1000+i)
+		mockUsers = append(mockUsers, usr)
+	}
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return mockUsers, nil
+	})
+	defer restore()
 
 	snapHomeDirs := []string{}
 	snapHomeDataDirs := []string{}
@@ -309,6 +329,16 @@ func (s *copydataSuite) testCopyDataUndo(c *C, snapDir string, opts *dirs.SnapDi
 	s.populateData(c, snap.R(10))
 	homedir := s.populateHomeDataWithSnapDir(c, "user1", snapDir, snap.R(10))
 
+	{
+		usr, err := user.Current()
+		c.Assert(err, IsNil)
+		usr.HomeDir = filepath.Join(dirs.GlobalRootDir, "home", "user1")
+		restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+			return []*user.User{usr}, nil
+		})
+		defer restore()
+	}
+
 	// pretend we install a new version
 	v2 := snaptest.MockSnap(c, helloYaml2, &snap.SideInfo{Revision: snap.R(20)})
 
@@ -443,6 +473,16 @@ func (s *copydataSuite) TestCopyDataDoIdempotent(c *C) {
 	s.populateData(c, snap.R(10))
 	homedir := s.populateHomeData(c, "user1", snap.R(10))
 
+	{
+		usr, err := user.Current()
+		c.Assert(err, IsNil)
+		usr.HomeDir = filepath.Join(dirs.GlobalRootDir, "home", "user1")
+		restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+			return []*user.User{usr}, nil
+		})
+		defer restore()
+	}
+
 	// pretend we install a new version
 	v2 := snaptest.MockSnap(c, helloYaml2, &snap.SideInfo{Revision: snap.R(20)})
 
@@ -469,6 +509,16 @@ func (s *copydataSuite) TestCopyDataUndoIdempotent(c *C) {
 	v1 := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
 	s.populateData(c, snap.R(10))
 	homedir := s.populateHomeData(c, "user1", snap.R(10))
+
+	{
+		usr, err := user.Current()
+		c.Assert(err, IsNil)
+		usr.HomeDir = filepath.Join(dirs.GlobalRootDir, "home", "user1")
+		restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+			return []*user.User{usr}, nil
+		})
+		defer restore()
+	}
 
 	// pretend we install a new version
 	v2 := snaptest.MockSnap(c, helloYaml2, &snap.SideInfo{Revision: snap.R(20)})
@@ -563,6 +613,19 @@ func (s *copydataSuite) TestCopyDataPartialFailure(c *C) {
 	s.populateData(c, snap.R(10))
 	homedir1 := s.populateHomeData(c, "user1", snap.R(10))
 	homedir2 := s.populateHomeData(c, "user2", snap.R(10))
+
+	{
+		usr1, err := user.Current()
+		c.Assert(err, IsNil)
+		usr1.HomeDir = filepath.Join(dirs.GlobalRootDir, "home", "user1")
+		usr2, err := user.Current()
+		c.Assert(err, IsNil)
+		usr2.HomeDir = filepath.Join(dirs.GlobalRootDir, "home", "user2")
+		restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+			return []*user.User{usr1, usr2}, nil
+		})
+		defer restore()
+	}
 
 	// pretend we install a new version
 	v2 := snaptest.MockSnap(c, helloYaml2, &snap.SideInfo{Revision: snap.R(20)})

--- a/overlord/snapstate/backend/copydata_test.go
+++ b/overlord/snapstate/backend/copydata_test.go
@@ -26,7 +26,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
-	"strings"
 
 	. "gopkg.in/check.v1"
 
@@ -83,7 +82,16 @@ func (s *copydataSuite) TestCopyData(c *C) {
 }
 
 func (s *copydataSuite) testCopyData(c *C, snapDir string, opts *dirs.SnapDirOptions) {
-	dirs.SetSnapHomeDirs("/home")
+	{
+		usr, err := user.Current()
+		c.Assert(err, IsNil)
+		usr.HomeDir = filepath.Join(dirs.GlobalRootDir, "home", "user1")
+		restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+			return []*user.User{usr}, nil
+		})
+		defer restore()
+	}
+
 	homedir := filepath.Join(dirs.GlobalRootDir, "home", "user1", snapDir)
 	homeData := filepath.Join(homedir, "hello/10")
 	err := os.MkdirAll(homeData, 0755)
@@ -150,7 +158,19 @@ func (s *copydataSuite) testCopyDataMulti(c *C, snapDir string, opts *dirs.SnapD
 		filepath.Join(dirs.GlobalRootDir, "home", "company"),
 		filepath.Join(dirs.GlobalRootDir, "home", "department"),
 		filepath.Join(dirs.GlobalRootDir, "office")}
-	dirs.SetSnapHomeDirs(strings.Join(homeDirs, ","))
+
+	var mockUsers []*user.User
+	for i, homeBase := range homeDirs {
+		usr, err := user.Current()
+		c.Assert(err, IsNil)
+		usr.HomeDir = filepath.Join(homeBase, "user1")
+		usr.Uid = fmt.Sprintf("%d", 1000+i)
+		mockUsers = append(mockUsers, usr)
+	}
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return mockUsers, nil
+	})
+	defer restore()
 
 	snapHomeDirs := []string{}
 	snapHomeDataDirs := []string{}
@@ -312,6 +332,16 @@ func (s *copydataSuite) testCopyDataUndo(c *C, snapDir string, opts *dirs.SnapDi
 	s.populateData(c, snap.R(10))
 	homedir := s.populateHomeDataWithSnapDir(c, "user1", snapDir, snap.R(10))
 
+	{
+		usr, err := user.Current()
+		c.Assert(err, IsNil)
+		usr.HomeDir = filepath.Join(dirs.GlobalRootDir, "home", "user1")
+		restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+			return []*user.User{usr}, nil
+		})
+		defer restore()
+	}
+
 	// pretend we install a new version
 	v2 := snaptest.MockSnap(c, helloYaml2, &snap.SideInfo{Revision: snap.R(20)})
 
@@ -446,6 +476,16 @@ func (s *copydataSuite) TestCopyDataDoIdempotent(c *C) {
 	s.populateData(c, snap.R(10))
 	homedir := s.populateHomeData(c, "user1", snap.R(10))
 
+	{
+		usr, err := user.Current()
+		c.Assert(err, IsNil)
+		usr.HomeDir = filepath.Join(dirs.GlobalRootDir, "home", "user1")
+		restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+			return []*user.User{usr}, nil
+		})
+		defer restore()
+	}
+
 	// pretend we install a new version
 	v2 := snaptest.MockSnap(c, helloYaml2, &snap.SideInfo{Revision: snap.R(20)})
 
@@ -472,6 +512,16 @@ func (s *copydataSuite) TestCopyDataUndoIdempotent(c *C) {
 	v1 := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
 	s.populateData(c, snap.R(10))
 	homedir := s.populateHomeData(c, "user1", snap.R(10))
+
+	{
+		usr, err := user.Current()
+		c.Assert(err, IsNil)
+		usr.HomeDir = filepath.Join(dirs.GlobalRootDir, "home", "user1")
+		restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+			return []*user.User{usr}, nil
+		})
+		defer restore()
+	}
 
 	// pretend we install a new version
 	v2 := snaptest.MockSnap(c, helloYaml2, &snap.SideInfo{Revision: snap.R(20)})
@@ -570,6 +620,19 @@ func (s *copydataSuite) TestCopyDataPartialFailure(c *C) {
 	s.populateData(c, snap.R(10))
 	homedir1 := s.populateHomeData(c, "user1", snap.R(10))
 	homedir2 := s.populateHomeData(c, "user2", snap.R(10))
+
+	{
+		usr1, err := user.Current()
+		c.Assert(err, IsNil)
+		usr1.HomeDir = filepath.Join(dirs.GlobalRootDir, "home", "user1")
+		usr2, err := user.Current()
+		c.Assert(err, IsNil)
+		usr2.HomeDir = filepath.Join(dirs.GlobalRootDir, "home", "user2")
+		restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+			return []*user.User{usr1, usr2}, nil
+		})
+		defer restore()
+	}
 
 	// pretend we install a new version
 	v2 := snaptest.MockSnap(c, helloYaml2, &snap.SideInfo{Revision: snap.R(20)})

--- a/overlord/snapstate/backend/copydata_test.go
+++ b/overlord/snapstate/backend/copydata_test.go
@@ -83,9 +83,7 @@ func (s *copydataSuite) TestCopyData(c *C) {
 
 func (s *copydataSuite) testCopyData(c *C, snapDir string, opts *dirs.SnapDirOptions) {
 	{
-		usr, err := user.Current()
-		c.Assert(err, IsNil)
-		usr.HomeDir = filepath.Join(dirs.GlobalRootDir, "home", "user1")
+		usr := &user.User{Uid: "1000", Gid: "1000", HomeDir: filepath.Join(dirs.GlobalRootDir, "home", "user1")}
 		restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
 			return []*user.User{usr}, nil
 		})
@@ -333,9 +331,7 @@ func (s *copydataSuite) testCopyDataUndo(c *C, snapDir string, opts *dirs.SnapDi
 	homedir := s.populateHomeDataWithSnapDir(c, "user1", snapDir, snap.R(10))
 
 	{
-		usr, err := user.Current()
-		c.Assert(err, IsNil)
-		usr.HomeDir = filepath.Join(dirs.GlobalRootDir, "home", "user1")
+		usr := &user.User{Uid: "1000", Gid: "1000", HomeDir: filepath.Join(dirs.GlobalRootDir, "home", "user1")}
 		restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
 			return []*user.User{usr}, nil
 		})
@@ -477,9 +473,7 @@ func (s *copydataSuite) TestCopyDataDoIdempotent(c *C) {
 	homedir := s.populateHomeData(c, "user1", snap.R(10))
 
 	{
-		usr, err := user.Current()
-		c.Assert(err, IsNil)
-		usr.HomeDir = filepath.Join(dirs.GlobalRootDir, "home", "user1")
+		usr := &user.User{Uid: "1000", Gid: "1000", HomeDir: filepath.Join(dirs.GlobalRootDir, "home", "user1")}
 		restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
 			return []*user.User{usr}, nil
 		})
@@ -514,9 +508,7 @@ func (s *copydataSuite) TestCopyDataUndoIdempotent(c *C) {
 	homedir := s.populateHomeData(c, "user1", snap.R(10))
 
 	{
-		usr, err := user.Current()
-		c.Assert(err, IsNil)
-		usr.HomeDir = filepath.Join(dirs.GlobalRootDir, "home", "user1")
+		usr := &user.User{Uid: "1000", Gid: "1000", HomeDir: filepath.Join(dirs.GlobalRootDir, "home", "user1")}
 		restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
 			return []*user.User{usr}, nil
 		})
@@ -622,12 +614,8 @@ func (s *copydataSuite) TestCopyDataPartialFailure(c *C) {
 	homedir2 := s.populateHomeData(c, "user2", snap.R(10))
 
 	{
-		usr1, err := user.Current()
-		c.Assert(err, IsNil)
-		usr1.HomeDir = filepath.Join(dirs.GlobalRootDir, "home", "user1")
-		usr2, err := user.Current()
-		c.Assert(err, IsNil)
-		usr2.HomeDir = filepath.Join(dirs.GlobalRootDir, "home", "user2")
+		usr1 := &user.User{Uid: "1000", Gid: "1000", HomeDir: filepath.Join(dirs.GlobalRootDir, "home", "user1")}
+		usr2 := &user.User{Uid: "1001", Gid: "1001", HomeDir: filepath.Join(dirs.GlobalRootDir, "home", "user2")}
 		restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
 			return []*user.User{usr1, usr2}, nil
 		})

--- a/overlord/snapstate/backend/mountunit_test.go
+++ b/overlord/snapstate/backend/mountunit_test.go
@@ -22,12 +22,12 @@ package backend_test
 import (
 	"errors"
 	"fmt"
-	"os"
 
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/user"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/progress"
 	"github.com/snapcore/snapd/snap"
@@ -533,24 +533,27 @@ func (s *mountunitSuite) TestListNonSnapctlMountsAllInRootUserDir(c *C) {
 }
 
 func (s *mountunitSuite) testListNonSnapctlMountsInHomeUserDir(c *C, variant scope) {
-	var userSnapDir, mountPath string
+	var mountPath string
 	switch variant {
 	case scopeRev:
-		userSnapDir = fmt.Sprintf("%s/home/user1/snap/foo/3", dirs.GlobalRootDir)
-		mountPath = userSnapDir + "/data"
+		mountPath = fmt.Sprintf("%s/home/user1/snap/foo/3/data", dirs.GlobalRootDir)
 	case scopeAll:
-		userSnapDir = fmt.Sprintf("%s/home/user1/snap/foo", dirs.GlobalRootDir)
-		mountPath = userSnapDir + "/data"
+		mountPath = fmt.Sprintf("%s/home/user1/snap/foo/data", dirs.GlobalRootDir)
 	}
-	// Create the user's snap directory so that the glob in snapDataDirs /
-	// snapBaseDataDirs expands to it.
-	c.Assert(os.MkdirAll(userSnapDir, 0755), IsNil)
-	defer os.RemoveAll(userSnapDir)
 
-	restore := systemd.MockNewSystemd(func(be systemd.Backend, rootDir string, mode systemd.InstanceMode, meter systemd.Reporter) systemd.Systemd {
-		return &systemdtest.FakeSystemd{}
+	// Mock allUsers to return user1 with the expected home dir so that
+	// snapDataDirs / snapBaseDataDirs include the user's snap directory.
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return []*user.User{
+			{Uid: "1000", HomeDir: fmt.Sprintf("%s/home/user1", dirs.GlobalRootDir)},
+		}, nil
 	})
 	defer restore()
+
+	restoreSysd := systemd.MockNewSystemd(func(be systemd.Backend, rootDir string, mode systemd.InstanceMode, meter systemd.Reporter) systemd.Systemd {
+		return &systemdtest.FakeSystemd{}
+	})
+	defer restoreSysd()
 
 	mountInfoContent := fmt.Sprintf("36 1 8:1 / %s rw - ext4 /dev/sda1 rw\n", mountPath)
 	restoreMI := osutil.MockMountInfo(mountInfoContent)

--- a/overlord/snapstate/backend/snapdata.go
+++ b/overlord/snapstate/backend/snapdata.go
@@ -160,17 +160,20 @@ func removeDirs(dirs []string) error {
 	return nil
 }
 
-// snapDataDirs returns the list of base data directories for the given snap.
+// snapBaseDataDirs returns the list of base data directories for the given snap.
 func snapBaseDataDirs(snapName string, opts *dirs.SnapDirOptions) ([]string, error) {
-	// collect the directories, homes first
+	// collect the directories, homes first — only for verified users
+	users, err := allUsers(opts)
+	if err != nil {
+		return nil, err
+	}
 	var found []string
-
-	for _, entry := range snap.BaseDataHomeDirs(snapName, opts) {
-		entryPaths, err := filepath.Glob(entry)
-		if err != nil {
-			return nil, err
+	for _, usr := range users {
+		if usr.Uid == "0" {
+			// root is ordered explicitly below
+			continue
 		}
-		found = append(found, entryPaths...)
+		found = append(found, snap.UserSnapDir(usr.HomeDir, snapName, opts))
 	}
 
 	// then the /root user (including GlobalRootDir for tests)
@@ -182,52 +185,60 @@ func snapBaseDataDirs(snapName string, opts *dirs.SnapDirOptions) ([]string, err
 }
 
 // snapDataDirs returns the list of data directories for the given snap version
-func snapDataDirs(snap *snap.Info, opts *dirs.SnapDirOptions) ([]string, error) {
-	// collect the directories, homes first
+func snapDataDirs(info *snap.Info, opts *dirs.SnapDirOptions) ([]string, error) {
+	// collect the directories, homes first — only for verified users
+	users, err := allUsers(opts)
+	if err != nil {
+		return nil, err
+	}
 	var found []string
-
-	for _, entry := range snap.DataHomeDirs(opts) {
-		entryPaths, err := filepath.Glob(entry)
-		if err != nil {
-			return nil, err
+	for _, usr := range users {
+		if usr.Uid == "0" {
+			// root is ordered explicitly below
+			continue
 		}
-		found = append(found, entryPaths...)
+		found = append(found, info.UserDataDir(usr.HomeDir, opts))
 	}
 
 	// then the /root user (including GlobalRootDir for tests)
-	found = append(found, snap.UserDataDir(filepath.Join(dirs.GlobalRootDir, "/root/"), opts))
+	found = append(found, info.UserDataDir(filepath.Join(dirs.GlobalRootDir, "/root/"), opts))
 	// then system data
-	found = append(found, snap.DataDir())
+	found = append(found, info.DataDir())
 
 	return found, nil
 }
 
 // snapCommonDataDirs returns the list of data directories common between versions of the given snap
-func snapCommonDataDirs(snap *snap.Info, opts *dirs.SnapDirOptions) ([]string, error) {
-	// collect the directories, homes first
-	var found []string
-
-	for _, entry := range snap.CommonDataHomeDirs(opts) {
-		entryPaths, err := filepath.Glob(entry)
-		if err != nil {
-			return nil, err
-		}
-		found = append(found, entryPaths...)
-	}
-
-	// then the root user's common data dir
-	rootCommon := snap.UserCommonDataDir(filepath.Join(dirs.GlobalRootDir, "/root/"), opts)
-	found = append(found, rootCommon)
-
-	// then XDG_RUNTIME_DIRs for the users
-	foundXdg, err := filepath.Glob(snap.XdgRuntimeDirs())
+func snapCommonDataDirs(info *snap.Info, opts *dirs.SnapDirOptions) ([]string, error) {
+	// collect the directories, homes first — only for verified users
+	users, err := allUsers(opts)
 	if err != nil {
 		return nil, err
 	}
-	found = append(found, foundXdg...)
+	var found []string
+	for _, usr := range users {
+		if usr.Uid == "0" {
+			// root is ordered explicitly below
+			continue
+		}
+		found = append(found, info.UserCommonDataDir(usr.HomeDir, opts))
+	}
+
+	// then the root user's common data dir
+	rootCommon := info.UserCommonDataDir(filepath.Join(dirs.GlobalRootDir, "/root/"), opts)
+	found = append(found, rootCommon)
+
+	// then XDG_RUNTIME_DIRs for the users
+	for _, usr := range users {
+		uid, _, err := osutil.UidGid(usr)
+		if err != nil {
+			return nil, err
+		}
+		found = append(found, info.UserXdgRuntimeDir(uid))
+	}
 
 	// then system data
-	found = append(found, snap.CommonDataDir())
+	found = append(found, info.CommonDataDir())
 
 	return found, nil
 }

--- a/overlord/snapstate/backend/snapdata.go
+++ b/overlord/snapstate/backend/snapdata.go
@@ -182,6 +182,10 @@ func snapBaseDataDirs(snapName string, opts *dirs.SnapDirOptions) ([]string, err
 			// root is ordered explicitly below
 			continue
 		}
+		// Skip users whose home is inaccessible (e.g. NFS root_squash maps
+		// root to nobody); snap subdirs under it are similarly restricted.
+		// Filtering early avoids spreading EACCES handling across the several
+		// consumers of snap data dir lists (remove, copy, undo etc).
 		if !canAccess(usr.HomeDir) {
 			continue
 		}
@@ -209,6 +213,10 @@ func snapDataDirs(info *snap.Info, opts *dirs.SnapDirOptions) ([]string, error) 
 			// root is ordered explicitly below
 			continue
 		}
+		// Skip users whose home is inaccessible (e.g. NFS root_squash maps
+		// root to nobody); snap subdirs under it are similarly restricted.
+		// Filtering early avoids spreading EACCES handling across the several
+		// consumers of snap data dir lists (remove, copy, undo etc).
 		if !canAccess(usr.HomeDir) {
 			continue
 		}
@@ -236,6 +244,10 @@ func snapCommonDataDirs(info *snap.Info, opts *dirs.SnapDirOptions) ([]string, e
 			// root is ordered explicitly below
 			continue
 		}
+		// Skip users whose home is inaccessible (e.g. NFS root_squash maps
+		// root to nobody); snap subdirs under it are similarly restricted.
+		// Filtering early avoids spreading EACCES handling across the several
+		// consumers of snap data dir lists (remove, copy, undo etc).
 		if !canAccess(usr.HomeDir) {
 			continue
 		}

--- a/overlord/snapstate/backend/snapdata.go
+++ b/overlord/snapstate/backend/snapdata.go
@@ -25,7 +25,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	unix "syscall"
+
+	"golang.org/x/sys/unix"
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/logger"
@@ -160,6 +161,14 @@ func removeDirs(dirs []string) error {
 	return nil
 }
 
+// canAccess reports whether the process is not denied access to dir.
+// unix.Access uses the real UID, so on NFS with root_squash it correctly
+// reflects the nobody mapping.
+func canAccess(dir string) bool {
+	err := unix.Access(dir, unix.R_OK|unix.W_OK|unix.X_OK)
+	return !errors.Is(err, unix.EACCES)
+}
+
 // snapBaseDataDirs returns the list of base data directories for the given snap.
 func snapBaseDataDirs(snapName string, opts *dirs.SnapDirOptions) ([]string, error) {
 	// collect the directories, homes first — only for verified users
@@ -171,6 +180,9 @@ func snapBaseDataDirs(snapName string, opts *dirs.SnapDirOptions) ([]string, err
 	for _, usr := range users {
 		if usr.Uid == "0" {
 			// root is ordered explicitly below
+			continue
+		}
+		if !canAccess(usr.HomeDir) {
 			continue
 		}
 		found = append(found, snap.UserSnapDir(usr.HomeDir, snapName, opts))
@@ -197,6 +209,9 @@ func snapDataDirs(info *snap.Info, opts *dirs.SnapDirOptions) ([]string, error) 
 			// root is ordered explicitly below
 			continue
 		}
+		if !canAccess(usr.HomeDir) {
+			continue
+		}
 		found = append(found, info.UserDataDir(usr.HomeDir, opts))
 	}
 
@@ -219,6 +234,9 @@ func snapCommonDataDirs(info *snap.Info, opts *dirs.SnapDirOptions) ([]string, e
 	for _, usr := range users {
 		if usr.Uid == "0" {
 			// root is ordered explicitly below
+			continue
+		}
+		if !canAccess(usr.HomeDir) {
 			continue
 		}
 		found = append(found, info.UserCommonDataDir(usr.HomeDir, opts))

--- a/overlord/snapstate/backend/snapdata.go
+++ b/overlord/snapstate/backend/snapdata.go
@@ -161,11 +161,12 @@ func removeDirs(dirs []string) error {
 	return nil
 }
 
-// canAccess reports whether the process is not denied access to dir.
+// canAccessSnapDir reports whether the process is not denied access to user snap dir.
 // unix.Access uses the real UID, so on NFS with root_squash it correctly
 // reflects the nobody mapping.
-func canAccess(dir string) bool {
-	err := unix.Access(dir, unix.R_OK|unix.W_OK|unix.X_OK)
+func canAccessSnapDir(homeDir string, opts *dirs.SnapDirOptions) bool {
+	snapDir := snap.SnapDir(homeDir, opts)
+	err := unix.Access(snapDir, unix.R_OK|unix.W_OK|unix.X_OK)
 	return !errors.Is(err, unix.EACCES)
 }
 
@@ -182,11 +183,11 @@ func snapBaseDataDirs(snapName string, opts *dirs.SnapDirOptions) ([]string, err
 			// root is ordered explicitly below
 			continue
 		}
-		// Skip users whose home is inaccessible (e.g. NFS root_squash maps
+		// Skip users whose snap dir is inaccessible (e.g. NFS root_squash maps
 		// root to nobody); snap subdirs under it are similarly restricted.
 		// Filtering early avoids spreading EACCES handling across the several
 		// consumers of snap data dir lists (remove, copy, undo etc).
-		if !canAccess(usr.HomeDir) {
+		if !canAccessSnapDir(usr.HomeDir, opts) {
 			continue
 		}
 		found = append(found, snap.UserSnapDir(usr.HomeDir, snapName, opts))
@@ -213,11 +214,11 @@ func snapDataDirs(info *snap.Info, opts *dirs.SnapDirOptions) ([]string, error) 
 			// root is ordered explicitly below
 			continue
 		}
-		// Skip users whose home is inaccessible (e.g. NFS root_squash maps
+		// Skip users whose snap dir is inaccessible (e.g. NFS root_squash maps
 		// root to nobody); snap subdirs under it are similarly restricted.
 		// Filtering early avoids spreading EACCES handling across the several
 		// consumers of snap data dir lists (remove, copy, undo etc).
-		if !canAccess(usr.HomeDir) {
+		if !canAccessSnapDir(usr.HomeDir, opts) {
 			continue
 		}
 		found = append(found, info.UserDataDir(usr.HomeDir, opts))
@@ -244,11 +245,11 @@ func snapCommonDataDirs(info *snap.Info, opts *dirs.SnapDirOptions) ([]string, e
 			// root is ordered explicitly below
 			continue
 		}
-		// Skip users whose home is inaccessible (e.g. NFS root_squash maps
+		// Skip users whose snap dir is inaccessible (e.g. NFS root_squash maps
 		// root to nobody); snap subdirs under it are similarly restricted.
 		// Filtering early avoids spreading EACCES handling across the several
 		// consumers of snap data dir lists (remove, copy, undo etc).
-		if !canAccess(usr.HomeDir) {
+		if !canAccessSnapDir(usr.HomeDir, opts) {
 			continue
 		}
 		found = append(found, info.UserCommonDataDir(usr.HomeDir, opts))

--- a/overlord/snapstate/backend/snapdata_test.go
+++ b/overlord/snapstate/backend/snapdata_test.go
@@ -20,6 +20,7 @@
 package backend_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -28,6 +29,7 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/user"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
@@ -50,12 +52,17 @@ func (s *snapdataSuite) TearDownTest(c *C) {
 }
 
 func (s *snapdataSuite) TestRemoveSnapData(c *C) {
-	dirs.SetSnapHomeDirs("/home")
-	homedir := filepath.Join(dirs.GlobalRootDir, "home", "user1", "snap")
-	homeData := filepath.Join(homedir, "hello/10")
+	homedir := filepath.Join(dirs.GlobalRootDir, "home", "user1")
+	usr := &user.User{Uid: "1000", HomeDir: homedir}
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return []*user.User{usr}, nil
+	})
+	defer restore()
+
+	homeData := filepath.Join(homedir, "snap", "hello", "10")
 	err := os.MkdirAll(homeData, 0755)
 	c.Assert(err, IsNil)
-	varData := filepath.Join(dirs.SnapDataDir, "hello/10")
+	varData := filepath.Join(dirs.SnapDataDir, "hello", "10")
 	err = os.MkdirAll(varData, 0755)
 	c.Assert(err, IsNil)
 
@@ -69,97 +76,123 @@ func (s *snapdataSuite) TestRemoveSnapData(c *C) {
 	c.Assert(osutil.FileExists(filepath.Dir(varData)), Equals, true)
 }
 
-// same as TestRemoveSnapData but with multiple homedirs
+// same as TestRemoveSnapData but with multiple users in different homedirs
 func (s *snapdataSuite) TestRemoveSnapDataMulti(c *C) {
-	homeDirs := []string{filepath.Join(dirs.GlobalRootDir, "home"),
-		filepath.Join(dirs.GlobalRootDir, "home", "company"),
-		filepath.Join(dirs.GlobalRootDir, "home", "department"),
-		filepath.Join(dirs.GlobalRootDir, "office")}
+	userHomes := []string{
+		filepath.Join(dirs.GlobalRootDir, "home", "user1"),
+		filepath.Join(dirs.GlobalRootDir, "home", "company", "user2"),
+		filepath.Join(dirs.GlobalRootDir, "home", "department", "user3"),
+		filepath.Join(dirs.GlobalRootDir, "office", "user4"),
+	}
+	var users []*user.User
+	for i, home := range userHomes {
+		users = append(users, &user.User{
+			Uid:     fmt.Sprintf("%d", 1000+i),
+			HomeDir: home,
+		})
+	}
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return users, nil
+	})
+	defer restore()
 
-	dirs.SetSnapHomeDirs(strings.Join(homeDirs, ","))
-	snapHomeDataDirs := []string{}
-
-	for _, v := range homeDirs {
-		snapHomeDir := filepath.Join(v, "user1", "snap")
-		snapHomeData := filepath.Join(snapHomeDir, "hello/10")
+	snapHomeDataDirs := make([]string, 0, len(userHomes))
+	for _, home := range userHomes {
+		snapHomeData := filepath.Join(home, "snap", "hello", "10")
 		err := os.MkdirAll(snapHomeData, 0755)
 		c.Assert(err, IsNil)
 		snapHomeDataDirs = append(snapHomeDataDirs, snapHomeData)
 	}
 
-	varData := filepath.Join(dirs.SnapDataDir, "hello/10")
+	varData := filepath.Join(dirs.SnapDataDir, "hello", "10")
 	err := os.MkdirAll(varData, 0755)
 	c.Assert(err, IsNil)
 	info := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
 	err = s.be.RemoveSnapData(info, nil)
+	c.Assert(err, IsNil)
 
 	for _, v := range snapHomeDataDirs {
-		c.Assert(err, IsNil)
 		c.Assert(osutil.FileExists(v), Equals, false)
 		c.Assert(osutil.FileExists(filepath.Dir(v)), Equals, true)
-
 	}
-
 	c.Assert(osutil.FileExists(varData), Equals, false)
 	c.Assert(osutil.FileExists(filepath.Dir(varData)), Equals, true)
 }
 
 func (s *snapdataSuite) TestSnapDataDirs(c *C) {
-	homeDir1 := filepath.Join("home", "users")
-	homeDir2 := filepath.Join("remote", "users")
-	homeDirs := homeDir1 + "," + homeDir2
-	dirs.SetSnapHomeDirs(homeDirs)
-	dataHomeDirs := []string{filepath.Join(dirs.GlobalRootDir, homeDir1, "user1", "snap", "hello", "10"),
-		filepath.Join(dirs.GlobalRootDir, homeDir1, "user2", "snap", "hello", "10"),
-		filepath.Join(dirs.GlobalRootDir, homeDir2, "user3", "snap", "hello", "10"),
-		filepath.Join(dirs.GlobalRootDir, homeDir2, "user4", "snap", "hello", "10"),
-		filepath.Join(dirs.GlobalRootDir, "root", "snap", "hello", "10"),
-		filepath.Join(dirs.GlobalRootDir, "var", "snap", "hello", "10")}
-	for _, path := range dataHomeDirs {
-		err := os.MkdirAll(path, 0755)
-		c.Assert(err, IsNil)
-	}
+	homeDir1 := filepath.Join(dirs.GlobalRootDir, "home", "users")
+	homeDir2 := filepath.Join(dirs.GlobalRootDir, "remote", "users")
+
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return []*user.User{
+			{Uid: "0", HomeDir: filepath.Join(dirs.GlobalRootDir, "/root")},
+			{Uid: "1001", HomeDir: filepath.Join(homeDir1, "user1")},
+			{Uid: "1002", HomeDir: filepath.Join(homeDir1, "user2")},
+			{Uid: "1003", HomeDir: filepath.Join(homeDir2, "user3")},
+			{Uid: "1004", HomeDir: filepath.Join(homeDir2, "user4")},
+		}, nil
+	})
+	defer restore()
 
 	info := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
-	snapDataDirs, err := backend.SnapDataDirs(info, nil)
+	result, err := backend.SnapDataDirs(info, nil)
 	c.Assert(err, IsNil)
-	c.Check(snapDataDirs, DeepEquals, dataHomeDirs)
+	c.Check(result, DeepEquals, []string{
+		filepath.Join(homeDir1, "user1", "snap", "hello", "10"),
+		filepath.Join(homeDir1, "user2", "snap", "hello", "10"),
+		filepath.Join(homeDir2, "user3", "snap", "hello", "10"),
+		filepath.Join(homeDir2, "user4", "snap", "hello", "10"),
+		filepath.Join(dirs.GlobalRootDir, "root", "snap", "hello", "10"),
+		filepath.Join(dirs.SnapDataDir, "hello", "10"),
+	})
 }
 
 func (s *snapdataSuite) TestSnapCommonDataDirs(c *C) {
 	homeDir1 := filepath.Join(dirs.GlobalRootDir, "home", "users")
 	homeDir2 := filepath.Join(dirs.GlobalRootDir, "remote", "users")
-	homeDirs := homeDir1 + "," + homeDir2
-	dirs.SetSnapHomeDirs(homeDirs)
-	dataHomeDirs := []string{filepath.Join(homeDir1, "user1", "snap", "hello", "common"), filepath.Join(homeDir1, "user2", "snap", "hello", "common"),
-		filepath.Join(homeDir2, "user3", "snap", "hello", "common"), filepath.Join(homeDir2, "user4", "snap", "hello", "common"),
-		filepath.Join(dirs.GlobalRootDir, "root", "snap", "hello", "common"), filepath.Join(dirs.GlobalRootDir, "var", "snap", "hello", "common")}
-	for _, path := range dataHomeDirs {
-		err := os.MkdirAll(path, 0755)
-		c.Assert(err, IsNil)
-	}
+
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return []*user.User{
+			{Uid: "0", Gid: "0", HomeDir: filepath.Join(dirs.GlobalRootDir, "/root")},
+			{Uid: "1001", Gid: "1001", HomeDir: filepath.Join(homeDir1, "user1")},
+			{Uid: "1002", Gid: "1002", HomeDir: filepath.Join(homeDir2, "user2")},
+		}, nil
+	})
+	defer restore()
 
 	info := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
-	snapCommonDataDirs, err := backend.SnapCommonDataDirs(info, nil)
+	result, err := backend.SnapCommonDataDirs(info, nil)
 	c.Assert(err, IsNil)
-	c.Check(snapCommonDataDirs, DeepEquals, dataHomeDirs)
+	// order: home common dirs, root common dir, XDG runtime dirs (all users incl. root), system common dir
+	c.Check(result, DeepEquals, []string{
+		filepath.Join(homeDir1, "user1", "snap", "hello", "common"),
+		filepath.Join(homeDir2, "user2", "snap", "hello", "common"),
+		filepath.Join(dirs.GlobalRootDir, "root", "snap", "hello", "common"),
+		filepath.Join(dirs.XdgRuntimeDirBase, "0", "snap.hello"),
+		filepath.Join(dirs.XdgRuntimeDirBase, "1001", "snap.hello"),
+		filepath.Join(dirs.XdgRuntimeDirBase, "1002", "snap.hello"),
+		filepath.Join(dirs.SnapDataDir, "hello", "common"),
+	})
 }
 
 func (s *snapdataSuite) TestRemoveSnapCommonData(c *C) {
-	dirs.SetSnapHomeDirs("/home")
-	homedir := filepath.Join(dirs.GlobalRootDir, "home", "user1", "snap")
-	homeCommonData := filepath.Join(homedir, "hello/common")
+	homedir := filepath.Join(dirs.GlobalRootDir, "home", "user1")
+	usr := &user.User{Uid: "1000", Gid: "1000", HomeDir: homedir}
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return []*user.User{usr}, nil
+	})
+	defer restore()
+
+	homeCommonData := filepath.Join(homedir, "snap", "hello", "common")
 	err := os.MkdirAll(homeCommonData, 0755)
 	c.Assert(err, IsNil)
-	varCommonData := filepath.Join(dirs.SnapDataDir, "hello/common")
+	varCommonData := filepath.Join(dirs.SnapDataDir, "hello", "common")
 	err = os.MkdirAll(varCommonData, 0755)
 	c.Assert(err, IsNil)
-
 	rootCommonDir := filepath.Join(dirs.GlobalRootDir, "root", "snap", "hello", "common")
 	c.Assert(os.MkdirAll(rootCommonDir, 0700), IsNil)
 
 	info := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
-
 	err = s.be.RemoveSnapCommonData(info, nil)
 	c.Assert(err, IsNil)
 	c.Assert(osutil.FileExists(homeCommonData), Equals, false)
@@ -207,18 +240,30 @@ func (s *snapdataSuite) testRemoveSnapDataDir(c *C, hasOtherInstances bool, opts
 	// root + user home data dirs
 	homeDir1 := filepath.Join(dirs.GlobalRootDir, "home", "users")
 	homeDir2 := filepath.Join(dirs.GlobalRootDir, "remote", "users")
-	homeDirs := homeDir1 + "," + homeDir2
-	dirs.SetSnapHomeDirs(homeDirs)
-	snapDataDirs := []string{
+	userHomes := []string{
 		filepath.Join(homeDir1, "user1"),
 		filepath.Join(homeDir1, "user2"),
 		filepath.Join(homeDir2, "user3"),
 		filepath.Join(homeDir2, "user4"),
-		filepath.Join(dirs.GlobalRootDir, "root"),
 	}
-	for _, dir := range snapDataDirs {
-		baseDataDirs = append(baseDataDirs, filepath.Join(dir, snapHomeDir, "hello"))
-		baseDataInstanceDirs = append(baseDataInstanceDirs, filepath.Join(dir, snapHomeDir, "hello_instance"))
+	rootHome := filepath.Join(dirs.GlobalRootDir, "root")
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		users := []*user.User{
+			{Uid: "0", HomeDir: rootHome},
+		}
+		for i, home := range userHomes {
+			users = append(users, &user.User{
+				Uid:     fmt.Sprintf("%d", 1001+i),
+				HomeDir: home,
+			})
+		}
+		return users, nil
+	})
+	defer restore()
+
+	for _, home := range append(userHomes, rootHome) {
+		baseDataDirs = append(baseDataDirs, filepath.Join(home, snapHomeDir, "hello"))
+		baseDataInstanceDirs = append(baseDataInstanceDirs, filepath.Join(home, snapHomeDir, "hello_instance"))
 	}
 
 	// create all base directories
@@ -294,7 +339,14 @@ func (s *snapdataSuite) TestRemoveSnapDataDirWithHiddenDataDirNoOtherInstances(c
 }
 
 func (s *snapdataSuite) TestRemoveSnapDataDirWithUnexpectedFiles(c *C) {
-	baseDataDir := filepath.Join(dirs.GlobalRootDir, "home", "users", "snap", "hello")
+	homedir := filepath.Join(dirs.GlobalRootDir, "home", "users")
+	usr := &user.User{Uid: "1000", HomeDir: homedir}
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return []*user.User{usr}, nil
+	})
+	defer restore()
+
+	baseDataDir := filepath.Join(homedir, "snap", "hello")
 	c.Assert(os.MkdirAll(baseDataDir, 0755), IsNil)
 	// expected current symlink
 	dataCurrentSymlink := filepath.Join(baseDataDir, "current")
@@ -308,7 +360,15 @@ func (s *snapdataSuite) TestRemoveSnapDataDirWithUnexpectedFiles(c *C) {
 }
 
 func (s *snapdataSuite) TestRemoveSnapDataDirEnotemptyWithReadDirError(c *C) {
-	baseDataDir := filepath.Join(dirs.GlobalRootDir, "home", "users", "snap", "hello")
+	homeDir := filepath.Join(dirs.GlobalRootDir, "home", "users")
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return []*user.User{
+			{Uid: "1000", HomeDir: homeDir},
+		}, nil
+	})
+	defer restore()
+
+	baseDataDir := filepath.Join(homeDir, "snap", "hello")
 	c.Assert(os.MkdirAll(baseDataDir, 0755), IsNil)
 	// unexpected folder to make removal fail with ENOTEMPTY
 	c.Assert(os.Mkdir(filepath.Join(baseDataDir, "unexpected"), 0755), IsNil)
@@ -323,7 +383,15 @@ func (s *snapdataSuite) TestRemoveSnapDataDirEnotemptyWithReadDirError(c *C) {
 }
 
 func (s *snapdataSuite) TestRemoveSnapDataDirErrorNotEnotempty(c *C) {
-	parentDir := filepath.Join(dirs.GlobalRootDir, "home", "users", "snap")
+	homeDir := filepath.Join(dirs.GlobalRootDir, "home", "users")
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return []*user.User{
+			{Uid: "1000", HomeDir: homeDir},
+		}, nil
+	})
+	defer restore()
+
+	parentDir := filepath.Join(homeDir, "snap")
 	baseDataDir := filepath.Join(parentDir, "hello")
 	c.Assert(os.MkdirAll(baseDataDir, 0755), IsNil)
 	// make parent non-writable so removal fails with EACCES, not ENOTEMPTY;
@@ -337,7 +405,15 @@ func (s *snapdataSuite) TestRemoveSnapDataDirErrorNotEnotempty(c *C) {
 }
 
 func (s *snapdataSuite) TestRemoveSnapDataDirCurrentSymlinkRemovalFails(c *C) {
-	baseDataDir := filepath.Join(dirs.GlobalRootDir, "home", "users", "snap", "hello")
+	homeDir := filepath.Join(dirs.GlobalRootDir, "home", "users")
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return []*user.User{
+			{Uid: "1000", HomeDir: homeDir},
+		}, nil
+	})
+	defer restore()
+
+	baseDataDir := filepath.Join(homeDir, "snap", "hello")
 	c.Assert(os.MkdirAll(baseDataDir, 0755), IsNil)
 	// create the current symlink
 	c.Assert(os.Symlink("10", filepath.Join(baseDataDir, "current")), IsNil)
@@ -349,4 +425,85 @@ func (s *snapdataSuite) TestRemoveSnapDataDirCurrentSymlinkRemovalFails(c *C) {
 	info := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
 	err := s.be.RemoveSnapDataDir(info, false, nil)
 	c.Assert(err, ErrorMatches, `failed to remove snap "hello" base directory: remove .*/home/users/snap/hello/current: permission denied`)
+}
+
+// TestRemoveSnapDataSkipsNonUserDir verifies that directories that look like
+// home dirs but don't belong to any real user are not removed.
+func (s *snapdataSuite) TestRemoveSnapDataSkipsNonUserDir(c *C) {
+	realHomeDir := filepath.Join(dirs.GlobalRootDir, "home", "real-user")
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return []*user.User{
+			{Uid: "1000", HomeDir: realHomeDir},
+		}, nil
+	})
+	defer restore()
+
+	// Create data for the real user
+	realData := filepath.Join(realHomeDir, "snap", "hello", "10")
+	c.Assert(os.MkdirAll(realData, 0755), IsNil)
+
+	// Create data under a directory that looks like a home dir but isn't a real user
+	nonUserData := filepath.Join(dirs.GlobalRootDir, "home", "build-artifact", "snap", "hello", "10")
+	c.Assert(os.MkdirAll(nonUserData, 0755), IsNil)
+
+	info := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
+	err := s.be.RemoveSnapData(info, nil)
+	c.Assert(err, IsNil)
+
+	// Real user's data is removed
+	c.Assert(osutil.FileExists(realData), Equals, false)
+	// Non-user directory is NOT removed
+	c.Assert(osutil.FileExists(nonUserData), Equals, true)
+}
+
+// TestSnapDataDirsAllUsersError verifies that errors from allUsers() are propagated.
+func (s *snapdataSuite) TestSnapDataDirsAllUsersError(c *C) {
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return nil, fmt.Errorf("mock AllUsers error")
+	})
+	defer restore()
+
+	info := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
+	_, err := backend.SnapDataDirs(info, nil)
+	c.Assert(err, ErrorMatches, "mock AllUsers error")
+}
+
+// TestSnapCommonDataDirsAllUsersError verifies that errors from allUsers() are propagated.
+func (s *snapdataSuite) TestSnapCommonDataDirsAllUsersError(c *C) {
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return nil, fmt.Errorf("mock AllUsers error")
+	})
+	defer restore()
+
+	info := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
+	_, err := backend.SnapCommonDataDirs(info, nil)
+	c.Assert(err, ErrorMatches, "mock AllUsers error")
+}
+
+// TestRemoveSnapDataDirAllUsersError verifies that errors from allUsers() are
+// propagated when removing the snap base data directory.
+func (s *snapdataSuite) TestRemoveSnapDataDirAllUsersError(c *C) {
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return nil, fmt.Errorf("mock AllUsers error")
+	})
+	defer restore()
+
+	info := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
+	err := s.be.RemoveSnapDataDir(info, false, nil)
+	c.Assert(err, ErrorMatches, "mock AllUsers error")
+}
+
+// TestSnapCommonDataDirsInvalidUid verifies that a non-numeric UID returned by
+// allUsers() causes an error when building the XDG runtime directory list.
+func (s *snapdataSuite) TestSnapCommonDataDirsInvalidUid(c *C) {
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return []*user.User{
+			{Uid: "not-a-uid", Gid: "0", HomeDir: filepath.Join(dirs.GlobalRootDir, "home", "user1")},
+		}, nil
+	})
+	defer restore()
+
+	info := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
+	_, err := backend.SnapCommonDataDirs(info, nil)
+	c.Assert(err, ErrorMatches, `cannot parse user id not-a-uid: .*`)
 }

--- a/overlord/snapstate/backend/snapdata_test.go
+++ b/overlord/snapstate/backend/snapdata_test.go
@@ -20,6 +20,7 @@
 package backend_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -28,6 +29,7 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/user"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
@@ -50,12 +52,17 @@ func (s *snapdataSuite) TearDownTest(c *C) {
 }
 
 func (s *snapdataSuite) TestRemoveSnapData(c *C) {
-	dirs.SetSnapHomeDirs("/home")
-	homedir := filepath.Join(dirs.GlobalRootDir, "home", "user1", "snap")
-	homeData := filepath.Join(homedir, "hello/10")
+	homedir := filepath.Join(dirs.GlobalRootDir, "home", "user1")
+	usr := &user.User{Uid: "1000", HomeDir: homedir}
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return []*user.User{usr}, nil
+	})
+	defer restore()
+
+	homeData := filepath.Join(homedir, "snap", "hello", "10")
 	err := os.MkdirAll(homeData, 0755)
 	c.Assert(err, IsNil)
-	varData := filepath.Join(dirs.SnapDataDir, "hello/10")
+	varData := filepath.Join(dirs.SnapDataDir, "hello", "10")
 	err = os.MkdirAll(varData, 0755)
 	c.Assert(err, IsNil)
 
@@ -69,97 +76,123 @@ func (s *snapdataSuite) TestRemoveSnapData(c *C) {
 	c.Assert(osutil.FileExists(filepath.Dir(varData)), Equals, true)
 }
 
-// same as TestRemoveSnapData but with multiple homedirs
+// same as TestRemoveSnapData but with multiple users in different homedirs
 func (s *snapdataSuite) TestRemoveSnapDataMulti(c *C) {
-	homeDirs := []string{filepath.Join(dirs.GlobalRootDir, "home"),
-		filepath.Join(dirs.GlobalRootDir, "home", "company"),
-		filepath.Join(dirs.GlobalRootDir, "home", "department"),
-		filepath.Join(dirs.GlobalRootDir, "office")}
+	userHomes := []string{
+		filepath.Join(dirs.GlobalRootDir, "home", "user1"),
+		filepath.Join(dirs.GlobalRootDir, "home", "company", "user2"),
+		filepath.Join(dirs.GlobalRootDir, "home", "department", "user3"),
+		filepath.Join(dirs.GlobalRootDir, "office", "user4"),
+	}
+	var users []*user.User
+	for i, home := range userHomes {
+		users = append(users, &user.User{
+			Uid:     fmt.Sprintf("%d", 1000+i),
+			HomeDir: home,
+		})
+	}
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return users, nil
+	})
+	defer restore()
 
-	dirs.SetSnapHomeDirs(strings.Join(homeDirs, ","))
-	snapHomeDataDirs := []string{}
-
-	for _, v := range homeDirs {
-		snapHomeDir := filepath.Join(v, "user1", "snap")
-		snapHomeData := filepath.Join(snapHomeDir, "hello/10")
+	snapHomeDataDirs := make([]string, 0, len(userHomes))
+	for _, home := range userHomes {
+		snapHomeData := filepath.Join(home, "snap", "hello", "10")
 		err := os.MkdirAll(snapHomeData, 0755)
 		c.Assert(err, IsNil)
 		snapHomeDataDirs = append(snapHomeDataDirs, snapHomeData)
 	}
 
-	varData := filepath.Join(dirs.SnapDataDir, "hello/10")
+	varData := filepath.Join(dirs.SnapDataDir, "hello", "10")
 	err := os.MkdirAll(varData, 0755)
 	c.Assert(err, IsNil)
 	info := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
 	err = s.be.RemoveSnapData(info, nil)
+	c.Assert(err, IsNil)
 
 	for _, v := range snapHomeDataDirs {
-		c.Assert(err, IsNil)
 		c.Assert(osutil.FileExists(v), Equals, false)
 		c.Assert(osutil.FileExists(filepath.Dir(v)), Equals, true)
-
 	}
-
 	c.Assert(osutil.FileExists(varData), Equals, false)
 	c.Assert(osutil.FileExists(filepath.Dir(varData)), Equals, true)
 }
 
 func (s *snapdataSuite) TestSnapDataDirs(c *C) {
-	homeDir1 := filepath.Join("home", "users")
-	homeDir2 := filepath.Join("remote", "users")
-	homeDirs := homeDir1 + "," + homeDir2
-	dirs.SetSnapHomeDirs(homeDirs)
-	dataHomeDirs := []string{filepath.Join(dirs.GlobalRootDir, homeDir1, "user1", "snap", "hello", "10"),
-		filepath.Join(dirs.GlobalRootDir, homeDir1, "user2", "snap", "hello", "10"),
-		filepath.Join(dirs.GlobalRootDir, homeDir2, "user3", "snap", "hello", "10"),
-		filepath.Join(dirs.GlobalRootDir, homeDir2, "user4", "snap", "hello", "10"),
-		filepath.Join(dirs.GlobalRootDir, "root", "snap", "hello", "10"),
-		filepath.Join(dirs.GlobalRootDir, "var", "snap", "hello", "10")}
-	for _, path := range dataHomeDirs {
-		err := os.MkdirAll(path, 0755)
-		c.Assert(err, IsNil)
-	}
+	homeDir1 := filepath.Join(dirs.GlobalRootDir, "home", "users")
+	homeDir2 := filepath.Join(dirs.GlobalRootDir, "remote", "users")
+
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return []*user.User{
+			{Uid: "0", HomeDir: filepath.Join(dirs.GlobalRootDir, "/root")},
+			{Uid: "1001", HomeDir: filepath.Join(homeDir1, "user1")},
+			{Uid: "1002", HomeDir: filepath.Join(homeDir1, "user2")},
+			{Uid: "1003", HomeDir: filepath.Join(homeDir2, "user3")},
+			{Uid: "1004", HomeDir: filepath.Join(homeDir2, "user4")},
+		}, nil
+	})
+	defer restore()
 
 	info := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
-	snapDataDirs, err := backend.SnapDataDirs(info, nil)
+	result, err := backend.SnapDataDirs(info, nil)
 	c.Assert(err, IsNil)
-	c.Check(snapDataDirs, DeepEquals, dataHomeDirs)
+	c.Check(result, DeepEquals, []string{
+		filepath.Join(homeDir1, "user1", "snap", "hello", "10"),
+		filepath.Join(homeDir1, "user2", "snap", "hello", "10"),
+		filepath.Join(homeDir2, "user3", "snap", "hello", "10"),
+		filepath.Join(homeDir2, "user4", "snap", "hello", "10"),
+		filepath.Join(dirs.GlobalRootDir, "root", "snap", "hello", "10"),
+		filepath.Join(dirs.SnapDataDir, "hello", "10"),
+	})
 }
 
 func (s *snapdataSuite) TestSnapCommonDataDirs(c *C) {
 	homeDir1 := filepath.Join(dirs.GlobalRootDir, "home", "users")
 	homeDir2 := filepath.Join(dirs.GlobalRootDir, "remote", "users")
-	homeDirs := homeDir1 + "," + homeDir2
-	dirs.SetSnapHomeDirs(homeDirs)
-	dataHomeDirs := []string{filepath.Join(homeDir1, "user1", "snap", "hello", "common"), filepath.Join(homeDir1, "user2", "snap", "hello", "common"),
-		filepath.Join(homeDir2, "user3", "snap", "hello", "common"), filepath.Join(homeDir2, "user4", "snap", "hello", "common"),
-		filepath.Join(dirs.GlobalRootDir, "root", "snap", "hello", "common"), filepath.Join(dirs.GlobalRootDir, "var", "snap", "hello", "common")}
-	for _, path := range dataHomeDirs {
-		err := os.MkdirAll(path, 0755)
-		c.Assert(err, IsNil)
-	}
+
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return []*user.User{
+			{Uid: "0", Gid: "0", HomeDir: filepath.Join(dirs.GlobalRootDir, "/root")},
+			{Uid: "1001", Gid: "1001", HomeDir: filepath.Join(homeDir1, "user1")},
+			{Uid: "1002", Gid: "1002", HomeDir: filepath.Join(homeDir2, "user2")},
+		}, nil
+	})
+	defer restore()
 
 	info := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
-	snapCommonDataDirs, err := backend.SnapCommonDataDirs(info, nil)
+	result, err := backend.SnapCommonDataDirs(info, nil)
 	c.Assert(err, IsNil)
-	c.Check(snapCommonDataDirs, DeepEquals, dataHomeDirs)
+	// order: home common dirs, root common dir, XDG runtime dirs (all users incl. root), system common dir
+	c.Check(result, DeepEquals, []string{
+		filepath.Join(homeDir1, "user1", "snap", "hello", "common"),
+		filepath.Join(homeDir2, "user2", "snap", "hello", "common"),
+		filepath.Join(dirs.GlobalRootDir, "root", "snap", "hello", "common"),
+		filepath.Join(dirs.XdgRuntimeDirBase, "0", "snap.hello"),
+		filepath.Join(dirs.XdgRuntimeDirBase, "1001", "snap.hello"),
+		filepath.Join(dirs.XdgRuntimeDirBase, "1002", "snap.hello"),
+		filepath.Join(dirs.SnapDataDir, "hello", "common"),
+	})
 }
 
 func (s *snapdataSuite) TestRemoveSnapCommonData(c *C) {
-	dirs.SetSnapHomeDirs("/home")
-	homedir := filepath.Join(dirs.GlobalRootDir, "home", "user1", "snap")
-	homeCommonData := filepath.Join(homedir, "hello/common")
+	homedir := filepath.Join(dirs.GlobalRootDir, "home", "user1")
+	usr := &user.User{Uid: "1000", Gid: "1000", HomeDir: homedir}
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return []*user.User{usr}, nil
+	})
+	defer restore()
+
+	homeCommonData := filepath.Join(homedir, "snap", "hello", "common")
 	err := os.MkdirAll(homeCommonData, 0755)
 	c.Assert(err, IsNil)
-	varCommonData := filepath.Join(dirs.SnapDataDir, "hello/common")
+	varCommonData := filepath.Join(dirs.SnapDataDir, "hello", "common")
 	err = os.MkdirAll(varCommonData, 0755)
 	c.Assert(err, IsNil)
-
 	rootCommonDir := filepath.Join(dirs.GlobalRootDir, "root", "snap", "hello", "common")
 	c.Assert(os.MkdirAll(rootCommonDir, 0700), IsNil)
 
 	info := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
-
 	err = s.be.RemoveSnapCommonData(info, nil)
 	c.Assert(err, IsNil)
 	c.Assert(osutil.FileExists(homeCommonData), Equals, false)
@@ -207,18 +240,30 @@ func (s *snapdataSuite) testRemoveSnapDataDir(c *C, hasOtherInstances bool, opts
 	// root + user home data dirs
 	homeDir1 := filepath.Join(dirs.GlobalRootDir, "home", "users")
 	homeDir2 := filepath.Join(dirs.GlobalRootDir, "remote", "users")
-	homeDirs := homeDir1 + "," + homeDir2
-	dirs.SetSnapHomeDirs(homeDirs)
-	snapDataDirs := []string{
+	userHomes := []string{
 		filepath.Join(homeDir1, "user1"),
 		filepath.Join(homeDir1, "user2"),
 		filepath.Join(homeDir2, "user3"),
 		filepath.Join(homeDir2, "user4"),
-		filepath.Join(dirs.GlobalRootDir, "root"),
 	}
-	for _, dir := range snapDataDirs {
-		baseDataDirs = append(baseDataDirs, filepath.Join(dir, snapHomeDir, "hello"))
-		baseDataInstanceDirs = append(baseDataInstanceDirs, filepath.Join(dir, snapHomeDir, "hello_instance"))
+	rootHome := filepath.Join(dirs.GlobalRootDir, "root")
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		users := []*user.User{
+			{Uid: "0", HomeDir: rootHome},
+		}
+		for i, home := range userHomes {
+			users = append(users, &user.User{
+				Uid:     fmt.Sprintf("%d", 1001+i),
+				HomeDir: home,
+			})
+		}
+		return users, nil
+	})
+	defer restore()
+
+	for _, home := range append(userHomes, rootHome) {
+		baseDataDirs = append(baseDataDirs, filepath.Join(home, snapHomeDir, "hello"))
+		baseDataInstanceDirs = append(baseDataInstanceDirs, filepath.Join(home, snapHomeDir, "hello_instance"))
 	}
 
 	// create all base directories
@@ -294,7 +339,14 @@ func (s *snapdataSuite) TestRemoveSnapDataDirWithHiddenDataDirNoOtherInstances(c
 }
 
 func (s *snapdataSuite) TestRemoveSnapDataDirWithUnexpectedFiles(c *C) {
-	baseDataDir := filepath.Join(dirs.GlobalRootDir, "home", "users", "snap", "hello")
+	homedir := filepath.Join(dirs.GlobalRootDir, "home", "users")
+	usr := &user.User{Uid: "1000", HomeDir: homedir}
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return []*user.User{usr}, nil
+	})
+	defer restore()
+
+	baseDataDir := filepath.Join(homedir, "snap", "hello")
 	c.Assert(os.MkdirAll(baseDataDir, 0755), IsNil)
 	// expected current symlink
 	dataCurrentSymlink := filepath.Join(baseDataDir, "current")
@@ -312,7 +364,15 @@ func (s *snapdataSuite) TestRemoveSnapDataDirEnotemptyWithReadDirError(c *C) {
 		c.Skip("this test cannot run as root (root can read directories regardless of mode)")
 	}
 
-	baseDataDir := filepath.Join(dirs.GlobalRootDir, "home", "users", "snap", "hello")
+	homeDir := filepath.Join(dirs.GlobalRootDir, "home", "users")
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return []*user.User{
+			{Uid: "1000", HomeDir: homeDir},
+		}, nil
+	})
+	defer restore()
+
+	baseDataDir := filepath.Join(homeDir, "snap", "hello")
 	c.Assert(os.MkdirAll(baseDataDir, 0755), IsNil)
 	// unexpected folder to make removal fail with ENOTEMPTY
 	c.Assert(os.Mkdir(filepath.Join(baseDataDir, "unexpected"), 0755), IsNil)
@@ -331,7 +391,15 @@ func (s *snapdataSuite) TestRemoveSnapDataDirErrorNotEnotempty(c *C) {
 		c.Skip("this test cannot run as root (root can remove directories from read-only parents)")
 	}
 
-	parentDir := filepath.Join(dirs.GlobalRootDir, "home", "users", "snap")
+	homeDir := filepath.Join(dirs.GlobalRootDir, "home", "users")
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return []*user.User{
+			{Uid: "1000", HomeDir: homeDir},
+		}, nil
+	})
+	defer restore()
+
+	parentDir := filepath.Join(homeDir, "snap")
 	baseDataDir := filepath.Join(parentDir, "hello")
 	c.Assert(os.MkdirAll(baseDataDir, 0755), IsNil)
 	// make parent non-writable so removal fails with EACCES, not ENOTEMPTY;
@@ -349,7 +417,15 @@ func (s *snapdataSuite) TestRemoveSnapDataDirCurrentSymlinkRemovalFails(c *C) {
 		c.Skip("this test cannot run as root (root can remove files from read-only directories)")
 	}
 
-	baseDataDir := filepath.Join(dirs.GlobalRootDir, "home", "users", "snap", "hello")
+	homeDir := filepath.Join(dirs.GlobalRootDir, "home", "users")
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return []*user.User{
+			{Uid: "1000", HomeDir: homeDir},
+		}, nil
+	})
+	defer restore()
+
+	baseDataDir := filepath.Join(homeDir, "snap", "hello")
 	c.Assert(os.MkdirAll(baseDataDir, 0755), IsNil)
 	// create the current symlink
 	c.Assert(os.Symlink("10", filepath.Join(baseDataDir, "current")), IsNil)
@@ -361,4 +437,85 @@ func (s *snapdataSuite) TestRemoveSnapDataDirCurrentSymlinkRemovalFails(c *C) {
 	info := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
 	err := s.be.RemoveSnapDataDir(info, false, nil)
 	c.Assert(err, ErrorMatches, `failed to remove snap "hello" base directory: remove .*/home/users/snap/hello/current: permission denied`)
+}
+
+// TestRemoveSnapDataSkipsNonUserDir verifies that directories that look like
+// home dirs but don't belong to any real user are not removed.
+func (s *snapdataSuite) TestRemoveSnapDataSkipsNonUserDir(c *C) {
+	realHomeDir := filepath.Join(dirs.GlobalRootDir, "home", "real-user")
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return []*user.User{
+			{Uid: "1000", HomeDir: realHomeDir},
+		}, nil
+	})
+	defer restore()
+
+	// Create data for the real user
+	realData := filepath.Join(realHomeDir, "snap", "hello", "10")
+	c.Assert(os.MkdirAll(realData, 0755), IsNil)
+
+	// Create data under a directory that looks like a home dir but isn't a real user
+	nonUserData := filepath.Join(dirs.GlobalRootDir, "home", "build-artifact", "snap", "hello", "10")
+	c.Assert(os.MkdirAll(nonUserData, 0755), IsNil)
+
+	info := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
+	err := s.be.RemoveSnapData(info, nil)
+	c.Assert(err, IsNil)
+
+	// Real user's data is removed
+	c.Assert(osutil.FileExists(realData), Equals, false)
+	// Non-user directory is NOT removed
+	c.Assert(osutil.FileExists(nonUserData), Equals, true)
+}
+
+// TestSnapDataDirsAllUsersError verifies that errors from allUsers() are propagated.
+func (s *snapdataSuite) TestSnapDataDirsAllUsersError(c *C) {
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return nil, fmt.Errorf("mock AllUsers error")
+	})
+	defer restore()
+
+	info := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
+	_, err := backend.SnapDataDirs(info, nil)
+	c.Assert(err, ErrorMatches, "mock AllUsers error")
+}
+
+// TestSnapCommonDataDirsAllUsersError verifies that errors from allUsers() are propagated.
+func (s *snapdataSuite) TestSnapCommonDataDirsAllUsersError(c *C) {
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return nil, fmt.Errorf("mock AllUsers error")
+	})
+	defer restore()
+
+	info := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
+	_, err := backend.SnapCommonDataDirs(info, nil)
+	c.Assert(err, ErrorMatches, "mock AllUsers error")
+}
+
+// TestRemoveSnapDataDirAllUsersError verifies that errors from allUsers() are
+// propagated when removing the snap base data directory.
+func (s *snapdataSuite) TestRemoveSnapDataDirAllUsersError(c *C) {
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return nil, fmt.Errorf("mock AllUsers error")
+	})
+	defer restore()
+
+	info := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
+	err := s.be.RemoveSnapDataDir(info, false, nil)
+	c.Assert(err, ErrorMatches, "mock AllUsers error")
+}
+
+// TestSnapCommonDataDirsInvalidUid verifies that a non-numeric UID returned by
+// allUsers() causes an error when building the XDG runtime directory list.
+func (s *snapdataSuite) TestSnapCommonDataDirsInvalidUid(c *C) {
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return []*user.User{
+			{Uid: "not-a-uid", Gid: "0", HomeDir: filepath.Join(dirs.GlobalRootDir, "home", "user1")},
+		}, nil
+	})
+	defer restore()
+
+	info := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
+	_, err := backend.SnapCommonDataDirs(info, nil)
+	c.Assert(err, ErrorMatches, `cannot parse user id not-a-uid: .*`)
 }

--- a/overlord/snapstate/backend/snapdata_test.go
+++ b/overlord/snapstate/backend/snapdata_test.go
@@ -175,6 +175,73 @@ func (s *snapdataSuite) TestSnapCommonDataDirs(c *C) {
 	})
 }
 
+// TestSnapDataDirsSkipsInaccessibleHomeDir verifies that home directories
+// that cannot be accessed (e.g. NFS with root_squash) are omitted from
+// the returned list so that callers do not encounter permission errors.
+func (s *snapdataSuite) TestSnapDataDirsSkipsInaccessibleHomeDir(c *C) {
+	homedir1 := filepath.Join(dirs.GlobalRootDir, "home_nfs", "user1")
+	homedir2 := filepath.Join(dirs.GlobalRootDir, "home", "user2")
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return []*user.User{
+			{Uid: "1000", HomeDir: homedir1},
+			{Uid: "1001", HomeDir: homedir2},
+		}, nil
+	})
+	defer restore()
+
+	// homedir1 is chmod'd to 0000 to simulate NFS root_squash (EACCES).
+	// homedir2 is accessible normally.
+	c.Assert(os.MkdirAll(homedir1, 0755), IsNil)
+	c.Assert(os.Chmod(homedir1, 0000), IsNil)
+	defer os.Chmod(homedir1, 0755)
+	c.Assert(os.MkdirAll(homedir2, 0755), IsNil)
+
+	info := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
+	result, err := backend.SnapDataDirs(info, nil)
+	c.Assert(err, IsNil)
+	// user1's dir is excluded; user2's and system dirs are present.
+	c.Check(result, DeepEquals, []string{
+		filepath.Join(homedir2, "snap", "hello", "10"),
+		filepath.Join(dirs.GlobalRootDir, "root", "snap", "hello", "10"),
+		filepath.Join(dirs.SnapDataDir, "hello", "10"),
+	})
+}
+
+// TestSnapCommonDataDirsSkipsInaccessibleHomeDir verifies that home directories
+// that cannot be accessed (e.g. NFS with root_squash) are omitted from
+// the returned list, while XDG runtime dirs (not under home) are still included.
+func (s *snapdataSuite) TestSnapCommonDataDirsSkipsInaccessibleHomeDir(c *C) {
+	homedir1 := filepath.Join(dirs.GlobalRootDir, "home_nfs", "user1")
+	homedir2 := filepath.Join(dirs.GlobalRootDir, "home", "user2")
+	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
+		return []*user.User{
+			{Uid: "1000", Gid: "1000", HomeDir: homedir1},
+			{Uid: "1001", Gid: "1001", HomeDir: homedir2},
+		}, nil
+	})
+	defer restore()
+
+	// homedir1 is chmod'd to 0000 to simulate NFS root_squash (EACCES).
+	// homedir2 is accessible normally.
+	c.Assert(os.MkdirAll(homedir1, 0755), IsNil)
+	c.Assert(os.Chmod(homedir1, 0000), IsNil)
+	defer os.Chmod(homedir1, 0755)
+	c.Assert(os.MkdirAll(homedir2, 0755), IsNil)
+
+	info := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
+	result, err := backend.SnapCommonDataDirs(info, nil)
+	c.Assert(err, IsNil)
+	c.Check(result, DeepEquals, []string{
+		// user1's home-based common dir is excluded (home inaccessible)
+		filepath.Join(homedir2, "snap", "hello", "common"),
+		filepath.Join(dirs.GlobalRootDir, "root", "snap", "hello", "common"),
+		// user1's XDG runtime dir is still included (not under home)
+		filepath.Join(dirs.XdgRuntimeDirBase, "1000", "snap.hello"),
+		filepath.Join(dirs.XdgRuntimeDirBase, "1001", "snap.hello"),
+		filepath.Join(dirs.SnapDataDir, "hello", "common"),
+	})
+}
+
 func (s *snapdataSuite) TestRemoveSnapCommonData(c *C) {
 	homedir := filepath.Join(dirs.GlobalRootDir, "home", "user1")
 	usr := &user.User{Uid: "1000", Gid: "1000", HomeDir: homedir}

--- a/overlord/snapstate/backend/snapdata_test.go
+++ b/overlord/snapstate/backend/snapdata_test.go
@@ -175,10 +175,13 @@ func (s *snapdataSuite) TestSnapCommonDataDirs(c *C) {
 	})
 }
 
-// TestSnapDataDirsSkipsInaccessibleHomeDir verifies that home directories
-// that cannot be accessed (e.g. NFS with root_squash) are omitted from
-// the returned list so that callers do not encounter permission errors.
-func (s *snapdataSuite) TestSnapDataDirsSkipsInaccessibleHomeDir(c *C) {
+// TestSnapDataDirsSkipsInaccessibleSnapDir verifies that snap dirs under home
+// directories that cannot be accessed (e.g. NFS with root_squash) are omitted
+// from the returned list so that callers do not encounter permission errors.
+func (s *snapdataSuite) TestSnapDataDirsSkipsInaccessibleSnapDir(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("this test cannot run as root (root bypasses directory permission checks)")
+	}
 	homedir1 := filepath.Join(dirs.GlobalRootDir, "home_nfs", "user1")
 	homedir2 := filepath.Join(dirs.GlobalRootDir, "home", "user2")
 	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
@@ -189,8 +192,8 @@ func (s *snapdataSuite) TestSnapDataDirsSkipsInaccessibleHomeDir(c *C) {
 	})
 	defer restore()
 
-	// homedir1 is chmod'd to 0000 to simulate NFS root_squash (EACCES).
-	// homedir2 is accessible normally.
+	// homedir1 is chmod'd to 0000 so its snap subdir is also inaccessible (EACCES),
+	// simulating NFS root_squash. homedir2 is accessible normally.
 	c.Assert(os.MkdirAll(homedir1, 0755), IsNil)
 	c.Assert(os.Chmod(homedir1, 0000), IsNil)
 	defer os.Chmod(homedir1, 0755)
@@ -207,10 +210,13 @@ func (s *snapdataSuite) TestSnapDataDirsSkipsInaccessibleHomeDir(c *C) {
 	})
 }
 
-// TestSnapCommonDataDirsSkipsInaccessibleHomeDir verifies that home directories
-// that cannot be accessed (e.g. NFS with root_squash) are omitted from
-// the returned list, while XDG runtime dirs (not under home) are still included.
-func (s *snapdataSuite) TestSnapCommonDataDirsSkipsInaccessibleHomeDir(c *C) {
+// TestSnapCommonDataDirsSkipsInaccessibleSnapDir verifies that snap dirs under
+// home directories that cannot be accessed (e.g. NFS with root_squash) are
+// omitted from the returned list, while XDG runtime dirs (not under home) are still included.
+func (s *snapdataSuite) TestSnapCommonDataDirsSkipsInaccessibleSnapDir(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("this test cannot run as root (root bypasses directory permission checks)")
+	}
 	homedir1 := filepath.Join(dirs.GlobalRootDir, "home_nfs", "user1")
 	homedir2 := filepath.Join(dirs.GlobalRootDir, "home", "user2")
 	restore := backend.MockAllUsers(func(_ *dirs.SnapDirOptions) ([]*user.User, error) {
@@ -221,8 +227,8 @@ func (s *snapdataSuite) TestSnapCommonDataDirsSkipsInaccessibleHomeDir(c *C) {
 	})
 	defer restore()
 
-	// homedir1 is chmod'd to 0000 to simulate NFS root_squash (EACCES).
-	// homedir2 is accessible normally.
+	// homedir1 is chmod'd to 0000 so its snap subdir is also inaccessible (EACCES),
+	// simulating NFS root_squash. homedir2 is accessible normally.
 	c.Assert(os.MkdirAll(homedir1, 0755), IsNil)
 	c.Assert(os.Chmod(homedir1, 0000), IsNil)
 	defer os.Chmod(homedir1, 0755)
@@ -453,7 +459,7 @@ func (s *snapdataSuite) TestRemoveSnapDataDirEnotemptyWithReadDirError(c *C) {
 	c.Assert(err, ErrorMatches, `failed to remove snap "hello" base directory: remove .*/home/users/snap/hello: directory not empty`)
 }
 
-func (s *snapdataSuite) TestRemoveSnapDataDirErrorNotEnotempty(c *C) {
+func (s *snapdataSuite) TestRemoveSnapDataDirSkipsInaccessibleSnapDir(c *C) {
 	if os.Geteuid() == 0 {
 		c.Skip("this test cannot run as root (root can remove directories from read-only parents)")
 	}
@@ -469,14 +475,15 @@ func (s *snapdataSuite) TestRemoveSnapDataDirErrorNotEnotempty(c *C) {
 	parentDir := filepath.Join(homeDir, "snap")
 	baseDataDir := filepath.Join(parentDir, "hello")
 	c.Assert(os.MkdirAll(baseDataDir, 0755), IsNil)
-	// make parent non-writable so removal fails with EACCES, not ENOTEMPTY;
-	// dir contents should not be appended to the error message in this case
+	// make the snap dir non-writable; canAccessSnapDir skips the user
 	c.Assert(os.Chmod(parentDir, 0555), IsNil)
 	defer os.Chmod(parentDir, 0755)
 
 	info := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
 	err := s.be.RemoveSnapDataDir(info, false, nil)
-	c.Assert(err, ErrorMatches, `failed to remove snap "hello" base directory: remove .*/home/users/snap/hello: permission denied`)
+	c.Assert(err, IsNil)
+	// data is left in place because the user was skipped
+	c.Assert(osutil.FileExists(baseDataDir), Equals, true)
 }
 
 func (s *snapdataSuite) TestRemoveSnapDataDirCurrentSymlinkRemovalFails(c *C) {

--- a/snap/info.go
+++ b/snap/info.go
@@ -126,18 +126,6 @@ type PlaceInfo interface {
 	// UserXdgRuntimeDir returns the per user XDG_RUNTIME_DIR directory
 	UserXdgRuntimeDir(userID sys.UserID) string
 
-	// DataHomeDirs returns a slice of globs that match all per user data directories
-	// of a snap.
-	DataHomeDirs(opts *dirs.SnapDirOptions) []string
-
-	// CommonDataHomeDirs returns a slice of globs that match all per user data
-	// directories common across revisions of the snap.
-	CommonDataHomeDirs(opts *dirs.SnapDirOptions) []string
-
-	// XdgRuntimeDirs returns a glob that matches all XDG_RUNTIME_DIR
-	// directories for all users of the snap.
-	XdgRuntimeDirs() string
-
 	// UserExposedHomeDir returns the snap's new home directory under ~/Snap.
 	UserExposedHomeDir(home string) string
 
@@ -296,16 +284,6 @@ func snapDataDir(opts *dirs.SnapDirOptions) string {
 	}
 
 	return dirs.UserHomeSnapDir
-}
-
-// BaseDataHomeDirs returns the per user base data directories of the snap across multiple
-// home directories.
-func BaseDataHomeDirs(name string, opts *dirs.SnapDirOptions) []string {
-	var dataHomeGlob []string
-	for _, glob := range dirs.DataHomeGlobs(opts) {
-		dataHomeGlob = append(dataHomeGlob, filepath.Join(glob, name))
-	}
-	return dataHomeGlob
 }
 
 // UserDataDir returns the user-specific data directory for given snap name. The
@@ -741,36 +719,10 @@ func (s *Info) CommonDataSaveDir() string {
 	return CommonDataSaveDir(s.InstanceName())
 }
 
-// DataHomeDirs returns the per user data directories of the snap across multiple
-// home directories.
-func (s *Info) DataHomeDirs(opts *dirs.SnapDirOptions) []string {
-	var dataHomeGlob []string
-	for _, glob := range dirs.DataHomeGlobs(opts) {
-		dataHomeGlob = append(dataHomeGlob, filepath.Join(glob, s.InstanceName(), s.Revision.String()))
-	}
-	return dataHomeGlob
-}
-
-// CommonDataHomeDirs returns the per user data directories common across revisions
-// of the snap in all defined home directories.
-func (s *Info) CommonDataHomeDirs(opts *dirs.SnapDirOptions) []string {
-	var comDataHomeGlob []string
-	for _, glob := range dirs.DataHomeGlobs(opts) {
-		comDataHomeGlob = append(comDataHomeGlob, filepath.Join(glob, s.InstanceName(), "common"))
-	}
-	return comDataHomeGlob
-}
-
 // UserXdgRuntimeDir returns the XDG_RUNTIME_DIR directory of the snap for a
 // particular user.
 func (s *Info) UserXdgRuntimeDir(euid sys.UserID) string {
 	return UserXdgRuntimeDir(euid, s.InstanceName())
-}
-
-// XdgRuntimeDirs returns the XDG_RUNTIME_DIR directories for all users of the
-// snap.
-func (s *Info) XdgRuntimeDirs() string {
-	return filepath.Join(dirs.XdgRuntimeDirGlob, fmt.Sprintf("snap.%s", s.InstanceName()))
 }
 
 func (s *Info) BinaryNameGlobs() []string {

--- a/snap/info.go
+++ b/snap/info.go
@@ -126,18 +126,6 @@ type PlaceInfo interface {
 	// UserXdgRuntimeDir returns the per user XDG_RUNTIME_DIR directory
 	UserXdgRuntimeDir(userID sys.UserID) string
 
-	// DataHomeDirs returns a slice of globs that match all per user data directories
-	// of a snap.
-	DataHomeDirs(opts *dirs.SnapDirOptions) []string
-
-	// CommonDataHomeDirs returns a slice of globs that match all per user data
-	// directories common across revisions of the snap.
-	CommonDataHomeDirs(opts *dirs.SnapDirOptions) []string
-
-	// XdgRuntimeDirs returns a glob that matches all XDG_RUNTIME_DIR
-	// directories for all users of the snap.
-	XdgRuntimeDirs() string
-
 	// UserExposedHomeDir returns the snap's new home directory under ~/Snap.
 	UserExposedHomeDir(home string) string
 
@@ -301,16 +289,6 @@ func snapDataDir(opts *dirs.SnapDirOptions) string {
 	}
 
 	return dirs.UserHomeSnapDir
-}
-
-// BaseDataHomeDirs returns the per user base data directories of the snap across multiple
-// home directories.
-func BaseDataHomeDirs(name string, opts *dirs.SnapDirOptions) []string {
-	var dataHomeGlob []string
-	for _, glob := range dirs.DataHomeGlobs(opts) {
-		dataHomeGlob = append(dataHomeGlob, filepath.Join(glob, name))
-	}
-	return dataHomeGlob
 }
 
 // UserDataDir returns the user-specific data directory for given snap name. The
@@ -746,36 +724,10 @@ func (s *Info) CommonDataSaveDir() string {
 	return CommonDataSaveDir(s.InstanceName())
 }
 
-// DataHomeDirs returns the per user data directories of the snap across multiple
-// home directories.
-func (s *Info) DataHomeDirs(opts *dirs.SnapDirOptions) []string {
-	var dataHomeGlob []string
-	for _, glob := range dirs.DataHomeGlobs(opts) {
-		dataHomeGlob = append(dataHomeGlob, filepath.Join(glob, s.InstanceName(), s.Revision.String()))
-	}
-	return dataHomeGlob
-}
-
-// CommonDataHomeDirs returns the per user data directories common across revisions
-// of the snap in all defined home directories.
-func (s *Info) CommonDataHomeDirs(opts *dirs.SnapDirOptions) []string {
-	var comDataHomeGlob []string
-	for _, glob := range dirs.DataHomeGlobs(opts) {
-		comDataHomeGlob = append(comDataHomeGlob, filepath.Join(glob, s.InstanceName(), "common"))
-	}
-	return comDataHomeGlob
-}
-
 // UserXdgRuntimeDir returns the XDG_RUNTIME_DIR directory of the snap for a
 // particular user.
 func (s *Info) UserXdgRuntimeDir(euid sys.UserID) string {
 	return UserXdgRuntimeDir(euid, s.InstanceName())
-}
-
-// XdgRuntimeDirs returns the XDG_RUNTIME_DIR directories for all users of the
-// snap.
-func (s *Info) XdgRuntimeDirs() string {
-	return filepath.Join(dirs.XdgRuntimeDirGlob, fmt.Sprintf("snap.%s", s.InstanceName()))
 }
 
 func (s *Info) BinaryNameGlobs() []string {

--- a/snap/info_test.go
+++ b/snap/info_test.go
@@ -1201,8 +1201,6 @@ func (s *infoSuite) testDirAndFileMethods(c *C, info snap.PlaceInfo) {
 	c.Check(info.CommonDataDir(), Equals, "/var/snap/name/common")
 	c.Check(info.CommonDataSaveDir(), Equals, "/var/lib/snapd/save/snap/name")
 	c.Check(info.UserXdgRuntimeDir(12345), Equals, "/run/user/12345/snap.name")
-	// XXX: Those are actually a globs, not directories
-	c.Check(info.XdgRuntimeDirs(), Equals, "/run/user/*/snap.name")
 	c.Check(info.BinaryNameGlobs(), DeepEquals, []string{"name", "name.*"})
 }
 
@@ -1229,8 +1227,6 @@ func (s *infoSuite) testInstanceDirAndFileMethods(c *C, info snap.PlaceInfo) {
 	c.Check(info.CommonDataDir(), Equals, "/var/snap/name_instance/common")
 	c.Check(info.CommonDataSaveDir(), Equals, "/var/lib/snapd/save/snap/name_instance")
 	c.Check(info.UserXdgRuntimeDir(12345), Equals, "/run/user/12345/snap.name_instance")
-	// XXX: Those are actually a globs, not directories
-	c.Check(info.XdgRuntimeDirs(), Equals, "/run/user/*/snap.name_instance")
 	c.Check(info.BinaryNameGlobs(), DeepEquals, []string{"name_instance", "name_instance.*"})
 }
 
@@ -1256,42 +1252,6 @@ func (s *infoSuite) TestComponentPlaceInfoMethodsParallelInstall(c *C) {
 	c.Check(cpi.MountDir(), Equals, fmt.Sprintf("%s/name_instance/1", dirs.SnapMountDir))
 	c.Check(cpi.MountFile(), Equals, "/var/lib/snapd/snaps/name_instance_1.snap")
 	c.Check(cpi.MountDescription(), Equals, "Mount unit for name_instance, revision 1")
-}
-
-func (s *infoSuite) TestDataHomeDirs(c *C) {
-	dirs.SetSnapHomeDirs("/home,/home/group1,/home/group2,/home/group3")
-	info := &snap.Info{SuggestedName: "name"}
-	info.SideInfo = snap.SideInfo{Revision: snap.R(1)}
-
-	homeDirs := []string{filepath.Join(dirs.GlobalRootDir, "/home/*/snap/name/1"), filepath.Join(dirs.GlobalRootDir, "/home/group1/*/snap/name/1"),
-		filepath.Join(dirs.GlobalRootDir, "/home/group2/*/snap/name/1"), filepath.Join(dirs.GlobalRootDir, "/home/group3/*/snap/name/1")}
-	commonHomeDirs := []string{filepath.Join(dirs.GlobalRootDir, "/home/*/snap/name/common"), filepath.Join(dirs.GlobalRootDir, "/home/group1/*/snap/name/common"),
-		filepath.Join(dirs.GlobalRootDir, "/home/group2/*/snap/name/common"), filepath.Join(dirs.GlobalRootDir, "/home/group3/*/snap/name/common")}
-	c.Check(info.DataHomeDirs(nil), DeepEquals, homeDirs)
-	c.Check(info.CommonDataHomeDirs(nil), DeepEquals, commonHomeDirs)
-
-	// Same test but with a hidden snap directory
-	opts := &dirs.SnapDirOptions{HiddenSnapDataDir: true}
-	hiddenHomeDirs := []string{filepath.Join(dirs.GlobalRootDir, "/home/*/.snap/data/name/1"), filepath.Join(dirs.GlobalRootDir, "/home/group1/*/.snap/data/name/1"),
-		filepath.Join(dirs.GlobalRootDir, "/home/group2/*/.snap/data/name/1"), filepath.Join(dirs.GlobalRootDir, "/home/group3/*/.snap/data/name/1")}
-	hiddenCommonHomeDirs := []string{filepath.Join(dirs.GlobalRootDir, "/home/*/.snap/data/name/common"), filepath.Join(dirs.GlobalRootDir, "/home/group1/*/.snap/data/name/common"),
-		filepath.Join(dirs.GlobalRootDir, "/home/group2/*/.snap/data/name/common"), filepath.Join(dirs.GlobalRootDir, "/home/group3/*/.snap/data/name/common")}
-	c.Check(info.DataHomeDirs(opts), DeepEquals, hiddenHomeDirs)
-	c.Check(info.CommonDataHomeDirs(opts), DeepEquals, hiddenCommonHomeDirs)
-}
-
-func (s *infoSuite) TestBaseDataHomeDirs(c *C) {
-	dirs.SetSnapHomeDirs("/home,/home/group1,/home/group2,/home/group3")
-
-	homeDirs := []string{filepath.Join(dirs.GlobalRootDir, "/home/*/snap/name"), filepath.Join(dirs.GlobalRootDir, "/home/group1/*/snap/name"),
-		filepath.Join(dirs.GlobalRootDir, "/home/group2/*/snap/name"), filepath.Join(dirs.GlobalRootDir, "/home/group3/*/snap/name")}
-	c.Check(snap.BaseDataHomeDirs("name", nil), DeepEquals, homeDirs)
-
-	// Same test but with a hidden snap directory
-	opts := &dirs.SnapDirOptions{HiddenSnapDataDir: true}
-	hiddenHomeDirs := []string{filepath.Join(dirs.GlobalRootDir, "/home/*/.snap/data/name"), filepath.Join(dirs.GlobalRootDir, "/home/group1/*/.snap/data/name"),
-		filepath.Join(dirs.GlobalRootDir, "/home/group2/*/.snap/data/name"), filepath.Join(dirs.GlobalRootDir, "/home/group3/*/.snap/data/name")}
-	c.Check(snap.BaseDataHomeDirs("name", opts), DeepEquals, hiddenHomeDirs)
 }
 
 func BenchmarkTestParsePlaceInfoFromSnapFileName(b *testing.B) {

--- a/tests/main/snapd-homedirs/task.yaml
+++ b/tests/main/snapd-homedirs/task.yaml
@@ -3,7 +3,8 @@ summary: Test support for non-standard home directory paths and data copy betwee
 details: |
     Verifies that the snap data in non-standard home directories gets properly copied between
     revisions when the snap package is refreshed to a newer revision. Also makes sure that the
-    snap data in non-standard home directories is deleted when the snap package is removed.
+    snap data in non-standard home directories is deleted (only for real users) when the snap
+    package is removed.
 
 systems:
     - -ubuntu-core-*  # Home dirs cannot be changed
@@ -84,6 +85,15 @@ execute: |
         test -e "${h}snap/test-snapd-sh/$rev/mock-data"
     done
 
+    echo "Simulate a directory that looks like a home dir but belongs to no real user"
+    fake_snap_user_base="/remote/users/not-a-real-user/snap/test-snapd-sh"
+    fake_snap_user_data="${fake_snap_user_base}/$rev"
+    fake_snap_user_common="${fake_snap_user_base}/common"
+    mkdir -p "${fake_snap_user_data}"
+    touch "${fake_snap_user_data}/should-not-be-deleted"
+    mkdir -p "${fake_snap_user_common}"
+    touch "${fake_snap_user_common}/should-not-be-deleted"
+
     echo "When the snap is removed"
     snap remove --purge test-snapd-sh
 
@@ -91,3 +101,7 @@ execute: |
     for h in "${homes[@]}"; do
         test ! -e "${h}snap/test-snapd-sh"
     done
+
+    echo "But data under a non-user directory is NOT removed"
+    test -e "${fake_snap_user_data}/should-not-be-deleted"
+    test -e "${fake_snap_user_common}/should-not-be-deleted"


### PR DESCRIPTION
Paths to snap user data dirs are constructed based on `AllUsers` HomeDir rather than just globs, so that only snap data that corresponds to real users is deleted.
[SNAPDENG-37175](https://warthogs.atlassian.net/browse/SNAPDENG-37175)

[SNAPDENG-37175]: https://warthogs.atlassian.net/browse/SNAPDENG-37175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

LP: https://bugs.launchpad.net/snapd/+bug/2106306