### PR TITLE
i/builtin: add ubuntu-drivers-observe interface

### DIFF
--- a/interfaces/builtin/ubuntu_drivers_observe.go
+++ b/interfaces/builtin/ubuntu_drivers_observe.go
@@ -1,0 +1,76 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+const ubuntuDriversObserveSummary = `allows querying the Ubuntu drivers service`
+
+const ubuntuDriversObserveBaseDeclarationSlots = `
+  ubuntu-drivers-observe:
+    allow-installation:
+      slot-snap-type:
+        - core
+    deny-auto-connection: true
+`
+
+const ubuntuDriversObserveConnectedPlugAppArmor = `
+# Description: Allow querying the Ubuntu drivers service for devices and their
+# available driver packages.
+
+#include <abstractions/dbus-strict>
+
+# allow calls to the well-known service name, including during activation
+dbus (send)
+    bus=system
+    path=/com/ubuntu/Drivers
+    interface=com.ubuntu.Drivers
+    member=drivers
+    peer=(name=com.ubuntu.Drivers),
+dbus (send)
+    bus=system
+    path=/com/ubuntu/Drivers
+    interface=org.freedesktop.DBus.Introspectable
+    member=Introspect
+    peer=(name=com.ubuntu.Drivers),
+
+# some D-Bus clients resolve the well-known service name to its unique bus
+# name after activation, so allow calls to the unconfined service process
+dbus (send)
+    bus=system
+    path=/com/ubuntu/Drivers
+    interface=com.ubuntu.Drivers
+    member=drivers
+    peer=(label=unconfined),
+dbus (send)
+    bus=system
+    path=/com/ubuntu/Drivers
+    interface=org.freedesktop.DBus.Introspectable
+    member=Introspect
+    peer=(label=unconfined),
+`
+
+func init() {
+	registerIface(&commonInterface{
+		name:                  "ubuntu-drivers-observe",
+		summary:               ubuntuDriversObserveSummary,
+		implicitOnClassic:     true,
+		baseDeclarationSlots:  ubuntuDriversObserveBaseDeclarationSlots,
+		connectedPlugAppArmor: ubuntuDriversObserveConnectedPlugAppArmor,
+	})
+}

