### PR TITLE
.github/workflows: change spread-results-reporter.yaml to a self-hosted runner

### DIFF
--- a/.github/workflows/spread-results-reporter.yaml
+++ b/.github/workflows/spread-results-reporter.yaml
@@ -90,7 +90,7 @@ jobs:
             }
 
             let matchingSkips = allArtifacts.filter((artifact) => {
-              return artifact.name.startsWith(`skipped-tests-list-${context.payload.workflow_run.id}-${context.payload.workflow_run.run_attempt}`);
+              return artifact.name.startsWith(`skipped-tests-list-${context.payload.workflow_run.id}`);
             });
 
             for (let artifact of matchingSkips) {

--- a/.github/workflows/spread-results-reporter.yaml
+++ b/.github/workflows/spread-results-reporter.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   report-spread-failures:
     if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion != 'cancelled' }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, spread-enabled]
     permissions:
       pull-requests: write
     env:
@@ -90,7 +90,7 @@ jobs:
             }
 
             let matchingSkips = allArtifacts.filter((artifact) => {
-              return artifact.name.startsWith(`skipped-tests-list-${context.payload.workflow_run.id}`);
+              return artifact.name.startsWith(`skipped-tests-list-${context.payload.workflow_run.id}-${context.payload.workflow_run.run_attempt}`);
             });
 
             for (let artifact of matchingSkips) {

--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,8 @@ cmd/install-sh
 cmd/missing
 cmd/stamp-h1
 cmd/test-driver
+cmd/snap-cli-wrap/snap-cli-wrap
+cmd/snapd-tool-wrap/snapd-tool-wrap
 
 # Mypy
 .mypy


### PR DESCRIPTION
The spread results reporter still fails to get the prediction percentages in the spread results reporter. This seems to be because it is running on GH's 'ubuntu-latest' runners. This PR changes the workflow to run on PS7s spread-enabled runners to ensure it ends up within the PS7 network infrastructure and can reach the predictor.