### PR TITLE
tests: add dbus interface name to provider in test-snapd-location-control-provider

### DIFF
--- a/tests/lib/snaps/store/test-snapd-location-control-provider/consumer
+++ b/tests/lib/snaps/store/test-snapd-location-control-provider/consumer
@@ -14,7 +14,7 @@ def _get_obj():
 
 def add_provider():
     obj = _get_obj()
-    return obj.AddProvider()
+    return obj.AddProvider(dbus_interface="com.ubuntu.location.Service")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The interface name is not automatically set on Stonking, and the apparmor policy requires `com.ubuntu.location.Service`.

With the change, the following tests pass:
```
spread -no-debug-output openstack-dev:tests/main/interfaces-location-control
```

Will require a snap update.