### PR TITLE
o/hookstate/ctlcmd: add snapctl components command to list all components for the calling snap

### DIFF
--- a/overlord/hookstate/ctlcmd/components.go
+++ b/overlord/hookstate/ctlcmd/components.go
@@ -1,0 +1,119 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ctlcmd
+
+import (
+	"fmt"
+	"sort"
+	"text/tabwriter"
+
+	"github.com/snapcore/snapd/i18n"
+	"github.com/snapcore/snapd/overlord/snapstate"
+)
+
+var (
+	shortComponentsHelp = i18n.G("List available and installed components for the calling snap")
+	longComponentsHelp  = i18n.G(`
+The components command displays a summary of the components that are installed
+and available for the calling snap.
+`)
+)
+
+func init() {
+	addCommand("components", shortComponentsHelp, longComponentsHelp, func() command {
+		return &componentsCommand{}
+	})
+}
+
+type componentsCommand struct {
+	baseCommand
+}
+
+func (c *componentsCommand) Execute(args []string) error {
+	if len(args) > 0 {
+		return fmt.Errorf("unexpected arguments: %v", args)
+	}
+
+	ctx, err := c.ensureContext()
+	if err != nil {
+		return err
+	}
+
+	snapName := ctx.InstanceName()
+	st := ctx.State()
+	st.Lock()
+	defer st.Unlock()
+
+	snapInfo, err := snapstate.CurrentInfo(st, snapName)
+	if err != nil {
+		return fmt.Errorf("cannot get snap info: %w", err)
+	}
+
+	if len(snapInfo.Components) == 0 {
+		fmt.Fprintln(c.stderr, i18n.G("No components are available for this snap."))
+		return nil
+	}
+
+	var snapst snapstate.SnapState
+	if err := snapstate.Get(st, snapName, &snapst); err != nil {
+		return fmt.Errorf("cannot get snap state: %w", err)
+	}
+
+	compStates := snapst.Sequence.ComponentsForRevision(snapst.Current)
+	installed := make(map[string]bool, len(compStates))
+	for _, cs := range compStates {
+		installed[cs.SideInfo.Component.ComponentName] = true
+	}
+
+	type compRow struct {
+		name   string
+		status string
+		ctype  string
+	}
+
+	rows := make([]compRow, 0, len(snapInfo.Components))
+	for name, comp := range snapInfo.Components {
+		status := "available"
+		if installed[name] {
+			status = "installed"
+		}
+		rows = append(rows, compRow{
+			name:   "+" + name,
+			status: status,
+			ctype:  string(comp.Type),
+		})
+	}
+
+	// installed first, then alphabetical within each group
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].status != rows[j].status {
+			return rows[i].status == "installed"
+		}
+		return rows[i].name < rows[j].name
+	})
+
+	// same as snap command
+	w := tabwriter.NewWriter(c.stdout, 5, 3, 2, ' ', 0)
+	fmt.Fprintln(w, "Component\tStatus\tType")
+	for _, r := range rows {
+		fmt.Fprintf(w, "%s\t%s\t%s\n", r.name, r.status, r.ctype)
+	}
+	return w.Flush()
+}

