### PR TITLE
osutil: fix tests that fail as root

### DIFF
--- a/osutil/cp_test.go
+++ b/osutil/cp_test.go
@@ -343,6 +343,9 @@ func (s *cpSuite) TestAtomicWriteFileCopySymlinks(c *C) {
 }
 
 func (s *cpSuite) TestAtomicWriteFileCopyErrReal(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
 	err := osutil.AtomicWriteFileCopy(s.f2, filepath.Join(s.dir, "random-file"), 0)
 	c.Assert(err, ErrorMatches, "unable to open source file .*/random-file: open .* no such file or directory")
 

--- a/osutil/fshelpers_test.go
+++ b/osutil/fshelpers_test.go
@@ -34,6 +34,9 @@ type fshelpersSuite struct{}
 var _ = Suite(&fshelpersSuite{})
 
 func (s *fshelpersSuite) TestSelfOwnedFile(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
 	name := filepath.Join(c.MkDir(), "testownedfile")
 	err := os.WriteFile(name, nil, 0644)
 	c.Assert(err, IsNil)

--- a/osutil/io_test.go
+++ b/osutil/io_test.go
@@ -75,6 +75,9 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFileOverwrite(c *C) {
 }
 
 func (ts *AtomicWriteTestSuite) TestAtomicWriteFileSymlinkNoFollow(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
 	tmpdir := c.MkDir()
 	rodir := filepath.Join(tmpdir, "ro")
 	p := filepath.Join(rodir, "foo")
@@ -108,6 +111,9 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFileAsteriskInBasenameError(c *C)
 }
 
 func (ts *AtomicWriteTestSuite) TestAtomicWriteFileTmpFileCreateError(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
 	tmpdir := c.MkDir()
 
 	err := os.Chmod(tmpdir, 0o644) // no directory traversal allowed
@@ -289,6 +295,9 @@ type AtomicSymlinkTestSuite struct{}
 var _ = Suite(&AtomicSymlinkTestSuite{})
 
 func (ts *AtomicSymlinkTestSuite) TestAtomicSymlink(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
 	mustReadSymlink := func(p, exp string) {
 		target, err := os.Readlink(p)
 		c.Assert(err, IsNil)
@@ -381,6 +390,9 @@ type AtomicLinkTestSuite struct{}
 var _ = Suite(&AtomicLinkTestSuite{})
 
 func (ts *AtomicLinkTestSuite) TestAtomicLink(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
 	mustReadLink := func(target, link string) {
 		match, err := osutil.ComparePathsByDeviceInode(target, link)
 		c.Assert(err, IsNil)
@@ -472,6 +484,9 @@ type AtomicRenameTestSuite struct{}
 var _ = Suite(&AtomicRenameTestSuite{})
 
 func (ts *AtomicRenameTestSuite) TestAtomicRenameFile(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
 	d := c.MkDir()
 
 	err := os.WriteFile(filepath.Join(d, "foo"), []byte("foobar"), 0644)

--- a/osutil/mountinfo_linux_test.go
+++ b/osutil/mountinfo_linux_test.go
@@ -238,6 +238,9 @@ func (s *mountinfoSuite) TestLoadMountInfo2(c *C) {
 
 // Test that trying to load mountinfo without permissions reports an error.
 func (s *mountinfoSuite) TestLoadMountInfo3(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
 	fname := filepath.Join(c.MkDir(), "mountinfo")
 	err := os.WriteFile(fname, []byte(mountInfoSample), 0644)
 	c.Assert(err, IsNil)

--- a/osutil/stat_test.go
+++ b/osutil/stat_test.go
@@ -147,6 +147,9 @@ func makeTestPathInDir(c *C, dir, path string, mode os.FileMode) string {
 }
 
 func (ts *StatTestSuite) TestIsWritableDir(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
 	for _, t := range []struct {
 		path       string
 		mode       os.FileMode
@@ -195,6 +198,9 @@ func (ts *StatTestSuite) TestIsDirNotExist(c *C) {
 }
 
 func (ts *StatTestSuite) TestDirExists(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
 	for _, t := range []struct {
 		make   string
 		path   string

--- a/osutil/syncdir_test.go
+++ b/osutil/syncdir_test.go
@@ -223,6 +223,9 @@ func (s *EnsureDirStateSuite) TestReportsAbnormalPatterns(c *C) {
 }
 
 func (s *EnsureDirStateSuite) TestRemovesAllManagedFilesOnError(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
 	// Create a "prior.snap" file
 	prior := filepath.Join(s.dir, "prior.snap")
 	err := os.WriteFile(prior, []byte("data"), 0600)


### PR DESCRIPTION
Fix failures seen with `sudo go test ./osutil/...`.
The failures are caused by tests which require permissions to function - skip them.

This is followed by a separate PR[1] which adds CI coverage as root for the osutil package.

[1] https://github.com/canonical/snapd/pull/17458