### PR TITLE
tests/main/system-usernames-hooks: make shellcheck < 0.7.2 happy

### DIFF
--- a/tests/main/system-usernames-hooks/task.yaml
+++ b/tests/main/system-usernames-hooks/task.yaml
@@ -14,6 +14,8 @@ execute: |
     # file is created and its ownership is set in the install hook
     stat --printf '%U' /var/snap/test-snapd-sh/common/data/foo | MATCH snap_daemon
 
+    # this is correct but shellcheck < 0.7.2 would flag it
+    # shellcheck disable=SC1004
     test-snapd-sh.sh -c 'setpriv --clear-groups \
             --reuid snap_daemon \
             --regid snap_daemon -- \


### PR DESCRIPTION
Focal has shellcheck 0.7.0, which flags the code while running tests/unit/go:static. The test never run in the original PR as the CI ran only the test being added.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
