### PR TITLE
github: move subset of tasks from nightly to PRs

### DIFF
--- a/.github/workflows/data-non-fundamental-systems.json
+++ b/.github/workflows/data-non-fundamental-systems.json
@@ -130,35 +130,99 @@
       },
       {
         "runs-on": "['ubuntu-latest']",
-        "group": "jammy (garden)",
+        "group": "ubuntu-focal-jammy (garden)",
         "backend": "garden",
-        "systems": "ubuntu-22.04-64",
-        "tasks": "tests/main/apparmor-prompting-integration-tests tests/main/interfaces-requests-activates-handlers tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap:lxd tests/main/apparmor-prompting-support tests/main/proxy",
-        "rules": ""
+        "systems": "ubuntu-20.04-64 ubuntu-22.04-64",
+        "tasks": "tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap:lxd tests/main/apparmor-prompting-support tests/main/proxy",
+        "rules": "main"
+      },
+      {
+        "runs-on": "['ubuntu-latest']",
+        "group": "ubuntu-noble-resolute (garden)",
+        "backend": "garden",
+        "systems": "ubuntu-24.04-64 ubuntu-26.04-64",
+        "tasks": "tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap tests/main/apparmor-prompting-support tests/main/proxy tests/main/auto-refresh-retry tests/main/network-retry",
+        "rules": "main"
       },
       {
         "runs-on": "['ubuntu-latest']",
         "group": "ubuntu-core-18 (garden)",
         "backend": "garden",
         "systems": "ubuntu-core-18-64",
-        "tasks": "tests/core/auto-refresh-backoff-after-reboot:kernel tests/core/failover:emptyinitrd tests/core/gadget-kernel-refs-update-pc tests/core/kernel-base-gadget-pair-single-reboot-failover tests/core/kernel-base-gadget-pair-single-reboot tests/core/kernel-base-gadget-single-reboot tests/core/kernel-base-gadget-single-reboot-failover tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap:lxd tests/main/apparmor-prompting-support tests/main/proxy",
-        "rules": ""
+        "tasks": "tests/core/auto-refresh-backoff-after-reboot:kernel tests/core/failover:emptyinitrd tests/core/gadget-kernel-refs-update-pc tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap tests/main/apparmor-prompting-support tests/main/proxy tests/main/auto-refresh-retry tests/main/network-retry",
+        "rules": "main"
+      },
+      {
+        "runs-on": "['ubuntu-latest']",
+        "group": "ubuntu-core-20 (garden)",
+        "backend": "garden",
+        "systems": "ubuntu-core-20-64",
+        "tasks": "tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap tests/main/apparmor-prompting-support tests/main/proxy tests/main/auto-refresh-retry tests/main/network-retry",
+        "rules": "main"
+      },
+      {
+        "runs-on": "['ubuntu-latest']",
+        "group": "ubuntu-core-22 (garden)",
+        "backend": "garden",
+        "systems": "ubuntu-core-22-64",
+        "tasks": "tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap tests/main/apparmor-prompting-support tests/main/proxy tests/main/auto-refresh-retry tests/main/network-retry",
+        "rules": "main"
       },
       {
         "runs-on": "['ubuntu-latest']",
         "group": "ubuntu-core-24 (garden)",
         "backend": "garden",
         "systems": "ubuntu-core-24-64",
-        "tasks": "tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap:lxd tests/main/apparmor-prompting-support tests/main/proxy",
-        "rules": ""
+        "tasks": "tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap tests/main/apparmor-prompting-support tests/main/proxy tests/main/auto-refresh-retry tests/main/network-retry",
+        "rules": "main"
       },
       {
         "runs-on": "['ubuntu-latest']",
-        "group": "focal (garden)",
+        "group": "ubuntu-core-26 (garden)",
         "backend": "garden",
-        "systems": "ubuntu-20.04-64",
+        "systems": "ubuntu-core-26-64",
+        "tasks": "tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap tests/main/apparmor-prompting-support tests/main/proxy tests/main/auto-refresh-retry tests/main/network-retry",
+        "rules": "main"
+      },
+      {
+        "runs-on": "['ubuntu-latest']",
+        "group": "debian (garden)",
+        "backend": "garden",
+        "systems": "debian-12-64 debian-sid-64",
         "tasks": "tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap:lxd tests/main/apparmor-prompting-support tests/main/proxy",
-        "rules": ""
+        "rules": "main"
+      },
+      {
+        "runs-on": "['ubuntu-latest']",
+        "group": "arch (garden)",
+        "backend": "garden",
+        "systems": "arch-linux-64",
+        "tasks": "tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap:lxd tests/main/apparmor-prompting-support tests/main/proxy",
+        "rules": "main"
+      },
+      {
+        "runs-on": "['ubuntu-latest']",
+        "group": "amazon (garden)",
+        "backend": "garden",
+        "systems": "amazon-linux-2-64 amazon-linux-2023-64",
+        "tasks": "tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap:lxd tests/main/apparmor-prompting-support tests/main/proxy",
+        "rules": "main"
+      },
+      {
+        "runs-on": "['ubuntu-latest']",
+        "group": "centos (garden)",
+        "backend": "garden",
+        "systems": "centos-9-64",
+        "tasks": "tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap:lxd tests/main/apparmor-prompting-support tests/main/proxy",
+        "rules": "main"
+      },
+      {
+        "runs-on": "['ubuntu-latest']",
+        "group": "opensuse (garden)",
+        "backend": "garden",
+        "systems": "opensuse-16.0-64 opensuse-tumbleweed-64 opensuse-tumbleweed-selinux-64",
+        "tasks": "tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap:lxd tests/main/apparmor-prompting-support tests/main/proxy",
+        "rules": "main"
       },
       {
         "runs-on": "['ubuntu-latest']",
@@ -166,15 +230,15 @@
         "backend": "garden",
         "systems": "ubuntu-26.10-64",
         "tasks": "tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap:lxd tests/main/apparmor-prompting-support tests/main/proxy",
-        "rules": ""
+        "rules": "main"
       },
       {
         "runs-on": "['ubuntu-latest']",
         "group": "fedora-44 (garden)",
         "backend": "garden",
         "systems": "fedora-44-64",
-        "tasks": "tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap:lxd tests/main/apparmor-prompting-support tests/main/proxy",
-        "rules": ""
+        "tasks": "tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap tests/main/apparmor-prompting-support tests/main/proxy tests/main/auto-refresh-retry tests/main/network-retry",
+        "rules": "main"
       }
     ]
   }

