### PR TITLE
tests: attempt to fix flaky auto-refresh-pre-download test

### DIFF
--- a/tests/main/auto-refresh-pre-download/task.yaml
+++ b/tests/main/auto-refresh-pre-download/task.yaml
@@ -23,6 +23,12 @@ prepare: |
   # ensure no other refreshes interfere with the test
   snap refresh
   snap install test-snapd-sh
+  # linger is needed so snapd.session-agent.socket is active for the test user to receive notifications
+  # notifications are only checked on ubuntu classic (see execute section)
+  if os.query is-ubuntu && os.query is-classic; then
+    tests.session prepare -u test
+    tests.cleanup defer tests.session restore -u test
+  fi
 
 restore: |
   snap remove --purge test-snapd-sh || true


### PR DESCRIPTION
Prepare user session to activate session agent socket in `auto-refresh-pre-download` test.

I saw that https://github.com/canonical/snapd/pull/17394 was merged to fix this test but there seems to be more recent observations of this test still failing, for ex. on https://github.com/canonical/snapd/pull/17420 | [failure](https://github.com/canonical/snapd/actions/runs/30557037414/job/90924007167?pr=17420#step:25:2721) | [PR17420_contains_changes_from_PR17394](https://github.com/kubiko/snapd/commits/bootloader-lk-fix-slot-search/).

[SNAPDENG-37237](https://warthogs.atlassian.net/browse/SNAPDENG-37237)

[SNAPDENG-37237]: https://warthogs.atlassian.net/browse/SNAPDENG-37237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