### PR TITLE
secboot: update to rev dd95d85 - support thunderbolt security level 0 on UC

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	// if below two libseccomp-golang lines are updated, one must also update packaging/ubuntu-14.04/rules
 	github.com/mvo5/libseccomp-golang v0.9.1-0.20180308152521-f4de83b52afb // old trusty builds only
 	github.com/seccomp/libseccomp-golang v0.9.2-0.20220502024300-f57e1d55ea18
-	github.com/snapcore/secboot v0.0.0-20260623135244-457b03a16d19
+	github.com/snapcore/secboot v0.0.0-20260814094831-dd95d855ad64
 	golang.org/x/crypto v0.23.0
 	golang.org/x/net v0.21.0 // indirect
 	golang.org/x/sync v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/seccomp/libseccomp-golang v0.9.2-0.20220502024300-f57e1d55ea18 h1:A15
 github.com/seccomp/libseccomp-golang v0.9.2-0.20220502024300-f57e1d55ea18/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
 github.com/snapcore/maze.io-x-crypto v0.0.0-20190131090603-9b94c9afe066 h1:InG0EmriMOiI4YgtQNOo+6fNxzLCYioo3Q3BCVLdMCE=
 github.com/snapcore/maze.io-x-crypto v0.0.0-20190131090603-9b94c9afe066/go.mod h1:VuAdaITF1MrGzxPU+8GxagM1HW2vg7QhEFEeGHbmEMU=
-github.com/snapcore/secboot v0.0.0-20260623135244-457b03a16d19 h1:nVT7EXqb2qUXWG94woDaS5IrWEy87pgj8esfvVFiZx0=
-github.com/snapcore/secboot v0.0.0-20260623135244-457b03a16d19/go.mod h1:/J5bNHw8HkyxuUZRrk2LUzkne3zO/kEwJlm+/oB16SE=
+github.com/snapcore/secboot v0.0.0-20260814094831-dd95d855ad64 h1:jZBwQI4+0/dypcKdQk9v5yi5pfKMVvXs/KG2XQlNjyI=
+github.com/snapcore/secboot v0.0.0-20260814094831-dd95d855ad64/go.mod h1:/J5bNHw8HkyxuUZRrk2LUzkne3zO/kEwJlm+/oB16SE=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 go.etcd.io/bbolt v1.3.9 h1:8x7aARPEXiXbHmtUwAIv7eV2fQFHrLLavdiJ3uzJXoI=
 go.etcd.io/bbolt v1.3.9/go.mod h1:zaO32+Ti0PK1ivdPtgMESzuzL2VPoIG1PCQNvOdo/dE=

