### PR TITLE
tests: skip broken-seeding test on 26.10 with broken deb as well

### DIFF
--- a/tests/main/broken-seeding/task.yaml
+++ b/tests/main/broken-seeding/task.yaml
@@ -16,9 +16,9 @@ skip:
     - reason: This test needs test keys to be trusted
       if: |
         [ "$TRUST_TEST_KEYS" = "false" ]
-    - reason: Known packaging bug in snapd 2.76+ubuntu26.04
+    - reason: Known packaging bug in snapd 2.76.x on Ubuntu 26.04 and 26.10
       if: |
-        os.query is-ubuntu 26.04 && ( dpkg -l snapd | MATCH '\s+2\.76\+ubuntu' )
+        ( os.query is-ubuntu 26.04 || os.query is-ubuntu 26.10 ) && ( dpkg -l snapd | MATCH '\s+2\.76(\.[0-9]+)*\+ubuntu' )
 
 prepare: |
     snap pack "$TESTSLIB/snaps/basic18"


### PR DESCRIPTION
Skip from https://github.com/canonical/snapd/pull/17394 should also be applied in this case, I think?