--- a/overlord/hookstate/ctlcmd/components_test.go
+++ b/overlord/hookstate/ctlcmd/components_test.go
@@ -1,0 +1,200 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package ctlcmd_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/hookstate"
+	"github.com/snapcore/snapd/overlord/hookstate/ctlcmd"
+	"github.com/snapcore/snapd/overlord/hookstate/hooktest"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/sequence"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/naming"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type componentsSuite struct {
+	testutil.BaseTest
+	st          *state.State
+	mockContext *hookstate.Context
+	mockHandler *hooktest.MockHandler
+}
+
+var _ = Suite(&componentsSuite{})
+
+const snapWithTwoCompsYaml = `name: test-snap
+version: 1.0
+summary: test-snap
+components:
+  comp1:
+    type: standard
+  comp2:
+    type: test
+`
+
+func (s *componentsSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+	dirs.SetRootDir(c.MkDir())
+	s.BaseTest.AddCleanup(func() { dirs.SetRootDir("/") })
+
+	s.mockHandler = hooktest.NewMockHandler()
+	s.st = state.New(nil)
+
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	info := snaptest.MockSnapCurrent(c, snapWithTwoCompsYaml, &snap.SideInfo{
+		RealName: "test-snap",
+		Revision: snap.R(1),
+	})
+
+	snapstate.Set(s.st, info.InstanceName(), &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: info.SnapName(), Revision: info.Revision},
+		}),
+		Current: info.Revision,
+	})
+
+	task := s.st.NewTask("test-task", "test task")
+	setup := &hookstate.HookSetup{Snap: "test-snap", Revision: snap.R(1), Hook: "install"}
+
+	var err error
+	s.mockContext, err = hookstate.NewContext(task, s.st, setup, s.mockHandler, "")
+	c.Assert(err, IsNil)
+}
+
+func (s *componentsSuite) TestNoComponents(c *C) {
+	// Set up snap state pointing at a revision with no declared components.
+	// We need a different snap name to avoid conflicting with the "current"
+	// symlink already created for "test-snap" in SetUpTest.
+	const noCompSnapYaml = `name: no-comp-snap
+version: 1.0
+summary: no-comp-snap
+`
+	info := snaptest.MockSnapCurrent(c, noCompSnapYaml, &snap.SideInfo{
+		RealName: "no-comp-snap",
+		Revision: snap.R(1),
+	})
+	s.st.Lock()
+	snapstate.Set(s.st, info.InstanceName(), &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: info.SnapName(), Revision: info.Revision},
+		}),
+		Current: info.Revision,
+	})
+	task := s.st.NewTask("no-comp-task", "no comp task")
+	s.st.Unlock()
+	setup := &hookstate.HookSetup{Snap: "no-comp-snap", Revision: snap.R(1), Hook: "install"}
+	ctx, err := hookstate.NewContext(task, s.st, setup, s.mockHandler, "")
+	c.Assert(err, IsNil)
+
+	stdout, stderr, _, err := ctlcmd.Run(ctx, []string{"components"}, 0, nil)
+	c.Assert(err, IsNil)
+	c.Check(string(stdout), Equals, "")
+	c.Check(string(stderr), Matches, `(?s).*No components are available for this snap.*`)
+}
+
+func (s *componentsSuite) setInstalledComponents(compNames []string, compRevs []snap.Revision) {
+	compStates := make([]*sequence.ComponentState, len(compNames))
+	for i, name := range compNames {
+		cref := naming.NewComponentRef("test-snap", name)
+		csi := snap.NewComponentSideInfo(cref, compRevs[i])
+		compStates[i] = sequence.NewComponentState(csi, snap.StandardComponent)
+	}
+
+	s.st.Lock()
+	defer s.st.Unlock()
+
+	snapstate.Set(s.st, "test-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos([]*sequence.RevisionSideState{
+			sequence.NewRevisionSideState(
+				&snap.SideInfo{RealName: "test-snap", Revision: snap.R(1)},
+				compStates,
+			),
+		}),
+		Current: snap.R(1),
+	})
+}
+
+func (s *componentsSuite) TestAllAvailable(c *C) {
+	stdout, stderr, _, err := ctlcmd.Run(s.mockContext, []string{"components"}, 0, nil)
+	c.Assert(err, IsNil)
+	c.Check(string(stderr), Equals, "")
+	c.Check(string(stdout), Equals, `
+Component  Status     Type
++comp1     available  standard
++comp2     available  test
+`[1:])
+}
+
+func (s *componentsSuite) TestOneInstalledOneAvailable(c *C) {
+	s.setInstalledComponents([]string{"comp2"}, []snap.Revision{snap.R(11)})
+
+	stdout, stderr, _, err := ctlcmd.Run(s.mockContext, []string{"components"}, 0, nil)
+	c.Assert(err, IsNil)
+	c.Check(string(stderr), Equals, "")
+	// installed components come first, regardless of name order
+	c.Check(string(stdout), Matches, `(?s).*\+comp2\s+installed\s+test.*\+comp1\s+available\s+standard.*`)
+}
+
+func (s *componentsSuite) TestAllInstalled(c *C) {
+	s.setInstalledComponents(
+		[]string{"comp1", "comp2"},
+		[]snap.Revision{snap.R(11), snap.R(22)},
+	)
+
+	// non-root users can also run snapctl components
+	stdout, stderr, _, err := ctlcmd.Run(s.mockContext, []string{"components"}, 1000, nil)
+	c.Assert(err, IsNil)
+	c.Check(string(stderr), Equals, "")
+	// alphabetical order within the installed group
+	c.Check(string(stdout), Matches, `(?s).*\+comp1\s+installed\s+standard.*\+comp2\s+installed\s+test.*`)
+}
+
+func (s *componentsSuite) TestEnsureContextError(c *C) {
+	_, _, _, err := ctlcmd.Run(nil, []string{"components"}, 0, nil)
+	c.Assert(err, ErrorMatches, `cannot invoke snapctl operation commands \(here "components"\) from outside of a snap`)
+}
+
+func (s *componentsSuite) TestCurrentInfoError(c *C) {
+	s.st.Lock()
+	task := s.st.NewTask("no-state-task", "no state task")
+	s.st.Unlock()
+	setup := &hookstate.HookSetup{Snap: "no-state-snap", Revision: snap.R(1), Hook: "install"}
+	ctx, err := hookstate.NewContext(task, s.st, setup, s.mockHandler, "")
+	c.Assert(err, IsNil)
+
+	_, _, _, err = ctlcmd.Run(ctx, []string{"components"}, 0, nil)
+	c.Assert(err, ErrorMatches, `cannot get snap info: snap "no-state-snap" is not installed`)
+}
+
+func (s *componentsSuite) TestExtraArgsRejected(c *C) {
+	_, _, _, err := ctlcmd.Run(s.mockContext, []string{"components", "unexpected"}, 0, nil)
+	c.Assert(err, ErrorMatches, `unexpected arguments: \[unexpected\]`)
+}

