### PR TITLE
o/devicestate: make sure we call restore function for mock

### DIFF
--- a/overlord/devicestate/devicestate_install_api_test.go
+++ b/overlord/devicestate/devicestate_install_api_test.go
@@ -598,14 +598,14 @@ func (s *deviceMgrInstallAPISuite) testInstallFinishStep(c *C, opts finishStepOp
 	}
 
 	if opts.hasSystemSeed {
-		devicestate.MockBootMakeRecoverySystemBootable(func(model *asserts.Model, rootdir string, relativeRecoverySystemDir string, bootWith *boot.RecoverySystemBootableSet) error {
+		s.AddCleanup(devicestate.MockBootMakeRecoverySystemBootable(func(model *asserts.Model, rootdir string, relativeRecoverySystemDir string, bootWith *boot.RecoverySystemBootableSet) error {
 			c.Check(model.Classic(), Equals, true)
 			c.Check(rootdir, Equals, filepath.Join(dirs.RunDir, "mnt/ubuntu-seed"))
 			c.Check(relativeRecoverySystemDir, Equals, filepath.Join("systems", label))
 			c.Check(bootWith.KernelPath, Equals, filepath.Join(dirs.RunDir, "mnt/ubuntu-seed/snaps/pc-kernel_1.snap"))
 			c.Check(bootWith.GadgetSnapOrDir, Equals, filepath.Join(s.SeedDir, "snaps/pc_1.snap"))
 			return nil
-		})
+		}))
 	}
 
 	s.state.Lock()


### PR DESCRIPTION
This was causing a captured `*check.C` to be used in future tests, resulting in odd "failures" that don't actually cause failures:

```
PASS: devicestate_install_api_test.go:65: deviceMgrInstallAPISuite.SetUpTest	0.009s

devicestate_install_api_test.go:602:
    c.Check(model.Classic(), Equals, true)
... obtained bool = false
... expected bool = true

devicestate_install_api_test.go:604:
    c.Check(relativeRecoverySystemDir, Equals, filepath.Join("systems", label))
... obtained string = "systems/core"
... expected string = "systems/classic"

START: <autogenerated>:1: deviceMgrInstallAPISuite.TearDownTest
```