### PR TITLE
tests: fix ambiguous matches of systemctl outputs

### DIFF
--- a/tests/core/base-refresh-cert-db/task.yaml
+++ b/tests/core/base-refresh-cert-db/task.yaml
@@ -53,7 +53,7 @@ execute: |
         NOMATCH '^Error' < tasks.done
         NOMATCH '^Undone' < tasks.done
         NOMATCH '^Wait' < tasks.done
-        retry -n 30 sh -c 'systemctl is-system-running | MATCH "(running|degraded)"'
+        retry -n 30 sh -c "systemctl is-system-running | MATCH '^(running|degraded)$'"
     }
 
     # Refreshing a non-model base should not request update-cert-db.

--- a/tests/core/ca-certificates-gc/task.yaml
+++ b/tests/core/ca-certificates-gc/task.yaml
@@ -25,7 +25,7 @@ execute: |
     # for snapd to return to a stable state before checking the published view.
     wait_for_snapd_ready() {
         snap wait system seed.loaded
-        retry -n 30 --wait 1 sh -c 'systemctl is-system-running | MATCH "(running|degraded)"'
+        retry -n 30 --wait 1 sh -c "systemctl is-system-running | MATCH '^(running|degraded)$'"
     }
 
     # Garbage collection only reasons about immutable published generations;
@@ -108,7 +108,7 @@ execute: |
         local cert_digest
 
         cert_digest="$(openssl x509 -in "$cert" -inform pem -outform der | sha256sum | awk '{print $1}')"
-        bundle_digests "$bundle" | grep -Fx "$cert_digest"
+        bundle_digests "$bundle" | MATCH "^${cert_digest}$"
     }
 
     wait_for_snapd_ready

--- a/tests/core/config-defaults-once/task.yaml
+++ b/tests/core/config-defaults-once/task.yaml
@@ -113,7 +113,7 @@ execute: |
     echo "The defaults are applied"
     for service in $SERVICES; do
         snap get system "service.$service.disable" | MATCH true
-        systemctl status "$service.service" | MATCH '(inactive|masked)'
+        systemctl status "$service.service" | MATCH ' (inactive|masked) '
     done
     MATCH "SSH has been disabled by snapd system configuration" < /etc/ssh/sshd_not_to_be_run
 

--- a/tests/core/gadget-config-defaults-to-snaps/task.yaml
+++ b/tests/core/gadget-config-defaults-to-snaps/task.yaml
@@ -187,8 +187,8 @@ execute: |
     if [ "$SERVICE" = ssh ]; then
         echo "And the ssh service is disabled"
         MATCH "SSH has been disabled by snapd system configuration" < /etc/ssh/sshd_not_to_be_run
-        systemctl status "$SERVICE.service" | MATCH inactive
+        systemctl status "$SERVICE.service" | MATCH ' inactive '
     else
         echo "And the service is masked"
-        systemctl status "$SERVICE.service" | MATCH masked
+        systemctl status "$SERVICE.service" | MATCH ' masked '
     fi

--- a/tests/core/kernel-base-gadget-pair-single-reboot-failover/task.yaml
+++ b/tests/core/kernel-base-gadget-pair-single-reboot-failover/task.yaml
@@ -211,7 +211,7 @@ execute: |
         # make sure the system is in stable state, no pending reboots
         # XXX systemctl exits with non-0 when in degraded state
         # Note: on bionic, is-system-running does not support --wait
-        retry -n 30 sh -c 'systemctl is-system-running | MATCH "(running|degraded)"'
+        retry -n 30 sh -c "systemctl is-system-running | MATCH '^(running|degraded)$'"
 
         # we're expecting the old revisions to be back
         original_kernel="$(cat pc-kernel.rev)"

--- a/tests/core/kernel-base-gadget-pair-single-reboot/task.yaml
+++ b/tests/core/kernel-base-gadget-pair-single-reboot/task.yaml
@@ -76,7 +76,7 @@ execute: |
         # the change is complete
         # XXX systemctl exits with non-0 when in degraded state
         # Note: on bionic, is-system-running does not support --wait
-        retry -n 30 sh -c 'systemctl is-system-running | MATCH "(running|degraded)"'
+        retry -n 30 sh -c "systemctl is-system-running | MATCH '^(running|degraded)$'"
     }
 
     if [ "$SPREAD_REBOOT" -eq 0 ]; then

--- a/tests/core/kernel-base-gadget-single-reboot-failover/task.yaml
+++ b/tests/core/kernel-base-gadget-single-reboot-failover/task.yaml
@@ -136,7 +136,7 @@ execute: |
         # make sure the system is in stable state, no pending reboots
         # XXX systemctl exits with non-0 when in degraded state
         # Note: on bionic, is-system-running does not support --wait
-        retry -n 30 sh -c 'systemctl is-system-running | MATCH "(running|degraded)"'
+        retry -n 30 sh -c "systemctl is-system-running | MATCH '^(running|degraded)$'"
 
         # we're expecting the old revisions to be back
         original_kernel="$(cat pc-kernel.rev)"

--- a/tests/core/kernel-base-gadget-single-reboot/task.yaml
+++ b/tests/core/kernel-base-gadget-single-reboot/task.yaml
@@ -59,7 +59,7 @@ execute: |
         # the change is complete
         # XXX systemctl exits with non-0 when in degraded state
         # Note: on bionic, is-system-running does not support --wait
-        retry -n 30 sh -c 'systemctl is-system-running | MATCH "(running|degraded)"'
+        retry -n 30 sh -c "systemctl is-system-running | MATCH '^(running|degraded)$'"
     }
 
     if [ "$SPREAD_REBOOT" -eq 0 ]; then

--- a/tests/core/model-base-refresh-cert-db/task.yaml
+++ b/tests/core/model-base-refresh-cert-db/task.yaml
@@ -21,7 +21,7 @@ execute: |
         NOMATCH '^Error' < tasks.done
         NOMATCH '^Undone' < tasks.done
         NOMATCH '^Wait' < tasks.done
-        retry -n 30 sh -c 'systemctl is-system-running | MATCH "(running|degraded)"'
+        retry -n 30 sh -c "systemctl is-system-running | MATCH '^(running|degraded)$'"
     }
 
     if [ "$SPREAD_REBOOT" -eq 0 ]; then

--- a/tests/core/services/task.yaml
+++ b/tests/core/services/task.yaml
@@ -11,7 +11,7 @@ execute: |
     done
 
     echo "Ensure services are working"
-    systemctl status snapd.service |MATCH active
+    systemctl status snapd.service |MATCH ' active '
 
     echo "Ensure timers are working"
     systemctl is-active snapd.snap-repair.timer

--- a/tests/core/snap-set-core-config/task.yaml
+++ b/tests/core/snap-set-core-config/task.yaml
@@ -63,11 +63,11 @@ execute: |
 
     echo "Check that ctrl-alt-del-action=none works"
     snap set core system.ctrl-alt-del-action=none
-    systemctl show --property=LoadState ctrl-alt-del.target | MATCH "LoadState=masked"
+    systemctl show --property=LoadState ctrl-alt-del.target | MATCH '^LoadState=masked$'
     echo "Check that ctrl-alt-del-action=reboot works"
     snap set core system.ctrl-alt-del-action=reboot
-    systemctl show --property=UnitFileState ctrl-alt-del.target | MATCH "UnitFileState=disabled"
-    systemctl show --property=LoadState ctrl-alt-del.target | MATCH "LoadState=loaded"
+    systemctl show --property=UnitFileState ctrl-alt-del.target | MATCH '^UnitFileState=disabled$'
+    systemctl show --property=LoadState ctrl-alt-del.target | MATCH '^LoadState=loaded$'
 
     echo "Check that pi config handline works"
     if [ -e /boot/uboot/config.txt ]; then

--- a/tests/core/update-snapd-symlink/task.yaml
+++ b/tests/core/update-snapd-symlink/task.yaml
@@ -92,7 +92,7 @@ execute: |
   snap change "${broken_install_id}" | MATCH 'Error'
 
   # snapd.failure.service is not running