--- a/overlord/hookstate/ctlcmd/ctlcmd.go
+++ b/overlord/hookstate/ctlcmd/ctlcmd.go
@@ -161,7 +161,7 @@ func (f ForbiddenCommandError) Error() string {
 
 // nonRootAllowed lists the commands that can be performed even when snapctl
 // is invoked not by root.
-var nonRootAllowed = []string{"get", "services", "set-health", "is-connected", "system-mode", "refresh", "model", "version", "is-ready", "tasks", "change"}
+var nonRootAllowed = []string{"get", "services", "set-health", "is-connected", "system-mode", "refresh", "model", "version", "is-ready", "tasks", "change", "components"}
 
 // Run runs the requested command.
 func Run(context *hookstate.Context, args []string, uid uint32, features []string) (stdout, stderr []byte, changeID string, err error) {

--- a/tests/main/component-snapctl/task.yaml
+++ b/tests/main/component-snapctl/task.yaml
@@ -1,7 +1,8 @@
-summary: Test snapctl install/remove
+summary: Test snapctl install/remove/components
 
 details: |
-  Verifies that snactl install/remove works from snap apps and from snaps hooks.
+  Verifies that snapctl install, remove, and components work from snap apps and
+  from snap hooks.
 
 systems: [ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-2*, ubuntu-core-*, fedora-*]
 
@@ -13,6 +14,11 @@ execute: |
   # test command installs and removes components using snapctl (ephemeral context)
   test-snap-components-snapctl
 
+  echo "Check snapctl components before any components are installed"
+  snap run --shell test-snap-components-snapctl -c "snapctl components" > comps.out
+  MATCH "\+one\s+available\s+test" < comps.out
+  MATCH "\+two\s+available\s+test" < comps.out
+
   # run install from configure hook (non-ephemeral context)
   snap set test-snap-components-snapctl command="install +one+two"
 
@@ -20,8 +26,23 @@ execute: |
   MATCH "First component" < "$SNAP_MOUNT_DIR/test-snap-components-snapctl/components/$snap_rev/one/meta/component.yaml"
   MATCH "Second component" < "$SNAP_MOUNT_DIR/test-snap-components-snapctl/components/$snap_rev/two/meta/component.yaml"
 
+  echo "Check snapctl components after installing both"
+  snap run --shell test-snap-components-snapctl -c "snapctl components" > comps.out
+  MATCH "\+one\s+installed\s+test" < comps.out
+  MATCH "\+two\s+installed\s+test" < comps.out
+
+  echo "Check snapctl components works from configure hook"
+  snap set test-snap-components-snapctl command="components"
+  MATCH "\+one\s+installed\s+test" < /var/snap/test-snap-components-snapctl/current/configure.log
+  MATCH "\+two\s+installed\s+test" < /var/snap/test-snap-components-snapctl/current/configure.log
+
   snap set test-snap-components-snapctl command="remove +one+two"
   test ! -d "$SNAP_MOUNT_DIR"/test-snap-components-snapctl/components/
+
+  echo "Check snapctl components after removing both"
+  snap run --shell test-snap-components-snapctl -c "snapctl components" > comps.out
+  MATCH "\+one\s+available\s+test" < comps.out
+  MATCH "\+two\s+available\s+test" < comps.out
 
   echo "Check already installed snap exits with code 0"
   snap run --shell test-snap-components-snapctl -c "snapctl install +one" 1>stdout.out 2>stderr.out
@@ -29,6 +50,9 @@ execute: |
   test ! -s stderr.out
   snap components test-snap-components-snapctl | MATCH "test-snap-components-snapctl\+one\s+installed\s+test"
   snap components test-snap-components-snapctl | MATCH "test-snap-components-snapctl\+two\s+available\s+test"
+  snap run --shell test-snap-components-snapctl -c "snapctl components" > comps.out
+  MATCH "\+one\s+installed\s+test" < comps.out
+  MATCH "\+two\s+available\s+test" < comps.out
 
   snap run --shell test-snap-components-snapctl -c "snapctl install +one" 1>stdout.out 2>stderr.out
   test ! -s stdout.out
@@ -40,6 +64,9 @@ execute: |
   MATCH "snapctl: component \"one\" is already installed" < stderr.out
   snap components test-snap-components-snapctl | MATCH "test-snap-components-snapctl\+one\s+installed\s+test"
   snap components test-snap-components-snapctl | MATCH "test-snap-components-snapctl\+two\s+installed\s+test"
+  snap run --shell test-snap-components-snapctl -c "snapctl components" > comps.out
+  MATCH "\+one\s+installed\s+test" < comps.out
+  MATCH "\+two\s+installed\s+test" < comps.out
 
   snap run --shell test-snap-components-snapctl -c "snapctl install +one +two" 1>stdout.out 2>stderr.out
   test ! -s stdout.out

--- a/tests/main/component-snapctl/task.yaml
+++ b/tests/main/component-snapctl/task.yaml
@@ -16,8 +16,8 @@ execute: |
 
   echo "Check snapctl components before any components are installed"
   snap run --shell test-snap-components-snapctl -c "snapctl components" > comps.out
-  MATCH "\+one\s+available\s+test" < comps.out
-  MATCH "\+two\s+available\s+test" < comps.out
+  MATCH "^\+one\s+available\s+test$" < comps.out
+  MATCH "^\+two\s+available\s+test$" < comps.out
 
   # run install from configure hook (non-ephemeral context)
   snap set test-snap-components-snapctl command="install +one+two"
@@ -28,21 +28,21 @@ execute: |
 
   echo "Check snapctl components after installing both"
   snap run --shell test-snap-components-snapctl -c "snapctl components" > comps.out
-  MATCH "\+one\s+installed\s+test" < comps.out
-  MATCH "\+two\s+installed\s+test" < comps.out
+  MATCH "^\+one\s+installed\s+test$" < comps.out
+  MATCH "^\+two\s+installed\s+test$" < comps.out
 
   echo "Check snapctl components works from configure hook"
   snap set test-snap-components-snapctl command="components"
-  MATCH "\+one\s+installed\s+test" < /var/snap/test-snap-components-snapctl/current/configure.log
-  MATCH "\+two\s+installed\s+test" < /var/snap/test-snap-components-snapctl/current/configure.log
+  MATCH "^\+one\s+installed\s+test$" < /var/snap/test-snap-components-snapctl/current/configure.log
+  MATCH "^\+two\s+installed\s+test$" < /var/snap/test-snap-components-snapctl/current/configure.log
 
   snap set test-snap-components-snapctl command="remove +one+two"
   test ! -d "$SNAP_MOUNT_DIR"/test-snap-components-snapctl/components/
 
   echo "Check snapctl components after removing both"
   snap run --shell test-snap-components-snapctl -c "snapctl components" > comps.out
-  MATCH "\+one\s+available\s+test" < comps.out
-  MATCH "\+two\s+available\s+test" < comps.out
+  MATCH "^\+one\s+available\s+test$" < comps.out
+  MATCH "^\+two\s+available\s+test$" < comps.out
 
   echo "Check already installed snap exits with code 0"
   snap run --shell test-snap-components-snapctl -c "snapctl install +one" 1>stdout.out 2>stderr.out
@@ -51,8 +51,8 @@ execute: |
   snap components test-snap-components-snapctl | MATCH "test-snap-components-snapctl\+one\s+installed\s+test"
   snap components test-snap-components-snapctl | MATCH "test-snap-components-snapctl\+two\s+available\s+test"
   snap run --shell test-snap-components-snapctl -c "snapctl components" > comps.out
-  MATCH "\+one\s+installed\s+test" < comps.out
-  MATCH "\+two\s+available\s+test" < comps.out
+  MATCH "^\+one\s+installed\s+test$" < comps.out
+  MATCH "^\+two\s+available\s+test$" < comps.out
 
   snap run --shell test-snap-components-snapctl -c "snapctl install +one" 1>stdout.out 2>stderr.out
   test ! -s stdout.out
@@ -65,8 +65,8 @@ execute: |
   snap components test-snap-components-snapctl | MATCH "test-snap-components-snapctl\+one\s+installed\s+test"
   snap components test-snap-components-snapctl | MATCH "test-snap-components-snapctl\+two\s+installed\s+test"
   snap run --shell test-snap-components-snapctl -c "snapctl components" > comps.out
-  MATCH "\+one\s+installed\s+test" < comps.out
-  MATCH "\+two\s+installed\s+test" < comps.out
+  MATCH "^\+one\s+installed\s+test$" < comps.out
+  MATCH "^\+two\s+installed\s+test$" < comps.out
 
   snap run --shell test-snap-components-snapctl -c "snapctl install +one +two" 1>stdout.out 2>stderr.out
   test ! -s stdout.out


### PR DESCRIPTION
https://bugs.launchpad.net/snapd/+bug/2162138  highlighted that it would be useful to have `snapctl components` sub-command that allows listing available and installed components from within the snap’s apps/hooks.

This doesn’t solve the issue of unexpected dirs / symlinks left behind (as mentioned in the bug) but it helps reduce the reliance on filesystem state and rather gets the correct info from snapd’s state regarding components' installation status.

[SNAPDENG-37282](https://warthogs.atlassian.net/browse/SNAPDENG-37282)

[SNAPDENG-37282]: https://warthogs.atlassian.net/browse/SNAPDENG-37282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