### PR TITLE
interfaces/u2f-devices: add Gemalto eToken Fusion

### DIFF
--- a/interfaces/builtin/u2f_devices.go
+++ b/interfaces/builtin/u2f_devices.go
@@ -227,6 +227,11 @@ var u2fDevices = []u2fDevice{
 		VendorIDPattern:  "20a0",
 		ProductIDPattern: "42d4",
 	},
+	{
+		Name:             "Gemalto eToken Fusion",
+		VendorIDPattern:  "08e6",
+		ProductIDPattern: "34d2",
+	},
 }
 
 const u2fDevicesConnectedPlugAppArmor = `

--- a/interfaces/builtin/u2f_devices_test.go
+++ b/interfaces/builtin/u2f_devices_test.go
@@ -93,7 +93,7 @@ func (s *u2fDevicesInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(err, IsNil)
 	spec := udev.NewSpecification(appSet)
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
-	c.Assert(spec.Snippets(), HasLen, 38)
+	c.Assert(spec.Snippets(), HasLen, 39)
 	c.Assert(spec.Snippets(), testutil.Contains, `# u2f-devices
 # Yubico YubiKey
 SUBSYSTEM=="hidraw", KERNEL=="hidraw*", ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0113|0114|0115|0116|0120|0121|0200|0402|0403|0406|0407|0410", TAG+="snap_consumer_app"`)


### PR DESCRIPTION
This FIDO token is used by banks in the Netherlands, but Chromium and Firefox cannot currently make use of it. I confirmed that adding this udev rule fixes the problem.

Ubuntu 26.04.

```
~$ lsusb
Bus 001 Device 012: ID 08e6:34d2 Gemalto (was Gemplus) eToken Fusion
```

```
$ udevadm info /dev/hidraw0
P: /devices/pci0000:00/0000:00:14.0/usb1/1-1/1-1.3/1-1.3:1.0/0003:08E6:34D2.000B/hidraw/hidraw0
M: hidraw0
R: 0
J: c238:0
U: hidraw
D: c 238:0
N: hidraw0
L: 0
S: input/by-path/pci-0000:00:14.0-usbv2-0:1.3:1.0-hidraw
S: input/by-id/usb-SafeNet_eToken_Fusion_2000260017W1C_93K-fido
S: input/by-id/usb-SafeNet_eToken_Fusion_2000260017W1C_93K-hidraw
S: input/by-path/pci-0000:00:14.0-usb-0:1.3:1.0-hidraw
E: DEVPATH=/devices/pci0000:00/0000:00:14.0/usb1/1-1/1-1.3/1-1.3:1.0/0003:08E6:34D2.000B/hidraw/hidraw0
E: DEVNAME=/dev/hidraw0
E: MAJOR=238
E: MINOR=0
E: SUBSYSTEM=hidraw
E: USEC_INITIALIZED=48696797404
E: ID_VENDOR_FROM_DATABASE=Gemalto (was Gemplus)
E: ID_FIDO_TOKEN=1
E: ID_SECURITY_TOKEN=1
E: ID_BUS=usb
E: ID_MODEL=eToken_Fusion
E: ID_MODEL_ENC=eToken\x20Fusion
E: ID_MODEL_ID=34d2
E: ID_SERIAL=SafeNet_eToken_Fusion_2000260017W1C_93K
E: ID_SERIAL_SHORT=2000260017W1C_93K
E: ID_VENDOR=SafeNet
E: ID_VENDOR_ENC=SafeNet
E: ID_VENDOR_ID=08e6
E: ID_REVISION=0009
E: ID_TYPE=hid
E: ID_USB_MODEL=eToken_Fusion
E: ID_USB_MODEL_ENC=eToken\x20Fusion
E: ID_USB_MODEL_ID=34d2
E: ID_USB_SERIAL=SafeNet_eToken_Fusion_2000260017W1C_93K
E: ID_USB_SERIAL_SHORT=2000260017W1C_93K
E: ID_USB_VENDOR=SafeNet
E: ID_USB_VENDOR_ENC=SafeNet
E: ID_USB_VENDOR_ID=08e6
E: ID_USB_REVISION=0009
E: ID_USB_TYPE=hid
E: ID_USB_INTERFACES=:030000:0b0000:
E: ID_USB_INTERFACE_NUM=00
E: ID_USB_DRIVER=usbhid
E: ID_PATH_WITH_USB_REVISION=pci-0000:00:14.0-usbv2-0:1.3:1.0
E: ID_PATH=pci-0000:00:14.0-usb-0:1.3:1.0
E: ID_PATH_TAG=pci-0000_00_14_0-usb-0_1_3_1_0
E: ID_FOR_SEAT=hidraw-pci-0000_00_14_0-usb-0_1_3_1_0
E: DEVLINKS=/dev/input/by-path/pci-0000:00:14.0-usbv2-0:1.3:1.0-hidraw /dev/input/by-id/usb-SafeNet_eToken_Fusion_2000260017W1C_93K-fido /dev/input/by-id/usb-SafeNet_eToken_Fusion_2000260017W1C_93K-hidraw /dev/input/by-p>
E: TAGS=:security-device:uaccess:seat:systemd:
E: CURRENT_TAGS=:security-device:uaccess:seat:systemd:
```