### PR TITLE
agents/skills/build-native-package: add skill for building native packages

### DIFF
--- a/.agents/skills/build-native-package/SKILL.md
+++ b/.agents/skills/build-native-package/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: build-native-package
+description: Build snapd native distribution packages (deb, rpm, pkg) using kulturysta. Use when building Debian, Ubuntu, Fedora, openSUSE, Arch, CentOS, or Amazon Linux packages.
+metadata:
+  project: snapd
+  task-type: build
+---
+
+## Build package
+
+Run from the workspace root, substituting the target directory name:
+
+```bash
+(
+# e.g. fedora-44, replace with ubuntu-26.04, or debian-sid, or arch
+cd packaging/fedora-44
+../kulturysta           # full build with tests
+../kulturysta --no-tests  # faster, skip tests
+)
+```
+
+`kulturysta` must be invoked from inside the target packaging directory. It reads
+three shell code blocks from the `README.md` in that directory:
+
+- `## Host Script` — runs on the host; creates the `.build/` directory structure
+- `## Build Container` — the `podman run` command used to launch the container
+- `## Container Script` — piped into the container on stdin; performs the actual build
+
+Output lands in `packaging/<target>/.build/`.
+
+## Targets
+
+| Target | Output |
+|--------|--------|
+| `ubuntu-26.04`, `ubuntu-16.04`, `debian-sid` | `.deb` |
+| `fedora`, `fedora-44`, `fedora-42`, `fedora-latest`, `fedora-rawhide` | `.rpm` |
+| `opensuse`, `opensuse-tumbleweed`, `opensuse-16.0` | `.rpm` |
+| `centos-7`, `centos-9`, `amzn-2`, `amzn-2023` | `.rpm` |
+| `arch` | `.pkg.tar.zst` |
+
+## Requirements
+
+podman 5+. Named volumes cache package downloads across runs.
+
+## On failure
+
+`.build/` is preserved. Debs in `.build/*.deb`, RPMs in `.build/RPMS/`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -77,6 +77,10 @@ func (m *SnapManager) undoMountSnap(t *state.Task, _ *tomb.Tomb) error {
 - Release lock only for slow I/O/network operations
 - Working state + status changes must be atomic via `Task.SetStatus()` before unlock
 
+## Skills
+
+Detailed, executable workflows for common tasks live in `.agents/skills/`.
+
 ## Developer Workflows
 
 ### Building & Testing


### PR DESCRIPTION
Add skill describing how to build the native packages for any distro for which we have reference packaging.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
