### PR TITLE
github: ensure that empty space files don't get uploaded

### DIFF
--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -335,7 +335,7 @@ jobs:
           echo "The following list of tests will run:"
           cat "$RUN_TESTS_FILE"
 
-          if [ -n "$SNAPD_TESTS_SKIP" ]; then
+          if [ -n "${SNAPD_TESTS_SKIP// /}" ]; then
               echo "$SNAPD_TESTS_SKIP" > skipped_tests_list.txt
           fi
 

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -335,7 +335,7 @@ jobs:
           echo "The following list of tests will run:"
           cat "$RUN_TESTS_FILE"
 
-          if [ -n "${SNAPD_TESTS_SKIP// /}" ]; then
+          if [ -n "${SNAPD_TESTS_SKIP//[[:space:]]/}" ]; then
               echo "$SNAPD_TESTS_SKIP" > skipped_tests_list.txt
           fi
 


### PR DESCRIPTION
The skipped_tests_list.txt can sometimes only contain whitespace. This strips out whitespace before performing the check to see if `SNAPD_TESTS_SKIP` contains any data.

[An example PR](https://github.com/canonical/snapd/actions/runs/31638301448) shows files that contain only whitespace

```
$ gh run download 31638301448 --pattern "skipped-tests-list*" --dir /tmp
$ find /tmp -name skipped_tests_list.txt -exec xxd {} \;
00000000: 2020 2020 2020 2020 200a                          .
00000000: 200a                                      .
00000000: 2020 0a                                    .
00000000: 2020 2020 2020 2020 2020 0a                        .
00000000: 2020 2020 2020 2020 2020 0a                        .
00000000: 2020 200a                                   .
00000000: 2020 2020 2020 2020 2020 0a                        .
$
```