-  retry -n 10 --wait 3 sh -c "systemctl show -p ActiveState --value snapd.failure.service | MATCH inactive"
+  retry -n 10 --wait 3 sh -c "systemctl show -p ActiveState --value snapd.failure.service | MATCH '^inactive$'"
   # but it has run since last install
   last_activated="$(date --date="$(systemctl show -p InactiveEnterTimestamp --value snapd.failure.service)" +%s)"
   [ -n "${last_activated}" ]

--- a/tests/main/basic-target-socket-activation/task.yaml
+++ b/tests/main/basic-target-socket-activation/task.yaml
@@ -50,7 +50,7 @@ execute: |
   else
 
     # Wait for systemd to have finished booting
-    systemctl --wait is-system-running | MATCH '(running|degraded)'
+    systemctl --wait is-system-running | MATCH '^(running|degraded)$'
 
     MATCH 'systemd[.]unit=basic[.]target' </proc/cmdline
 
@@ -70,7 +70,7 @@ execute: |
     systemctl is-active snapd.service
 
     # the mounts should be active
-    systemctl show --all --state=loaded -p ActiveState 'snap-*.mount' | tee states.txt | MATCH 'ActiveState=active'
+    systemctl show --all --state=loaded -p ActiveState 'snap-*.mount' | tee states.txt | MATCH '^ActiveState=active$'
     NOMATCH 'ActiveState=inactive' <states.txt
 
     # bonus, we check we did not cheat, nothing should be installed to default.target

--- a/tests/main/interfaces-audio-playback-record/task.yaml
+++ b/tests/main/interfaces-audio-playback-record/task.yaml
@@ -68,7 +68,7 @@ prepare: |
     # User session services do not posses a logind session session so
     # pulseaudio immediately quits, and remains inactive outside of the moments
     # we execute paplay through tests.session.
-    tests.session -u test exec systemctl --user is-active pulseaudio.socket | MATCH active
+    tests.session -u test exec systemctl --user is-active pulseaudio.socket | MATCH '^active$'
 
     # Start pulseaudio to give it a chance to write the pulseaudio cookie file.
     # Otherwise paplay invocation will race with pulse startup, and will race

--- a/tests/main/interfaces-pulseaudio/task.yaml
+++ b/tests/main/interfaces-pulseaudio/task.yaml
@@ -58,7 +58,7 @@ prepare: |
     # User session services do not posses a logind session session so
     # pulseaudio immediately quits, and remains inactive outside of the moments
     # we execute paplay through tests.session.
-    tests.session -u test exec systemctl --user is-active pulseaudio.socket | MATCH active
+    tests.session -u test exec systemctl --user is-active pulseaudio.socket | MATCH '^active$'
 
     # Start pulseaudio to give it a chance to write the pulseaudio cookie file.
     # Otherwise paplay invocation will race with pulse startup, and will race

--- a/tests/main/lxd-mount-units/task.yaml
+++ b/tests/main/lxd-mount-units/task.yaml
@@ -32,7 +32,7 @@ execute: |
 
     # wait for the container to be fully up
     # the retry is needed because of the error "Failed to connect to bus: No such file or directory"
-    retry --wait 1 -n 10 sh -c 'lxd.lxc exec ubuntu -- systemctl --wait is-system-running | grep -Eq "(running|degraded)"'
+    retry --wait 1 -n 10 sh -c "lxd.lxc exec ubuntu -- systemctl --wait is-system-running | grep -Eq '^(running|degraded)$'"
 
     lxd.lxc file push --quiet "$GOHOME"/snapd_*.deb "ubuntu/root/"
     DEB=$(basename "$GOHOME"/snapd_*.deb)

--- a/tests/main/lxd-snapfuse/task.yaml
+++ b/tests/main/lxd-snapfuse/task.yaml
@@ -31,7 +31,7 @@ execute: |
     fi
     # wait for the container to be fully up
     # the retry is needed because of the error "Failed to connect to bus: No such file or directory"
-    retry --wait 1 -n 10 sh -c 'lxd.lxc exec my-ubuntu -- systemctl --wait is-system-running | grep -Eq "(running|degraded)"'
+    retry --wait 1 -n 10 sh -c "lxd.lxc exec my-ubuntu -- systemctl --wait is-system-running | grep -Eq '^(running|degraded)$'"
 
     echo "Install snapd"
     lxd.lxc exec my-ubuntu -- mkdir -p "$GOHOME"

--- a/tests/main/lxd-try/task.yaml
+++ b/tests/main/lxd-try/task.yaml
@@ -18,7 +18,7 @@ prepare: |
 
   # wait for the container to be fully up
   # the retry is needed because of the error "Failed to connect to bus: No such file or directory"
-  retry --wait 1 -n 10 sh -c 'lxd.lxc exec ubuntu -- systemctl --wait is-system-running | grep -Eq "(running|degraded)"'
+  retry --wait 1 -n 10 sh -c "lxd.lxc exec ubuntu -- systemctl --wait is-system-running | grep -Eq '^(running|degraded)$'"
 
   lxd.lxc file push --quiet "$GOHOME"/snapd_*.deb "ubuntu/root/"
   DEB=$(basename "$GOHOME"/snapd_*.deb)

--- a/tests/main/mounts-persist-refresh-content-snap/task.yaml
+++ b/tests/main/mounts-persist-refresh-content-snap/task.yaml
@@ -57,7 +57,7 @@ execute: |
   pid=$!
 
   # Wait for the script to start.
-  retry MATCH '^started$' < ~test/snap/test-snapd-desktop-layout-with-content/common/status
+  retry grep -xF 'started' ~test/snap/test-snapd-desktop-layout-with-content/common/status
 
   # Refresh the content slot snap.
   # TODO: when refresh app awareness is enabled, this will need to ignore running processes to

--- a/tests/main/mounts-persist-refresh-content-snap/task.yaml
+++ b/tests/main/mounts-persist-refresh-content-snap/task.yaml
@@ -57,7 +57,7 @@ execute: |
   pid=$!
 
   # Wait for the script to start.
-  retry grep -xF 'started' ~test/snap/test-snapd-desktop-layout-with-content/common/status
+  retry MATCH '^started$' < ~test/snap/test-snapd-desktop-layout-with-content/common/status
 
   # Refresh the content slot snap.
   # TODO: when refresh app awareness is enabled, this will need to ignore running processes to

--- a/tests/main/parallel-install-services/task.yaml
+++ b/tests/main/parallel-install-services/task.yaml
@@ -51,32 +51,32 @@ execute: |
 
     echo "Ensure we can use snapctl to stop a service of the main installation, but not affect others"
     snap run --shell test-snapd-service -c "snapctl stop test-snapd-service.test-snapd-other-service"
-    systemctl is-active snap.test-snapd-service.test-snapd-other-service | MATCH "inactive"
-    systemctl is-active snap.test-snapd-service_foo.test-snapd-other-service | MATCH "^active"
-    systemctl is-active snap.test-snapd-service_longname.test-snapd-other-service | MATCH "^active"
+    systemctl is-active snap.test-snapd-service.test-snapd-other-service | MATCH '^inactive$'
+    systemctl is-active snap.test-snapd-service_foo.test-snapd-other-service | MATCH '^active$'
+    systemctl is-active snap.test-snapd-service_longname.test-snapd-other-service | MATCH '^active$'
 
     echo "Ensure we can start it again"
     snap run --shell test-snapd-service -c "snapctl start test-snapd-service.test-snapd-other-service"
