### PR TITLE
interfaces: expand power-control AppArmor rules for battery state files

### DIFF
--- a/interfaces/builtin/power_control.go
+++ b/interfaces/builtin/power_control.go
@@ -60,8 +60,9 @@ const powerControlConnectedPlugAppArmor = `
 /sys/devices/**/power_supply/BAT[0-9]*/charge_stop_threshold rw,
 /sys/devices/**/power_supply/BAT[0-9]*/charge_control_start_threshold rw,
 /sys/devices/**/power_supply/BAT[0-9]*/charge_control_end_threshold rw,
-/sys/devices/**/power_supply/BAT[0-9]*/type r,
-/sys/devices/**/power_supply/BAT[0-9]*/status r,
+# Allow reading all battery state files (capacity, voltage, current, health,
+# identification, etc.). See Documentation/ABI/testing/sysfs-class-power.
+/sys/devices/**/power_supply/BAT[0-9]*/** r,
 /sys/devices/**/power_supply/AC/type r,
 /sys/devices/**/power_supply/AC/online r,
 `


### PR DESCRIPTION
The power-control interface previously only permitted read access to a minimal set of battery sysfs attributes (status, type), but the Linux power_supply class ABI documents many more read-only attributes that power management tools need to report battery capacity, voltage, current, health, and identification information. Without these permissions, snaps using this interface generate AppArmor DENIED audit messages when reading standard battery state files like capacity, voltage_now, or cycle_count.

Add read access for all documented battery state attributes organized by:
- Identification and general properties (manufacturer, model_name, etc.)
- Capacity and charge state (capacity, charge_full, energy_now, etc.)
- Electrical characteristics (current_now, voltage_now, power_now, etc.)
- Health and lifecycle reporting (health, cycle_count)

See Documentation/ABI/testing/sysfs-class-power in the kernel source.
