### PR TITLE
i/builtin: add disconnected /systemd/notify to daemon_notify

### DIFF
--- a/interfaces/builtin/daemon_notify.go
+++ b/interfaces/builtin/daemon_notify.go
@@ -74,6 +74,12 @@ func (iface *daemoNotifyInterface) AppArmorConnectedPlug(spec *apparmor.Specific
 	switch {
 	case strings.HasPrefix(notifySocket, "/"):
 		rule = fmt.Sprintf(`"%s" w`, notifySocket)
+		if notifySocket == "/run/systemd/notify" {
+			// Seen on OpenSUSE Tumbleweed: this socket can get mediated as the
+			// disconnected path /systemd/notify instead of /run/systemd/notify.
+			rule += `,
+"/systemd/notify" w`
+		}
 	case strings.HasPrefix(notifySocket, "@/org/freedesktop/systemd1/notify/"):
 		// special case for Ubuntu 14.04 where the manpage states that
 		// /run/systemd/notify is used, but in fact the services get an

--- a/interfaces/builtin/daemon_notify.go
+++ b/interfaces/builtin/daemon_notify.go
@@ -77,6 +77,8 @@ func (iface *daemoNotifyInterface) AppArmorConnectedPlug(spec *apparmor.Specific
 		if notifySocket == "/run/systemd/notify" {
 			// Seen on OpenSUSE Tumbleweed: this socket can get mediated as the
 			// disconnected path /systemd/notify instead of /run/systemd/notify.
+			// Related bug reports (eg https://bugzilla.opensuse.org/show_bug.cgi?id=1265864)
+			// were fixed in apparmor upstream by adding the disconnected path.
 			rule += `,
 "/systemd/notify" w`
 		}

--- a/interfaces/builtin/daemon_notify_test.go
+++ b/interfaces/builtin/daemon_notify_test.go
@@ -87,7 +87,9 @@ func (s *daemoNotifySuite) TestAppArmorConnectedPlugNotifySocketDefault(c *C) {
 	err = spec.AddConnectedPlug(s.iface, s.plug, s.slot)
 	c.Assert(err, IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "\n\"/run/systemd/notify\" w,")
+	snippet := spec.SnippetForTag("snap.consumer.app")
+	c.Assert(snippet, testutil.Contains, "\n\"/run/systemd/notify\" w,")
+	c.Assert(snippet, testutil.Contains, "\n\"/systemd/notify\" w,")
 }
 
 func (s *daemoNotifySuite) TestAppArmorConnectedPlugNotifySocketEnvAbstractSpecial(c *C) {


### PR DESCRIPTION
`tests/main/services-watchdog` on opensuse-tumbleweed has the following denial:
```
type=AVC msg=audit(1786427870.650:1316): apparmor="DENIED" operation="sendmsg" class="file" profile="snap.test-snapd-service-watchdog.direct-watchdog-bad" name="/systemd/notify" pid=21234 comm="python3" requeste
d_mask="w" denied_mask="w" fsuid=0 ouid=0
```

Following apparmor upstream approach to the problem (https://gitlab.com/apparmor/apparmor/-/commits/master?message=%2Fsystemd%2Fnotify), this adds `w` permissions to the disconnected path `/systemd/notify` whenever the notify socket is `/run/systemd/notify`.