-    systemctl is-active snap.test-snapd-service.test-snapd-other-service | MATCH "^active"
-    systemctl is-active snap.test-snapd-service_foo.test-snapd-other-service | MATCH "^active"
-    systemctl is-active snap.test-snapd-service_longname.test-snapd-other-service | MATCH "^active"
+    systemctl is-active snap.test-snapd-service.test-snapd-other-service | MATCH '^active$'
+    systemctl is-active snap.test-snapd-service_foo.test-snapd-other-service | MATCH '^active$'
+    systemctl is-active snap.test-snapd-service_longname.test-snapd-other-service | MATCH '^active$'
 
     echo "Ensure we can use snapctl to stop a service in parallel installs without affecting others"
     for instance in foo longname; do
         echo "Testing stop of test-snapd-service_$instance"
-        systemctl is-active "snap.test-snapd-service_${instance}.test-snapd-other-service" | MATCH "^active"
+        systemctl is-active "snap.test-snapd-service_${instance}.test-snapd-other-service" | MATCH '^active$'
         snap run --shell test-snapd-service_${instance} -c "snapctl stop test-snapd-service_${instance}.test-snapd-other-service"
-        systemctl is-active "snap.test-snapd-service_${instance}.test-snapd-other-service" | MATCH "inactive"
+        systemctl is-active "snap.test-snapd-service_${instance}.test-snapd-other-service" | MATCH '^inactive$'
     done
 
     echo "Verifying the main install should be unaffected after stop"
-    systemctl is-active snap.test-snapd-service.test-snapd-other-service | MATCH "^active"
+    systemctl is-active snap.test-snapd-service.test-snapd-other-service | MATCH '^active$'
 
     for instance in foo longname; do
         echo "Testing start of test-snapd-service_$instance"
-        systemctl is-active "snap.test-snapd-service_${instance}.test-snapd-other-service" | MATCH "inactive"
+        systemctl is-active "snap.test-snapd-service_${instance}.test-snapd-other-service" | MATCH '^inactive$'
         snap run --shell test-snapd-service_${instance} -c "snapctl start test-snapd-service_${instance}.test-snapd-other-service"
-        systemctl is-active "snap.test-snapd-service_${instance}.test-snapd-other-service" | MATCH "^active"
+        systemctl is-active "snap.test-snapd-service_${instance}.test-snapd-other-service" | MATCH '^active$'
     done
 
     svc_other_nokey="$(service_start_time snap.test-snapd-service.test-snapd-other-service)"

--- a/tests/main/services-after-before-install/task.yaml
+++ b/tests/main/services-after-before-install/task.yaml
@@ -50,7 +50,7 @@ execute: |
 
         echo "We can see all services running"
         for service in before-middle middle after-middle; do
-            systemctl status "$service_prefix.$service" | MATCH "running"
+            systemctl status "$service_prefix.$service" | MATCH ' \(running\) '
         done
 
         inactive_leave="$(get_prop "InactiveExitTimestampMonotonic" "$service_prefix.before-middle")"

--- a/tests/main/services-after-before/task.yaml
+++ b/tests/main/services-after-before/task.yaml
@@ -17,7 +17,7 @@ execute: |
 
     echo "We can see all services running"
     for service in before-middle middle after-middle; do
-        systemctl status snap.test-snapd-after-before-service.$service | MATCH "running"
+        systemctl status snap.test-snapd-after-before-service.$service | MATCH ' \(running\) '
     done
 
     echo "Service 'middle' is started after 'before-middle'"

--- a/tests/main/services-refresh-mode/task.yaml
+++ b/tests/main/services-refresh-mode/task.yaml
@@ -24,7 +24,7 @@ execute: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-service
 
     echo "We can see it running"
-    systemctl status snap.test-snapd-service.test-snapd-endure-service|MATCH "running"
+    systemctl status snap.test-snapd-service.test-snapd-endure-service|MATCH ' \(running\) '
     systemctl show -p MainPID snap.test-snapd-service.test-snapd-endure-service > old-main.pid
 
     # keep track of the mount namespace of the snap

--- a/tests/main/services-restart/task.yaml
+++ b/tests/main/services-restart/task.yaml
@@ -31,7 +31,7 @@ execute: |
 
     echo "We can see all services running"
     for id in 1 2 3 4; do
-        systemctl status snap.test-snapd-service-restart.svc${id}.service | MATCH "running"
+        systemctl status snap.test-snapd-service-restart.svc${id}.service | MATCH ' \(running\) '
     done
 
     echo "Stopping services 3 and 4"
@@ -62,11 +62,11 @@ execute: |
 
     echo "Check that services 1, 2 and 4 are running"
     for id in 1 2 4; do
-        systemctl status snap.test-snapd-service-restart.svc${id}.service | MATCH "running"
+        systemctl status snap.test-snapd-service-restart.svc${id}.service | MATCH ' \(running\) '
     done
 
     echo "Check that service 3 is not running"
-    systemctl status snap.test-snapd-service-restart.svc3.service | MATCH "inactive"
+    systemctl status snap.test-snapd-service-restart.svc3.service | MATCH ' inactive '
 
     echo "Fetching execution timestamps after restart"
     for id in 1 2 3 4; do
@@ -85,4 +85,4 @@ execute: |
     # Now verify that services explicitly mentioned on the command line always
     # get restarted, regardless of their current state
     snap restart $EXTRA_FLAGS test-snapd-service-restart.svc3
-    systemctl status snap.test-snapd-service-restart.svc3.service | MATCH "running"
+    systemctl status snap.test-snapd-service-restart.svc3.service | MATCH ' \(running\) '

--- a/tests/main/services-socket-activation/task.yaml
+++ b/tests/main/services-socket-activation/task.yaml
@@ -49,12 +49,12 @@ execute: |
         MATCH "     2\s+socket-activation.sleep-daemon\s+${ENABLED}\s+${MAIN_ACTIVE}\s+socket-activated$" < svcs.txt
 
         echo "Check that systemctl for the main unit is as expected"
-        systemctl show --property=UnitFileState snap.socket-activation.sleep-daemon.service | grep "static"
-        systemctl show --property=ActiveState snap.socket-activation.sleep-daemon.service | grep "ActiveState=${MAIN_ACTIVE}"
+        systemctl show --property=UnitFileState snap.socket-activation.sleep-daemon.service | MATCH '^UnitFileState=static$'
+        systemctl show --property=ActiveState snap.socket-activation.sleep-daemon.service | MATCH "^ActiveState=${MAIN_ACTIVE}$"
 
         echo "Check that systemctl for the socket is looking correct too"
-        systemctl show --property=UnitFileState snap.socket-activation.sleep-daemon.sock.socket | grep "${ENABLED}"
-        systemctl show --property=ActiveState snap.socket-activation.sleep-daemon.sock.socket | grep "ActiveState=${ACT_ACTIVE}"
+        systemctl show --property=UnitFileState snap.socket-activation.sleep-daemon.sock.socket | MATCH "^UnitFileState=${ENABLED}$"
+        systemctl show --property=ActiveState snap.socket-activation.sleep-daemon.sock.socket | MATCH "^ActiveState=${ACT_ACTIVE}$"
     }
 
     # verify default behavior on install is that the main service

--- a/tests/main/services-stop-mode/task.yaml
+++ b/tests/main/services-stop-mode/task.yaml
@@ -31,12 +31,12 @@ execute: |
     retry -n 20 --wait 1 sh -c 'test -f /var/snap/test-snapd-service/common/ready'
 
     echo "We can see it running"
-    systemctl status snap.test-snapd-service.test-snapd-service|MATCH "running"
+    systemctl status snap.test-snapd-service.test-snapd-service|MATCH ' \(running\) '
     systemctl show -p MainPID snap.test-snapd-service.test-snapd-service > old-main.pid
 
     stop_modes="sighup sighup-all sigusr1 sigusr1-all sigusr2 sigusr2-all sigint sigint-all"
     for s in $stop_modes; do
-        systemctl show -p ActiveState "snap.test-snapd-service.test-snapd-${s}-service" | MATCH "ActiveState=active"
+        systemctl show -p ActiveState "snap.test-snapd-service.test-snapd-${s}-service" | MATCH '^ActiveState=active$'
     done
 
     echo "When it is re-installed"