--- a/overlord/fdestate/backend/reseal.go
+++ b/overlord/fdestate/backend/reseal.go
@@ -60,6 +60,7 @@ func MockSecbootBuildPCRProtectionProfile(f func(
 	modelParams []*secboot.SealKeyModelParams,
 	checkResult *secboot.PreinstallCheckResult,
 	allowInsufficientDmaProtection bool,
+	allowThunderboltSecurityLevel0 bool,
 ) (secboot.SerializedPCRProfile, error)) (restore func()) {
 	osutil.MustBeTestBinary("secbootBuildPCRProtectionProfile only can be mocked in tests")
 	old := secbootBuildPCRProtectionProfile
@@ -544,12 +545,12 @@ func updateRunProtectionProfile(
 	err = func() error {
 		var err error
 
-		pcrProfile, err = secbootBuildPCRProtectionProfile(modelParams, checkResult, !hasClassicModel)
+		pcrProfile, err = secbootBuildPCRProtectionProfile(modelParams, checkResult, !hasClassicModel, !hasClassicModel)
 		if err != nil {
 			return err
 		}
 
-		pcrProfileRunOnly, err = secbootBuildPCRProtectionProfile(modelParamsRunOnly, checkResult, !hasClassicModel)
+		pcrProfileRunOnly, err = secbootBuildPCRProtectionProfile(modelParamsRunOnly, checkResult, !hasClassicModel, !hasClassicModel)
 		if err != nil {
 			return err
 		}
@@ -606,7 +607,7 @@ func updateFallbackProtectionProfile(
 	err = func() error {
 		var err error
 
-		pcrProfile, err = secbootBuildPCRProtectionProfile(modelParams, checkResult, !hasClassicModel)
+		pcrProfile, err = secbootBuildPCRProtectionProfile(modelParams, checkResult, !hasClassicModel, !hasClassicModel)
 		if err != nil {
 			return err
 		}

--- a/overlord/fdestate/backend/reseal.go
+++ b/overlord/fdestate/backend/reseal.go
@@ -59,8 +59,7 @@ func MockSecbootResealKey(f func(key secboot.KeyDataLocation, params *secboot.Re
 func MockSecbootBuildPCRProtectionProfile(f func(
 	modelParams []*secboot.SealKeyModelParams,
 	checkResult *secboot.PreinstallCheckResult,
-	allowInsufficientDmaProtection bool,
-	allowThunderboltSecurityLevel0 bool,
+	opts secboot.PCRProtectionProfileOptions,
 ) (secboot.SerializedPCRProfile, error)) (restore func()) {
 	osutil.MustBeTestBinary("secbootBuildPCRProtectionProfile only can be mocked in tests")
 	old := secbootBuildPCRProtectionProfile
@@ -545,12 +544,17 @@ func updateRunProtectionProfile(
 	err = func() error {
 		var err error
 
-		pcrProfile, err = secbootBuildPCRProtectionProfile(modelParams, checkResult, !hasClassicModel, !hasClassicModel)
+		pcrProfileOpts := secboot.PCRProtectionProfileOptions{
+			AllowInsufficientDmaProtection: !hasClassicModel,
+			AllowThunderboltSecurityLevel0: !hasClassicModel,
+		}
+
+		pcrProfile, err = secbootBuildPCRProtectionProfile(modelParams, checkResult, pcrProfileOpts)
 		if err != nil {
 			return err
 		}
 
-		pcrProfileRunOnly, err = secbootBuildPCRProtectionProfile(modelParamsRunOnly, checkResult, !hasClassicModel, !hasClassicModel)
+		pcrProfileRunOnly, err = secbootBuildPCRProtectionProfile(modelParamsRunOnly, checkResult, pcrProfileOpts)
 		if err != nil {
 			return err
 		}
@@ -607,7 +611,11 @@ func updateFallbackProtectionProfile(
 	err = func() error {
 		var err error
 
-		pcrProfile, err = secbootBuildPCRProtectionProfile(modelParams, checkResult, !hasClassicModel, !hasClassicModel)
+		pcrProfileOpts := secboot.PCRProtectionProfileOptions{
+			AllowInsufficientDmaProtection: !hasClassicModel,
+			AllowThunderboltSecurityLevel0: !hasClassicModel,
+		}
+		pcrProfile, err = secbootBuildPCRProtectionProfile(modelParams, checkResult, pcrProfileOpts)
 		if err != nil {
 			return err
 		}

--- a/overlord/fdestate/backend/reseal_test.go
+++ b/overlord/fdestate/backend/reseal_test.go
@@ -399,10 +399,11 @@ func (s *resealTestSuite) testTPMResealHappy(c *C, tc tpmResealHappyCase) {
 	})()
 
 	buildProfileCalls := 0
-	restore := backend.MockSecbootBuildPCRProtectionProfile(func(modelParams []*secboot.SealKeyModelParams, checkResult *secboot.PreinstallCheckResult, allowInsufficientDmaProtection bool) (secboot.SerializedPCRProfile, error) {
+	restore := backend.MockSecbootBuildPCRProtectionProfile(func(modelParams []*secboot.SealKeyModelParams, checkResult *secboot.PreinstallCheckResult, allowInsufficientDmaProtection, allowThunderboltSecurityLevel0 bool) (secboot.SerializedPCRProfile, error) {
 		buildProfileCalls++
 
 		c.Check(allowInsufficientDmaProtection, Equals, !tc.onClassic)
+		c.Check(allowThunderboltSecurityLevel0, Equals, !tc.onClassic)
 
 		if tc.onClassic {
 			c.Check(checkResult, Equals, expectedCheckResult)
@@ -864,10 +865,12 @@ func (s *resealTestSuite) TestResealKeyForBootchainsWithSystemFallback(c *C) {
 			modelParams []*secboot.SealKeyModelParams,
 			checkResult *secboot.PreinstallCheckResult,
 			allowInsufficientDmaProtection bool,
+			allowThunderboltSecurityLevel0 bool,
 		) (secboot.SerializedPCRProfile, error) {
 			buildProfileCalls++
 
 			c.Check(allowInsufficientDmaProtection, Equals, true)
+			c.Check(allowThunderboltSecurityLevel0, Equals, true)
 			c.Check(checkResult, Equals, expectedCheckResult)
 
 			c.Assert(modelParams, HasLen, 1)
@@ -1443,10 +1446,11 @@ func (s *resealTestSuite) TestResealKeyForBootchainsRecoveryKeysForGoodSystemsOn
 	})()
 
 	buildProfileCalls := 0
-	restore := backend.MockSecbootBuildPCRProtectionProfile(func(modelParams []*secboot.SealKeyModelParams, checkResult *secboot.PreinstallCheckResult, allowInsufficientDmaProtection bool) (secboot.SerializedPCRProfile, error) {
+	restore := backend.MockSecbootBuildPCRProtectionProfile(func(modelParams []*secboot.SealKeyModelParams, checkResult *secboot.PreinstallCheckResult, allowInsufficientDmaProtection, allowThunderboltSecurityLevel0 bool) (secboot.SerializedPCRProfile, error) {
 		buildProfileCalls++
 
 		c.Check(allowInsufficientDmaProtection, Equals, true)
+		c.Check(allowThunderboltSecurityLevel0, Equals, true)
 		c.Check(checkResult, Equals, expectedCheckResult)
 
 		// shared parameters
@@ -1747,10 +1751,11 @@ func (s *resealTestSuite) testResealKeyForBootchainsWithTryModel(c *C, shimId, g
 	})()
 
 	buildProfileCalls := 0
-	restore := backend.MockSecbootBuildPCRProtectionProfile(func(modelParams []*secboot.SealKeyModelParams, checkResult *secboot.PreinstallCheckResult, allowInsufficientDmaProtection bool) (secboot.SerializedPCRProfile, error) {
+	restore := backend.MockSecbootBuildPCRProtectionProfile(func(modelParams []*secboot.SealKeyModelParams, checkResult *secboot.PreinstallCheckResult, allowInsufficientDmaProtection, allowThunderboltSecurityLevel0 bool) (secboot.SerializedPCRProfile, error) {
 		buildProfileCalls++
 
 		c.Check(allowInsufficientDmaProtection, Equals, true)
+		c.Check(allowThunderboltSecurityLevel0, Equals, true)
 		c.Check(checkResult, Equals, expectedCheckResult)
 
 		switch buildProfileCalls {
@@ -2116,10 +2121,11 @@ func (s *resealTestSuite) TestResealKeyForBootchainsFallbackCmdline(c *C) {
 	})()
 
 	buildProfileCalls := 0
-	restore := backend.MockSecbootBuildPCRProtectionProfile(func(modelParams []*secboot.SealKeyModelParams, checkResult *secboot.PreinstallCheckResult, allowInsufficientDmaProtection bool) (secboot.SerializedPCRProfile, error) {
+	restore := backend.MockSecbootBuildPCRProtectionProfile(func(modelParams []*secboot.SealKeyModelParams, checkResult *secboot.PreinstallCheckResult, allowInsufficientDmaProtection, allowThunderboltSecurityLevel0 bool) (secboot.SerializedPCRProfile, error) {
 		buildProfileCalls++
 
 		c.Check(allowInsufficientDmaProtection, Equals, true)
+		c.Check(allowThunderboltSecurityLevel0, Equals, true)
 		c.Check(checkResult, Equals, expectedCheckResult)
 
 		c.Assert(modelParams, HasLen, 1)
@@ -2586,10 +2592,11 @@ func (s *resealTestSuite) TestResealKeyForSignatureDBUpdate(c *C) {
 	})()
 
 	buildProfileCalls := 0
-	restore := backend.MockSecbootBuildPCRProtectionProfile(func(modelParams []*secboot.SealKeyModelParams, checkResult *secboot.PreinstallCheckResult, allowInsufficientDmaProtection bool) (secboot.SerializedPCRProfile, error) {
+	restore := backend.MockSecbootBuildPCRProtectionProfile(func(modelParams []*secboot.SealKeyModelParams, checkResult *secboot.PreinstallCheckResult, allowInsufficientDmaProtection, allowThunderboltSecurityLevel0 bool) (secboot.SerializedPCRProfile, error) {
 		buildProfileCalls++
 
 		c.Check(allowInsufficientDmaProtection, Equals, true)
+		c.Check(allowThunderboltSecurityLevel0, Equals, true)
 		c.Check(checkResult, Equals, expectedCheckResult)
 
 		c.Assert(modelParams, HasLen, 1)

--- a/overlord/fdestate/backend/reseal_test.go
+++ b/overlord/fdestate/backend/reseal_test.go
@@ -399,11 +399,11 @@ func (s *resealTestSuite) testTPMResealHappy(c *C, tc tpmResealHappyCase) {
 	})()
 
 	buildProfileCalls := 0
-	restore := backend.MockSecbootBuildPCRProtectionProfile(func(modelParams []*secboot.SealKeyModelParams, checkResult *secboot.PreinstallCheckResult, allowInsufficientDmaProtection, allowThunderboltSecurityLevel0 bool) (secboot.SerializedPCRProfile, error) {
+	restore := backend.MockSecbootBuildPCRProtectionProfile(func(modelParams []*secboot.SealKeyModelParams, checkResult *secboot.PreinstallCheckResult, opts secboot.PCRProtectionProfileOptions) (secboot.SerializedPCRProfile, error) {
 		buildProfileCalls++
 
-		c.Check(allowInsufficientDmaProtection, Equals, !tc.onClassic)
-		c.Check(allowThunderboltSecurityLevel0, Equals, !tc.onClassic)
+		c.Check(opts.AllowInsufficientDmaProtection, Equals, !tc.onClassic)
+		c.Check(opts.AllowThunderboltSecurityLevel0, Equals, !tc.onClassic)
 
 		if tc.onClassic {
 			c.Check(checkResult, Equals, expectedCheckResult)
@@ -864,13 +864,12 @@ func (s *resealTestSuite) TestResealKeyForBootchainsWithSystemFallback(c *C) {
 		restore := backend.MockSecbootBuildPCRProtectionProfile(func(
 			modelParams []*secboot.SealKeyModelParams,
 			checkResult *secboot.PreinstallCheckResult,
-			allowInsufficientDmaProtection bool,
-			allowThunderboltSecurityLevel0 bool,
+			opts secboot.PCRProtectionProfileOptions,
 		) (secboot.SerializedPCRProfile, error) {
 			buildProfileCalls++
 
-			c.Check(allowInsufficientDmaProtection, Equals, true)
-			c.Check(allowThunderboltSecurityLevel0, Equals, true)
+			c.Check(opts.AllowInsufficientDmaProtection, Equals, true)
+			c.Check(opts.AllowThunderboltSecurityLevel0, Equals, true)
 			c.Check(checkResult, Equals, expectedCheckResult)
 
 			c.Assert(modelParams, HasLen, 1)
@@ -1446,11 +1445,11 @@ func (s *resealTestSuite) TestResealKeyForBootchainsRecoveryKeysForGoodSystemsOn
 	})()
 
 	buildProfileCalls := 0
-	restore := backend.MockSecbootBuildPCRProtectionProfile(func(modelParams []*secboot.SealKeyModelParams, checkResult *secboot.PreinstallCheckResult, allowInsufficientDmaProtection, allowThunderboltSecurityLevel0 bool) (secboot.SerializedPCRProfile, error) {
+	restore := backend.MockSecbootBuildPCRProtectionProfile(func(modelParams []*secboot.SealKeyModelParams, checkResult *secboot.PreinstallCheckResult, opts secboot.PCRProtectionProfileOptions) (secboot.SerializedPCRProfile, error) {
 		buildProfileCalls++
 
-		c.Check(allowInsufficientDmaProtection, Equals, true)
-		c.Check(allowThunderboltSecurityLevel0, Equals, true)
+		c.Check(opts.AllowInsufficientDmaProtection, Equals, true)
+		c.Check(opts.AllowThunderboltSecurityLevel0, Equals, true)
 		c.Check(checkResult, Equals, expectedCheckResult)
 
 		// shared parameters
@@ -1751,11 +1750,11 @@ func (s *resealTestSuite) testResealKeyForBootchainsWithTryModel(c *C, shimId, g
 	})()
 
 	buildProfileCalls := 0
-	restore := backend.MockSecbootBuildPCRProtectionProfile(func(modelParams []*secboot.SealKeyModelParams, checkResult *secboot.PreinstallCheckResult, allowInsufficientDmaProtection, allowThunderboltSecurityLevel0 bool) (secboot.SerializedPCRProfile, error) {
+	restore := backend.MockSecbootBuildPCRProtectionProfile(func(modelParams []*secboot.SealKeyModelParams, checkResult *secboot.PreinstallCheckResult, opts secboot.PCRProtectionProfileOptions) (secboot.SerializedPCRProfile, error) {
 		buildProfileCalls++
 
-		c.Check(allowInsufficientDmaProtection, Equals, true)
-		c.Check(allowThunderboltSecurityLevel0, Equals, true)
+		c.Check(opts.AllowInsufficientDmaProtection, Equals, true)
+		c.Check(opts.AllowThunderboltSecurityLevel0, Equals, true)
 		c.Check(checkResult, Equals, expectedCheckResult)
 
 		switch buildProfileCalls {
@@ -2121,11 +2120,11 @@ func (s *resealTestSuite) TestResealKeyForBootchainsFallbackCmdline(c *C) {
 	})()
 
 	buildProfileCalls := 0
-	restore := backend.MockSecbootBuildPCRProtectionProfile(func(modelParams []*secboot.SealKeyModelParams, checkResult *secboot.PreinstallCheckResult, allowInsufficientDmaProtection, allowThunderboltSecurityLevel0 bool) (secboot.SerializedPCRProfile, error) {
+	restore := backend.MockSecbootBuildPCRProtectionProfile(func(modelParams []*secboot.SealKeyModelParams, checkResult *secboot.PreinstallCheckResult, opts secboot.PCRProtectionProfileOptions) (secboot.SerializedPCRProfile, error) {
 		buildProfileCalls++
 
-		c.Check(allowInsufficientDmaProtection, Equals, true)
-		c.Check(allowThunderboltSecurityLevel0, Equals, true)
+		c.Check(opts.AllowInsufficientDmaProtection, Equals, true)
+		c.Check(opts.AllowThunderboltSecurityLevel0, Equals, true)
 		c.Check(checkResult, Equals, expectedCheckResult)
 
 		c.Assert(modelParams, HasLen, 1)
@@ -2592,11 +2591,11 @@ func (s *resealTestSuite) TestResealKeyForSignatureDBUpdate(c *C) {
 	})()
 
 	buildProfileCalls := 0
-	restore := backend.MockSecbootBuildPCRProtectionProfile(func(modelParams []*secboot.SealKeyModelParams, checkResult *secboot.PreinstallCheckResult, allowInsufficientDmaProtection, allowThunderboltSecurityLevel0 bool) (secboot.SerializedPCRProfile, error) {
+	restore := backend.MockSecbootBuildPCRProtectionProfile(func(modelParams []*secboot.SealKeyModelParams, checkResult *secboot.PreinstallCheckResult, opts secboot.PCRProtectionProfileOptions) (secboot.SerializedPCRProfile, error) {
 		buildProfileCalls++
 
-		c.Check(allowInsufficientDmaProtection, Equals, true)
-		c.Check(allowThunderboltSecurityLevel0, Equals, true)
+		c.Check(opts.AllowInsufficientDmaProtection, Equals, true)
+		c.Check(opts.AllowThunderboltSecurityLevel0, Equals, true)
 		c.Check(checkResult, Equals, expectedCheckResult)
 
 		c.Assert(modelParams, HasLen, 1)

--- a/overlord/fdestate/backend/seal.go
+++ b/overlord/fdestate/backend/seal.go
@@ -118,6 +118,7 @@ func sealRunObjectKeys(
 		PCRPolicyCounterHandle:         pcrHandle,
 		KeyRole:                        keyRole,
 		AllowInsufficientDmaProtection: !hasClassicModel,
+		AllowThunderboltSecurityLevel0: !hasClassicModel,
 	}
 
 	if !useTokens {
@@ -172,6 +173,7 @@ func sealFallbackObjectKeys(
 		PCRPolicyCounterHandle:         pcrHandle,
 		KeyRole:                        keyRole,
 		AllowInsufficientDmaProtection: !hasClassicModel,
+		AllowThunderboltSecurityLevel0: !hasClassicModel,
 	}
 	logger.Debugf("sealing fallback key with PCR handle: %#x", sealKeyParams.PCRPolicyCounterHandle)
 	// The fallback object contains the ubuntu-data and ubuntu-save keys. The

--- a/overlord/fdestate/backend/seal_test.go
+++ b/overlord/fdestate/backend/seal_test.go
@@ -215,6 +215,7 @@ func (s *sealSuite) TestSealKeyForBootChains(c *C) {
 		sealKeysCalls := 0
 		restore = fdeBackend.MockSecbootSealKeys(func(keys []secboot.SealKeyRequest, params *secboot.SealKeysParams) ([]byte, error) {
 			c.Check(params.AllowInsufficientDmaProtection, Equals, tc.onCore)
+			c.Check(params.AllowThunderboltSecurityLevel0, Equals, tc.onCore)
 			c.Assert(provisionCalls, Equals, 1, Commentf("TPM must have been provisioned before"))
 			c.Check(params.PCRPolicyCounterHandle, Equals, uint32(42))
 			sealKeysCalls++

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -147,6 +147,17 @@ const (
 	TPMProvisionFullWithoutLockout
 )
 
+// PCRProtectionProfileOptions carries the options that influence how a PCR
+// protection profile is built.
+type PCRProtectionProfileOptions struct {
+	// AllowInsufficientDmaProtection allows systems lacking sufficient DMA
+	// protection.
+	AllowInsufficientDmaProtection bool
+	// AllowThunderboltSecurityLevel0 allows systems reporting the "Security
+	// Level is Downgraded to 0" Thunderbolt event.
+	AllowThunderboltSecurityLevel0 bool
+}
+
 type SealKeysParams struct {
 	// The parameters we're sealing the key to
 	ModelParams []*SealKeyModelParams

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -165,6 +165,8 @@ type SealKeysParams struct {
 	KeyRole string
 	// Whether to allow disabled DMA protection
 	AllowInsufficientDmaProtection bool
+	// Whether to allow the "Security Level is Downgraded to 0" Thunderbolt event
+	AllowThunderboltSecurityLevel0 bool
 }
 
 type SealKeysWithFDESetupHookParams struct {

--- a/secboot/secboot_nosb.go
+++ b/secboot/secboot_nosb.go
@@ -110,7 +110,7 @@ func DeleteKeys(node string, matches map[string]bool) error {
 	return errBuildWithoutSecboot
 }
 
-func BuildPCRProtectionProfile(modelParams []*SealKeyModelParams, checkResult *PreinstallCheckResult, allowInsufficientDmaProtection bool) (SerializedPCRProfile, error) {
+func BuildPCRProtectionProfile(modelParams []*SealKeyModelParams, checkResult *PreinstallCheckResult, allowInsufficientDmaProtection, allowThunderboltSecurityLevel0 bool) (SerializedPCRProfile, error) {
 	return nil, errBuildWithoutSecboot
 }
 

--- a/secboot/secboot_nosb.go
+++ b/secboot/secboot_nosb.go
@@ -110,7 +110,7 @@ func DeleteKeys(node string, matches map[string]bool) error {
 	return errBuildWithoutSecboot
 }
 
-func BuildPCRProtectionProfile(modelParams []*SealKeyModelParams, checkResult *PreinstallCheckResult, allowInsufficientDmaProtection, allowThunderboltSecurityLevel0 bool) (SerializedPCRProfile, error) {
+func BuildPCRProtectionProfile(modelParams []*SealKeyModelParams, checkResult *PreinstallCheckResult, opts PCRProtectionProfileOptions) (SerializedPCRProfile, error) {
 	return nil, errBuildWithoutSecboot
 }
 

--- a/secboot/secboot_sb_test.go
+++ b/secboot/secboot_sb_test.go
@@ -1580,6 +1580,7 @@ func (s *secbootSuite) TestResealKeysWithTPM(c *C) {
 		dbxUpdates             []secboot.DbUpdate
 		revoke                 bool
 		noDmaProtection        bool
+		noThunderboltSecurity  bool
 		// Preinstall check was used to determine for encryption availability at install time
 		hasCheckResult bool
 	}{
@@ -1591,6 +1592,10 @@ func (s *secbootSuite) TestResealKeysWithTPM(c *C) {
 		{tpmEnabled: true, resealCalls: 1, noDmaProtection: true},
 		// happy case with check result available on disk and AllowInsufficientDmaProtection true
 		{tpmEnabled: true, resealCalls: 1, noDmaProtection: true, hasCheckResult: true},
+		// happy case with AllowThunderboltSecurityLevel0
+		{tpmEnabled: true, resealCalls: 1, noThunderboltSecurity: true},
+		// happy case with check result available on disk and AllowThunderboltSecurityLevel0 true
+		{tpmEnabled: true, resealCalls: 1, noThunderboltSecurity: true, hasCheckResult: true},
 		// happy case with check result available on disk and DBX update
 		{tpmEnabled: true, resealCalls: 1, hasCheckResult: true, dbxUpdates: []secboot.DbUpdate{{Database: secboot.KeyDatabaseDBX, Payload: []byte("dbx-update")}}},
 		// happy case with key files
@@ -1723,6 +1728,14 @@ func (s *secbootSuite) TestResealKeysWithTPM(c *C) {
 			)
 		}
 
+		if !tc.hasCheckResult && tc.noThunderboltSecurity {
+			// add option to deal with downgraded Thunderbolt security level
+			expectedOptions = append(
+				expectedOptions,
+				sb_efi.WithAllowThunderboltSecurityLevel0(),
+			)
+		}
+
 		addPCRProfileCalls := 0
 		restore := secboot.MockSbEfiAddPCRProfile(func(pcrAlg tpm2.HashAlgorithmId, branch *sb_tpm2.PCRProtectionProfileBranch, loadSequences *sb_efi.ImageLoadSequences, options ...sb_efi.PCRProfileOption) error {
 			addPCRProfileCalls++
@@ -1763,7 +1776,7 @@ func (s *secbootSuite) TestResealKeysWithTPM(c *C) {
 		})
 		defer restore()
 
-		pcrProfile, err := secboot.BuildPCRProtectionProfile(modelParams, checkResult, tc.noDmaProtection)
+		pcrProfile, err := secboot.BuildPCRProtectionProfile(modelParams, checkResult, tc.noDmaProtection, tc.noThunderboltSecurity)
 		if len(tc.buildProfileErr) > 0 {
 			c.Assert(err, ErrorMatches, tc.buildProfileErr)
 			continue
@@ -5210,7 +5223,7 @@ func (s *secbootSuite) TestAddContainerTPMProtectedKey(c *C) {
 	} {
 		c.Logf("tc: %v", idx)
 
-		pcrProfile, err := secboot.BuildPCRProtectionProfile(nil, nil, false)
+		pcrProfile, err := secboot.BuildPCRProtectionProfile(nil, nil, false, false)
 		c.Assert(err, IsNil)
 
 		defer secboot.MockGetDiskUnlockKeyFromKernel(func(prefix, devicePath string, remove bool) (sb.DiskUnlockKey, error) {

--- a/secboot/secboot_sb_test.go
+++ b/secboot/secboot_sb_test.go
@@ -1776,7 +1776,10 @@ func (s *secbootSuite) TestResealKeysWithTPM(c *C) {
 		})
 		defer restore()
 
-		pcrProfile, err := secboot.BuildPCRProtectionProfile(modelParams, checkResult, tc.noDmaProtection, tc.noThunderboltSecurity)
+		pcrProfile, err := secboot.BuildPCRProtectionProfile(modelParams, checkResult, secboot.PCRProtectionProfileOptions{
+			AllowInsufficientDmaProtection: tc.noDmaProtection,
+			AllowThunderboltSecurityLevel0: tc.noThunderboltSecurity,
+		})
 		if len(tc.buildProfileErr) > 0 {
 			c.Assert(err, ErrorMatches, tc.buildProfileErr)
 			continue
@@ -5223,7 +5226,7 @@ func (s *secbootSuite) TestAddContainerTPMProtectedKey(c *C) {
 	} {
 		c.Logf("tc: %v", idx)
 
-		pcrProfile, err := secboot.BuildPCRProtectionProfile(nil, nil, false, false)
+		pcrProfile, err := secboot.BuildPCRProtectionProfile(nil, nil, secboot.PCRProtectionProfileOptions{})
 		c.Assert(err, IsNil)
 
 		defer secboot.MockGetDiskUnlockKeyFromKernel(func(prefix, devicePath string, remove bool) (sb.DiskUnlockKey, error) {

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -546,7 +546,11 @@ func SealKeys(keys []SealKeyRequest, params *SealKeysParams) ([]byte, error) {
 		return nil, fmt.Errorf("TPM device is not enabled")
 	}
 
-	pcrProfile, err := buildPCRProtectionProfile(params.ModelParams, params.CheckResult, params.AllowInsufficientDmaProtection, params.AllowThunderboltSecurityLevel0)
+	pcrProfileOpts := PCRProtectionProfileOptions{
+		AllowInsufficientDmaProtection: params.AllowInsufficientDmaProtection,
+		AllowThunderboltSecurityLevel0: params.AllowThunderboltSecurityLevel0,
+	}
+	pcrProfile, err := buildPCRProtectionProfile(params.ModelParams, params.CheckResult, pcrProfileOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -797,18 +801,19 @@ var resealKeysWithTPM = resealKeysWithTPMImpl
 // encryption keys.
 //
 // If checkResult is non-nil, it provides the PCR configuration recommended by
-// the pre-install check. In this mode, allowInsufficientDmaProtection is ignored,
-// because all relevant information is carried by checkResult.
+// the pre-install check. In this mode, opts.AllowInsufficientDmaProtection
+// and opts.AllowThunderboltSecurityLevel0 are ignored, because all relevant
+// information is carried by checkResult.
 //
 // If checkResult is nil, the function falls back to the legacy profile-generation
 // path, which relies on static assumptions about the system’s boot configuration.
-// In this legacy mode, allowInsufficientDmaProtection determines whether systems
-// lacking sufficient DMA protection are still permitted, and
-// allowThunderboltSecurityLevel0 determines whether systems reporting a downgraded
-// Thunderbolt security level are still permitted.
-func buildPCRProtectionProfile(modelParams []*SealKeyModelParams, checkResult *PreinstallCheckResult, allowInsufficientDmaProtection, allowThunderboltSecurityLevel0 bool) (*sb_tpm2.PCRProtectionProfile, error) {
+// In this legacy mode, opts.AllowInsufficientDmaProtection determines whether
+// systems lacking sufficient DMA protection are still permitted, and
+// opts.AllowThunderboltSecurityLevel0 determines whether systems reporting a
+// downgraded Thunderbolt security level are still permitted.
+func buildPCRProtectionProfile(modelParams []*SealKeyModelParams, checkResult *PreinstallCheckResult, opts PCRProtectionProfileOptions) (*sb_tpm2.PCRProtectionProfile, error) {
 	if checkResult == nil {
-		return buildPCRProtectionProfileLegacy(modelParams, allowInsufficientDmaProtection, allowThunderboltSecurityLevel0)
+		return buildPCRProtectionProfileLegacy(modelParams, opts)
 	}
 
 	// build EFI load image event trees
@@ -902,7 +907,7 @@ func (lc *LoadChain) loadEvent(params ...sb_efi.ImageLoadParams) (sb_efi.ImageLo
 
 // buildPCRProtectionProfileLegacy constructs a PCR protection profile used for
 // sealing encryption keys using an outdated secboot API.
-func buildPCRProtectionProfileLegacy(modelParams []*SealKeyModelParams, allowInsufficientDmaProtection, allowThunderboltSecurityLevel0 bool) (*sb_tpm2.PCRProtectionProfile, error) {
+func buildPCRProtectionProfileLegacy(modelParams []*SealKeyModelParams, opts PCRProtectionProfileOptions) (*sb_tpm2.PCRProtectionProfile, error) {
 	numModels := len(modelParams)
 	modelPCRProfiles := make([]*sb_tpm2.PCRProtectionProfile, 0, numModels)
 
@@ -941,10 +946,10 @@ func buildPCRProtectionProfileLegacy(modelParams []*SealKeyModelParams, allowIns
 			sb_efi.WithBootManagerCodeProfile(),
 			sb_efi.WithSignatureDBUpdates(updateDB...),
 		)
-		if allowInsufficientDmaProtection {
+		if opts.AllowInsufficientDmaProtection {
 			options = append(options, sb_efi.WithAllowInsufficientDmaProtection())
 		}
-		if allowThunderboltSecurityLevel0 {
+		if opts.AllowThunderboltSecurityLevel0 {
 			options = append(options, sb_efi.WithAllowThunderboltSecurityLevel0())
 		}
 		if err := sbefiAddPCRProfile(
@@ -1018,17 +1023,18 @@ func buildLoadSequences(chains []*LoadChain) (loadseqs *sb_efi.ImageLoadSequence
 // a list of SealKeyModelParams.
 //
 // If checkResult is non-nil, it provides the PCR configuration recommended by
-// the pre-install check. In this mode, allowInsufficientDmaProtection is ignored,
-// because all relevant information is carried by checkResult.
+// the pre-install check. In this mode, opts.AllowInsufficientDmaProtection
+// and opts.AllowThunderboltSecurityLevel0 are ignored, because all relevant
+// information is carried by checkResult.
 //
 // If checkResult is nil, the function falls back to the legacy profile-generation
 // path, which relies on static assumptions about the system’s boot configuration.
-// In this legacy mode, allowInsufficientDmaProtection determines whether systems
-// lacking sufficient DMA protection are still permitted, and
-// allowThunderboltSecurityLevel0 determines whether systems reporting a downgraded
-// Thunderbolt security level are still permitted.
-func BuildPCRProtectionProfile(modelParams []*SealKeyModelParams, checkResult *PreinstallCheckResult, allowInsufficientDmaProtection, allowThunderboltSecurityLevel0 bool) (SerializedPCRProfile, error) {
-	pcrProfile, err := buildPCRProtectionProfile(modelParams, checkResult, allowInsufficientDmaProtection, allowThunderboltSecurityLevel0)
+// In this legacy mode, opts.AllowInsufficientDmaProtection determines whether
+// systems lacking sufficient DMA protection are still permitted, and
+// opts.AllowThunderboltSecurityLevel0 determines whether systems reporting a
+// downgraded Thunderbolt security level are still permitted.
+func BuildPCRProtectionProfile(modelParams []*SealKeyModelParams, checkResult *PreinstallCheckResult, opts PCRProtectionProfileOptions) (SerializedPCRProfile, error) {
+	pcrProfile, err := buildPCRProtectionProfile(modelParams, checkResult, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/secboot/secboot_tpm.go
+++ b/secboot/secboot_tpm.go
@@ -546,7 +546,7 @@ func SealKeys(keys []SealKeyRequest, params *SealKeysParams) ([]byte, error) {
 		return nil, fmt.Errorf("TPM device is not enabled")
 	}
 
-	pcrProfile, err := buildPCRProtectionProfile(params.ModelParams, params.CheckResult, params.AllowInsufficientDmaProtection)
+	pcrProfile, err := buildPCRProtectionProfile(params.ModelParams, params.CheckResult, params.AllowInsufficientDmaProtection, params.AllowThunderboltSecurityLevel0)
 	if err != nil {
 		return nil, err
 	}
@@ -803,10 +803,12 @@ var resealKeysWithTPM = resealKeysWithTPMImpl
 // If checkResult is nil, the function falls back to the legacy profile-generation
 // path, which relies on static assumptions about the system’s boot configuration.
 // In this legacy mode, allowInsufficientDmaProtection determines whether systems
-// lacking sufficient DMA protection are still permitted.
-func buildPCRProtectionProfile(modelParams []*SealKeyModelParams, checkResult *PreinstallCheckResult, allowInsufficientDmaProtection bool) (*sb_tpm2.PCRProtectionProfile, error) {
+// lacking sufficient DMA protection are still permitted, and
+// allowThunderboltSecurityLevel0 determines whether systems reporting a downgraded
+// Thunderbolt security level are still permitted.
+func buildPCRProtectionProfile(modelParams []*SealKeyModelParams, checkResult *PreinstallCheckResult, allowInsufficientDmaProtection, allowThunderboltSecurityLevel0 bool) (*sb_tpm2.PCRProtectionProfile, error) {
 	if checkResult == nil {
-		return buildPCRProtectionProfileLegacy(modelParams, allowInsufficientDmaProtection)
+		return buildPCRProtectionProfileLegacy(modelParams, allowInsufficientDmaProtection, allowThunderboltSecurityLevel0)
 	}
 
 	// build EFI load image event trees
@@ -900,7 +902,7 @@ func (lc *LoadChain) loadEvent(params ...sb_efi.ImageLoadParams) (sb_efi.ImageLo
 
 // buildPCRProtectionProfileLegacy constructs a PCR protection profile used for
 // sealing encryption keys using an outdated secboot API.
-func buildPCRProtectionProfileLegacy(modelParams []*SealKeyModelParams, allowInsufficientDmaProtection bool) (*sb_tpm2.PCRProtectionProfile, error) {
+func buildPCRProtectionProfileLegacy(modelParams []*SealKeyModelParams, allowInsufficientDmaProtection, allowThunderboltSecurityLevel0 bool) (*sb_tpm2.PCRProtectionProfile, error) {
 	numModels := len(modelParams)
 	modelPCRProfiles := make([]*sb_tpm2.PCRProtectionProfile, 0, numModels)
 
@@ -941,6 +943,9 @@ func buildPCRProtectionProfileLegacy(modelParams []*SealKeyModelParams, allowIns
 		)
 		if allowInsufficientDmaProtection {
 			options = append(options, sb_efi.WithAllowInsufficientDmaProtection())
+		}
+		if allowThunderboltSecurityLevel0 {
+			options = append(options, sb_efi.WithAllowThunderboltSecurityLevel0())
 		}
 		if err := sbefiAddPCRProfile(
 			tpm2.HashAlgorithmSHA256,
@@ -1019,9 +1024,11 @@ func buildLoadSequences(chains []*LoadChain) (loadseqs *sb_efi.ImageLoadSequence
 // If checkResult is nil, the function falls back to the legacy profile-generation
 // path, which relies on static assumptions about the system’s boot configuration.
 // In this legacy mode, allowInsufficientDmaProtection determines whether systems
-// lacking sufficient DMA protection are still permitted.
-func BuildPCRProtectionProfile(modelParams []*SealKeyModelParams, checkResult *PreinstallCheckResult, allowInsufficientDmaProtection bool) (SerializedPCRProfile, error) {
-	pcrProfile, err := buildPCRProtectionProfile(modelParams, checkResult, allowInsufficientDmaProtection)
+// lacking sufficient DMA protection are still permitted, and
+// allowThunderboltSecurityLevel0 determines whether systems reporting a downgraded
+// Thunderbolt security level are still permitted.
+func BuildPCRProtectionProfile(modelParams []*SealKeyModelParams, checkResult *PreinstallCheckResult, allowInsufficientDmaProtection, allowThunderboltSecurityLevel0 bool) (SerializedPCRProfile, error) {
+	pcrProfile, err := buildPCRProtectionProfile(modelParams, checkResult, allowInsufficientDmaProtection, allowThunderboltSecurityLevel0)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is similar to allowing disabled DMA on UC from https://github.com/canonical/snapd/pull/15695.

Some BIOS firmwares measure this event and that breaks the computation of the PCR policy, with this error:
```
  cannot measure secure boot policy: unexpected event type (EV_EFI_ACTION) found in log
```

This allows bypassing this problem on UC only where the new FDE preinstall checks mechanism is not used.

JIRA: [SNAPDENG-37311](https://warthogs.atlassian.net/browse/SNAPDENG-37311)

[SNAPDENG-37311]: https://warthogs.atlassian.net/browse/SNAPDENG-37311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