### PR TITLE
.github: add spread-results-reporter retry logic

### DIFF
--- a/.github/scripts/parse-results-predictor.py
+++ b/.github/scripts/parse-results-predictor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import glob
 import json
+import os
 import sys
 from collections import defaultdict
 from typing import Callable, TypeAlias, cast
@@ -12,7 +13,7 @@ from typing import Callable, TypeAlias, cast
 
 JsonValue: TypeAlias = None | bool | int | float | str | list["JsonValue"] | dict[str, "JsonValue"]
 JsonObject: TypeAlias = dict[str, JsonValue]
-PredictorKey: TypeAlias = tuple[str, str, str, str]
+PredictorKey: TypeAlias = tuple[str, str, str, str, str]
 
 
 def load_json_object(path: str) -> JsonObject:
@@ -63,7 +64,11 @@ def consolidate(args: argparse.Namespace) -> int:
 			report = load_json_object(path)
 			report_items = report.get("items", [])
 			if isinstance(report_items, list):
-				items.extend(item for item in report_items if isinstance(item, dict))
+				group = os.path.basename(os.path.dirname(path)).split("-", 4)[-1]
+				for item in report_items:
+					if isinstance(item, dict):
+						item["source_group"] = group
+						items.append(item)
 
 	with open(args.output, "w", encoding="utf-8") as output_file:
 		json.dump({"items": items}, output_file)
@@ -85,6 +90,7 @@ def predictor_rows(args: argparse.Namespace) -> int:
 			continue
 
 		key = (
+			string_value(item.get("source_group", "")),
 			string_value(item.get("backend", "")),
 			string_value(item.get("system", "")),
 			full_name(item),
@@ -93,13 +99,13 @@ def predictor_rows(args: argparse.Namespace) -> int:
 		grouped_items[key].append(item)
 
 	for key in sorted(grouped_items):
-		backend, system, test_name, scenario = key
+		source_group, backend, system, test_name, scenario = key
 		occurrences = len(grouped_items[key])
 		if backend:
 			test_display_name = f"{backend}:{system}:{test_name}"
 		else:
 			test_display_name = f"{system}:{test_name}"
-		print("\t".join([test_display_name, str(occurrences), test_name, system, scenario]))
+		print("\t".join([test_display_name, str(occurrences), test_name, system, scenario, source_group]))
 	return 0
 
 

--- a/.github/scripts/test-predictor-reporter.sh
+++ b/.github/scripts/test-predictor-reporter.sh
@@ -47,9 +47,12 @@ append_predictor_table() {
 	} >>report
 
 	printf '%s\n' "${predictor_rows[@]}" |
-		while IFS=$'\t' read -r display_name occurrences full_name system scenario; do
+		while IFS=$'\t' read -r display_name occurrences full_name system scenario source_group; do
 			if ((occurrences > 1)); then
 				display_name+=" <kbd>${occurrences} times</kbd>"
+			fi
+			if [ -n "$source_group" ]; then
+				printf '%s\n' "$source_group" >>predictor-groups-seen
 			fi
 
 			response='{}'
@@ -65,8 +68,14 @@ append_predictor_table() {
 			fi
 			probability=$(python3 "${parser}" success-probability <<<"$response")
 			if [ -z "$probability" ]; then
+				if [ -n "$source_group" ]; then
+					printf '%s\n' "$source_group" >>predictor-groups-ineligible
+				fi
 				probability="unavailable"
 			else
+				if [ -n "$source_group" ] && ! awk -v probability="$probability" 'BEGIN { exit !(probability > 0.5) }'; then
+					printf '%s\n' "$source_group" >>predictor-groups-ineligible
+				fi
 				probability=$(awk -v probability="$probability" 'BEGIN {
                     if (probability >= 0.8) marker = "🟢";
                     else if (probability >= 0.3) marker = "🟡";
@@ -81,11 +90,53 @@ append_predictor_table() {
 	echo "" >>report
 }
 
+rerun_predictor_jobs() {
+	if [ "$workflow_run_attempt" != 1 ]; then
+		return
+	fi
+
+	comm -23 \
+		<(sort -u predictor-groups-seen) \
+		<(sort -u predictor-groups-ineligible) >predictor-rerun-groups
+	if [ ! -s predictor-rerun-groups ]; then
+		return
+	fi
+
+	if ! gh api --paginate "/repos/${repository}/actions/runs/${workflow_run_id}/jobs?filter=latest&per_page=100" \
+		--jq '.jobs[] | [.id, .name] | @tsv' >workflow-jobs; then
+		echo "Unable to retrieve workflow jobs; predictor-selected tests were not retried." >>report
+		return
+	fi
+
+	echo "### Predictor-selected retries" >>report
+	while IFS= read -r group; do
+		job_id=""
+		while IFS=$'\t' read -r candidate_id job_name; do
+			if [[ "$job_name" == "spread ${group} /"* ]]; then
+				job_id="$candidate_id"
+				break
+			fi
+		done <workflow-jobs
+
+		if [ -z "$job_id" ]; then
+			echo "- Could not find the completed spread job for \`${group}\`." >>report
+		elif gh api --method POST "/repos/${repository}/actions/jobs/${job_id}/rerun" >/dev/null; then
+			echo "- Retrying failed tests from \`${group}\` (all predictor scores > 50%)." >>report
+		else
+			echo "- Failed to request a retry for \`${group}\`." >>report
+		fi
+	done <predictor-rerun-groups
+	echo "" >>report
+}
+
 if [ -f consolidated-report.json ] && python3 "${parser}" has-predictor-rows consolidated-report.json; then
+	: >predictor-groups-seen
+	: >predictor-groups-ineligible
 	echo "## Test Predictor Analysis" >>report
 	append_predictor_table "preparing" "Preparing"
 	append_predictor_table "executing" "Executing"
 	append_predictor_table "restoring" "Restoring"
+	rerun_predictor_jobs
 fi
 
 if find . -name skipped_tests_list.txt | grep -q .; then

--- a/.github/workflows/spread-results-reporter.yaml
+++ b/.github/workflows/spread-results-reporter.yaml
@@ -11,6 +11,7 @@ jobs:
     if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion != 'cancelled' }}
     runs-on: [self-hosted, spread-enabled]
     permissions:
+      actions: write
       pull-requests: write
     env:
       GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
The current test-predictor integration prints a table showing retrieved test predictions. This PR allows the spread-results-reporter workflow to selectively re-run spread tests based on expected probability of success.