### PR TITLE
i/udev: remove udev tag dir on snap removal

### DIFF
--- a/interfaces/udev/backend.go
+++ b/interfaces/udev/backend.go
@@ -48,6 +48,9 @@ type Backend struct {
 	isContainer bool
 }
 
+// udevTagsDir is the directory where udev maintains per-tag device lists.
+const udevTagsDir = "/run/udev/tags"
+
 // Initialize does nothing.
 func (b *Backend) Initialize(opts *interfaces.SecurityBackendOptions) error {
 	if opts != nil && opts.Preseed {
@@ -229,7 +232,22 @@ func (b *Backend) Remove(snapName string) error {
 	// subsystemTriggers appropriately. ATM, it is always going to be empty
 	// on disconnect.
 	if needReload {
-		return b.reloadRules(nil)
+		if err := b.reloadRules(nil); err != nil {
+			return err
+		}
+
+		// Remove empty udev tag directories left behind for this snap.
+		// After reloadRules/udevadm-trigger, udev removes device entries
+		// from the tag dirs for re-evaluated subsystems; we sweep what
+		// remains. Dirs that are still non-empty (e.g. input devices
+		// skipped by --subsystem-nomatch=input) are left alone — /run is
+		// ephemeral and will be cleaned up on reboot.
+		tagPrefix := udevTag(snap.SecurityTag(snapName)) + "_"
+		matches, _ := filepath.Glob(filepath.Join(dirs.GlobalRootDir, udevTagsDir, tagPrefix+"*"))
+		for _, dir := range matches {
+			// ignore errors
+			os.Remove(dir)
+		}
 	}
 	return nil
 }

--- a/interfaces/udev/backend_test.go
+++ b/interfaces/udev/backend_test.go
@@ -659,3 +659,53 @@ func (s *backendSuite) TestPreseed(c *C) {
 
 	c.Check(s.udevadmCmd.Calls(), HasLen, 0)
 }
+
+func (s *backendSuite) TestRemovingSnapRemovesUdevTagDirs(c *C) {
+	// give the snap udev rules so the rules file is created on install
+	s.Iface.UDevPermanentSlotCallback = func(spec *udev.Specification, slot *snap.SlotInfo) error {
+		spec.AddSnippet("sample")
+		return nil
+	}
+
+	tagsDir := filepath.Join(dirs.GlobalRootDir, "run/udev/tags")
+
+	// simulate tag dirs left behind by udev for snap.samba.smbd and a hook
+	snapTagDir := filepath.Join(tagsDir, "snap_samba_smbd")
+	hookTagDir := filepath.Join(tagsDir, "snap_samba_hook_configure")
+	c.Assert(os.MkdirAll(snapTagDir, 0755), IsNil)
+	c.Assert(os.MkdirAll(hookTagDir, 0755), IsNil)
+
+	// a tag dir for a different snap must not be touched
+	otherTagDir := filepath.Join(tagsDir, "snap_other_app")
+	c.Assert(os.MkdirAll(otherTagDir, 0755), IsNil)
+
+	snapInfo := s.InstallSnap(c, interfaces.ConfinementOptions{}, "", ifacetest.SambaYamlV1, 0)
+	s.RemoveSnap(c, snapInfo)
+
+	c.Check(snapTagDir, testutil.FileAbsent)
+	c.Check(hookTagDir, testutil.FileAbsent)
+	c.Check(otherTagDir, testutil.FilePresent)
+}
+
+func (s *backendSuite) TestRemovingSnapLeavesNonEmptyUdevTagDir(c *C) {
+	// give the snap udev rules so the rules file is created on install
+	s.Iface.UDevPermanentSlotCallback = func(spec *udev.Specification, slot *snap.SlotInfo) error {
+		spec.AddSnippet("sample")
+		return nil
+	}
+
+	tagsDir := filepath.Join(dirs.GlobalRootDir, "run/udev/tags")
+
+	// simulate a tag dir that still has a device entry (e.g. input subsystem
+	// device not processed by udevadm trigger --subsystem-nomatch=input)
+	snapTagDir := filepath.Join(tagsDir, "snap_samba_smbd")
+	c.Assert(os.MkdirAll(snapTagDir, 0755), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(snapTagDir, "c13:64"), nil, 0644), IsNil)
+
+	snapInfo := s.InstallSnap(c, interfaces.ConfinementOptions{}, "", ifacetest.SambaYamlV1, 0)
+	// RemoveSnap must not fail even though the tag dir is not empty
+	s.RemoveSnap(c, snapInfo)
+
+	// non-empty dir is left in place
+	c.Check(snapTagDir, testutil.FilePresent)
+}


### PR DESCRIPTION
udev leaves behind empty tag dirs in `/run/udev/tags` after reloading rules and `udevadm trigger` post the removal of rules file of the snap being removed. This is just a minor cleanup of those ephemeral tag dirs.

[SNAPDENG-37196](https://warthogs.atlassian.net/browse/SNAPDENG-37196)

[SNAPDENG-37196]: https://warthogs.atlassian.net/browse/SNAPDENG-37196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