### PR TITLE
snap/snapenv: add SNAP_COMPONENTS environment variable

### DIFF
--- a/snap/snapenv/snapenv.go
+++ b/snap/snapenv/snapenv.go
@@ -134,6 +134,11 @@ func basicEnv(info *snap.Info) osutil.Environment {
 		"SNAP_EUID": fmt.Sprint(sys.Geteuid()),
 	}
 
+	if len(info.Components) > 0 {
+		env["SNAP_COMPONENTS"] = filepath.Join(dirs.CoreSnapMountDir, info.SnapName(),
+			"components", info.Revision.String())
+	}
+
 	// Add the ubuntu-save specific environment variable if
 	// the snap folder exists in the save directory.
 	if exists, isDir, err := osutil.DirExists(snap.CommonDataSaveDir(info.InstanceName())); err == nil && exists && isDir {

--- a/snap/snapenv/snapenv_test.go
+++ b/snap/snapenv/snapenv_test.go
@@ -62,6 +62,21 @@ var mockSnapInfo = &snap.Info{
 		Revision: snap.R(17),
 	},
 }
+
+var mockSnapInfoWithComponents = &snap.Info{
+	SuggestedName: "foo",
+	Version:       "1.0",
+	SideInfo: snap.SideInfo{
+		Revision: snap.R(17),
+	},
+	Components: map[string]*snap.Component{
+		"comp1": &snap.Component{
+			Name: "comp1",
+			Type: "standard",
+		},
+	},
+}
+
 var mockSnapInfoWithDesktopFile = func() *snap.Info {
 	mi := *mockSnapInfo
 	mi.Plugs = map[string]*snap.PlugInfo{
@@ -137,6 +152,24 @@ func (ts *HTestSuite) TestBasic(c *C) {
 	c.Assert(env, DeepEquals, osutil.Environment{
 		"SNAP":               fmt.Sprintf("%s/foo/17", dirs.CoreSnapMountDir),
 		"SNAP_COMMON":        "/var/snap/foo/common",
+		"SNAP_DATA":          "/var/snap/foo/17",
+		"SNAP_NAME":          "foo",
+		"SNAP_INSTANCE_NAME": "foo",
+		"SNAP_INSTANCE_KEY":  "",
+		"SNAP_VERSION":       "1.0",
+		"SNAP_REVISION":      "17",
+		"SNAP_ARCH":          arch.DpkgArchitecture(),
+		"SNAP_LIBRARY_PATH":  "/var/lib/snapd/lib/gl:/var/lib/snapd/lib/gl32",
+		"SNAP_REEXEC":        os.Getenv("SNAP_REEXEC"),
+		"SNAP_UID":           fmt.Sprint(sys.Getuid()),
+		"SNAP_EUID":          fmt.Sprint(sys.Geteuid()),
+	})
+
+	envWithComps := basicEnv(mockSnapInfoWithComponents)
+	c.Assert(envWithComps, DeepEquals, osutil.Environment{
+		"SNAP":               fmt.Sprintf("%s/foo/17", dirs.CoreSnapMountDir),
+		"SNAP_COMMON":        "/var/snap/foo/common",
+		"SNAP_COMPONENTS":    fmt.Sprintf("%s/foo/components/17", dirs.CoreSnapMountDir),
 		"SNAP_DATA":          "/var/snap/foo/17",
 		"SNAP_NAME":          "foo",
 		"SNAP_INSTANCE_NAME": "foo",

--- a/snap/snapenv/snapenv_test.go
+++ b/snap/snapenv/snapenv_test.go
@@ -70,7 +70,7 @@ var mockSnapInfoWithComponents = &snap.Info{
 		Revision: snap.R(17),
 	},
 	Components: map[string]*snap.Component{
-		"comp1": &snap.Component{
+		"comp1": {
 			Name: "comp1",
 			Type: "standard",
 		},

--- a/tests/main/component/snap-with-comps/test
+++ b/tests/main/component/snap-with-comps/test
@@ -1,4 +1,4 @@
 #!/bin/sh -ex
 
 printf "Check that component is seen from snap\n"
-grep "Component 1" "/snap/$SNAP_NAME/components/$SNAP_REVISION/comp1/meta/component.yaml"
+grep "Component 1" "$SNAP_COMPONENTS/comp1/meta/component.yaml"

--- a/tests/main/snap-env/task.yaml
+++ b/tests/main/snap-env/task.yaml
@@ -66,6 +66,7 @@ execute: |
     MATCH "^SNAP_REAL_HOME=/root$"                                        < snap-vars.txt
     MATCH "^SNAP_UID=0$"                                                  < snap-vars.txt
     MATCH "^SNAP_EUID=0$"                                                 < snap-vars.txt
+    NOMATCH "SNAP_COMPONENTS"                                             < snap-vars.txt
     # if on UC20+, then we should see an additional variable (SNAP_SAVE_DATA)
     if [[ "$SPREAD_SYSTEM" == ubuntu-core-2* ]]; then
         MATCH "^SNAP_SAVE_DATA=/var/lib/snapd/save/snap/$NAME$"           < snap-vars.txt


### PR DESCRIPTION
snap/snapenv: add SNAP_COMPONENTS environment variable
Add SNAP_COMPONENTS environment variable which points to the location
where all fully set-up components are available.