### PR TITLE
many: default enable refresh-app-awareness-ux

### DIFF
--- a/features/features.go
+++ b/features/features.go
@@ -130,7 +130,8 @@ var featureNames = map[SnapdFeature]string{
 
 // featuresEnabledWhenUnset contains a set of features that are enabled when not explicitly configured.
 var featuresEnabledWhenUnset = map[SnapdFeature]bool{
-	QuotaGroups: true,
+	QuotaGroups:           true,
+	RefreshAppAwarenessUX: true,
 }
 
 // featuresExported contains a set of features that are exported outside of snapd.

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -230,7 +230,7 @@ func (*featureSuite) TestIsEnabledWhenUnset(c *C) {
 	check(features.CheckDiskSpaceRemove, false)
 	check(features.GateAutoRefreshHook, false)
 	check(features.QuotaGroups, true)
-	check(features.RefreshAppAwarenessUX, false)
+	check(features.RefreshAppAwarenessUX, true)
 	check(features.Confdb, false)
 	check(features.AppArmorPrompting, false)
 	check(features.ConfdbControl, false)

--- a/overlord/snapstate/agentnotify/agentnotify_test.go
+++ b/overlord/snapstate/agentnotify/agentnotify_test.go
@@ -112,16 +112,13 @@ func (s *agentNotifySuite) TestMaybeAsyncFinishedRefreshNotification(c *C) {
 	})
 	defer restore()
 
-	tr := config.NewTransaction(s.st)
-	tr.Set("core", "experimental.refresh-app-awareness-ux", true)
-	tr.Commit()
-
 	agentnotify.MaybeSendClientFinishedRefreshNotification(s.st, sendInfo)
 	// no notification as refresh-appawareness-ux is enabled
 	// i.e. notices + warnings fallback is used instead
 	c.Check(connCheckCalled, Equals, 0)
 	c.Check(notificationCalled, Equals, 0)
 
+	tr := config.NewTransaction(s.st)
 	tr.Set("core", "experimental.refresh-app-awareness-ux", false)
 	tr.Commit()
 

--- a/overlord/snapstate/autorefresh_test.go
+++ b/overlord/snapstate/autorefresh_test.go
@@ -1034,14 +1034,6 @@ func (s *autoRefreshTestSuite) TestInhibitRefreshRefreshesWhenOverdue(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
-	notificationCount := 0
-	restore := snapstate.MockAsyncPendingRefreshNotification(func(ctx context.Context, refreshInfo *userclient.PendingSnapRefreshInfo) {
-		notificationCount++
-		c.Check(refreshInfo.InstanceName, Equals, "pkg")
-		c.Check(refreshInfo.TimeRemaining, Equals, time.Duration(0))
-	})
-	defer restore()
-
 	instant := time.Now()
 	pastInstant := instant.Add(-snapstate.MaxInhibitionDuration(s.state) * 2)
 
@@ -1054,7 +1046,7 @@ func (s *autoRefreshTestSuite) TestInhibitRefreshRefreshesWhenOverdue(c *C) {
 	}
 	snapsup := &snapstate.SnapSetup{Flags: snapstate.Flags{IsAutoRefresh: true}}
 
-	restore = snapstate.MockRefreshAppsCheck(func(si *snap.Info) error {
+	restore := snapstate.MockRefreshAppsCheck(func(si *snap.Info) error {
 		return &snapstate.BusySnapError{SnapInfo: si}
 	})
 	defer restore()
@@ -1062,7 +1054,6 @@ func (s *autoRefreshTestSuite) TestInhibitRefreshRefreshesWhenOverdue(c *C) {
 	inhibitionTimeout, err := snapstate.InhibitRefresh(s.state, snapst, snapsup, info)
 	c.Assert(err == nil, Equals, true)
 	c.Check(inhibitionTimeout, Equals, true)
-	c.Check(notificationCount, Equals, 1)
 }
 
 func (s *autoRefreshTestSuite) TestInhibitNoNotificationOnManualRefresh(c *C) {
@@ -1418,7 +1409,6 @@ func (s *autoRefreshTestSuite) testMaybeAddRefreshInhibitNotice(c *C, markerInte
 }
 
 func (s *autoRefreshTestSuite) TestMaybeAddRefreshInhibitNotice(c *C) {
-	s.enableRefreshAppAwarenessUX()
 	const markerInterfaceConnected = true
 	const warningFallback = false
 	s.testMaybeAddRefreshInhibitNotice(c, markerInterfaceConnected, warningFallback)
@@ -1464,9 +1454,9 @@ func (s *autoRefreshTestSuite) TestMaybeAddRefreshInhibitNoticeWarningFallbackEr
 	})
 	defer restore()
 
-	st.Unlock()
-	s.enableRefreshAppAwarenessUX()
-	st.Lock()
+	// unset the invalid value so the default-enabled path reaches the connection check
+	tr.Set("core", "experimental.refresh-app-awareness-ux", nil)
+	tr.Commit()
 	err = snapstate.MaybeAddRefreshInhibitNotice(st)
 	// warning fallback error is not propagated, only logged
 	c.Assert(err, IsNil)
@@ -1480,24 +1470,21 @@ func (s *autoRefreshTestSuite) TestMaybeAddRefreshInhibitNoticeWarningFallbackEr
 }
 
 func (s *autoRefreshTestSuite) TestMaybeAddRefreshInhibitNoticeWarningFallback(c *C) {
-	s.enableRefreshAppAwarenessUX()
 	const markerInterfaceConnected = false
 	const warningFallback = true
 	s.testMaybeAddRefreshInhibitNotice(c, markerInterfaceConnected, warningFallback)
 }
 
 func (s *autoRefreshTestSuite) TestMaybeAddRefreshInhibitNoticeWarningFallbackNoRAAUX(c *C) {
+	s.state.Lock()
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.refresh-app-awareness-ux", false)
+	tr.Commit()
+	s.state.Unlock()
+
 	const markerInterfaceConnected = false
 	const warningFallback = false // because refresh-app-awareness-ux is disabled
 	s.testMaybeAddRefreshInhibitNotice(c, markerInterfaceConnected, warningFallback)
-}
-
-func (s *autoRefreshTestSuite) enableRefreshAppAwarenessUX() {
-	s.state.Lock()
-	tr := config.NewTransaction(s.state)
-	tr.Set("core", "experimental.refresh-app-awareness-ux", true)
-	tr.Commit()
-	s.state.Unlock()
 }
 
 func checkNoRefreshInhibitWarning(c *C, st *state.State) {
@@ -1569,16 +1556,13 @@ func (s *autoRefreshTestSuite) TestMaybeAsyncPendingRefreshNotification(c *C) {
 	})
 	defer restore()
 
-	tr := config.NewTransaction(s.state)
-	tr.Set("core", "experimental.refresh-app-awareness-ux", true)
-	tr.Commit()
-
 	snapstate.MaybeAsyncPendingRefreshNotification(context.TODO(), s.state, expectedInfo)
 	// no notification as refresh-appawareness-ux is enabled
 	// i.e. notices + warnings fallback is used instead
 	c.Check(connCheckCalled, Equals, 0)
 	c.Check(notificationCalled, Equals, 0)
 
+	tr := config.NewTransaction(s.state)
 	tr.Set("core", "experimental.refresh-app-awareness-ux", false)
 	tr.Commit()
 

--- a/overlord/snapstate/handlers_aliasesv2_test.go
+++ b/overlord/snapstate/handlers_aliasesv2_test.go
@@ -25,7 +25,6 @@ import (
 	. "gopkg.in/check.v1"
 	"gopkg.in/tomb.v2"
 
-	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/snapstate/backend"
 	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
@@ -50,10 +49,6 @@ func (s *snapmgrTestSuite) TestDoRemoveAliasesExcludeFromRefreshAppAwareness(c *
 		},
 	})
 
-	// enable experimental refresh-app-awareness-ux
-	tr := config.NewTransaction(s.state)
-	tr.Set("core", "experimental.refresh-app-awareness-ux", true)
-	tr.Commit()
 	// With excluded from refresh-app-awareness
 	restore := snapstate.MockExcludeFromRefreshAppAwareness(func(t snap.Type) bool {
 		return true
@@ -162,10 +157,6 @@ func (s *snapmgrTestSuite) TestDoRemoveAliasesSkipped(c *C) {
 		},
 	})
 
-	// enable experimental refresh-app-awareness-ux
-	tr := config.NewTransaction(s.state)
-	tr.Set("core", "experimental.refresh-app-awareness-ux", true)
-	tr.Commit()
 	t := s.state.NewTask("remove-aliases", "test")
 	t.Set("snap-setup", &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{RealName: "alias-snap"},
@@ -211,10 +202,6 @@ func (s *snapmgrTestSuite) TestDoUndoRemoveAliasesSkipped(c *C) {
 		},
 	})
 
-	// enable experimental refresh-app-awareness-ux
-	tr := config.NewTransaction(s.state)
-	tr.Set("core", "experimental.refresh-app-awareness-ux", true)
-	tr.Commit()
 	t := s.state.NewTask("remove-aliases", "test")
 	t.Set("snap-setup", &snapstate.SnapSetup{
 		SideInfo: &snap.SideInfo{RealName: "alias-snap"},
@@ -1025,10 +1012,6 @@ func (s *snapmgrTestSuite) TestDoSetupAliasesAutoPruneOldAliases(c *C) {
 		SideInfo: &snap.SideInfo{RealName: "alias-snap"},
 	}
 
-	// enable experimental refresh-app-awareness-ux
-	tr := config.NewTransaction(s.state)
-	tr.Set("core", "experimental.refresh-app-awareness-ux", true)
-	tr.Commit()
 	// remove-aliases + refresh-app-awareness task triggers pruning
 	removeAliasesTask := s.state.NewTask("remove-aliases", "test")
 	removeAliasesTask.Set("snap-setup", &snapsup)
@@ -1124,10 +1107,6 @@ func (s *snapmgrTestSuite) TestDoUndoSetupAliasesAutoPruneOldAliases(c *C) {
 		SideInfo: &snap.SideInfo{RealName: "alias-snap"},
 	}
 
-	// enable experimental refresh-app-awareness-ux
-	tr := config.NewTransaction(s.state)
-	tr.Set("core", "experimental.refresh-app-awareness-ux", true)
-	tr.Commit()
 	// remove-aliases + refresh-app-awareness task triggers pruning
 	removeAliasesTask := s.state.NewTask("remove-aliases", "test")
 	removeAliasesTask.Set("snap-setup", &snapsup)
@@ -1240,10 +1219,6 @@ func (s *snapmgrTestSuite) TestDoUndoSetupAliasesAutoErrorMidwayPruneOldAliases(
 		SideInfo: &snap.SideInfo{RealName: "alias-snap"},
 	}
 
-	// enable experimental refresh-app-awareness-ux
-	tr := config.NewTransaction(s.state)
-	tr.Set("core", "experimental.refresh-app-awareness-ux", true)
-	tr.Commit()
 	// remove-aliases + refresh-app-awareness task triggers pruning
 	removeAliasesTask := s.state.NewTask("remove-aliases", "test")
 	removeAliasesTask.Set("snap-setup", &snapsup)
@@ -1420,10 +1395,6 @@ func (s *snapmgrTestSuite) TestDoUndoSetupAliasesAutoPruneOldAliasesConflict(c *
 		SideInfo: &snap.SideInfo{RealName: "alias-snap"},
 	}
 
-	// enable experimental refresh-app-awareness-ux
-	tr := config.NewTransaction(s.state)
-	tr.Set("core", "experimental.refresh-app-awareness-ux", true)
-	tr.Commit()
 	// remove-aliases + refresh-app-awareness task triggers pruning
 	removeAliasesTask := s.state.NewTask("remove-aliases", "test")
 	removeAliasesTask.Set("snap-setup", &snapsup)

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -2894,7 +2894,7 @@ version: 1.0`)
 	c.Assert(snapst.LocalRevision(), Equals, snap.R(-1))
 }
 
-func (s *snapmgrTestSuite) testInstallSubsequentLocalRunThrough(c *C, refreshAppAwarenessUX bool) {
+func (s *snapmgrTestSuite) testInstallSubsequentLocalRunThrough(c *C) {
 	// use the real thing for this one
 	snapstate.MockOpenSnapFile(backend.OpenSnapFile)
 
@@ -2933,13 +2933,6 @@ epoch: 1*
 			revno: snap.R("x3"),
 		},
 	}
-	// aliases removal is skipped when refresh-app-awareness-ux is enabled
-	if !refreshAppAwarenessUX {
-		expected = append(expected, fakeOp{
-			op:   "remove-snap-aliases",
-			name: "mock",
-		})
-	}
 	expected = append(expected, fakeOps{
 		{
 			op:          "run-inhibit-snap-for-unlink",
@@ -2953,7 +2946,7 @@ epoch: 1*
 		{
 			op:                 "unlink-snap",
 			path:               filepath.Join(dirs.SnapMountDir, "mock/x2"),
-			unlinkSkipBinaries: refreshAppAwarenessUX,
+			unlinkSkipBinaries: true,
 			inhibitHint:        "refresh",
 		},
 		{
@@ -3036,12 +3029,11 @@ epoch: 1*
 }
 
 func (s *snapmgrTestSuite) TestInstallSubsequentLocalRunThrough(c *C) {
-	s.testInstallSubsequentLocalRunThrough(c, false)
+	s.testInstallSubsequentLocalRunThrough(c)
 }
 
 func (s *snapmgrTestSuite) TestInstallSubsequentLocalRunThroughSkipBinaries(c *C) {
-	s.enableRefreshAppAwarenessUX()
-	s.testInstallSubsequentLocalRunThrough(c, true)
+	s.testInstallSubsequentLocalRunThrough(c)
 }
 
 func (s *snapmgrTestSuite) TestInstallOldSubsequentLocalRunThrough(c *C) {
@@ -3085,10 +3077,6 @@ epoch: 1*
 			revno: snap.R("x1"),
 		},
 		{
-			op:   "remove-snap-aliases",
-			name: "mock",
-		},
-		{
 			op:          "run-inhibit-snap-for-unlink",
 			name:        "mock",
 			inhibitHint: "refresh",
@@ -3098,9 +3086,10 @@ epoch: 1*
 			name: "mock",
 		},
 		{
-			op:          "unlink-snap",
-			path:        filepath.Join(dirs.SnapMountDir, "mock/100001"),
-			inhibitHint: "refresh",
+			op:                 "unlink-snap",
+			path:               filepath.Join(dirs.SnapMountDir, "mock/100001"),
+			unlinkSkipBinaries: true,
+			inhibitHint:        "refresh",
 		},
 		{
 			op:   "copy-data",

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -1825,7 +1825,7 @@ func (s *snapmgrTestSuite) TestRevertToRevisionAlreadyCurrent(c *C) {
 	c.Assert(ts, IsNil)
 }
 
-func (s *snapmgrTestSuite) testRevertRunThrough(c *C, refreshAppAwarenessUX bool) {
+func (s *snapmgrTestSuite) TestRevertRunThrough(c *C) {
 	si := snap.SideInfo{
 		RealName: "some-snap",
 		Revision: snap.R(7),
@@ -1854,10 +1854,6 @@ func (s *snapmgrTestSuite) testRevertRunThrough(c *C, refreshAppAwarenessUX bool
 
 	expected := fakeOps{
 		{
-			op:   "remove-snap-aliases",
-			name: "some-snap",
-		},
-		{
 			op:          "run-inhibit-snap-for-unlink",
 			name:        "some-snap",
 			inhibitHint: "refresh",
@@ -1869,7 +1865,7 @@ func (s *snapmgrTestSuite) testRevertRunThrough(c *C, refreshAppAwarenessUX bool
 		{
 			op:                 "unlink-snap",
 			path:               filepath.Join(dirs.SnapMountDir, "some-snap/7"),
-			unlinkSkipBinaries: refreshAppAwarenessUX,
+			unlinkSkipBinaries: true,
 			inhibitHint:        "refresh",
 		},
 		{
@@ -1900,12 +1896,6 @@ func (s *snapmgrTestSuite) testRevertRunThrough(c *C, refreshAppAwarenessUX bool
 			op: "update-aliases",
 		},
 	}
-	// aliases removal is skipped when refresh-app-awareness-ux is enabled
-	if refreshAppAwarenessUX {
-		// remove "remove-snap-aliases" operation
-		expected = expected[1:]
-	}
-
 	// start with an easier-to-read error if this fails:
 	c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
 	c.Assert(s.fakeBackend.ops, DeepEquals, expected)
@@ -1932,15 +1922,6 @@ func (s *snapmgrTestSuite) testRevertRunThrough(c *C, refreshAppAwarenessUX bool
 	}, nil))
 	c.Check(snapst.RevertStatus, HasLen, 0)
 	c.Assert(snapst.Block(), DeepEquals, []snap.Revision{snap.R(7)})
-}
-
-func (s *snapmgrTestSuite) TestRevertRunThrough(c *C) {
-	s.testRevertRunThrough(c, false)
-}
-
-func (s *snapmgrTestSuite) TestRevertRunThroughSkipBinaries(c *C) {
-	s.enableRefreshAppAwarenessUX()
-	s.testRevertRunThrough(c, true)
 }
 
 func (s *snapmgrTestSuite) TestRevertRevisionNotBlocked(c *C) {
@@ -2132,10 +2113,6 @@ func (s *snapmgrTestSuite) revertWithBase(c *C, expectedRev snap.Revision, expec
 	if !failing {
 		expected := fakeOps{
 			{
-				op:   "remove-snap-aliases",
-				name: "snap-core18-to-core22",
-			},
-			{
 				op:          "run-inhibit-snap-for-unlink",
 				name:        "snap-core18-to-core22",
 				inhibitHint: "refresh",
@@ -2145,9 +2122,10 @@ func (s *snapmgrTestSuite) revertWithBase(c *C, expectedRev snap.Revision, expec
 				name: "snap-core18-to-core22",
 			},
 			{
-				op:          "unlink-snap",
-				path:        filepath.Join(dirs.SnapMountDir, "snap-core18-to-core22/7"),
-				inhibitHint: "refresh",
+				op:                 "unlink-snap",
+				path:               filepath.Join(dirs.SnapMountDir, "snap-core18-to-core22/7"),
+				unlinkSkipBinaries: true,
+				inhibitHint:        "refresh",
 			},
 			{
 				op:    "setup-profiles:Doing",
@@ -2229,10 +2207,6 @@ func (s *snapmgrTestSuite) TestParallelInstanceRevertRunThrough(c *C) {
 
 	expected := fakeOps{
 		{
-			op:   "remove-snap-aliases",
-			name: "some-snap_instance",
-		},
-		{
 			op:          "run-inhibit-snap-for-unlink",
 			name:        "some-snap_instance",
 			inhibitHint: "refresh",
@@ -2242,10 +2216,11 @@ func (s *snapmgrTestSuite) TestParallelInstanceRevertRunThrough(c *C) {
 			name: "some-snap_instance",
 		},
 		{
-			op:             "unlink-snap",
-			path:           filepath.Join(dirs.SnapMountDir, "some-snap_instance/7"),
-			inhibitHint:    "refresh",
-			otherInstances: true,
+			op:                 "unlink-snap",
+			path:               filepath.Join(dirs.SnapMountDir, "some-snap_instance/7"),
+			unlinkSkipBinaries: true,
+			inhibitHint:        "refresh",
+			otherInstances:     true,
 		},
 		{
 			op:    "setup-profiles:Doing",
@@ -2336,7 +2311,7 @@ func (s *snapmgrTestSuite) TestRevertWithLocalRevisionRunThrough(c *C) {
 
 	s.settle(c)
 
-	c.Assert(s.fakeBackend.ops.Ops(), HasLen, 10)
+	c.Assert(s.fakeBackend.ops.Ops(), HasLen, 9)
 
 	// verify that LocalRevision is still -7
 	var snapst snapstate.SnapState
@@ -2379,10 +2354,6 @@ func (s *snapmgrTestSuite) TestRevertToRevisionNewVersion(c *C) {
 
 	expected := fakeOps{
 		{
-			op:   "remove-snap-aliases",
-			name: "some-snap",
-		},
-		{
 			op:          "run-inhibit-snap-for-unlink",
 			name:        "some-snap",
 			inhibitHint: "refresh",
@@ -2392,9 +2363,10 @@ func (s *snapmgrTestSuite) TestRevertToRevisionNewVersion(c *C) {
 			name: "some-snap",
 		},
 		{
-			op:          "unlink-snap",
-			path:        filepath.Join(dirs.SnapMountDir, "some-snap/2"),
-			inhibitHint: "refresh",
+			op:                 "unlink-snap",
+			path:               filepath.Join(dirs.SnapMountDir, "some-snap/2"),
+			unlinkSkipBinaries: true,
+			inhibitHint:        "refresh",
 		},
 		{
 			op:    "setup-profiles:Doing",
@@ -2475,10 +2447,6 @@ func (s *snapmgrTestSuite) TestRevertTotalUndoRunThrough(c *C) {
 
 	expected := fakeOps{
 		{
-			op:   "remove-snap-aliases",
-			name: "some-snap",
-		},
-		{
 			op:          "run-inhibit-snap-for-unlink",
 			name:        "some-snap",
 			inhibitHint: "refresh",
@@ -2488,9 +2456,10 @@ func (s *snapmgrTestSuite) TestRevertTotalUndoRunThrough(c *C) {
 			name: "some-snap",
 		},
 		{
-			op:          "unlink-snap",
-			path:        filepath.Join(dirs.SnapMountDir, "some-snap/2"),
-			inhibitHint: "refresh",
+			op:                 "unlink-snap",
+			path:               filepath.Join(dirs.SnapMountDir, "some-snap/2"),
+			unlinkSkipBinaries: true,
+			inhibitHint:        "refresh",
 		},
 		{
 			op:    "setup-profiles:Doing",
@@ -2521,8 +2490,7 @@ func (s *snapmgrTestSuite) TestRevertTotalUndoRunThrough(c *C) {
 		},
 		// undoing everything from here down...
 		{
-			op:   "remove-snap-aliases",
-			name: "some-snap",
+			op: "update-aliases",
 		},
 		{
 			op:    "auto-connect:Undoing",
@@ -2545,9 +2513,6 @@ func (s *snapmgrTestSuite) TestRevertTotalUndoRunThrough(c *C) {
 		{
 			op:     "maybe-set-next-boot",
 			isUndo: true,
-		},
-		{
-			op: "update-aliases",
 		},
 	}
 	// start with an easier-to-read error if this fails:
@@ -2595,10 +2560,6 @@ func (s *snapmgrTestSuite) TestRevertUndoRunThrough(c *C) {
 
 	expected := fakeOps{
 		{
-			op:   "remove-snap-aliases",
-			name: "some-snap",
-		},
-		{
 			op:          "run-inhibit-snap-for-unlink",
 			name:        "some-snap",
 			inhibitHint: "refresh",
@@ -2608,9 +2569,10 @@ func (s *snapmgrTestSuite) TestRevertUndoRunThrough(c *C) {
 			name: "some-snap",
 		},
 		{
-			op:          "unlink-snap",
-			path:        filepath.Join(dirs.SnapMountDir, "some-snap/2"),
-			inhibitHint: "refresh",
+			op:                 "unlink-snap",
+			path:               filepath.Join(dirs.SnapMountDir, "some-snap/2"),
+			unlinkSkipBinaries: true,
+			inhibitHint:        "refresh",
 		},
 		{
 			op:    "setup-profiles:Doing",
@@ -2645,9 +2607,6 @@ func (s *snapmgrTestSuite) TestRevertUndoRunThrough(c *C) {
 		{
 			op:     "maybe-set-next-boot",
 			isUndo: true,
-		},
-		{
-			op: "update-aliases",
 		},
 	}
 
@@ -9316,7 +9275,6 @@ func (s *snapmgrTestSuite) TestRemodelAddGadgetAssetNoRemodelConflict(c *C) {
 }
 
 func (s *snapmgrTestSuite) TestMigrateHome(c *C) {
-	s.enableRefreshAppAwarenessUX()
 	s.state.Lock()
 	defer s.state.Unlock()
 

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -609,7 +609,6 @@ func (s *snapmgrTestSuite) testUpdateScenario(c *C, desc string, t switchScenari
 		"current",
 		"open-snap-file",
 		"setup-snap",
-		"remove-snap-aliases",
 		"run-inhibit-snap-for-unlink",
 		"discard-namespace-locked",
 		"unlink-snap",
@@ -686,15 +685,7 @@ func (s *snapmgrTestSuite) TestUpdateTasksWithOldCurrent(c *C) {
 	c.Check(snapsup.Revision(), Equals, si4.Revision)
 }
 
-func (s *snapmgrTestSuite) enableRefreshAppAwarenessUX() {
-	s.state.Lock()
-	tr := config.NewTransaction(s.state)
-	tr.Set("core", "experimental.refresh-app-awareness-ux", true)
-	tr.Commit()
-	s.state.Unlock()
-}
-
-func (s *snapmgrTestSuite) testUpdateCanDoBackwards(c *C, refreshAppAwarenessUX bool) {
+func (s *snapmgrTestSuite) TestUpdateCanDoBackwards(c *C) {
 	si7 := snap.SideInfo{
 		RealName: "some-snap",
 		SnapID:   "some-snap-id",
@@ -725,10 +716,6 @@ func (s *snapmgrTestSuite) testUpdateCanDoBackwards(c *C, refreshAppAwarenessUX 
 
 	expected := fakeOps{
 		{
-			op:   "remove-snap-aliases",
-			name: "some-snap",
-		},
-		{
 			op:          "run-inhibit-snap-for-unlink",
 			name:        "some-snap",
 			inhibitHint: "refresh",
@@ -740,7 +727,7 @@ func (s *snapmgrTestSuite) testUpdateCanDoBackwards(c *C, refreshAppAwarenessUX 
 		{
 			op:                 "unlink-snap",
 			path:               filepath.Join(dirs.SnapMountDir, "some-snap/11"),
-			unlinkSkipBinaries: refreshAppAwarenessUX,
+			unlinkSkipBinaries: true,
 			inhibitHint:        "refresh",
 		},
 		{
@@ -787,23 +774,9 @@ func (s *snapmgrTestSuite) testUpdateCanDoBackwards(c *C, refreshAppAwarenessUX 
 			revno: snap.R(7),
 		},
 	}
-	// aliases removal is skipped when refresh-app-awareness-ux is enabled
-	if refreshAppAwarenessUX {
-		// remove "remove-snap-aliases" operation
-		expected = expected[1:]
-	}
 	// start with an easier-to-read error if this fails:
 	c.Assert(s.fakeBackend.ops.Ops(), DeepEquals, expected.Ops())
 	c.Assert(s.fakeBackend.ops, DeepEquals, expected)
-}
-
-func (s *snapmgrTestSuite) TestUpdateCanDoBackwards(c *C) {
-	s.testUpdateCanDoBackwards(c, false)
-}
-
-func (s *snapmgrTestSuite) TestUpdateCanDoBackwardsSkipBinaries(c *C) {
-	s.enableRefreshAppAwarenessUX()
-	s.testUpdateCanDoBackwards(c, true)
 }
 
 func revs(seq []*sequence.RevisionSideState) []int {
@@ -1223,7 +1196,6 @@ func (s *snapmgrTestSuite) testUpdateAmendRunThrough(c *C, tryMode bool, compone
 		ops = append(ops, "setup-component")
 	}
 	ops = append(ops, []string{
-		"remove-snap-aliases",
 		"run-inhibit-snap-for-unlink",
 		"discard-namespace-locked",
 		"unlink-snap",
@@ -1459,7 +1431,6 @@ func (s *snapmgrTestSuite) testUpdateRunThrough(c *C, refreshAppAwarenessUX bool
 			services: []string{"svc1", "svc2", "svc3"},
 		},
 	}
-	// aliases removal is skipped when refresh-app-awareness-ux is enabled
 	if !refreshAppAwarenessUX {
 		expected = append(expected, fakeOp{
 			op:   "remove-snap-aliases",
@@ -1622,12 +1593,17 @@ func (s *snapmgrTestSuite) testUpdateRunThrough(c *C, refreshAppAwarenessUX bool
 }
 
 func (s *snapmgrTestSuite) TestUpdateRunThrough(c *C) {
-	s.testUpdateRunThrough(c, false)
+	s.testUpdateRunThrough(c, true)
 }
 
-func (s *snapmgrTestSuite) TestUpdateRunThroughSkipBinaries(c *C) {
-	s.enableRefreshAppAwarenessUX()
-	s.testUpdateRunThrough(c, true)
+func (s *snapmgrTestSuite) TestUpdateRunThroughNoRAAUX(c *C) {
+	s.state.Lock()
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.refresh-app-awareness-ux", false)
+	tr.Commit()
+	s.state.Unlock()
+
+	s.testUpdateRunThrough(c, false)
 }
 
 func (s *snapmgrTestSuite) TestUpdateDropsRevertStatus(c *C) {
@@ -1749,7 +1725,7 @@ func (s *snapmgrTestSuite) TestUpdateResetsHoldState(c *C) {
 	})
 }
 
-func (s *snapmgrTestSuite) testParallelInstanceUpdateRunThrough(c *C, refreshAppAwarenessUX bool) {
+func (s *snapmgrTestSuite) TestParallelInstanceUpdateRunThrough(c *C) {
 	// use services-snap here to make sure services would be stopped/started appropriately
 	si := snap.SideInfo{
 		RealName: "services-snap",
@@ -1851,13 +1827,6 @@ func (s *snapmgrTestSuite) testParallelInstanceUpdateRunThrough(c *C, refreshApp
 			services: []string{"svc1", "svc2", "svc3"},
 		},
 	}
-	// aliases removal is skipped when refresh-app-awareness-ux is enabled
-	if !refreshAppAwarenessUX {
-		expected = append(expected, fakeOp{
-			op:   "remove-snap-aliases",
-			name: "services-snap_instance",
-		})
-	}
 	expected = append(expected, fakeOps{
 		{
 			op:          "run-inhibit-snap-for-unlink",
@@ -1871,7 +1840,7 @@ func (s *snapmgrTestSuite) testParallelInstanceUpdateRunThrough(c *C, refreshApp
 		{
 			op:                 "unlink-snap",
 			path:               filepath.Join(dirs.SnapMountDir, "services-snap_instance/7"),
-			unlinkSkipBinaries: refreshAppAwarenessUX,
+			unlinkSkipBinaries: true,
 			inhibitHint:        "refresh",
 		},
 		{
@@ -2004,15 +1973,6 @@ func (s *snapmgrTestSuite) testParallelInstanceUpdateRunThrough(c *C, refreshApp
 		SnapID:   "services-snap-id",
 		Revision: snap.R(11),
 	}, nil))
-}
-
-func (s *snapmgrTestSuite) TestParallelInstanceUpdateRunThrough(c *C) {
-	s.testParallelInstanceUpdateRunThrough(c, false)
-}
-
-func (s *snapmgrTestSuite) TestParallelInstanceUpdateRunThroughSkipBinaries(c *C) {
-	s.enableRefreshAppAwarenessUX()
-	s.testParallelInstanceUpdateRunThrough(c, true)
 }
 
 func (s *snapmgrTestSuite) TestUpdateWithNewBase(c *C) {
@@ -2696,7 +2656,7 @@ func (s *snapmgrTestSuite) TestUpdateManyMultipleCredsUserWithNoStoreAuthRunThro
 	c.Check(seen["core-snap-id"], Equals, 1)
 }
 
-func (s *snapmgrTestSuite) testUpdateUndoRunThrough(c *C, refreshAppAwarenessUX bool) {
+func (s *snapmgrTestSuite) TestUpdateUndoRunThrough(c *C) {
 	si := snap.SideInfo{
 		RealName: "some-snap",
 		SnapID:   "some-snap-id",
@@ -2777,13 +2737,6 @@ func (s *snapmgrTestSuite) testUpdateUndoRunThrough(c *C, refreshAppAwarenessUX 
 			revno: snap.R(11),
 		},
 	}
-	// aliases removal is skipped when refresh-app-awareness-ux is enabled
-	if !refreshAppAwarenessUX {
-		expected = append(expected, fakeOp{
-			op:   "remove-snap-aliases",
-			name: "some-snap",
-		})
-	}
 	expected = append(expected, fakeOps{
 		{
 			op:          "run-inhibit-snap-for-unlink",
@@ -2797,7 +2750,7 @@ func (s *snapmgrTestSuite) testUpdateUndoRunThrough(c *C, refreshAppAwarenessUX 
 		{
 			op:                 "unlink-snap",
 			path:               filepath.Join(dirs.SnapMountDir, "some-snap/7"),
-			unlinkSkipBinaries: refreshAppAwarenessUX,
+			unlinkSkipBinaries: true,
 			inhibitHint:        "refresh",
 		},
 		{
@@ -2856,12 +2809,6 @@ func (s *snapmgrTestSuite) testUpdateUndoRunThrough(c *C, refreshAppAwarenessUX 
 			isUndo: true,
 		},
 	}...)
-	// aliases removal undo is skipped when refresh-app-awareness-ux is enabled
-	if !refreshAppAwarenessUX {
-		expected = append(expected, fakeOp{
-			op: "update-aliases",
-		})
-	}
 	expected = append(expected, fakeOps{
 		{
 			op:    "undo-setup-snap",
@@ -2905,15 +2852,6 @@ func (s *snapmgrTestSuite) testUpdateUndoRunThrough(c *C, refreshAppAwarenessUX 
 		Channel:  "",
 		Revision: snap.R(7),
 	}, nil))
-}
-
-func (s *snapmgrTestSuite) TestUpdateUndoRunThrough(c *C) {
-	s.testUpdateUndoRunThrough(c, false)
-}
-
-func (s *snapmgrTestSuite) TestUpdateUndoRunThroughSkipBinaries(c *C) {
-	s.enableRefreshAppAwarenessUX()
-	s.testUpdateUndoRunThrough(c, true)
 }
 
 func lastWithLane(tasks []*state.Task) *state.Task {
@@ -3131,7 +3069,6 @@ func (s *snapmgrTestSuite) testUpdateTotalUndoRunThrough(c *C, refreshAppAwarene
 			revno: snap.R(11),
 		},
 	}
-	// aliases removal is skipped when refresh-app-awareness-ux is enabled
 	if !refreshAppAwarenessUX {
 		expected = append(expected, fakeOp{
 			op:   "remove-snap-aliases",
@@ -3195,7 +3132,6 @@ func (s *snapmgrTestSuite) testUpdateTotalUndoRunThrough(c *C, refreshAppAwarene
 	}...)
 	// undoing everything from here down...
 	if refreshAppAwarenessUX {
-		// refresh-app-awareness-ux changes setup-aliases undo behavior
 		expected = append(expected, fakeOp{
 			op: "update-aliases",
 		})
@@ -3239,7 +3175,6 @@ func (s *snapmgrTestSuite) testUpdateTotalUndoRunThrough(c *C, refreshAppAwarene
 			isUndo: true,
 		},
 	}...)
-	// aliases removal undo is skipped when refresh-app-awareness-ux is enabled
 	if !refreshAppAwarenessUX {
 		expected = append(expected, fakeOp{
 			op: "update-aliases",
@@ -3291,12 +3226,17 @@ func (s *snapmgrTestSuite) testUpdateTotalUndoRunThrough(c *C, refreshAppAwarene
 }
 
 func (s *snapmgrTestSuite) TestUpdateTotalUndoRunThrough(c *C) {
-	s.testUpdateTotalUndoRunThrough(c, false)
+	s.testUpdateTotalUndoRunThrough(c, true)
 }
 
-func (s *snapmgrTestSuite) TestUpdateTotalUndoRunThroughSkipBinaries(c *C) {
-	s.enableRefreshAppAwarenessUX()
-	s.testUpdateTotalUndoRunThrough(c, true)
+func (s *snapmgrTestSuite) TestUpdateTotalUndoRunThroughNoRAAUX(c *C) {
+	s.state.Lock()
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.refresh-app-awareness-ux", false)
+	tr.Commit()
+	s.state.Unlock()
+
+	s.testUpdateTotalUndoRunThrough(c, false)
 }
 
 func (s *snapmgrTestSuite) TestUpdateSameRevision(c *C) {
@@ -12268,20 +12208,24 @@ func (s *snapmgrTestSuite) testAutoRefreshRefreshInhibitNoticeRecorded(c *C, mar
 }
 
 func (s *snapmgrTestSuite) TestAutoRefreshRefreshInhibitNoticeRecorded(c *C) {
-	s.enableRefreshAppAwarenessUX()
 	const markerInterfaceConnected = true
 	const warningFallback = false
 	s.testAutoRefreshRefreshInhibitNoticeRecorded(c, markerInterfaceConnected, warningFallback)
 }
 
 func (s *snapmgrTestSuite) TestAutoRefreshRefreshInhibitNoticeRecordedWarningFallback(c *C) {
-	s.enableRefreshAppAwarenessUX()
 	const markerInterfaceConnected = false
 	const warningFallback = true
 	s.testAutoRefreshRefreshInhibitNoticeRecorded(c, markerInterfaceConnected, warningFallback)
 }
 
 func (s *snapmgrTestSuite) TestAutoRefreshRefreshInhibitNoticeRecordedWarningFallbackNoRAAUX(c *C) {
+	s.state.Lock()
+	tr := config.NewTransaction(s.state)
+	tr.Set("core", "experimental.refresh-app-awareness-ux", false)
+	tr.Commit()
+	s.state.Unlock()
+
 	const markerInterfaceConnected = false
 	const warningFallback = false
 	s.testAutoRefreshRefreshInhibitNoticeRecorded(c, markerInterfaceConnected, warningFallback)
@@ -12703,12 +12647,6 @@ func (s *snapmgrTestSuite) TestDownloadTaskWaitsForPreDownload(c *C) {
 	restore := state.MockTime(now)
 	defer restore()
 
-	var notified bool
-	restore = snapstate.MockAsyncPendingRefreshNotification(func(context.Context, *userclient.PendingSnapRefreshInfo) {
-		notified = true
-	})
-	defer restore()
-
 	var monitored bool
 	restore = snapstate.MockCgroupMonitorSnapEnded(func(string, chan<- string) error {
 		monitored = true
@@ -12784,7 +12722,6 @@ func (s *snapmgrTestSuite) TestDownloadTaskWaitsForPreDownload(c *C) {
 	c.Assert(downloadCalls, Equals, 2)
 	c.Assert(preDlTask.Status(), Equals, state.DoneStatus)
 	c.Assert(dlTask.Status(), Equals, state.DoneStatus)
-	c.Check(notified, Equals, false)
 	c.Check(monitored, Equals, false)
 }
 
@@ -12794,12 +12731,6 @@ func (s *snapmgrTestSuite) TestPreDownloadTaskContinuesAutoRefreshIfSoftCheckOk(
 		c.Assert(info.InstanceName(), Equals, "foo")
 		softChecked = true
 		return nil
-	})
-	defer restore()
-
-	var notified bool
-	restore = snapstate.MockAsyncPendingRefreshNotification(func(context.Context, *userclient.PendingSnapRefreshInfo) {
-		notified = true
 	})
 	defer restore()
 
@@ -12851,7 +12782,6 @@ func (s *snapmgrTestSuite) TestPreDownloadTaskContinuesAutoRefreshIfSoftCheckOk(
 	c.Assert(preDlTask.Status(), Equals, state.DoneStatus)
 
 	c.Check(softChecked, Equals, true)
-	c.Check(notified, Equals, false)
 	c.Check(monitored, Equals, false)
 
 	autoRefreshChg := findChange(s.state, "auto-refresh")
@@ -12891,7 +12821,7 @@ func findChange(st *state.State, kind string) *state.Change {
 	return nil
 }
 
-func (s *snapmgrTestSuite) TestDownloadTaskMonitorsSnapStoppedAndNotifiesOnSoftCheckFail(c *C) {
+func (s *snapmgrTestSuite) TestDownloadTaskMonitorsSnapStoppedOnSoftCheckFail(c *C) {
 	s.state.Lock()
 	si := &snap.SideInfo{
 		RealName: "foo",
@@ -12930,12 +12860,6 @@ func (s *snapmgrTestSuite) TestDownloadTaskMonitorsSnapStoppedAndNotifiesOnSoftC
 	})
 	defer restore()
 
-	var notified bool
-	restore = snapstate.MockAsyncPendingRefreshNotification(func(context.Context, *userclient.PendingSnapRefreshInfo) {
-		notified = true
-	})
-	defer restore()
-
 	var monitorSignal chan<- string
 	restore = snapstate.MockCgroupMonitorSnapEnded(func(name string, done chan<- string) error {
 		c.Assert(name, Equals, "foo")
@@ -12957,9 +12881,8 @@ func (s *snapmgrTestSuite) TestDownloadTaskMonitorsSnapStoppedAndNotifiesOnSoftC
 	c.Assert(s.fakeStore.downloads, HasLen, 1)
 	c.Check(s.fakeStore.downloads[0].name, Equals, "foo")
 
-	// the soft check failed so we notified and started monitoring
+	// the soft check failed, so monitoring started
 	c.Check(softChecked, Equals, true)
-	c.Check(notified, Equals, true)
 	c.Assert(monitorSignal, NotNil)
 
 	var hints map[string]*snapstate.RefreshCandidate
@@ -13034,12 +12957,6 @@ func (s *snapmgrTestSuite) TestDownloadTaskMonitorsRepeated(c *C) {
 	})
 	defer restore()
 
-	var notified bool
-	restore = snapstate.MockAsyncPendingRefreshNotification(func(context.Context, *userclient.PendingSnapRefreshInfo) {
-		notified = true
-	})
-	defer restore()
-
 	var monitorSignal chan<- string
 	restore = snapstate.MockCgroupMonitorSnapEnded(func(name string, done chan<- string) error {
 		c.Assert(name, Equals, "foo")
@@ -13062,7 +12979,6 @@ func (s *snapmgrTestSuite) TestDownloadTaskMonitorsRepeated(c *C) {
 	monitored := s.state.Cached("monitored-snaps")
 	c.Assert(monitored, FitsTypeOf, map[string]context.CancelFunc{})
 	c.Assert(monitored.(map[string]context.CancelFunc)["foo"], NotNil)
-	c.Assert(notified, Equals, true)
 
 	// waiting for the monitoring to end
 	c.Check(s.state.Cached("monitored-snaps"), NotNil)
@@ -13076,7 +12992,6 @@ func (s *snapmgrTestSuite) TestDownloadTaskMonitorsRepeated(c *C) {
 	preDlChg.AddTask(preDlTask)
 
 	// reset the watcher variables
-	notified = false
 	softChecked = false
 	firstMonitorSignal := monitorSignal
 	monitorSignal = nil
@@ -13084,7 +12999,6 @@ func (s *snapmgrTestSuite) TestDownloadTaskMonitorsRepeated(c *C) {
 	s.settle(c)
 
 	c.Check(softChecked, Equals, true)
-	c.Check(notified, Equals, true)
 	// didn't wait for snap to stop because there's already a goroutine doing it
 	c.Check(monitorSignal, IsNil)
 
@@ -13119,16 +13033,8 @@ func (s *snapmgrTestSuite) TestUnlinkMonitorSnapOnHardCheckFailure(c *C) {
 		target:   filepath.Join(dirs.SnapBlobDir, "some-snap_instance_11.snap"),
 	}}
 
-	var notified bool
-	restore := snapstate.MockAsyncPendingRefreshNotification(func(_ context.Context, pendingInfo *userclient.PendingSnapRefreshInfo) {
-		c.Check(pendingInfo.InstanceName, Equals, "some-snap")
-		c.Check(pendingInfo.TimeRemaining, Equals, snapstate.MaxInhibitionDuration(s.state))
-		notified = true
-	})
-	defer restore()
-
 	var monitorSignal chan<- string
-	restore = snapstate.MockCgroupMonitorSnapEnded(func(name string, done chan<- string) error {
+	restore := snapstate.MockCgroupMonitorSnapEnded(func(name string, done chan<- string) error {
 		c.Check(name, Equals, "some-snap")
 		monitorSignal = done
 		return nil
@@ -13166,7 +13072,6 @@ func (s *snapmgrTestSuite) TestUnlinkMonitorSnapOnHardCheckFailure(c *C) {
 	s.settle(c)
 	c.Assert(chg.Status(), Equals, state.ErrorStatus)
 
-	c.Check(notified, Equals, true)
 	c.Check(check, Equals, 2)
 	c.Check(monitorSignal, NotNil)
 
@@ -13231,15 +13136,8 @@ func (s *snapmgrTestSuite) TestRefreshForcedOnRefreshInhibitionTimeout(c *C) {
 		},
 	}
 
-	var notified int
-	restore := snapstate.MockAsyncPendingRefreshNotification(func(_ context.Context, pendingInfo *userclient.PendingSnapRefreshInfo) {
-		c.Check(pendingInfo.TimeRemaining, Equals, time.Duration(0))
-		notified++
-	})
-	defer restore()
-
 	check := make(map[string]int, 2)
-	restore = snapstate.MockRefreshAppsCheck(func(info *snap.Info) error {
+	restore := snapstate.MockRefreshAppsCheck(func(info *snap.Info) error {
 		check[info.InstanceName()]++
 
 		switch check[info.InstanceName()] {
@@ -13287,7 +13185,6 @@ func (s *snapmgrTestSuite) TestRefreshForcedOnRefreshInhibitionTimeout(c *C) {
 	// 3 status changes (Default -> Doing -> Done) + 2 forced refreshes
 	c.Check(n["occurrences"], Equals, 5.0)
 
-	c.Check(notified, Equals, 2)
 	c.Check(check["some-snap"], Equals, 2)
 	c.Check(check["some-other-snap"], Equals, 2)
 }
@@ -13748,11 +13645,7 @@ func (s *snapmgrTestSuite) TestMonitoringIsPersistedAndRestored(c *C) {
 		"some-snap": {SnapSetup: *snapsup, Monitored: true},
 	})
 
-	var notified bool
-	restore := snapstate.MockAsyncPendingRefreshNotification(func(ctx context.Context, refreshInfo *userclient.PendingSnapRefreshInfo) {})
-	defer restore()
-
-	restore = snapstate.MockRefreshAppsCheck(func(info *snap.Info) error {
+	restore := snapstate.MockRefreshAppsCheck(func(info *snap.Info) error {
 		return nil
 	})
 	defer restore()
@@ -13771,9 +13664,8 @@ func (s *snapmgrTestSuite) TestMonitoringIsPersistedAndRestored(c *C) {
 	err := af.Ensure()
 	c.Check(err, IsNil)
 
-	// restores monitoring but doesn't notify again
+	// restores monitoring
 	c.Assert(stopMonitor, NotNil)
-	c.Assert(notified, Equals, false)
 
 	s.state.Lock()
 	aborts := s.state.Cached("monitored-snaps").(map[string]context.CancelFunc)
@@ -13836,14 +13728,8 @@ func (s *snapmgrTestSuite) testNoMonitoringWithCands(c *C, cands map[string]*sna
 	// that the candidate was reverted before the pre-download task runs
 	s.state.Set("refresh-candidates", cands)
 
-	var notified bool
-	restore := snapstate.MockAsyncPendingRefreshNotification(func(ctx context.Context, refreshInfo *userclient.PendingSnapRefreshInfo) {
-		notified = true
-	})
-	defer restore()
-
 	var inhibited bool
-	restore = snapstate.MockRefreshAppsCheck(func(info *snap.Info) error {
+	restore := snapstate.MockRefreshAppsCheck(func(info *snap.Info) error {
 		inhibited = true
 		return snapstate.NewBusySnapError(info, []int{123}, nil, nil)
 	})
@@ -13871,8 +13757,6 @@ func (s *snapmgrTestSuite) testNoMonitoringWithCands(c *C, cands map[string]*sna
 	c.Assert(s.state.Cached("monitored-snap"), IsNil)
 	c.Assert(buf.String(), testutil.Contains, `cannot get refresh candidate for "some-snap" (possibly reverted): nothing to refresh`)
 
-	// we didn't notify since there's no candidate to refresh to
-	c.Assert(notified, Equals, false)
 	c.Assert(inhibited, Equals, true)
 }
 
@@ -15731,10 +15615,6 @@ func (s *snapmgrTestSuite) TestUpdateBackToPrevRevision(c *C) {
 
 	expected := fakeOps{
 		{
-			op:   "remove-snap-aliases",
-			name: instanceName,
-		},
-		{
 			op:          "run-inhibit-snap-for-unlink",
 			name:        instanceName,
 			inhibitHint: "refresh",
@@ -15744,9 +15624,10 @@ func (s *snapmgrTestSuite) TestUpdateBackToPrevRevision(c *C) {
 			name: instanceName,
 		},
 		{
-			op:          "unlink-snap",
-			path:        filepath.Join(dirs.SnapMountDir, instanceName, currentSnapRev.String()),
-			inhibitHint: "refresh",
+			op:                 "unlink-snap",
+			path:               filepath.Join(dirs.SnapMountDir, instanceName, currentSnapRev.String()),
+			unlinkSkipBinaries: true,
+			inhibitHint:        "refresh",
 		},
 		{
 			op:   "copy-data",
@@ -15982,10 +15863,6 @@ func (s *snapmgrTestSuite) testRevertWithComponents(c *C, undo bool) {
 	// as they were part of a the previous revision
 	expected = append(expected, fakeOps{
 		{
-			op:   "remove-snap-aliases",
-			name: instanceName,
-		},
-		{
 			op:          "run-inhibit-snap-for-unlink",
 			name:        instanceName,
 			inhibitHint: "refresh",
@@ -15995,9 +15872,10 @@ func (s *snapmgrTestSuite) testRevertWithComponents(c *C, undo bool) {
 			name: instanceName,
 		},
 		{
-			op:          "unlink-snap",
-			path:        filepath.Join(dirs.SnapMountDir, instanceName, currentSnapRev.String()),
-			inhibitHint: "refresh",
+			op:                 "unlink-snap",
+			path:               filepath.Join(dirs.SnapMountDir, instanceName, currentSnapRev.String()),
+			unlinkSkipBinaries: true,
+			inhibitHint:        "refresh",
 		},
 		{
 			op:    "setup-profiles:Doing",
@@ -16033,8 +15911,7 @@ func (s *snapmgrTestSuite) testRevertWithComponents(c *C, undo bool) {
 	if undo {
 		expected = append(expected, []fakeOp{
 			{
-				op:   "remove-snap-aliases",
-				name: instanceName,
+				op: "update-aliases",
 			},
 			{
 				op:    "auto-connect:Undoing",
@@ -16057,9 +15934,6 @@ func (s *snapmgrTestSuite) testRevertWithComponents(c *C, undo bool) {
 			{
 				op:     "maybe-set-next-boot",
 				isUndo: true,
-			},
-			{
-				op: "update-aliases",
 			},
 		}...)
 	}
@@ -16371,11 +16245,6 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
 		})
 	}
 
-	expected = append(expected, fakeOp{
-		op:   "remove-snap-aliases",
-		name: snapName,
-	})
-
 	expected = append(expected, fakeOps{
 		{
 			op:          "run-inhibit-snap-for-unlink",
@@ -16387,9 +16256,10 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
 			name: snapName,
 		},
 		{
-			op:          "unlink-snap",
-			path:        filepath.Join(dirs.SnapMountDir, snapName, currentSnapRev.String()),
-			inhibitHint: "refresh",
+			op:                 "unlink-snap",
+			path:               filepath.Join(dirs.SnapMountDir, snapName, currentSnapRev.String()),
+			unlinkSkipBinaries: true,
+			inhibitHint:        "refresh",
 		},
 		{
 			op: "prepare-kernel-snap",
@@ -16936,11 +16806,6 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevisionAddComponen
 		}}...)
 	}
 
-	expected = append(expected, fakeOp{
-		op:   "remove-snap-aliases",
-		name: snapName,
-	})
-
 	expected = append(expected, fakeOps{
 		{
 			op:          "run-inhibit-snap-for-unlink",
@@ -16952,9 +16817,10 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevisionAddComponen
 			name: snapName,
 		},
 		{
-			op:          "unlink-snap",
-			path:        filepath.Join(dirs.SnapMountDir, snapName, currentSnapRev.String()),
-			inhibitHint: "refresh",
+			op:                 "unlink-snap",
+			path:               filepath.Join(dirs.SnapMountDir, snapName, currentSnapRev.String()),
+			unlinkSkipBinaries: true,
+			inhibitHint:        "refresh",
 		},
 		{
 			op: "prepare-kernel-snap",
@@ -17105,47 +16971,42 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThroughNoComponents(c *C) 
 
 func (s *snapmgrTestSuite) TestUpdateExplicitlyToSameRevisionRunThrough(c *C) {
 	s.testUpdateWithComponentsRunThrough(c, updateWithComponentsOpts{
-		snapType:              snap.TypeKernel,
-		useSameSnapRev:        true,
-		refreshAppAwarenessUX: true,
+		snapType:       snap.TypeKernel,
+		useSameSnapRev: true,
 	})
 }
 
 func (s *snapmgrTestSuite) TestUpdateExplicitlyToSameRevisionRunThroughUndo(c *C) {
 	s.testUpdateWithComponentsRunThrough(c, updateWithComponentsOpts{
-		snapType:              snap.TypeKernel,
-		useSameSnapRev:        true,
-		undo:                  true,
-		refreshAppAwarenessUX: true,
+		snapType:       snap.TypeKernel,
+		useSameSnapRev: true,
+		undo:           true,
 	})
 }
 
 func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThroughUndo(c *C) {
 	s.testUpdateWithComponentsRunThrough(c, updateWithComponentsOpts{
-		snapType:              snap.TypeKernel,
-		components:            []string{"standard-component", "kernel-modules-component"},
-		refreshAppAwarenessUX: true,
-		undo:                  true,
+		snapType:   snap.TypeKernel,
+		components: []string{"standard-component", "kernel-modules-component"},
+		undo:       true,
 	})
 }
 
 func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThroughInstanceKey(c *C) {
 	s.testUpdateWithComponentsRunThrough(c, updateWithComponentsOpts{
-		snapType:              snap.TypeApp,
-		instanceKey:           "key",
-		components:            []string{"standard-component", "standard-component-extra"},
-		refreshAppAwarenessUX: true,
-		undo:                  false,
+		snapType:    snap.TypeApp,
+		instanceKey: "key",
+		components:  []string{"standard-component", "standard-component-extra"},
+		undo:        false,
 	})
 }
 
 func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThroughInstanceKeyUndo(c *C) {
 	s.testUpdateWithComponentsRunThrough(c, updateWithComponentsOpts{
-		snapType:              snap.TypeApp,
-		instanceKey:           "key",
-		components:            []string{"standard-component", "standard-component-extra"},
-		refreshAppAwarenessUX: true,
-		undo:                  true,
+		snapType:    snap.TypeApp,
+		instanceKey: "key",
+		components:  []string{"standard-component", "standard-component-extra"},
+		undo:        true,
 	})
 }
 
@@ -17154,7 +17015,6 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThroughLoseComponents(c *C
 		snapType:              snap.TypeKernel,
 		components:            []string{"standard-component", "kernel-modules-component"},
 		postRefreshComponents: []string{"standard-component"},
-		refreshAppAwarenessUX: true,
 	})
 }
 
@@ -17163,7 +17023,6 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThroughLoseComponentsUndo(
 		snapType:              snap.TypeKernel,
 		components:            []string{"standard-component", "kernel-modules-component"},
 		postRefreshComponents: []string{"standard-component"},
-		refreshAppAwarenessUX: true,
 		undo:                  true,
 	})
 }
@@ -17174,7 +17033,6 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThroughAdditionalComponent
 		components:            []string{"standard-component"},
 		postRefreshComponents: []string{"standard-component", "kernel-modules-component"},
 		additionalComponents:  []string{"kernel-modules-component"},
-		refreshAppAwarenessUX: true,
 	})
 }
 
@@ -17184,7 +17042,6 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThroughAdditionalComponent
 		components:            []string{"standard-component"},
 		postRefreshComponents: []string{"standard-component"},
 		additionalComponents:  []string{"standard-component"},
-		refreshAppAwarenessUX: true,
 	})
 }
 
@@ -17194,7 +17051,6 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThroughAdditionalComponent
 		components:            []string{"standard-component"},
 		postRefreshComponents: []string{"standard-component", "kernel-modules-component"},
 		additionalComponents:  []string{"kernel-modules-component"},
-		refreshAppAwarenessUX: true,
 		undo:                  true,
 	})
 }
@@ -17205,7 +17061,6 @@ type updateWithComponentsOpts struct {
 	components            []string
 	postRefreshComponents []string
 	additionalComponents  []string
-	refreshAppAwarenessUX bool
 	undo                  bool
 	useSameSnapRev        bool
 }
@@ -17228,10 +17083,6 @@ func componentNameToType(c *C, name string) snap.ComponentType {
 }
 
 func (s *snapmgrTestSuite) testUpdateWithComponentsRunThrough(c *C, opts updateWithComponentsOpts) {
-	if opts.refreshAppAwarenessUX {
-		s.enableRefreshAppAwarenessUX()
-	}
-
 	var snapName, snapID string
 	switch opts.snapType {
 	case snap.TypeKernel:
@@ -17640,13 +17491,6 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThrough(c *C, opts updateW
 		})
 	}
 
-	if !opts.refreshAppAwarenessUX {
-		expected = append(expected, fakeOp{
-			op:   "remove-snap-aliases",
-			name: instanceName,
-		})
-	}
-
 	expected = append(expected, fakeOps{
 		{
 			op:          "run-inhibit-snap-for-unlink",
@@ -17660,7 +17504,7 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThrough(c *C, opts updateW
 		{
 			op:                 "unlink-snap",
 			path:               filepath.Join(dirs.SnapMountDir, instanceName, currentSnapRev.String()),
-			unlinkSkipBinaries: opts.refreshAppAwarenessUX,
+			unlinkSkipBinaries: true,
 			inhibitHint:        "refresh",
 		}}...)
 	if opts.snapType == snap.TypeKernel {
@@ -17937,8 +17781,6 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThroughShareComponentsUndo
 }
 
 func (s *snapmgrTestSuite) testUpdateWithComponentsRunThroughShareComponents(c *C, undo bool) {
-	s.enableRefreshAppAwarenessUX()
-
 	const (
 		snapName = "kernel"
 		snapID   = "kernel-id"
@@ -18585,49 +18427,45 @@ func (s *snapmgrTestSuite) TestUpdateTasksWithComponentsRemoved(c *C) {
 
 func (s *snapmgrTestSuite) TestUpdateWithComponentsFromPathRunThrough(c *C) {
 	const (
-		instanceKey           = ""
-		snapType              = snap.TypeKernel
-		refreshAppAwarenessUX = true
-		undo                  = false
+		instanceKey = ""
+		snapType    = snap.TypeKernel
+		undo        = false
 	)
 	s.testUpdateWithComponentsFromPathRunThrough(c, instanceKey, snapType,
-		[]string{"standard-component", "kernel-modules-component"}, refreshAppAwarenessUX, undo)
+		[]string{"standard-component", "kernel-modules-component"}, undo)
 }
 
 func (s *snapmgrTestSuite) TestUpdateWithComponentsFromPathRunThroughUndo(c *C) {
 	const (
-		instanceKey           = ""
-		snapType              = snap.TypeKernel
-		refreshAppAwarenessUX = true
-		undo                  = true
+		instanceKey = ""
+		snapType    = snap.TypeKernel
+		undo        = true
 	)
 	s.testUpdateWithComponentsFromPathRunThrough(c, instanceKey, snapType,
-		[]string{"standard-component", "kernel-modules-component"}, refreshAppAwarenessUX, undo)
+		[]string{"standard-component", "kernel-modules-component"}, undo)
 }
 
 func (s *snapmgrTestSuite) TestUpdateInstanceWithComponentsFromPathRunThrough(c *C) {
 	const (
-		instanceKey           = "key"
-		snapType              = snap.TypeApp
-		refreshAppAwarenessUX = true
-		undo                  = false
+		instanceKey = "key"
+		snapType    = snap.TypeApp
+		undo        = false
 	)
 	s.testUpdateWithComponentsFromPathRunThrough(c, instanceKey, snapType,
-		[]string{"standard-component", "standard-component-extra"}, refreshAppAwarenessUX, undo)
+		[]string{"standard-component", "standard-component-extra"}, undo)
 }
 
 func (s *snapmgrTestSuite) TestUpdateInstanceWithComponentsFromPathRunThroughUndo(c *C) {
 	const (
-		instanceKey           = "key"
-		snapType              = snap.TypeApp
-		refreshAppAwarenessUX = true
-		undo                  = true
+		instanceKey = "key"
+		snapType    = snap.TypeApp
+		undo        = true
 	)
 	s.testUpdateWithComponentsFromPathRunThrough(c, instanceKey, snapType,
-		[]string{"standard-component", "standard-component-extra"}, refreshAppAwarenessUX, undo)
+		[]string{"standard-component", "standard-component-extra"}, undo)
 }
 
-func (s *snapmgrTestSuite) testUpdateWithComponentsFromPathRunThrough(c *C, instanceKey string, snapType snap.Type, compNames []string, refreshAppAwarenessUX, undo bool) {
+func (s *snapmgrTestSuite) testUpdateWithComponentsFromPathRunThrough(c *C, instanceKey string, snapType snap.Type, compNames []string, undo bool) {
 	// use the real thing for this one
 	snapstate.MockOpenSnapFile(backend.OpenSnapFile)
 
@@ -18646,10 +18484,6 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsFromPathRunThrough(c *C, inst
 
 	r := snapstatetest.MockDeviceModel(MakeModel20("pc", map[string]any{"base": "core24"}))
 	defer r()
-
-	if refreshAppAwarenessUX {
-		s.enableRefreshAppAwarenessUX()
-	}
 
 	currentSnapRev := snap.R(7)
 	newSnapRev := snap.R(11)
@@ -18890,13 +18724,6 @@ components:
 		},
 	}...)
 
-	if !refreshAppAwarenessUX {
-		expected = append(expected, fakeOp{
-			op:   "remove-snap-aliases",
-			name: instanceName,
-		})
-	}
-
 	for _, cs := range expectedComponentStates {
 		compName := cs.SideInfo.Component.ComponentName
 		compRev := cs.SideInfo.Revision
@@ -18923,7 +18750,7 @@ components:
 		{
 			op:                 "unlink-snap",
 			path:               filepath.Join(dirs.SnapMountDir, instanceName, currentSnapRev.String()),
-			unlinkSkipBinaries: refreshAppAwarenessUX,
+			unlinkSkipBinaries: true,
 			inhibitHint:        "refresh",
 		}}...)
 	if snapType == snap.TypeKernel {
@@ -19147,8 +18974,6 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsFromPathBackToInstalledRevisi
 
 	r := snapstatetest.MockDeviceModel(MakeModel20("pc", map[string]any{"base": "core24"}))
 	defer r()
-
-	s.enableRefreshAppAwarenessUX()
 
 	oldSnapRev := snap.R(7)
 	currentSnapRev := snap.R(11)
@@ -19480,37 +19305,33 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsFromPathBackToInstalledRevisi
 
 func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThroughOnlyComponentUpdate(c *C) {
 	s.testUpdateWithComponentsRunThroughOnlyComponentUpdate(c, updateWithComponentsOpts{
-		snapType:              snap.TypeKernel,
-		components:            []string{"standard-component", "kernel-modules-component"},
-		refreshAppAwarenessUX: true,
+		snapType:   snap.TypeKernel,
+		components: []string{"standard-component", "kernel-modules-component"},
 	})
 }
 
 func (s *snapmgrTestSuite) TestUpdateWithComponentsRunThroughOnlyComponentUpdateUndo(c *C) {
 	s.testUpdateWithComponentsRunThroughOnlyComponentUpdate(c, updateWithComponentsOpts{
-		snapType:              snap.TypeKernel,
-		components:            []string{"standard-component", "kernel-modules-component"},
-		refreshAppAwarenessUX: true,
-		undo:                  true,
+		snapType:   snap.TypeKernel,
+		components: []string{"standard-component", "kernel-modules-component"},
+		undo:       true,
 	})
 }
 
 func (s *snapmgrTestSuite) TestUpdateInstanceWithComponentsRunThroughOnlyComponentUpdate(c *C) {
 	s.testUpdateWithComponentsRunThroughOnlyComponentUpdate(c, updateWithComponentsOpts{
-		snapType:              snap.TypeApp,
-		instanceKey:           "key",
-		components:            []string{"standard-component", "standard-component-extra"},
-		refreshAppAwarenessUX: true,
+		snapType:    snap.TypeApp,
+		instanceKey: "key",
+		components:  []string{"standard-component", "standard-component-extra"},
 	})
 }
 
 func (s *snapmgrTestSuite) TestUpdateInstanceWithComponentsRunThroughOnlyComponentUpdateUndo(c *C) {
 	s.testUpdateWithComponentsRunThroughOnlyComponentUpdate(c, updateWithComponentsOpts{
-		snapType:              snap.TypeApp,
-		instanceKey:           "key",
-		components:            []string{"standard-component", "standard-component-extra"},
-		refreshAppAwarenessUX: true,
-		undo:                  true,
+		snapType:    snap.TypeApp,
+		instanceKey: "key",
+		components:  []string{"standard-component", "standard-component-extra"},
+		undo:        true,
 	})
 }
 
@@ -19522,11 +19343,6 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThroughOnlyComponentUpdate
 	if opts.postRefreshComponents != nil {
 		c.Fatalf("when refreshing a snap that results in only component revision changes, you cannot lose or gain components")
 	}
-
-	if opts.refreshAppAwarenessUX {
-		s.enableRefreshAppAwarenessUX()
-	}
-
 	var snapName, snapID string
 	switch opts.snapType {
 	case snap.TypeKernel:
@@ -19742,13 +19558,6 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThroughOnlyComponentUpdate
 		},
 	}
 
-	if !opts.refreshAppAwarenessUX {
-		expected = append(expected, fakeOp{
-			op:   "remove-snap-aliases",
-			name: instanceName,
-		})
-	}
-
 	for _, cs := range expectedComponentStates {
 		compName := cs.SideInfo.Component.ComponentName
 		compRev := cs.SideInfo.Revision
@@ -19798,7 +19607,7 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThroughOnlyComponentUpdate
 		fakeOp{
 			op:                 "unlink-snap",
 			path:               filepath.Join(dirs.SnapMountDir, instanceName, currentSnapRev.String()),
-			unlinkSkipBinaries: opts.refreshAppAwarenessUX,
+			unlinkSkipBinaries: true,
 			inhibitHint:        "refresh",
 		})
 	if opts.snapType == snap.TypeKernel {

--- a/tests/main/auto-refresh-pre-download/task.yaml
+++ b/tests/main/auto-refresh-pre-download/task.yaml
@@ -1,7 +1,8 @@
 summary: Check auto-refresh from a pre-download change
 
 details: |
-  Verify that an inhibited auto-refresh triggers a pre-download change and resumes on close
+  Verify that an inhibited auto-refresh triggers a pre-download change,
+  reports the inhibition through the warning fallback, and resumes on close.
 
 
 # Ubuntu 14.04's special version of systemd doesn't have StartTransientUnit API.
@@ -23,19 +24,12 @@ prepare: |
   # ensure no other refreshes interfere with the test
   snap refresh
   snap install test-snapd-sh
-  # linger is needed so snapd.session-agent.socket is active for the test user to receive notifications
-  # notifications are only checked on ubuntu classic (see execute section)
-  if os.query is-ubuntu && os.query is-classic; then
-    tests.session prepare -u test
-    tests.cleanup defer tests.session restore -u test
-  fi
 
 restore: |
   snap remove --purge test-snapd-sh || true
 
 debug: |
   snap changes
-  cat /home/test/notif.log || true
 
 execute: |
   err_and_exit(){
@@ -70,12 +64,6 @@ execute: |
   APP_PID="$!"
   tests.cleanup defer "kill \"$APP_PID\" || true"
 
-  # TODO: test notifications in other distros as well
-  if os.query is-ubuntu && os.query is-classic; then
-    tests.session -u test exec sh -c 'dbus-monitor > notif.log' &
-    tests.cleanup defer "systemctl kill user-12345.slice || true"
-  fi
-
   # trigger an auto-refresh
   OLD_CHANGE=$(snap changes | tail -n 2 | head -n 1 | awk '{print $1}')
   systemctl stop snapd.{service,socket}
@@ -92,14 +80,8 @@ execute: |
     err_and_exit "expected a completed pre-download change"
   fi
 
-  if os.query is-ubuntu && os.query is-classic; then
-    # check that the pre-download notified the user to close the snap
-    retry -n 20 MATCH 'string "Update available for test-snapd-sh."' < /home/test/notif.log
-    MATCH 'string "Close the application to update now. It will update automatically in .* days."' < /home/test/notif.log
-
-    # stop all the dbus monitoring related processes
-    systemctl kill user-12345.slice 2>/dev/null || true
-  fi
+  echo "Check that snapd reports the inhibited refresh through the warning fallback"
+  retry -n 20 sh -c "snap warnings | tr '\n' ' ' | tr -s ' ' | MATCH 'cannot refresh .*test-snapd-sh.* due running apps; close running apps to continue refresh.'"
 
   OLD_CHANGE=$(snap changes | tail -n 2 | head -n 1 | awk '{print $1}')
   if [ "$VARIANT" == "close" ]; then

--- a/tests/main/refresh-app-awareness-notify/task.yaml
+++ b/tests/main/refresh-app-awareness-notify/task.yaml
@@ -1,23 +1,28 @@
-summary: Ensure that refresh app-awareness notifications work
+summary: Ensure that legacy refresh app-awareness notifications work
 
 details: |
-    Test that notifications for continued auto-refreshes are delivered
+    Test that session-agent notifications for continued auto-refreshes are
+    delivered when refresh-app-awareness-ux is explicitly disabled.
 
 # Ubuntu 14.04's special version of systemd doesn't have StartTransientUnit API.
 systems: [-ubuntu-14.04-*]
 
 prepare: |
+    snap set system experimental.refresh-app-awareness-ux=false
+
     # ensure no other refreshes interfere with the test
     snap refresh
     snap install test-snapd-sh
 
 restore: |
     snap remove --purge test-snapd-sh || true
+    snap unset system experimental.refresh-app-awareness-ux
 
 execute: |
     # make sure an app keeps the test snap busy
     test-snapd-sh.sh -c 'exec sleep infinity' &
     PID="$!"
+    tests.cleanup defer "kill \"$PID\" || true"
     # Note that test-snapd-sh has different revisions in stable and edge
     snap switch --edge test-snapd-sh
 
@@ -30,4 +35,5 @@ execute: |
     "$TESTSTOOLS"/journal-state match-log -n 60 -u snapd 'notifying agents about pending refresh for snap [\]?"test-snapd-sh[\]?"'
     # exit test-snap, this should trigger the refresh right away
     kill "$PID"
+    wait "$PID" || true
     "$TESTSTOOLS"/journal-state match-log -n 60 -u snapd 'notifying user client about continued refresh for [\]?"test-snapd-sh[\]?"'


### PR DESCRIPTION
This marks `refresh-app-awareness-ux` as default-enabled and updates our tests with these new expectations.

This should land in 2.78, and then we'll graduate the feature forever in 2.79.