### PR TITLE
tests/main/system-usernames-hooks: a snap using system-usernames and hooks

### DIFF
--- a/tests/main/system-usernames-hooks/task.yaml
+++ b/tests/main/system-usernames-hooks/task.yaml
@@ -1,0 +1,18 @@
+summary: exercise snap hooks using system-usernames
+
+details: |
+    Exercise a scenario in which a snap that uses system-usernames carries
+    hooks. Make sure that hooks are able to exercise functionality provided by
+    system-usernames.
+
+prepare: |
+    tests.cleanup defer "$TESTSTOOLS"/user-state remove-with-group snap_daemon
+
+execute: |
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
+    test-snapd-sh.sh -c 'setpriv --clear-groups \
+            --reuid snap_daemon \
+            --regid snap_daemon -- \
+            id'
+
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-sh

--- a/tests/main/system-usernames-hooks/task.yaml
+++ b/tests/main/system-usernames-hooks/task.yaml
@@ -10,9 +10,14 @@ prepare: |
 
 execute: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
+    MATCH 'running install hook' < /var/snap/test-snapd-sh/common/hook.log
+    # file is created and its ownership is set in the install hook
+    stat --printf '%U' /var/snap/test-snapd-sh/common/data/foo | MATCH snap_daemon
+
     test-snapd-sh.sh -c 'setpriv --clear-groups \
             --reuid snap_daemon \
             --regid snap_daemon -- \
             id'
-
     "$TESTSTOOLS"/snaps-state install-local test-snapd-sh
+    MATCH 'running post-refresh hook' < /var/snap/test-snapd-sh/common/hook.log
+    MATCH 'post refresh' < /var/snap/test-snapd-sh/common/data/foo

--- a/tests/main/system-usernames-hooks/test-snapd-sh/bin/sh
+++ b/tests/main/system-usernames-hooks/test-snapd-sh/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+PS1='$ '
+exec /bin/sh "$@"

--- a/tests/main/system-usernames-hooks/test-snapd-sh/meta/hooks/install
+++ b/tests/main/system-usernames-hooks/test-snapd-sh/meta/hooks/install
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+exec 2>&1
+
+echo "running install hook" >> "$SNAP_COMMON"/hook.log
+
+mkdir "$SNAP_COMMON"/data
+touch "$SNAP_COMMON"/data/foo
+
+chown -R snap_daemon "$SNAP_COMMON"/data
+chgrp -R root "$SNAP_COMMON"/data

--- a/tests/main/system-usernames-hooks/test-snapd-sh/meta/hooks/post-refresh
+++ b/tests/main/system-usernames-hooks/test-snapd-sh/meta/hooks/post-refresh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+exec 2>&1
+
+echo "running post-refresh hook" >> "$SNAP_COMMON"/hook.log
+
+setpriv \
+    --clear-groups \
+    --reuid snap_daemon \
+    --regid snap_daemon -- \
+            /bin/sh -c "echo 'post refresh' >> $SNAP_COMMON/data/foo"

--- a/tests/main/system-usernames-hooks/test-snapd-sh/meta/snap.yaml
+++ b/tests/main/system-usernames-hooks/test-snapd-sh/meta/snap.yaml
@@ -1,0 +1,11 @@
+name: test-snapd-sh
+summary: Minimal snap for testing
+version: 1.0
+base: core24
+
+apps:
+    sh:
+        command: bin/sh
+
+system-usernames:
+  snap_daemon: shared


### PR DESCRIPTION
Add a spread tests which executes a refresh like scenario with a snap using system-usernames and a post-refresh hook.

Related: SNAPDENG-37266

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
