### PR TITLE
tests: robustify restore of nss-modules:winbind test 

### DIFF
--- a/tests/main/nss-modules/task.yaml
+++ b/tests/main/nss-modules/task.yaml
@@ -46,7 +46,8 @@ prepare: |
                 exit 1
             fi
             cp "$item" "$item.bak"
-            tests.cleanup defer mv "$item.bak" "$item"
+            # purging the package during task restore may remove the .bak along with their config dirs
+            tests.cleanup defer "mv \"$item.bak\" \"$item\" || true"
         elif [ -d "$item" ]; then
             tests.backup prepare "$item"
             tests.cleanup defer tests.backup restore "$item"


### PR DESCRIPTION
It has been observed that the restore of `tests/main/nss-modules:winbind` sometimes fails due to
```
mv: cannot stat '/etc/samba/smb.conf.bak': No such file or directory
tests.cleanup: deferred command "mv /etc/samba/smb.conf.bak /etc/samba/smb.conf" failed with exit code 1
```
Example [failure1](https://github.com/canonical/snapd/actions/runs/31028714240/job/92401342978?pr=17346#step:25:3178), [failure2](https://github.com/canonical/snapd/actions/runs/31103569949/job/92626744572?pr=17425#step:25:3458).

This can happen during test re-runs where `/etc/samba/smb.conf` file exists but `samba` is not pre-installed before the test, which leads to the backup and `tests.cleanup defer` registration for that conf file. But during task restore the package is purged along with its configuration files (as it was installed for the test), so `/etc/samba` dir along with the containing `smb.conf.bak` file are removed. Thus, when the suite-restore executes `tests.cleanup restore`, it fails to find the `/etc/samba/smb.conf.bak` file.

Thus, here we make the restoring of `.bak` file as optional.