### PR TITLE
spread: also use drop-in for disabling excludedocs on opensuse

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -1253,7 +1253,14 @@ prepare: |
     download.max_silent_tries = 20
     EOF
 
-        # Make sure docs are installed with the packages
+        # Make sure docs are installed with the packages. Newer systems use a
+        # vendor drop-in under /usr/etc, while older ones keep the setting in
+        # /etc/zypp/zypp.conf.
+        mkdir -p /etc/zypp/zypp.conf.d
+        cat <<-EOF > /etc/zypp/zypp.conf.d/excludedocs.conf
+    [main]
+    rpm.install.excludedocs = no
+    EOF
         sed 's/rpm.install.excludedocs = yes/rpm.install.excludedocs = no/g' -i /etc/zypp/zypp.conf
 
         # TODO: enable enforcing mode


### PR DESCRIPTION
Fixes [manpage test failure](https://github.com/canonical/snapd/actions/runs/31455579494/job/93690069039#step:25:123)
```
2026-08-11 05:57:01 Error executing openstack:opensuse-tumbleweed-64:tests/main/manpages (aug110551-865609) :
-----
+ case "$SPREAD_SYSTEM" in
+ for manpage in snap snap-confine snap-discard-ns
+ LC_ALL=C
+ man -u --where snap
No manual entry for snap
Possibly, man page is not installed, try online at: https://manpages.opensuse.org/snap
+ echo 'Expected to see manual page path for snap'
Expected to see manual page path for snap
+ exit 1
-----
.
```