### PR TITLE
interfaces,o/ifacestate: name the nil components slice passed to NewSnapAppSet

### DIFF
--- a/interfaces/snap_app_set.go
+++ b/interfaces/snap_app_set.go
@@ -19,6 +19,17 @@ type SnapAppSet struct {
 	components []*snap.ComponentInfo
 }
 
+// NoComponents is a typed nil slice of *snap.ComponentInfo, meant to be passed
+// explicitly to NewSnapAppSet at call sites that only need a SnapAppSet to
+// describe the snap's own apps/hooks and never call SnapAppSet.Runnables,
+// SnapAppSet.SecurityTagsForPlug/Slot, or ExpandSliceSnapVariables* on the
+// result.
+//
+// Using this named value instead of a bare "nil" documents that the omission
+// is deliberate, and makes it easy to find (and reconsider) every place that
+// currently does not thread through accurate component data.
+var NoComponents []*snap.ComponentInfo
+
 // NewSnapAppSet returns a new SnapAppSet for the given snap.Info.
 func NewSnapAppSet(info *snap.Info, components []*snap.ComponentInfo) (*SnapAppSet, error) {
 	for _, c := range components {

--- a/overlord/ifacestate/helpers.go
+++ b/overlord/ifacestate/helpers.go
@@ -627,11 +627,11 @@ ConnsLoop:
 			policyChecker = connChecker.check
 		}
 
-		plugAppSet, err := interfaces.NewSnapAppSet(plugInfo.Snap, nil)
+		plugAppSet, err := interfaces.NewSnapAppSet(plugInfo.Snap, interfaces.NoComponents)
 		if err != nil {
 			return nil, nil, err
 		}
-		slotAppSet, err := interfaces.NewSnapAppSet(slotInfo.Snap, nil)
+		slotAppSet, err := interfaces.NewSnapAppSet(slotInfo.Snap, interfaces.NoComponents)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
Introduce interfaces.NoComponents, a documented package-level nil slice of *snap.ComponentInfo, and use it instead of a bare nil in reloadConnections where SnapAppSet is only needed to build ConnectedPlug/ConnectedSlot for interface policy re-checks.

The doc comment explains why omitting components is safe there (those call sites never call Runnables, SecurityTagsForPlug/Slot, or ExpandSliceSnapVariables*, which are the only places component information is actually consumed), and flags that other consumers of SnapAppSet must not omit it.