--- a/.github/workflows/nightly-spread.yaml
+++ b/.github/workflows/nightly-spread.yaml
@@ -52,44 +52,6 @@ jobs:
       rules: ''
       use-snapd-snap-from-master: true
 
-  spread-nightly-google:
-    if: ${{ github.event.schedule == '0 2 * * *' || (github.event_name == 'workflow_dispatch' && inputs.job == 'spread-nightly-google') }}
-    uses: ./.github/workflows/spread-tests.yaml
-    secrets: inherit
-    with:
-      runs-on: '["self-hosted", "spread-enabled"]'
-      group: ${{ matrix.group }}
-      backend: ${{ matrix.backend }}
-      systems: ${{ matrix.systems }}
-      tasks: ${{ matrix.tasks }}
-      rules: ''
-      use-snapd-snap-from-master: true
-      skip-tests: 'ubuntu-14.04-64 ubuntu-core-16-64'
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - group: jammy
-            backend: google
-            systems: 'ubuntu-22.04-64'
-            tasks: 'tests/main/apparmor-prompting-integration-tests tests/main/interfaces-requests-activates-handlers'
-          - group: google
-            backend: google
-            systems: 'ALL'
-            tasks: 'tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap:lxd tests/main/apparmor-prompting-support tests/main/proxy'
-          - group: google-core
-            backend: google-core
-            systems: 'ALL'
-            tasks: 'tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap:lxd tests/main/apparmor-prompting-support tests/main/proxy'
-          - group: google-distro
-            backend: google-distro
-            systems: 'ALL'
-            tasks: 'tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap:lxd tests/main/apparmor-prompting-support tests/main/proxy'
-          - group: google-arm
-            backend: google-distro
-            systems: 'ubuntu-22.04-arm-64 ubuntu-core-24-arm-64'
-            tasks: 'tests/main/microk8s-smoke tests/main/download-timeout tests/main/snap-network-errors tests/main/snapd-snap:lxd tests/main/apparmor-prompting-support tests/main/proxy'
-
   spread-test-build-from-current:
     if: ${{ github.event.schedule == '0 6 * * *' || (github.event_name == 'workflow_dispatch' && inputs.job == 'spread-test-build-from-current') }}
     uses: ./.github/workflows/spread-tests.yaml


### PR DESCRIPTION
This is a split from https://github.com/canonical/snapd/pull/17280 that removes xenial/bionic and ARM. Those need more work, so in the meantime we can merge all the others.