@@ -46,7 +46,7 @@ execute: |
     # note that sigterm{,-all} is tested separately
     for s in $stop_modes; do
         echo "We can see it is running"
-        systemctl show -p ActiveState "snap.test-snapd-service.test-snapd-${s}-service" | MATCH "ActiveState=active"
+        systemctl show -p ActiveState "snap.test-snapd-service.test-snapd-${s}-service" | MATCH '^ActiveState=active$'
 
         echo "and it got the right signal"
         echo "checking that the right signal was sent"

--- a/tests/main/services-timer/task.yaml
+++ b/tests/main/services-timer/task.yaml
@@ -16,11 +16,11 @@ execute: |
 
     echo "We can see the timers being active"
     for service in regular-timer random-timer range-timer trivial-timer; do
-        systemctl show -p ActiveState snap.test-snapd-timer-service.$service.timer | MATCH "ActiveState=active"
-        systemctl show -p SubState snap.test-snapd-timer-service.$service.timer | MATCH "SubState=(waiting|running)"
+        systemctl show -p ActiveState snap.test-snapd-timer-service.$service.timer | MATCH '^ActiveState=active$'
+        systemctl show -p SubState snap.test-snapd-timer-service.$service.timer | MATCH '^SubState=(waiting|running)$'
         systemctl show -p Triggers snap.test-snapd-timer-service.$service.timer | \
             MATCH "snap.test-snapd-timer-service.$service.service"
-        systemctl show -p UnitFileState snap.test-snapd-timer-service.$service.timer | MATCH "UnitFileState=enabled"
+        systemctl show -p UnitFileState snap.test-snapd-timer-service.$service.timer | MATCH '^UnitFileState=enabled$'
     done
     # systemctl list-timers output:
     # NEXT                         LEFT          LAST                         PASSED        UNIT                                        ACTIVATES
@@ -30,7 +30,7 @@ execute: |
     snap disable test-snapd-timer-service
     if os.query is-trusty; then
         for service in regular-timer random-timer range-timer trivial-timer; do
-            systemctl show -p UnitFileState snap.test-snapd-timer-service.$service.timer | MATCH "UnitFileState="
+            systemctl show -p UnitFileState snap.test-snapd-timer-service.$service.timer | MATCH '^UnitFileState=$'
         done
     else
         systemctl list-timers | NOMATCH "test-snapd-timer-service"
@@ -40,7 +40,7 @@ execute: |
     snap enable test-snapd-timer-service
     if os.query is-trusty; then
         for service in regular-timer random-timer range-timer trivial-timer; do
-            systemctl show -p UnitFileState snap.test-snapd-timer-service.$service.timer | MATCH "UnitFileState=enabled"
+            systemctl show -p UnitFileState snap.test-snapd-timer-service.$service.timer | MATCH '^UnitFileState=enabled$'
         done
     else
         systemctl list-timers | MATCH "test-snapd-timer-service"
@@ -50,7 +50,7 @@ execute: |
     snap remove --purge test-snapd-timer-service
     if os.query is-trusty; then
         for service in regular-timer random-timer range-timer trivial-timer; do
-            systemctl show -p UnitFileState snap.test-snapd-timer-service.$service.timer | MATCH "UnitFileState="
+            systemctl show -p UnitFileState snap.test-snapd-timer-service.$service.timer | MATCH '^UnitFileState=$'
         done
     else
         systemctl list-timers | NOMATCH "test-snapd-timer-service"

--- a/tests/main/services-user/task.yaml
+++ b/tests/main/services-user/task.yaml
@@ -66,8 +66,8 @@ execute: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-user-service
 
     echo "We can see the system services running"
-    systemctl status snap.test-snapd-user-service.svc3.service | MATCH "running"
-    systemctl status snap.test-snapd-user-service.svc4.service | MATCH "running"
+    systemctl status snap.test-snapd-user-service.svc3.service | MATCH ' \(running\) '
+    systemctl status snap.test-snapd-user-service.svc4.service | MATCH ' \(running\) '
 
     echo "(root) Verifying what snap services is reporting"
     snap services | cat -n > services-root.txt
@@ -87,8 +87,8 @@ execute: |
     MATCH "     5\s+test-snapd-user-service.svc4\s+enabled\s+active\s+-$" < services-root-user.txt
 
     echo "(user test) We can see the user services running"
-    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "active"
-    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "active"
+    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH '^active$'
+    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH '^active$'
 
     echo "(user test) Verifying what snap services is reporting"
     tests.session -u test exec snap services | cat -n > services-user.txt
@@ -99,8 +99,8 @@ execute: |
     MATCH "     5\s+test-snapd-user-service.svc4\s+enabled\s+active\s+-$" < services-user.txt
 
     echo "(user test2) We can see the user services running"
-    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "active"
-    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "active"
+    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH '^active$'
+    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH '^active$'
 
     echo "(user test2) Verifying what snap services is reporting"
     tests.session -u test2 exec snap services | cat -n > services-user2.txt
@@ -121,16 +121,16 @@ execute: |
     # if root is making this request, implied scopes are all
     echo "(root) Stopping all services for snap"
     snap stop test-snapd-user-service
-    systemctl status snap.test-snapd-user-service.svc3.service | MATCH "inactive"
-    systemctl status snap.test-snapd-user-service.svc4.service | MATCH "inactive"
+    systemctl status snap.test-snapd-user-service.svc3.service | MATCH ' inactive '
+    systemctl status snap.test-snapd-user-service.svc4.service | MATCH ' inactive '
 
     echo "(user test) We can see the user services stopped"
-    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "inactive"
-    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "inactive"
+    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH '^inactive$'
+    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH '^inactive$'
 
     echo "(user test2) We can see the user services stopped"
-    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "inactive"
-    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "inactive"
+    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH '^inactive$'
+    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH '^inactive$'
 
     # if non-root are making requests, and user services are the target,
     # then its an error to not specify --user scope
@@ -141,40 +141,40 @@ execute: |
     tests.session -u test exec snap start --user test-snapd-user-service
 
     echo "(user test) And we can see the user services running"
-    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "active"
-    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "active"
+    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH '^active$'
+    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH '^active$'
 
     echo "(user test2) Services are still not running"
-    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "inactive"
-    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "inactive"
+    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH '^inactive$'
+    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH '^inactive$'
 
     echo "(root) Services are still not running"
-    systemctl status snap.test-snapd-user-service.svc3.service | MATCH "inactive"
-    systemctl status snap.test-snapd-user-service.svc4.service | MATCH "inactive"
+    systemctl status snap.test-snapd-user-service.svc3.service | MATCH ' inactive '
+    systemctl status snap.test-snapd-user-service.svc4.service | MATCH ' inactive '
 
     echo "(user test) Trying to start system services without root, will fail"
     tests.session -u test exec snap start --system test-snapd-user-service 2>&1 | tr '\n' ' ' | tr -s ' ' | MATCH "non-root users must specify users when targeting user services"
 
     echo "(root) Stopping all services for snap"
     snap stop test-snapd-user-service
-    systemctl status snap.test-snapd-user-service.svc3.service | MATCH "inactive"
-    systemctl status snap.test-snapd-user-service.svc4.service | MATCH "inactive"
-    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "inactive"
-    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "inactive"
-    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "inactive"
-    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "inactive"
+    systemctl status snap.test-snapd-user-service.svc3.service | MATCH ' inactive '
+    systemctl status snap.test-snapd-user-service.svc4.service | MATCH ' inactive '
+    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH '^inactive$'
+    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH '^inactive$'
+    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH '^inactive$'
+    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH '^inactive$'
 
     echo "(root) Starting system services for snap with scope --system"
     snap start --system test-snapd-user-service
 
     echo "And only system services are running"
-    systemctl status snap.test-snapd-user-service.svc3.service | MATCH "running"
-    systemctl status snap.test-snapd-user-service.svc4.service | MATCH "running"
+    systemctl status snap.test-snapd-user-service.svc3.service | MATCH ' \(running\) '
+    systemctl status snap.test-snapd-user-service.svc4.service | MATCH ' \(running\) '
 
