### PR TITLE
tests: remove unnecessary sudo for snap debug api call

### DIFF
--- a/tests/main/snap-quota-memory/task.yaml
+++ b/tests/main/snap-quota-memory/task.yaml
@@ -94,7 +94,7 @@ execute: |
   # So having the retries make sense.
   total_iters=5
   for iter in $(seq "$total_iters"); do
-      snapdSaysMemUsage="$(sudo snap debug api /v2/quotas/group-one | gojq -r '.result.current.memory')"
+      snapdSaysMemUsage="$(snap debug api /v2/quotas/group-one | gojq -r '.result.current.memory')"
       kernelSaysMemUsage="$(cat "$cgroupMemFile")"
 
       pyCmd="import math; print(math.ceil(abs($snapdSaysMemUsage - $kernelSaysMemUsage) / $snapdSaysMemUsage * 100))"


### PR DESCRIPTION
Should fix [openstack:fedora-44-64:tests/main/snap-quota-memory failure](https://github.com/canonical/snapd/actions/runs/31724943749/job/94616509907?pr=17453#step:25:4533)

```
++ gojq -r .result.current.memory
sudo: PAM account management error: Module is unknown
sudo: a password is required
+ snapdSaysMemUsage=
++ cat '/sys/fs/cgroup/snap.group\x2done.slice/memory.current'
+ kernelSaysMemUsage=1130496
+ pyCmd='import math; print(math.ceil(abs( - 1130496) /  * 100))'
++ python3 -c 'import math; print(math.ceil(abs( - 1130496) /  * 100))'
File "<string>", line 1
import math; print(math.ceil(abs( - 1130496) /  * 100))
^
SyntaxError: invalid syntax
+ percentChg=
```