### PR TITLE
build-aux/snap: use github mirror of glibc instead of launchpad

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -51,7 +51,7 @@ parts:
       - quilt
       - python3-pyelftools
       - xz-utils
-    source: https://git.launchpad.net/ubuntu/+source/glibc
+    source: https://github.com/canonical/glibc
     source-branch: ubuntu/jammy-updates
     source-type: git
     <<:


### PR DESCRIPTION
Launchpad git hosting is unreliable and causes intermittent build failures. Use the canonical/glibc mirror on GitHub instead. The mirror is maintained by an action that periodically synchronizes all the branches from launchpad.