### PR TITLE
tests: fix extra "failed" polluting tests.session exec output

### DIFF
--- a/tests/lib/tools/tests.session
+++ b/tests/lib/tools/tests.session
@@ -290,7 +290,10 @@ main() {
 
 		# Prevent accumulation of failed sessions.
 		if systemctl cat "$unit_name" &>/dev/null; then
-			if systemctl is-failed "$unit_name"; then
+			# only the exit status matters here; keep stdout quiet so that a
+			# failed payload does not print a stray "failed" line that could be
+			# mistaken for the wrapped command's own output
+			if systemctl is-failed --quiet "$unit_name"; then
 				systemctl reset-failed "$unit_name"
 				exit 1
 			fi

--- a/tests/main/apparmor-prompting-smoke/task.yaml
+++ b/tests/main/apparmor-prompting-smoke/task.yaml
@@ -141,7 +141,6 @@ execute: |
                     "home")
                         ;& # fallthrough
                     "camera")
-                        MATCH "failed" < "$TMP_STDOUT"
                         MATCH "Permission denied" < "$TMP_STDERR"
                         ;;
                     "audio-record")


### PR DESCRIPTION
Sometimes, the output of `tests.session exec` has an extra `failed` line, which is particularly confusing when we try to call `systemctl is-{active,failed,...}` from within the `tests.session exec` and check the output. So let's prevent that extra line from being emitted.

Cherry-picked from https://github.com/canonical/snapd/pull/17380

Tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-37326