-    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "inactive"
-    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "inactive"
-    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "inactive"
-    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "inactive"
+    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH '^inactive$'
+    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH '^inactive$'
+    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH '^inactive$'
+    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH '^inactive$'
 
     echo "(root) Starting user services for snap with scope --user"
     snap start --user test-snapd-user-service 2>&1 | tr '\n' ' ' | tr -s ' ' | MATCH "cannot use \"self\" for root user"
@@ -183,27 +183,27 @@ execute: |
     snap start --users=all test-snapd-user-service
 
     echo "(user test) And we can see the user services running"
-    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "active"
-    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "active"
+    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH '^active$'
+    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH '^active$'
 
     echo "(user test2) And we can see the user services running"
-    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "active"
-    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "active"
+    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH '^active$'
+    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH '^active$'
 
     echo "(root) Stopping all services for snap again"
     snap stop test-snapd-user-service
-    systemctl status snap.test-snapd-user-service.svc3.service | MATCH "inactive"
-    systemctl status snap.test-snapd-user-service.svc4.service | MATCH "inactive"
-    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "inactive"
-    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "inactive"
-    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "inactive"
-    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "inactive"
+    systemctl status snap.test-snapd-user-service.svc3.service | MATCH ' inactive '
+    systemctl status snap.test-snapd-user-service.svc4.service | MATCH ' inactive '
+    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH '^inactive$'
+    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH '^inactive$'
+    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH '^inactive$'
+    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH '^inactive$'
 
     echo "(root) Starting all services for snap with scopes --system and --users=all"
     snap start --system --users=all test-snapd-user-service
-    systemctl status snap.test-snapd-user-service.svc3.service | MATCH "active"
-    systemctl status snap.test-snapd-user-service.svc4.service | MATCH "active"
-    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "active"
-    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "active"
-    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH "active"
-    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH "active"
+    systemctl status snap.test-snapd-user-service.svc3.service | MATCH ' active '
+    systemctl status snap.test-snapd-user-service.svc4.service | MATCH ' active '
+    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH '^active$'
+    tests.session -u test exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH '^active$'
+    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc1.service | MATCH '^active$'
+    tests.session -u test2 exec systemctl --user is-active snap.test-snapd-user-service.svc2.service | MATCH '^active$'

--- a/tests/main/services-watchdog/task.yaml
+++ b/tests/main/services-watchdog/task.yaml
@@ -35,7 +35,7 @@ execute: |
 
     echo "We can see all services running"
     for service in direct-watchdog-ok direct-watchdog-bad; do
-        systemctl show -p SubState snap.test-snapd-service-watchdog.$service | NOMATCH "SubState=dead"
+        systemctl show -p SubState snap.test-snapd-service-watchdog.$service | NOMATCH '^SubState=dead$'
     done
 
     echo "Services that are correctly poking the watchdog remain running"
@@ -48,7 +48,7 @@ execute: |
         test "$cnt" -lt 20
         sleep 1
     done
-    systemctl show -p SubState snap.test-snapd-service-watchdog.direct-watchdog-ok | MATCH 'SubState=running'
+    systemctl show -p SubState snap.test-snapd-service-watchdog.direct-watchdog-ok | MATCH '^SubState=running$'
 
     if os.query is-trusty; then
         # service watchdog does not appear to work in Ubuntu 14.04 at all
@@ -58,13 +58,13 @@ execute: |
     echo "Services not poking the watchdog fail due to watchdog"
     service=direct-watchdog-bad
     for _ in $(seq 1 20); do
-        if systemctl show -p SubState snap.test-snapd-service-watchdog.$service | MATCH 'SubState=(failed|stop-sigabrt)'; then
+        if systemctl show -p SubState snap.test-snapd-service-watchdog.$service | MATCH '^SubState=(failed|stop-sigabrt)$'; then
             break
         fi
         sleep 1
     done
-    systemctl show -p SubState snap.test-snapd-service-watchdog.$service | MATCH 'SubState=(failed|stop-sigabrt)'
+    systemctl show -p SubState snap.test-snapd-service-watchdog.$service | MATCH '^SubState=(failed|stop-sigabrt)$'
     # reported differently by different systemd versions
-    systemctl show -p Result snap.test-snapd-service-watchdog.$service | MATCH 'Result=(watchdog|signal|core-dump)'
+    systemctl show -p Result snap.test-snapd-service-watchdog.$service | MATCH '^Result=(watchdog|signal|core-dump)$'
 
     "$TESTSTOOLS"/journal-state match-log "systemd.*: snap.test-snapd-service-watchdog.$service.service:? [Ww]atchdog timeout" -u snap.test-snapd-service-watchdog.$service

--- a/tests/main/snap-quota-cpu/task.yaml
+++ b/tests/main/snap-quota-cpu/task.yaml
@@ -58,7 +58,7 @@ execute: |
 
   echo "The systemd slice should be active now"
   sliceName="snap.$(systemd-escape --path group-one).slice"
-  systemctl show --property=ActiveState "$sliceName" | MATCH "ActiveState=active"
+  systemctl show --property=ActiveState "$sliceName" | MATCH '^ActiveState=active$'
 
   echo "The service should also still be active"
   snap services test-snapd-stressd.stress-sc | MATCH "test-snapd-stressd.stress-sc\s+disabled\s+active"
@@ -139,7 +139,7 @@ execute: |
   systemctl show --property=ControlGroup snap.test-snapd-stressd.stress-sc.service | NOMATCH "/$sliceName/snap.test-snapd-stressd.stress-sc.service"
 
   echo "And the slice is not active anymore"
-  systemctl show --property=ActiveState "$sliceName" | MATCH "ActiveState=inactive"
+  systemctl show --property=ActiveState "$sliceName" | MATCH '^ActiveState=inactive$'
 
   echo "Verifying cpu usage, expecting at least above 60% again"
   ensure_cpu_usage_higher_than "stress" 60

--- a/tests/main/snap-quota-journal/task.yaml
+++ b/tests/main/snap-quota-journal/task.yaml
@@ -101,7 +101,7 @@ execute: |
   systemctl show --property=ControlGroup snap.test-snapd-journal-quota.logger.service | grep -vF "$SLICE_REGEXP"
 
   echo "And the slice is not active anymore"
-  systemctl show --property=ActiveState "$sliceName" | MATCH "ActiveState=inactive"
+  systemctl show --property=ActiveState "$sliceName" | MATCH '^ActiveState=inactive$'
 
   # Make sure that the service is running still and now outputting logs
   # into the original journal.

--- a/tests/main/snap-quota-memory/task.yaml
+++ b/tests/main/snap-quota-memory/task.yaml
@@ -34,7 +34,7 @@ execute: |
 
   echo "The systemd slice should be active now"
   sliceName="snap.$(systemd-escape --path group-one).slice"
-  systemctl show --property=ActiveState "$sliceName" | MATCH "ActiveState=active"
+  systemctl show --property=ActiveState "$sliceName" | MATCH '^ActiveState=active$'
 
   echo "The service should also still be active"
   snap services go-example-webserver.webserver | MATCH "go-example-webserver.webserver\s+enabled\s+active"
@@ -119,7 +119,7 @@ execute: |
   systemctl show --property=ControlGroup snap.go-example-webserver.webserver.service | NOMATCH "/$sliceName/snap.go-example-webserver.webserver.service"
 
   echo "And the slice is not active anymore"
-  systemctl show --property=ActiveState "$sliceName" | MATCH "ActiveState=inactive"
+  systemctl show --property=ActiveState "$sliceName" | MATCH '^ActiveState=inactive$'
 
   # snap.go-example-webserver.webserver.service is using about 540K and it is not killed
   if not os.query is-fedora; then
