### PR TITLE
i/power-control: allow standardized charge threshold sysfs attributes

### DIFF
--- a/interfaces/builtin/power_control.go
+++ b/interfaces/builtin/power_control.go
@@ -52,8 +52,14 @@ const powerControlConnectedPlugAppArmor = `
 
 # Needed for ACPI modules to read and set values for battery charging thresholds & other functionality
 # required by auto-cpufreq, reference: https://github.com/snapcore/snapd/pull/13722
-/sys/devices/**/power_supply/BAT[0-9]*/charge_start_threshold rw, 
-/sys/devices/**/power_supply/BAT[0-9]*/charge_stop_threshold rw, 
+# Both charge_start/stop_threshold (legacy ThinkPad naming) and
+# charge_control_start/end_threshold (standardized kernel ABI since v4.16,
+# Documentation/ABI/testing/sysfs-class-power) are allowed; they control the same
+# underlying firmware state on supported hardware but use different sysfs names.
+/sys/devices/**/power_supply/BAT[0-9]*/charge_start_threshold rw,
+/sys/devices/**/power_supply/BAT[0-9]*/charge_stop_threshold rw,
+/sys/devices/**/power_supply/BAT[0-9]*/charge_control_start_threshold rw,
+/sys/devices/**/power_supply/BAT[0-9]*/charge_control_end_threshold rw,
 /sys/devices/**/power_supply/BAT[0-9]*/type r,
 /sys/devices/**/power_supply/BAT[0-9]*/status r,
 /sys/devices/**/power_supply/AC/type r,


### PR DESCRIPTION
The Linux kernel power_supply class exposes battery charge control thresholds through two naming conventions that have evolved over time:

- charge_start_threshold / charge_stop_threshold (legacy ThinkPad ACPI names)
- charge_control_start_threshold / charge_control_end_threshold (standardized kernel ABI documented in Documentation/ABI/testing/sysfs-class-power since v4.16)

On ThinkPad hardware, both sets of attributes are exposed simultaneously and control the same underlying firmware state via identical show/store callbacks. Other laptop vendors (ASUS, Dell, Fujitsu, Huawei, MSI, Samsung Galaxy Book, System76, Toshiba) only implement the standardized naming scheme.

Previously, the power-control interface only allowed access to charge_start/ stop_threshold, which blocked snap confinement on hardware that exclusively exposes the standardized charge_control_start/end_threshold attributes. This change adds AppArmor permissions for both naming schemes, ensuring battery charge threshold management works across all supported laptop models regardless of their sysfs attribute naming convention.

Fix trailing whitespace in existing rules and document the kernel ABI transition rationale.