--- a/interfaces/builtin/ubuntu_drivers_observe_test.go
+++ b/interfaces/builtin/ubuntu_drivers_observe_test.go
@@ -1,0 +1,112 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	"strings"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type UbuntuDriversObserveInterfaceSuite struct {
+	iface    interfaces.Interface
+	slot     *interfaces.ConnectedSlot
+	slotInfo *snap.SlotInfo
+	plug     *interfaces.ConnectedPlug
+	plugInfo *snap.PlugInfo
+}
+
+var _ = Suite(&UbuntuDriversObserveInterfaceSuite{
+	iface: builtin.MustInterface("ubuntu-drivers-observe"),
+})
+
+func (s *UbuntuDriversObserveInterfaceSuite) SetUpTest(c *C) {
+	const coreYaml = `name: core
+version: 0
+type: os
+slots:
+  ubuntu-drivers-observe:
+    interface: ubuntu-drivers-observe
+`
+	s.slot, s.slotInfo = MockConnectedSlot(c, coreYaml, nil, "ubuntu-drivers-observe")
+
+	const consumerYaml = `name: consumer
+version: 0
+apps:
+  app:
+    plugs: [ubuntu-drivers-observe]
+`
+	s.plug, s.plugInfo = MockConnectedPlug(c, consumerYaml, nil, "ubuntu-drivers-observe")
+}
+
+func (s *UbuntuDriversObserveInterfaceSuite) TestName(c *C) {
+	c.Assert(s.iface.Name(), Equals, "ubuntu-drivers-observe")
+}
+
+func (s *UbuntuDriversObserveInterfaceSuite) TestSanitize(c *C) {
+	c.Assert(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
+}
+
+func (s *UbuntuDriversObserveInterfaceSuite) TestAppArmorConnectedPlug(c *C) {
+	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
+	c.Assert(err, IsNil)
+	spec := apparmor.NewSpecification(appSet)
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+
+	snippet := spec.SnippetForTag("snap.consumer.app")
+	c.Check(snippet, testutil.Contains, "#include <abstractions/dbus-strict>")
+	c.Check(strings.Count(snippet, "path=/com/ubuntu/Drivers"), Equals, 4)
+	c.Check(strings.Count(snippet, "interface=com.ubuntu.Drivers"), Equals, 2)
+	c.Check(strings.Count(snippet, "member=drivers"), Equals, 2)
+	c.Check(strings.Count(snippet, "interface=org.freedesktop.DBus.Introspectable"), Equals, 2)
+	c.Check(strings.Count(snippet, "member=Introspect"), Equals, 2)
+	c.Check(strings.Count(snippet, "peer=(name=com.ubuntu.Drivers)"), Equals, 2)
+	c.Check(strings.Count(snippet, "peer=(label=unconfined)"), Equals, 2)
+	c.Check(snippet, Not(testutil.Contains), "interface=com.ubuntu.*")
+	c.Check(snippet, Not(testutil.Contains), "path=/com/ubuntu/**")
+	c.Check(snippet, Not(testutil.Contains), "org.freedesktop.DBus.Properties")
+}
+
+func (s *UbuntuDriversObserveInterfaceSuite) TestStaticInfo(c *C) {
+	si := interfaces.StaticInfoOf(s.iface)
+	c.Check(si.ImplicitOnCore, Equals, false)
+	c.Check(si.ImplicitOnClassic, Equals, true)
+	c.Check(si.Summary, Equals, "allows querying the Ubuntu drivers service")
+	c.Check(si.BaseDeclarationPlugs, Equals, "")
+	c.Check(si.BaseDeclarationSlots, testutil.Contains, "ubuntu-drivers-observe")
+	c.Check(si.BaseDeclarationSlots, testutil.Contains, "slot-snap-type:\n        - core")
+	c.Check(si.BaseDeclarationSlots, testutil.Contains, "deny-auto-connection: true")
+}
+
+func (s *UbuntuDriversObserveInterfaceSuite) TestAutoConnect(c *C) {
+	c.Check(s.iface.AutoConnect(s.plugInfo, s.slotInfo), Equals, true)
+}
+
+func (s *UbuntuDriversObserveInterfaceSuite) TestInterfaces(c *C) {
+	c.Check(builtin.Interfaces(), testutil.DeepContains, s.iface)
+}

--- a/tests/lib/snaps/test-snapd-ubuntu-drivers-observe/bin/drivers
+++ b/tests/lib/snaps/test-snapd-ubuntu-drivers-observe/bin/drivers
@@ -1,0 +1,6 @@
+#!/bin/sh -e
+
+exec dbus-send --system --print-reply --reply-timeout=120000 \
+    --dest=com.ubuntu.Drivers \
+    /com/ubuntu/Drivers \
+    com.ubuntu.Drivers.drivers

--- a/tests/lib/snaps/test-snapd-ubuntu-drivers-observe/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-ubuntu-drivers-observe/meta/snap.yaml
@@ -1,0 +1,10 @@
+name: test-snapd-ubuntu-drivers-observe
+version: 1.0
+architectures: [all]
+base: core24
+confinement: strict
+
+apps:
+  drivers:
+    command: bin/drivers
+    plugs: [ubuntu-drivers-observe]

--- a/tests/main/interfaces-ubuntu-drivers-observe/task.yaml
+++ b/tests/main/interfaces-ubuntu-drivers-observe/task.yaml
@@ -1,0 +1,47 @@
+summary: Ensure that the ubuntu-drivers-observe interface works
+
+details: |
+    Verify that a snap using the ubuntu-drivers-observe interface can activate
+    and query the ubuntu-drivers-common D-Bus service, and that the interface
+    is not connected by default.
+
+systems:
+    # limit to releases where ubuntu-drivers-common is available
+    - ubuntu-26.10-64
+
+prepare: |
+    tests.pkgs install ubuntu-drivers-common
+
+    test -f /usr/share/dbus-1/system-services/com.ubuntu.Drivers.service
+    test -f /usr/share/dbus-1/system.d/com.ubuntu.Drivers.conf
+    test -f /usr/lib/systemd/system/ubuntu-drivers.service
+
+    "$TESTSTOOLS"/snaps-state install-local test-snapd-ubuntu-drivers-observe
+
+execute: |
+    echo "The plug is disconnected by default"
+    snap connections test-snapd-ubuntu-drivers-observe | MATCH "ubuntu-drivers-observe +test-snapd-ubuntu-drivers-observe:ubuntu-drivers-observe +- +-"
+
+    echo "The disconnected snap cannot query the service"
+    if test-snapd-ubuntu-drivers-observe.drivers 2> disconnected.error; then
+        echo "Expected permission error while interface is disconnected"
+        exit 1
+    fi
+    MATCH "Permission denied" < disconnected.error
+
+    echo "The plug can be connected"
+    snap connect test-snapd-ubuntu-drivers-observe:ubuntu-drivers-observe
+    snap connections test-snapd-ubuntu-drivers-observe | MATCH "ubuntu-drivers-observe +test-snapd-ubuntu-drivers-observe:ubuntu-drivers-observe +:ubuntu-drivers-observe +manual"
+
+    echo "A query activates the service and returns a driver array"
+    systemctl stop ubuntu-drivers.service
+    test-snapd-ubuntu-drivers-observe.drivers | MATCH "method return"
+    systemctl is-active ubuntu-drivers.service
+
+    echo "The disconnected snap can no longer query the service"
+    snap disconnect test-snapd-ubuntu-drivers-observe:ubuntu-drivers-observe
+    if test-snapd-ubuntu-drivers-observe.drivers 2> disconnected-again.error; then
+        echo "Expected permission error while interface is disconnected"
+        exit 1
+    fi
+    MATCH "Permission denied" < disconnected-again.error


### PR DESCRIPTION
Adds the `ubuntu-drivers-observe` interface, to enable access to the DBus API provided by https://github.com/canonical/ubuntu-drivers-common/pull/163.