@@ -132,7 +132,7 @@ execute: |
     # the unit will jump between SubState=running and SubState=auto-restart while
     # trying to restart it in a loop, but after systemd has hit the limit it will
     # give up and mark the unit as failed
-    retry --wait 1 -n 30 sh -c "systemctl show --property=SubState snap.go-example-webserver.webserver.service | MATCH 'SubState=failed'"
+    retry --wait 1 -n 30 sh -c "systemctl show --property=SubState snap.go-example-webserver.webserver.service | MATCH '^SubState=failed$'"
 
     # clear "oom-killer" messages from dmesg or prepare-restore.sh will fail due
     # to the oom-killer messages from go-example-webserver
@@ -140,7 +140,7 @@ execute: |
 
     echo "The systemd slice should be active"
     sliceName="snap.$(systemd-escape --path too-small).slice"
-    systemctl show --property=ActiveState "$sliceName" | MATCH "ActiveState=active"
+    systemctl show --property=ActiveState "$sliceName" | MATCH '^ActiveState=active$'
 
     echo "But the service is not running after a short amount of time"
     retry --wait 1 -n 100 sh -c 'snap services go-example-webserver.webserver | MATCH "go-example-webserver.webserver\s+enabled\s+inactive"'

--- a/tests/main/snap-quota-thread/task.yaml
+++ b/tests/main/snap-quota-thread/task.yaml
@@ -55,7 +55,7 @@ execute: |
 
   echo "The systemd slice should be active now"
   sliceName="snap.$(systemd-escape --path group-one).slice"
-  systemctl show --property=ActiveState "$sliceName" | MATCH "ActiveState=active"
+  systemctl show --property=ActiveState "$sliceName" | MATCH '^ActiveState=active$'
 
   echo "The service should be active"
   snap services test-snapd-stressd.spawner | MATCH "test-snapd-stressd.spawner\s+disabled\s+active"
@@ -122,7 +122,7 @@ execute: |
   systemctl show --property=ControlGroup snap.test-snapd-stressd.spawner.service | NOMATCH "/$sliceName/snap.test-snapd-stressd.spawner.service"
 
   echo "And the slice is not active anymore"
-  systemctl show --property=ActiveState "$sliceName" | MATCH "ActiveState=inactive"
+  systemctl show --property=ActiveState "$sliceName" | MATCH '^ActiveState=inactive$'
 
   echo "Verify the service is now running at full capacity"
   total_iters=5

--- a/tests/main/snap-service-install-mode/task.yaml
+++ b/tests/main/snap-service-install-mode/task.yaml
@@ -30,7 +30,7 @@ execute: |
     snap services | MATCH 'svc.svc-enabled-by-timer\s+disabled\s+inactive'
 
     # ensure that the timer service unit is also disabled by poking systemd
-    systemctl show --property=UnitFileState snap.svc.svc-enabled-by-timer.timer | grep "disabled"
+    systemctl show --property=UnitFileState snap.svc.svc-enabled-by-timer.timer | MATCH '^UnitFileState=disabled$'
 
     echo "And after a refresh nothing changes"
     "$TESTSTOOLS"/snaps-state install-local ./svc.v1
@@ -39,7 +39,7 @@ execute: |
     snap services | MATCH 'svc.svc-enabled-by-hook\s+enabled\s+active'
 
     # ensure again that the timer service unit is still disabled by poking systemd
-    systemctl show --property=UnitFileState snap.svc.svc-enabled-by-timer.timer | grep "disabled"
+    systemctl show --property=UnitFileState snap.svc.svc-enabled-by-timer.timer | MATCH '^UnitFileState=disabled$'
 
     echo "But install-mode: disable services can be enabled"
     snap start --enable svc.svc2

--- a/tests/main/snap-service/task.yaml
+++ b/tests/main/snap-service/task.yaml
@@ -20,7 +20,7 @@ execute: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-service
 
     echo "We can see it running"
-    systemctl status snap.test-snapd-service.test-snapd-service|MATCH "running"
+    systemctl status snap.test-snapd-service.test-snapd-service|MATCH ' \(running\) '
 
     echo "When we reload"
     systemctl reload snap.test-snapd-service.test-snapd-service

--- a/tests/main/snap-services/task.yaml
+++ b/tests/main/snap-services/task.yaml
@@ -28,7 +28,7 @@ execute: |
     # precondition check of systemctl behavior for non-existing services;
     # it is expected that the returned UnitFileState is empty.
     systemctl show --property=Id foo.service | MATCH "foo.service"
-    systemctl show --property=ActiveState foo.service | MATCH "inactive"
+    systemctl show --property=ActiveState foo.service | MATCH '^ActiveState=inactive$'
     UNIT_FILE_STATE=$(systemctl show --property=UnitFileState foo.service)
     if [[ "$UNIT_FILE_STATE" != "UnitFileState=" ]]; then
         echo "unexpected value of UnitFileState for non-existing service: $UNIT_FILE_STATE"

--- a/tests/main/snap-session-agent-service-control/task.yaml
+++ b/tests/main/snap-session-agent-service-control/task.yaml
@@ -50,19 +50,19 @@ execute: |
         -X POST -H "Content-Type: application/json" \
         /v1/service-control
     echo "The service is now visible but not active"
-    tests.session -u test exec systemctl --user show --property=LoadState snap.test-service.service | MATCH LoadState=loaded
-    tests.session -u test exec systemctl --user show --property=ActiveState snap.test-service.service | MATCH ActiveState=inactive
+    tests.session -u test exec systemctl --user show --property=LoadState snap.test-service.service | MATCH '^LoadState=loaded$'
+    tests.session -u test exec systemctl --user show --property=ActiveState snap.test-service.service | MATCH '^ActiveState=inactive$'
 
     echo "The session agent can start user mode services"
     echo '{"action": "start", "services": ["snap.test-service.service"]}' | snap debug api \
         --fail --session-agent-uid=12345 \
          -X POST -H "Content-Type: application/json" \
         /v1/service-control
-    tests.session -u test exec systemctl --user show --property=ActiveState snap.test-service.service | MATCH ActiveState=active
+    tests.session -u test exec systemctl --user show --property=ActiveState snap.test-service.service | MATCH '^ActiveState=active$'
 
     echo "The session agent can stop user mode services"
     echo '{"action": "stop", "services": ["snap.test-service.service"]}' | snap debug api \
         --fail --session-agent-uid=12345 \
         -X POST -H "Content-Type: application/json" \
         /v1/service-control
-    tests.session -u test exec systemctl --user show --property=ActiveState snap.test-service.service | MATCH ActiveState=inactive
+    tests.session -u test exec systemctl --user show --property=ActiveState snap.test-service.service | MATCH '^ActiveState=inactive$'

--- a/tests/main/snap-user-service-enabled-after-install/task.yaml
+++ b/tests/main/snap-user-service-enabled-after-install/task.yaml
@@ -87,17 +87,17 @@ execute: |
     # expect that three runs and is enabled for current user
 
     echo "Verify status of running services after install"
-    systemctl_as_test is-active snap.test-snapd-user-service-disabled.user-service | MATCH "inactive"
-    systemctl_as_test is-enabled snap.test-snapd-user-service-disabled.user-service | MATCH "disabled"
+    systemctl_as_test is-active snap.test-snapd-user-service-disabled.user-service | MATCH '^inactive$'
+    systemctl_as_test is-enabled snap.test-snapd-user-service-disabled.user-service | MATCH '^disabled$'
 
-    systemctl_as_test is-active snap.test-snapd-user-service-disabled.user-service-two | MATCH "active"
-    systemctl_as_test is-enabled snap.test-snapd-user-service-disabled.user-service-two | MATCH "enabled"
+    systemctl_as_test is-active snap.test-snapd-user-service-disabled.user-service-two | MATCH '^active$'
+    systemctl_as_test is-enabled snap.test-snapd-user-service-disabled.user-service-two | MATCH '^enabled$'
 
     echo "Enable the first user service for just us"
     snap_as_test start --user --enable test-snapd-user-service-disabled.user-service
 
