### PR TITLE
asserts: support registering custom assertion type

### DIFF
--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -194,6 +194,50 @@ var typeRegistry = map[string]*AssertionType{
 	ResponseMessageType.Name:      ResponseMessageType,
 }
 
+// RegisterCustomType registers a custom signed assertion type.
+//
+// It must be called during package initialization.
+// The validator, when non-nil, is called when an assertion of this type is
+// assembled.
+// RegisterCustomType panics if name or primaryKey is empty or name is already
+// registered.
+func RegisterCustomType(
+	name string,
+	primaryKey []string,
+	validator func(Assertion) error,
+) *AssertionType {
+	if name == "" {
+		panic("custom assertion type name cannot be empty")
+	}
+	if len(primaryKey) == 0 {
+		panic(fmt.Sprintf(
+			"custom assertion type %q must have a primary key",
+			name,
+		))
+	}
+	if Type(name) != nil {
+		panic(fmt.Sprintf("assertion type %q is already registered", name))
+	}
+
+	assertType := &AssertionType{
+		Name:       name,
+		PrimaryKey: primaryKey,
+		assembler: func(assert assertionBase) (Assertion, error) {
+			custom := &assert
+			if validator != nil {
+				err := validator(custom)
+				if err != nil {
+					return nil, err
+				}
+			}
+			return custom, nil
+		},
+	}
+	assertType.validate()
+	typeRegistry[name] = assertType
+	return assertType
+}
+
 // Type returns the AssertionType with name or nil
 func Type(name string) *AssertionType {
 	return typeRegistry[name]

--- a/asserts/asserts_test.go
+++ b/asserts/asserts_test.go
@@ -42,6 +42,50 @@ func (as *assertsSuite) TestUnknown(c *C) {
 	c.Check(asserts.Type("unknown"), IsNil)
 }
 
+func (as *assertsSuite) TestCustomTypeValidator(c *C) {
+	encoded := "type: custom-test\n" +
+		"authority-id: canonical\n" +
+		"id: one\n" +
+		"count: invalid\n" +
+		"sign-key-sha3-384: " + testPrivKey1.PublicKey().ID() + "\n\n" +
+		"AXNpZw=="
+
+	_, err := asserts.Decode([]byte(encoded))
+	c.Check(
+		err,
+		ErrorMatches,
+		`assertion custom-test: "count" header is not an integer: invalid`,
+	)
+}
+
+func (as *assertsSuite) TestRegisterCustomTypeErrors(c *C) {
+	c.Check(
+		func() {
+			asserts.RegisterCustomType("", []string{"id"}, nil)
+		},
+		PanicMatches,
+		"custom assertion type name cannot be empty",
+	)
+	c.Check(
+		func() {
+			asserts.RegisterCustomType("missing-primary-key", nil, nil)
+		},
+		PanicMatches,
+		`custom assertion type "missing-primary-key" must have a primary key`,
+	)
+	c.Check(
+		func() {
+			asserts.RegisterCustomType(
+				asserts.CustomTestType.Name,
+				[]string{"id"},
+				nil,
+			)
+		},
+		PanicMatches,
+		`assertion type "custom-test" is already registered`,
+	)
+}
+
 func (as *assertsSuite) TestTypeMaxSupportedFormat(c *C) {
 	c.Check(asserts.Type("test-only").MaxSupportedFormat(), Equals, 1)
 }
@@ -55,6 +99,7 @@ func (as *assertsSuite) TestTypeNames(c *C) {
 		"cluster",
 		"confdb-control",
 		"confdb-schema",
+		"custom-test",
 		"device-session-request",
 		"hardware-identity",
 		"model",

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -141,6 +141,13 @@ func assembleTestOnly2(assert assertionBase) (Assertion, error) {
 
 var TestOnly2Type = &AssertionType{"test-only-2", []string{"pk1", "pk2"}, nil, assembleTestOnly2, 0}
 
+var CustomTestType *AssertionType
+
+func validateCustomTest(assert Assertion) error {
+	_, err := checkIntWithDefault(assert.Headers(), "count", 0)
+	return err
+}
+
 // TestOnlyDecl is a test-only assertion that mimics snap-declaration
 // relations with other assertions.
 type TestOnlyDecl struct {
@@ -252,6 +259,11 @@ func init() {
 	typeRegistry[TestOnlyType.Name] = TestOnlyType
 	maxSupportedFormat[TestOnlyType.Name] = 1
 	typeRegistry[TestOnly2Type.Name] = TestOnly2Type
+	CustomTestType = RegisterCustomType(
+		"custom-test",
+		[]string{"id"},
+		validateCustomTest,
+	)
 	typeRegistry[TestOnlyNoAuthorityType.Name] = TestOnlyNoAuthorityType
 	typeRegistry[TestOnlyNoAuthorityPKType.Name] = TestOnlyNoAuthorityPKType
 	formatAnalyzer[TestOnlyType] = func(headers map[string]any, _ []byte) (int, error) {


### PR DESCRIPTION
Add a way to register custom assertion types. WIP