-    systemctl_as_test is-active snap.test-snapd-user-service-disabled.user-service | MATCH "active"
-    systemctl_as_test is-enabled snap.test-snapd-user-service-disabled.user-service | MATCH "enabled"
+    systemctl_as_test is-active snap.test-snapd-user-service-disabled.user-service | MATCH '^active$'
+    systemctl_as_test is-enabled snap.test-snapd-user-service-disabled.user-service | MATCH '^enabled$'
 
     function systemctl_as_test2() {
       tests.session -u test2 exec systemctl --user "$@"
@@ -110,10 +110,10 @@ execute: |
 
     # the first user-service that we started and enabled for just user
     # 'test' should not be running 
-    systemctl_as_test2 is-active snap.test-snapd-user-service-disabled.user-service | MATCH "inactive"
-    systemctl_as_test2 is-enabled snap.test-snapd-user-service-disabled.user-service | MATCH "disabled"
+    systemctl_as_test2 is-active snap.test-snapd-user-service-disabled.user-service | MATCH '^inactive$'
+    systemctl_as_test2 is-enabled snap.test-snapd-user-service-disabled.user-service | MATCH '^disabled$'
 
     # the second one which was enabled globally by the install hook should
     # be running
-    systemctl_as_test2 is-active snap.test-snapd-user-service-disabled.user-service-two | MATCH "active"
-    systemctl_as_test2 is-enabled snap.test-snapd-user-service-disabled.user-service-two | MATCH "enabled"
+    systemctl_as_test2 is-active snap.test-snapd-user-service-disabled.user-service-two | MATCH '^active$'
+    systemctl_as_test2 is-enabled snap.test-snapd-user-service-disabled.user-service-two | MATCH '^enabled$'

--- a/tests/main/snap-user-services-mixed-refresh-all-disabled/task.yaml
+++ b/tests/main/snap-user-services-mixed-refresh-all-disabled/task.yaml
@@ -81,37 +81,37 @@ execute: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-mixed-service
 
     echo "Verify status of running services after install"
-    systemctl is-active snap.test-snapd-mixed-service.sys-service | MATCH "active"
-    systemctl is-enabled snap.test-snapd-mixed-service.sys-service | MATCH "enabled"
+    systemctl is-active snap.test-snapd-mixed-service.sys-service | MATCH '^active$'
+    systemctl is-enabled snap.test-snapd-mixed-service.sys-service | MATCH '^enabled$'
 
-    systemctl_as_test is-active snap.test-snapd-mixed-service.user-service | MATCH "active"
-    systemctl_as_test is-enabled snap.test-snapd-mixed-service.user-service | MATCH "enabled"
+    systemctl_as_test is-active snap.test-snapd-mixed-service.user-service | MATCH '^active$'
+    systemctl_as_test is-enabled snap.test-snapd-mixed-service.user-service | MATCH '^enabled$'
 
-    systemctl_as_test2 is-active snap.test-snapd-mixed-service.user-service | MATCH "active"
-    systemctl_as_test2 is-enabled snap.test-snapd-mixed-service.user-service | MATCH "enabled"
+    systemctl_as_test2 is-active snap.test-snapd-mixed-service.user-service | MATCH '^active$'
+    systemctl_as_test2 is-enabled snap.test-snapd-mixed-service.user-service | MATCH '^enabled$'
 
     # stop and disable both services, scope of user one for all
     snap stop --disable --system --users=all test-snapd-mixed-service
 
     # verify this worked
-    systemctl is-active snap.test-snapd-mixed-service.sys-service | MATCH "inactive"
-    systemctl is-enabled snap.test-snapd-mixed-service.sys-service | MATCH "disabled"
+    systemctl is-active snap.test-snapd-mixed-service.sys-service | MATCH '^inactive$'
+    systemctl is-enabled snap.test-snapd-mixed-service.sys-service | MATCH '^disabled$'
 
-    systemctl_as_test is-active snap.test-snapd-mixed-service.user-service | MATCH "inactive"
-    systemctl_as_test is-enabled snap.test-snapd-mixed-service.user-service | MATCH "disabled"
+    systemctl_as_test is-active snap.test-snapd-mixed-service.user-service | MATCH '^inactive$'
+    systemctl_as_test is-enabled snap.test-snapd-mixed-service.user-service | MATCH '^disabled$'
 
-    systemctl_as_test2 is-active snap.test-snapd-mixed-service.user-service | MATCH "inactive"
-    systemctl_as_test2 is-enabled snap.test-snapd-mixed-service.user-service | MATCH "disabled"
+    systemctl_as_test2 is-active snap.test-snapd-mixed-service.user-service | MATCH '^inactive$'
+    systemctl_as_test2 is-enabled snap.test-snapd-mixed-service.user-service | MATCH '^disabled$'
 
     # now refresh snap to a new version
     "$TESTSTOOLS"/snaps-state install-local test-snapd-mixed-service-v2
     
     # verify nothing changed
-    systemctl is-active snap.test-snapd-mixed-service.sys-service | MATCH "inactive"
-    systemctl is-enabled snap.test-snapd-mixed-service.sys-service | MATCH "disabled"
+    systemctl is-active snap.test-snapd-mixed-service.sys-service | MATCH '^inactive$'
+    systemctl is-enabled snap.test-snapd-mixed-service.sys-service | MATCH '^disabled$'
 
-    systemctl_as_test is-active snap.test-snapd-mixed-service.user-service | MATCH "inactive"
-    systemctl_as_test is-enabled snap.test-snapd-mixed-service.user-service | MATCH "disabled"
+    systemctl_as_test is-active snap.test-snapd-mixed-service.user-service | MATCH '^inactive$'
+    systemctl_as_test is-enabled snap.test-snapd-mixed-service.user-service | MATCH '^disabled$'
 
-    systemctl_as_test2 is-active snap.test-snapd-mixed-service.user-service | MATCH "inactive"
-    systemctl_as_test2 is-enabled snap.test-snapd-mixed-service.user-service | MATCH "disabled"
+    systemctl_as_test2 is-active snap.test-snapd-mixed-service.user-service | MATCH '^inactive$'
+    systemctl_as_test2 is-enabled snap.test-snapd-mixed-service.user-service | MATCH '^disabled$'

--- a/tests/main/snap-user-services-mixed-refresh-single-disabled/task.yaml
+++ b/tests/main/snap-user-services-mixed-refresh-single-disabled/task.yaml
@@ -85,14 +85,14 @@ execute: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-mixed-service
 
     echo "Verify status of running services after install"
-    systemctl is-active snap.test-snapd-mixed-service.sys-service | MATCH "active"
-    systemctl is-enabled snap.test-snapd-mixed-service.sys-service | MATCH "enabled"
+    systemctl is-active snap.test-snapd-mixed-service.sys-service | MATCH '^active$'
+    systemctl is-enabled snap.test-snapd-mixed-service.sys-service | MATCH '^enabled$'
 
-    systemctl_as_test is-active snap.test-snapd-mixed-service.user-service | MATCH "active"
-    systemctl_as_test is-enabled snap.test-snapd-mixed-service.user-service | MATCH "enabled"
+    systemctl_as_test is-active snap.test-snapd-mixed-service.user-service | MATCH '^active$'
+    systemctl_as_test is-enabled snap.test-snapd-mixed-service.user-service | MATCH '^enabled$'
 
-    systemctl_as_test2 is-active snap.test-snapd-mixed-service.user-service | MATCH "active"
-    systemctl_as_test2 is-enabled snap.test-snapd-mixed-service.user-service | MATCH "enabled"
+    systemctl_as_test2 is-active snap.test-snapd-mixed-service.user-service | MATCH '^active$'
+    systemctl_as_test2 is-enabled snap.test-snapd-mixed-service.user-service | MATCH '^enabled$'
 
     # stop and disable user services, but the scope of the disable
     # for users should only affect the current user.
@@ -104,25 +104,25 @@ execute: |
     snap_as_test stop --disable --user test-snapd-mixed-service
 
     # verify this worked
-    systemctl is-active snap.test-snapd-mixed-service.sys-service | MATCH "active"
-    systemctl is-enabled snap.test-snapd-mixed-service.sys-service | MATCH "enabled"
+    systemctl is-active snap.test-snapd-mixed-service.sys-service | MATCH '^active$'
+    systemctl is-enabled snap.test-snapd-mixed-service.sys-service | MATCH '^enabled$'
 
-    systemctl_as_test is-active snap.test-snapd-mixed-service.user-service | MATCH "inactive"
+    systemctl_as_test is-active snap.test-snapd-mixed-service.user-service | MATCH '^inactive$'
     # this should be "disabled", but it will not be currently
-    systemctl_as_test is-enabled snap.test-snapd-mixed-service.user-service | MATCH "enabled"
+    systemctl_as_test is-enabled snap.test-snapd-mixed-service.user-service | MATCH '^enabled$'
 
-    systemctl_as_test2 is-active snap.test-snapd-mixed-service.user-service | MATCH "active"
-    systemctl_as_test2 is-enabled snap.test-snapd-mixed-service.user-service | MATCH "enabled"
+    systemctl_as_test2 is-active snap.test-snapd-mixed-service.user-service | MATCH '^active$'
+    systemctl_as_test2 is-enabled snap.test-snapd-mixed-service.user-service | MATCH '^enabled$'
 
     # now refresh snap to a new version
     "$TESTSTOOLS"/snaps-state install-local test-snapd-mixed-service-v2
     
     # verify that things now look as we expect
-    systemctl is-active snap.test-snapd-mixed-service.sys-service | MATCH "active"
-    systemctl is-enabled snap.test-snapd-mixed-service.sys-service | MATCH "enabled"
+    systemctl is-active snap.test-snapd-mixed-service.sys-service | MATCH '^active$'
+    systemctl is-enabled snap.test-snapd-mixed-service.sys-service | MATCH '^enabled$'
 
-    systemctl_as_test is-active snap.test-snapd-mixed-service.user-service | MATCH "inactive"
-    systemctl_as_test is-enabled snap.test-snapd-mixed-service.user-service | MATCH "disabled"
+    systemctl_as_test is-active snap.test-snapd-mixed-service.user-service | MATCH '^inactive$'
+    systemctl_as_test is-enabled snap.test-snapd-mixed-service.user-service | MATCH '^disabled$'
 
-    systemctl_as_test2 is-active snap.test-snapd-mixed-service.user-service | MATCH "active"
-    systemctl_as_test2 is-enabled snap.test-snapd-mixed-service.user-service | MATCH "enabled"
+    systemctl_as_test2 is-active snap.test-snapd-mixed-service.user-service | MATCH '^active$'
+    systemctl_as_test2 is-enabled snap.test-snapd-mixed-service.user-service | MATCH '^enabled$'

--- a/tests/main/snapd-go-socket-activated/task.yaml
+++ b/tests/main/snapd-go-socket-activated/task.yaml
@@ -22,12 +22,12 @@ execute: |
 
     echo "And then goes into socket activation mode"
     for _ in $(seq 120); do
-        if systemctl status snapd.service | grep -q -E "Active: inactive"; then
+        if systemctl status snapd.service | grep -q -E 'Active: inactive'; then
             break
         fi
         sleep 1
     done
-    systemctl status snapd.service | MATCH "Active: inactive"
+    systemctl status snapd.service | MATCH 'Active: inactive'
 
     echo "But the snap command keeps working"
     snap list
@@ -37,4 +37,4 @@ execute: |
     test-snapd-sh.sh -c 'echo hello' | MATCH hello
 
     echo "And snapd is running"
-    systemctl status snapd.service | MATCH "Active: active"
+    systemctl status snapd.service | MATCH 'Active: active'

--- a/tests/main/snapd-sigterm/task.yaml
+++ b/tests/main/snapd-sigterm/task.yaml
@@ -40,7 +40,7 @@ execute: |
     # extra safe check that it's either inactive or has just been restarted. We
     # don't want to stop the socket itself, as that might hide the issue we
     # want to test.
-    retry -n 100 --wait 0.1 sh -c 'systemctl status snapd.service | MATCH "inactive"'
+    retry -n 100 --wait 0.1 sh -c "systemctl status snapd.service | MATCH ' inactive '"
 
     TEST_TIME1="$(date +'%s')"
 

--- a/tests/main/systemd-service/task.yaml
+++ b/tests/main/systemd-service/task.yaml
@@ -16,7 +16,7 @@ execute: |
     "$TESTSTOOLS"/snaps-state install-local test-snapd-service
 
     echo "When the service state is reported as active"
-    while ! systemctl show -p ActiveState "$SERVICE_NAME" | grep -Pq "ActiveState=active"; do sleep 0.5; done
+    while ! systemctl show -p ActiveState "$SERVICE_NAME" | grep -Pq '^ActiveState=active$'; do sleep 0.5; done
 
     echo "Then systemctl reports the status of the service as loaded, active and running"
     expected='(?s).*?Loaded: loaded .*?Active: active \(running\)'

--- a/tests/main/systemd-success-exit-status/task.yaml
+++ b/tests/main/systemd-success-exit-status/task.yaml
@@ -48,7 +48,7 @@ execute: |
     fi
 
     echo "When the signal is propagated to the service"
-    retry -n 20 --wait 1 sh -c "systemctl show -p ActiveState '$SERVICE_NAME' | MATCH 'ActiveState=inactive'"
+    retry -n 20 --wait 1 sh -c "systemctl show -p ActiveState '$SERVICE_NAME' | MATCH '^ActiveState=inactive$'"
 
     echo "Then systemctl reports the status of the service as terminated"
     systemctl show -p ExecMainStatus "$SERVICE_NAME" | MATCH "ExecMainStatus=42"
@@ -78,7 +78,7 @@ execute: |
     fi
 
     echo "When the signal is propagated to the service"
-    retry -n 20 --wait 1 sh -c "systemctl show -p ActiveState '$SERVICE_NAME' | MATCH 'ActiveState=inactive'"
+    retry -n 20 --wait 1 sh -c "systemctl show -p ActiveState '$SERVICE_NAME' | MATCH '^ActiveState=inactive$'"
 
     echo "Then systemctl reports the status of the service as terminated"
     systemctl show -p ExecMainStatus "$SERVICE_NAME" | MATCH "ExecMainStatus=250"
@@ -109,10 +109,10 @@ execute: |
     fi
 
     echo "When the signal is propagated to the service"
-    retry -n 20 --wait 1 sh -c "systemctl show -p ActiveState '$SERVICE_NAME' | MATCH 'ActiveState=active'"
+    retry -n 20 --wait 1 sh -c "systemctl show -p ActiveState '$SERVICE_NAME' | MATCH '^ActiveState=active$'"
 
     echo "Then systemctl reports the status of the service as running due to 'restart on-failure'"
-    systemctl show -p SubState "$SERVICE_NAME" | MATCH "SubState=running"
+    systemctl show -p SubState "$SERVICE_NAME" | MATCH '^SubState=running$'
 
     echo "And the marker file is recreated after the service restarts"
     retry -n 20 --wait 1 stat "$MARKER"

--- a/tests/regression/lp-1802581/task.yaml
+++ b/tests/regression/lp-1802581/task.yaml
@@ -73,4 +73,4 @@ execute: |
     snap interfaces | MATCH ":gpio-pin.*gpio-consumer:gpio"
 
     echo "Ensure that our mock service is full functional"
-    systemctl status fake-gpio.service | MATCH "Active: active"
+    systemctl status fake-gpio.service | MATCH 'Active: active'


### PR DESCRIPTION
In various places, there were things like `systemctl is-active | MATCH active`, which could match both `active` and `inactive`. Let's disambiguate the matches and generally ensure we're doing to most specific/correct matches we can.