### PR TITLE
tests: add tests.session create-session/destroy-session

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -1477,7 +1477,7 @@ restore-each: |
 suites:
     tests/lib/tools/suite/:
         summary: Tests for tests/lib/tools tools
-        backends: [google, qemu, garden]
+        backends: [openstack, qemu, garden]
         prepare-each: |
             tests.invariant set snap-mount-dir "$(os.paths snap-mount-dir)"
             "$TESTSLIB"/prepare-restore.sh --prepare-suite-each-minimal-no-snaps

--- a/tests/lib/tools/suite/tests.session/task.yaml
+++ b/tests/lib/tools/suite/tests.session/task.yaml
@@ -96,10 +96,6 @@ execute: |
     # user, as destroying sessions of the root user would interfere with the
     # spread connection itself.
     #
-    # A created session is a real logind session of the requested class, and
-    # it is elected as the user's display session, so "loginctl show-session
-    # auto" resolves to it.
-    #
     # Note on counting sessions: on systemd >= 256, "tests.session prepare"
     # (linger) leaves a manager-class session of the user manager behind, and
     # "loginctl list-sessions" shows a class column starting with the same
@@ -107,19 +103,18 @@ execute: |
     # when counting; on older systemd there are neither manager sessions nor
     # a class column, so the filter is a no-op.
     #
-    # Note on "loginctl show-session auto" (requires systemd >= 245): it
-    # resolves to "the caller's own session if they have one, otherwise their
-    # user's display session". Only user- and greeter-class sessions are ever
-    # display-eligible; the display election prefers class user over greeter,
-    # then graphical types (x11/wayland/mir) over tty over unspecified.
-    # Background sessions (and manager-class sessions on systemd >= 256, when
-    # they were introduced) are never display-eligible, so they cannot shadow
-    # the session created here and the "auto" assertions below hold on both
-    # sides of the systemd 256 boundary.
+    # Note on "loginctl show-user $USER -p Display": it uses systemd's display-
+    # eligible session election, which resolves to "the caller's own session if
+    # they have one, otherwise their user's display session". Only user- and
+    # greeter-class sessions are ever display-eligible, along with some user-*
+    # classes in systemd versions 256 and later; the display election prefers
+    # class user over greeter, then graphical types (x11/wayland/mir) over tty
+    # over unspecified. Background sessions (and manager-class sessions on
+    # systemd >= 256, when they were introduced) are never display-eligible, so
+    # they cannot shadow the session created here and the display session
+    # assertions below hold on both sides of the systemd 256 boundary.
     if [ "$USER" != root ]; then
-        # The "loginctl show-session auto" assertions below require
-        # systemd >= 245, and "manager"-class sessions require
-        # systemd >= 256 (see the note above).
+        # "manager"-class sessions require systemd >= 256 (see the note above).
         systemd_ver="$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }' | cut -f1 -d"~")"
 
         # Check that there are no sessions for $USER when filtering out "manager"
@@ -134,34 +129,26 @@ execute: |
             loginctl list-sessions --no-legend | grep "$USER" | MATCH "manager"
         fi
 
-        # Running a user service places the command outside any session, so
-        # "auto" tries to find any user session, and fails without a session
-        if [ "$systemd_ver" -ge 245 ]; then
-            not tests.session -u "$USER" exec systemd-run --user --quiet --wait --pipe loginctl show-session auto
-        fi
+        # There are no display-eligible sessions for $USER
+        loginctl show-user "$USER" -p Display | MATCH '^Display=$'
 
         # Create session, check that it appears to loginctl
         tests.session create-session -u "$USER" -c user -t wayland
         loginctl list-sessions --no-legend | grep -v 'manager' | MATCH "$USER"
 
-        # Running a user service places the command outside any session, so
-        # "auto" falls back to the user's display session, which is the
-        # session just created.
-        if [ "$systemd_ver" -ge 245 ]; then
-            tests.session -u "$USER" exec systemd-run --user --quiet --wait --pipe loginctl show-session auto -p Class | MATCH '^Class=user$'
-            tests.session -u "$USER" exec systemd-run --user --quiet --wait --pipe loginctl show-session auto -p Type | MATCH '^Type=wayland$'
-        fi
-
         # There's just one active session for the user (ignoring "manager"
         # sessions on systemd >= 256)
         loginctl list-sessions --no-legend | grep -v 'manager' | grep --count "$USER" | MATCH '^1$'
 
+        # The new session is display-eligible, so there are one or more session ID characters
+        loginctl show-user "$USER" -p Display | MATCH '^Display=..*$'
+        session_id="$(loginctl show-user "$USER" -p Display | cut -d '=' -f 2)"
+        # And the session's class and type are correct
+        loginctl show-session "$session_id" -p Class | MATCH '^Class=user$'
+        loginctl show-session "$session_id" -p Type | MATCH '^Type=wayland$'
+
         # Running `tests.session exec` executes in its own background session,
-        # so there are two sessions while `tests.session exec` is running, and
-        # `loginctl show-session` from within finds the background session.
-        if [ "$systemd_ver" -ge 245 ]; then
-            tests.session -u "$USER" exec loginctl show-session auto -p Class | MATCH "Class=background"
-        fi
+        # so there are two sessions while `tests.session exec` is running
         tests.session -u "$USER" exec loginctl list-sessions --no-legend | grep -v 'manager' | grep --count "$USER" | MATCH '^2$'
         loginctl list-sessions --no-legend | grep -v 'manager' | grep --count "$USER" | MATCH '^1$'
 
@@ -192,8 +179,7 @@ execute: |
             loginctl list-sessions --no-legend | grep -v 'manager' | grep --count "$USER" | MATCH '^4$'
         done
 
-        # A labelled session can be destroyed individually, the rest can be
-        # destroyed without a label.
+        # Sessions can be destroyed individually
         tests.session destroy-session -u "$USER" -l fourth
         retry -n 10 --wait 1 sh -c "loginctl list-sessions --no-legend | grep -v 'manager' | grep --count $USER | MATCH '^3$'"
         tests.session destroy-session -u "$USER" -l third

--- a/tests/lib/tools/suite/tests.session/task.yaml
+++ b/tests/lib/tools/suite/tests.session/task.yaml
@@ -99,68 +99,117 @@ execute: |
     # A created session is a real logind session of the requested class, and
     # it is elected as the user's display session, so "loginctl show-session
     # auto" resolves to it.
+    #
+    # Note on counting sessions: on systemd >= 256, "tests.session prepare"
+    # (linger) leaves a manager-class session of the user manager behind, and
+    # "loginctl list-sessions" shows a class column starting with the same
+    # release. Manager-class sessions are filtered out with "grep -v manager"
+    # when counting; on older systemd there are neither manager sessions nor
+    # a class column, so the filter is a no-op.
+    #
+    # Note on "loginctl show-session auto" (requires systemd >= 245): it
+    # resolves to "the caller's own session if they have one, otherwise their
+    # user's display session". Only user- and greeter-class sessions are ever
+    # display-eligible; the display election prefers class user over greeter,
+    # then graphical types (x11/wayland/mir) over tty over unspecified.
+    # Background sessions (and manager-class sessions on systemd >= 256, when
+    # they were introduced) are never display-eligible, so they cannot shadow
+    # the session created here and the "auto" assertions below hold on both
+    # sides of the systemd 256 boundary.
     if [ "$USER" != root ]; then
-        # No sessions initially
-        loginctl list-sessions --no-legend | NOMATCH "$USER"
+        # The "loginctl show-session auto" assertions below require
+        # systemd >= 245, and "manager"-class sessions require
+        # systemd >= 256 (see the note above).
+        systemd_ver="$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }' | cut -f1 -d"~")"
+
+        # Check that there are no sessions for $USER when filtering out "manager"
+        loginctl list-sessions --no-legend | grep -v 'manager' | NOMATCH "$USER"
+        if [ "$systemd_ver" -lt 256 ]; then
+            # Truly no sessions for $USER on < 256
+            loginctl list-sessions --no-legend | NOMATCH "$USER"
+        else
+            # One manager session on >= 256
+            loginctl list-sessions --no-legend | MATCH "$USER"
+            loginctl list-sessions --no-legend | grep --count "$USER" | MATCH '^1$'
+            loginctl list-sessions --no-legend | grep "$USER" | MATCH "manager"
+        fi
 
         # Running a user service places the command outside any session, so
         # "auto" tries to find any user session, and fails without a session
-        not tests.session -u "$USER" exec systemd-run --user --quiet --wait --pipe loginctl show-session auto
+        if [ "$systemd_ver" -ge 245 ]; then
+            not tests.session -u "$USER" exec systemd-run --user --quiet --wait --pipe loginctl show-session auto
+        fi
 
         # Create session, check that it appears to loginctl
         tests.session create-session -u "$USER" -c user -t wayland
-        loginctl list-sessions --no-legend | MATCH "$USER"
+        loginctl list-sessions --no-legend | grep -v 'manager' | MATCH "$USER"
 
         # Running a user service places the command outside any session, so
-        # "auto" falls back to the user's display session.
-        tests.session -u "$USER" exec systemd-run --user --quiet --wait --pipe loginctl show-session auto -p Class | MATCH '^Class=user$'
-        tests.session -u "$USER" exec systemd-run --user --quiet --wait --pipe loginctl show-session auto -p Type | MATCH '^Type=wayland$'
+        # "auto" falls back to the user's display session, which is the
+        # session just created.
+        if [ "$systemd_ver" -ge 245 ]; then
+            tests.session -u "$USER" exec systemd-run --user --quiet --wait --pipe loginctl show-session auto -p Class | MATCH '^Class=user$'
+            tests.session -u "$USER" exec systemd-run --user --quiet --wait --pipe loginctl show-session auto -p Type | MATCH '^Type=wayland$'
+        fi
 
-        # There's just one active session for the user
-        loginctl list-sessions --no-legend | grep --count "$USER" | MATCH '^1$'
+        # There's just one active session for the user (ignoring "manager"
+        # sessions on systemd >= 256)
+        loginctl list-sessions --no-legend | grep -v 'manager' | grep --count "$USER" | MATCH '^1$'
 
         # Running `tests.session exec` executes in its own background session,
         # so there are two sessions while `tests.session exec` is running, and
         # `loginctl show-session` from within finds the background session.
-        tests.session -u "$USER" exec loginctl show-session auto -p Class | MATCH "Class=background"
-        tests.session -u "$USER" exec loginctl list-sessions --no-legend | grep --count "$USER" | MATCH '^2$'
-        loginctl list-sessions --no-legend | grep --count "$USER" | MATCH '^1$'
+        if [ "$systemd_ver" -ge 245 ]; then
+            tests.session -u "$USER" exec loginctl show-session auto -p Class | MATCH "Class=background"
+        fi
+        tests.session -u "$USER" exec loginctl list-sessions --no-legend | grep -v 'manager' | grep --count "$USER" | MATCH '^2$'
+        loginctl list-sessions --no-legend | grep -v 'manager' | grep --count "$USER" | MATCH '^1$'
 
         # A second session with the same class/type but a distinct label can co-exist.
         tests.session create-session -u "$USER" -c user -t wayland -l second
-        loginctl list-sessions --no-legend | grep --count "$USER" | MATCH '^2$'
+        loginctl list-sessions --no-legend | grep -v 'manager' | grep --count "$USER" | MATCH '^2$'
 
         # A third session with a different class, type, and label can co-exist.
         tests.session create-session -u "$USER" -c greeter -t x11 -l third
-        loginctl list-sessions --no-legend | grep --count "$USER" | MATCH '^3$'
+        loginctl list-sessions --no-legend | grep -v 'manager' | grep --count "$USER" | MATCH '^3$'
 
         # A fourth session with an unspecified class and type but different label can co-exist.
         tests.session create-session -u "$USER" -l fourth
-        loginctl list-sessions --no-legend | grep --count "$USER" | MATCH '^4$'
+        loginctl list-sessions --no-legend | grep -v 'manager' | grep --count "$USER" | MATCH '^4$'
 
         # Creating an already-existing session is an error.
         not tests.session create-session -u "$USER" -c user
-        loginctl list-sessions --no-legend | grep --count "$USER" | MATCH '^4$'
+        loginctl list-sessions --no-legend | grep -v 'manager' | grep --count "$USER" | MATCH '^4$'
 
         # Cannot call tests.session create-session/destroy-session with root or
         # other invalid users
         for invalid_user in "" "root" "user1,user2" "foo," ",bar"; do
             not tests.session create-session -u "$invalid_user"
             tests.session create-session -u "$invalid_user" 2>&1 | MATCH 'invalid user, must be single non-root username'
-            loginctl list-sessions --no-legend | grep --count "$USER" | MATCH '^4$'
+            loginctl list-sessions --no-legend | grep -v 'manager' | grep --count "$USER" | MATCH '^4$'
             not tests.session destroy-session -u "$invalid_user"
             tests.session destroy-session -u "$invalid_user" 2>&1 | MATCH 'invalid user, must be single non-root username'
-            loginctl list-sessions --no-legend | grep --count "$USER" | MATCH '^4$'
+            loginctl list-sessions --no-legend | grep -v 'manager' | grep --count "$USER" | MATCH '^4$'
         done
 
         # A labelled session can be destroyed individually, the rest can be
         # destroyed without a label.
         tests.session destroy-session -u "$USER" -l fourth
-        retry -n 10 --wait 1 sh -c "loginctl list-sessions --no-legend | grep --count $USER | MATCH '^3$'"
+        retry -n 10 --wait 1 sh -c "loginctl list-sessions --no-legend | grep -v 'manager' | grep --count $USER | MATCH '^3$'"
         tests.session destroy-session -u "$USER" -l third
-        retry -n 10 --wait 1 sh -c "loginctl list-sessions --no-legend | grep --count $USER | MATCH '^2$'"
+        retry -n 10 --wait 1 sh -c "loginctl list-sessions --no-legend | grep -v 'manager' | grep --count $USER | MATCH '^2$'"
         tests.session destroy-session -u "$USER" -l second
-        retry -n 10 --wait 1 sh -c "loginctl list-sessions --no-legend | grep --count $USER | MATCH '^1$'"
+        retry -n 10 --wait 1 sh -c "loginctl list-sessions --no-legend | grep -v 'manager' | grep --count $USER | MATCH '^1$'"
         tests.session destroy-session -u "$USER"
-        retry -n 10 --wait 1 sh -c "loginctl list-sessions --no-legend | NOMATCH $USER"
+        retry -n 10 --wait 1 sh -c "loginctl list-sessions --no-legend | grep -v 'manager' | NOMATCH $USER"
+
+        if [ "$systemd_ver" -lt 256 ]; then
+            # Stil no sessions for $USER on < 256
+            loginctl list-sessions --no-legend | NOMATCH "$USER"
+        else
+            # Still one manager session on >= 256
+            loginctl list-sessions --no-legend | MATCH "$USER"
+            loginctl list-sessions --no-legend | grep --count "$USER" | MATCH '^1$'
+            loginctl list-sessions --no-legend | grep "$USER" | MATCH "manager"
+        fi
     fi

--- a/tests/lib/tools/suite/tests.session/task.yaml
+++ b/tests/lib/tools/suite/tests.session/task.yaml
@@ -100,16 +100,33 @@ execute: |
     # it is elected as the user's display session, so "loginctl show-session
     # auto" resolves to it.
     if [ "$USER" != root ]; then
+        # No sessions initially
+        loginctl list-sessions --no-legend | NOMATCH "$USER"
+
+        # Create session, check that it appears to loginctl
         tests.session create-session -u "$USER" -c user
-        tests.session -u "$USER" exec loginctl show-session auto -p Class | MATCH "Class=user"
-        loginctl list-sessions --no-legend | grep "$USER"
+        loginctl list-sessions --no-legend | MATCH "$USER"
+
+        # Running a command as user outside a session falls back to the session
+        sudo -iu "$USER" loginctl show-session auto -p Class | MATCH "Class=user"
+
+        # There's just one active session for the user
+        test "$(loginctl list-sessions --no-legend | grep --count "$USER")" -eq 1
+
+        # Running `tests.session exec` executes in its own background session,
+        # so there are two sessions while `tests.session exec` is running, and
+        # `loginctl show-session` from within finds the background session.
+        tests.session -u "$USER" exec loginctl show-session auto -p Class | MATCH "Class=background"
+        test "$(tests.session -u "$USER" exec loginctl list-sessions --no-legend | grep --count "$USER")" -eq 2
+        test "$(loginctl list-sessions --no-legend | grep --count "$USER")" -eq 1
 
         # A second session with the same class but a distinct label can co-exist.
         tests.session create-session -u "$USER" -c user -l second
-        test "$(loginctl list-sessions --no-legend | grep -c "$USER")" -ge 2
+        test "$(loginctl list-sessions --no-legend | grep --count "$USER")" -eq 2
 
         # Creating an already-existing session is an error.
         not tests.session create-session -u "$USER" -c user
+        test "$(loginctl list-sessions --no-legend | grep --count "$USER")" -eq 2
 
         # A labelled session can be destroyed individually, the rest can be
         # destroyed without a label.

--- a/tests/lib/tools/suite/tests.session/task.yaml
+++ b/tests/lib/tools/suite/tests.session/task.yaml
@@ -118,7 +118,7 @@ execute: |
         systemd_ver="$(systemctl --version | awk '/systemd [0-9]+/ { print $2 }' | cut -f1 -d"~")"
 
         # Check that there are no sessions for $USER when filtering out "manager"
-        loginctl list-sessions --no-legend | grep -v 'manager' | NOMATCH "$USER"
+        retry -n 10 --wait 1 sh -c "loginctl list-sessions --no-legend | grep -v 'manager' | NOMATCH \"$USER\""
         if [ "$systemd_ver" -lt 256 ]; then
             # Truly no sessions for $USER on < 256
             loginctl list-sessions --no-legend | NOMATCH "$USER"
@@ -150,7 +150,7 @@ execute: |
         # Running `tests.session exec` executes in its own background session,
         # so there are two sessions while `tests.session exec` is running
         tests.session -u "$USER" exec loginctl list-sessions --no-legend | grep -v 'manager' | grep --count "$USER" | MATCH '^2$'
-        loginctl list-sessions --no-legend | grep -v 'manager' | grep --count "$USER" | MATCH '^1$'
+        retry -n 10 --wait 1 sh -c "loginctl list-sessions --no-legend | grep -v 'manager' | grep --count \"$USER\" | MATCH '^1$'"
 
         # A second session with the same class/type but a distinct label can co-exist.
         tests.session create-session -u "$USER" -c user -t wayland -l second

--- a/tests/lib/tools/suite/tests.session/task.yaml
+++ b/tests/lib/tools/suite/tests.session/task.yaml
@@ -103,34 +103,64 @@ execute: |
         # No sessions initially
         loginctl list-sessions --no-legend | NOMATCH "$USER"
 
+        # Running a user service places the command outside any session, so
+        # "auto" tries to find any user session, and fails without a session
+        not tests.session -u "$USER" exec systemd-run --user --quiet --wait --pipe loginctl show-session auto
+
         # Create session, check that it appears to loginctl
-        tests.session create-session -u "$USER" -c user
+        tests.session create-session -u "$USER" -c user -t wayland
         loginctl list-sessions --no-legend | MATCH "$USER"
 
-        # Running a command as user outside a session falls back to the session
-        sudo -iu "$USER" loginctl show-session auto -p Class | MATCH "Class=user"
+        # Running a user service places the command outside any session, so
+        # "auto" falls back to the user's display session.
+        tests.session -u "$USER" exec systemd-run --user --quiet --wait --pipe loginctl show-session auto -p Class | MATCH '^Class=user$'
+        tests.session -u "$USER" exec systemd-run --user --quiet --wait --pipe loginctl show-session auto -p Type | MATCH '^Type=wayland$'
 
         # There's just one active session for the user
-        test "$(loginctl list-sessions --no-legend | grep --count "$USER")" -eq 1
+        loginctl list-sessions --no-legend | grep --count "$USER" | MATCH '^1$'
 
         # Running `tests.session exec` executes in its own background session,
         # so there are two sessions while `tests.session exec` is running, and
         # `loginctl show-session` from within finds the background session.
         tests.session -u "$USER" exec loginctl show-session auto -p Class | MATCH "Class=background"
-        test "$(tests.session -u "$USER" exec loginctl list-sessions --no-legend | grep --count "$USER")" -eq 2
-        test "$(loginctl list-sessions --no-legend | grep --count "$USER")" -eq 1
+        tests.session -u "$USER" exec loginctl list-sessions --no-legend | grep --count "$USER" | MATCH '^2$'
+        loginctl list-sessions --no-legend | grep --count "$USER" | MATCH '^1$'
 
-        # A second session with the same class but a distinct label can co-exist.
-        tests.session create-session -u "$USER" -c user -l second
-        test "$(loginctl list-sessions --no-legend | grep --count "$USER")" -eq 2
+        # A second session with the same class/type but a distinct label can co-exist.
+        tests.session create-session -u "$USER" -c user -t wayland -l second
+        loginctl list-sessions --no-legend | grep --count "$USER" | MATCH '^2$'
+
+        # A third session with a different class, type, and label can co-exist.
+        tests.session create-session -u "$USER" -c greeter -t x11 -l third
+        loginctl list-sessions --no-legend | grep --count "$USER" | MATCH '^3$'
+
+        # A fourth session with an unspecified class and type but different label can co-exist.
+        tests.session create-session -u "$USER" -l fourth
+        loginctl list-sessions --no-legend | grep --count "$USER" | MATCH '^4$'
 
         # Creating an already-existing session is an error.
         not tests.session create-session -u "$USER" -c user
-        test "$(loginctl list-sessions --no-legend | grep --count "$USER")" -eq 2
+        loginctl list-sessions --no-legend | grep --count "$USER" | MATCH '^4$'
+
+        # Cannot call tests.session create-session/destroy-session with root or
+        # other invalid users
+        for invalid_user in "" "root" "user1,user2" "foo," ",bar"; do
+            not tests.session create-session -u "$invalid_user"
+            tests.session create-session -u "$invalid_user" 2>&1 | MATCH 'invalid user, must be single non-root username'
+            loginctl list-sessions --no-legend | grep --count "$USER" | MATCH '^4$'
+            not tests.session destroy-session -u "$invalid_user"
+            tests.session destroy-session -u "$invalid_user" 2>&1 | MATCH 'invalid user, must be single non-root username'
+            loginctl list-sessions --no-legend | grep --count "$USER" | MATCH '^4$'
+        done
 
         # A labelled session can be destroyed individually, the rest can be
         # destroyed without a label.
+        tests.session destroy-session -u "$USER" -l fourth
+        retry -n 10 --wait 1 sh -c "loginctl list-sessions --no-legend | grep --count $USER | MATCH '^3$'"
+        tests.session destroy-session -u "$USER" -l third
+        retry -n 10 --wait 1 sh -c "loginctl list-sessions --no-legend | grep --count $USER | MATCH '^2$'"
         tests.session destroy-session -u "$USER" -l second
+        retry -n 10 --wait 1 sh -c "loginctl list-sessions --no-legend | grep --count $USER | MATCH '^1$'"
         tests.session destroy-session -u "$USER"
-        retry -n 10 --wait 1 sh -c "! loginctl list-sessions --no-legend | grep -q $USER"
+        retry -n 10 --wait 1 sh -c "loginctl list-sessions --no-legend | NOMATCH $USER"
     fi

--- a/tests/lib/tools/suite/tests.session/task.yaml
+++ b/tests/lib/tools/suite/tests.session/task.yaml
@@ -91,3 +91,29 @@ execute: |
         tests.session -u "$USER" -p /tmp/outer.pid exec python3 -c 'import os; print(os.getpid())' >/tmp/inner.pid
         test "$(cat /tmp/outer.pid)" = "$(cat /tmp/inner.pid)"
     done
+
+    # Check persistent session management. Only run this for the non-root
+    # user, as destroying sessions of the root user would interfere with the
+    # spread connection itself.
+    #
+    # A created session is a real logind session of the requested class, and
+    # it is elected as the user's display session, so "loginctl show-session
+    # auto" resolves to it.
+    if [ "$USER" != root ]; then
+        tests.session create-session -u "$USER" -c user
+        tests.session -u "$USER" exec loginctl show-session auto -p Class | MATCH "Class=user"
+        loginctl list-sessions --no-legend | grep "$USER"
+
+        # A second session with the same class but a distinct label can co-exist.
+        tests.session create-session -u "$USER" -c user -l second
+        test "$(loginctl list-sessions --no-legend | grep -c "$USER")" -ge 2
+
+        # Creating an already-existing session is an error.
+        not tests.session create-session -u "$USER" -c user
+
+        # A labelled session can be destroyed individually, the rest can be
+        # destroyed without a label.
+        tests.session destroy-session -u "$USER" -l second
+        tests.session destroy-session -u "$USER"
+        retry -n 10 --wait 1 sh -c "! loginctl list-sessions --no-legend | grep -q $USER"
+    fi

--- a/tests/lib/tools/tests.session
+++ b/tests/lib/tools/tests.session
@@ -3,6 +3,8 @@
 show_help() {
 	echo "usage: tests.session [-u USER] [-p PID_FILE] exec <CMD>"
 	echo "       tests.session prepare | restore [-u USER | -u USER1,USER2,...]"
+	echo "       tests.session create-session -u USER [-c CLASS] [-t TYPE] [-l LABEL]"
+	echo "       tests.session destroy-session -u USER [-l LABEL]"
 	echo "       tests.session kill-leaked"
 	echo "       tests.session dump"
 	echo "       tests.session has-system-systemd-and-dbus"
@@ -16,6 +18,9 @@ main() {
 	fi
 	user=root
 	pid_file=
+	session_class=
+	session_type=
+	session_label=
 	action=
 	while [ $# -gt 0 ]; do
 		case "$1" in
@@ -32,6 +37,30 @@ main() {
 				pid_file="$2"
 				shift 2
 				;;
+			-c)
+				if [ $# -eq 1 ]; then
+					echo "tests.session: option -c requires an argument" >&2
+					exit 1
+				fi
+				session_class="$2"
+				shift 2
+				;;
+			-t)
+				if [ $# -eq 1 ]; then
+					echo "tests.session: option -t requires an argument" >&2
+					exit 1
+				fi
+				session_type="$2"
+				shift 2
+				;;
+			-l)
+				if [ $# -eq 1 ]; then
+					echo "tests.session: option -l requires an argument" >&2
+					exit 1
+				fi
+				session_label="$2"
+				shift 2
+				;;
 			kill-leaked)
 				action=kill-leaked
 				shift
@@ -42,6 +71,14 @@ main() {
 				;;
 			restore)
 				action=restore
+				shift
+				;;
+			create-session)
+				action=create-session
+				shift
+				;;
+			destroy-session)
+				action=destroy-session
 				shift
 				;;
 			dump)
@@ -195,6 +232,121 @@ main() {
 					setsebool unconfined_service_transition_to_unconfined_user 0
 				;;
 			esac
+
+			exit 0
+			;;
+		create-session)
+			# Create a persistent logind session for the selected user. The
+			# session is backed by a detached systemd service whose payload is a
+			# "sleep infinity" process running as the user through "runuser -l",
+			# so pam_systemd registers a real session. The session class and type
+			# can be requested with -c and -t, which are passed to pam_systemd as
+			# XDG_SESSION_CLASS and XDG_SESSION_TYPE respectively.
+			#
+			# The session ID is stored in /run/tests.session/<user>[-<label>].id
+			# so that destroy-session can later find and stop the exact session.
+			#
+			# Note: if the user has several concurrent display-eligible sessions
+			# (e.g. classes user or greeter), "loginctl show-session auto"
+			# resolves to the session systemd-logind elects as the user's display
+			# session, preferring graphical types over tty over unspecified; the
+			# session class is not a factor in that election.
+			if [ -z "$session_label" ]; then
+				session_suffix=""
+			else
+				if ! echo "$session_label" | grep -qE '^[a-zA-Z0-9_-]+$'; then
+					echo "tests.session: invalid session label $session_label" >&2
+					exit 1
+				fi
+				session_suffix="-$session_label"
+			fi
+			unit_name="tests.session-persist-$user$session_suffix.service"
+			id_file="/run/tests.session/$user$session_suffix.id"
+
+			if systemctl is-active --quiet "$unit_name"; then
+				echo "tests.session: session for user $user$session_suffix already exists, run destroy-session first" >&2
+				exit 1
+			fi
+
+			# check for --whitelist-environment; the requested session class and
+			# type must survive runuser's environment reset to reach pam_systemd
+			runuser_env_arg=
+			if runuser --help 2>&1 | grep -q whitelist-environment ; then
+				runuser_env_arg="-w XDG_SESSION_CLASS,XDG_SESSION_TYPE"
+			else
+				echo "tests.session: create-session requires runuser with --whitelist-environment support" >&2
+				exit 1
+			fi
+
+			env_args=""
+			if [ -n "$session_class" ]; then
+				env_args="XDG_SESSION_CLASS=$session_class"
+			fi
+			if [ -n "$session_type" ]; then
+				env_args="${env_args:+$env_args }XDG_SESSION_TYPE=$session_type"
+			fi
+
+			mkdir -p /run/tests.session
+			# pre-create the ID file owned by the user, so the payload running as
+			# the user can write its session ID into it
+			rm -f "$id_file"
+			touch "$id_file"
+			chown "$user:" "$id_file"
+
+			# shellcheck disable=SC2086
+			systemd-run \
+			--system \
+			--quiet \
+			--unit="$unit_name" \
+			--description "tests.session persistent session for $user$session_suffix" \
+			${env_args:+--property "Environment=$env_args"} \
+			"$(command -v runuser)" $runuser_env_arg -l "$user" -c "echo \"\$XDG_SESSION_ID\" >\"$id_file\"; exec sleep infinity"
+
+			# Wait for the session to be registered, then verify that the
+			# requested class and type were honored by pam_systemd.
+			retry -n 10 --wait 1 test -s "$id_file"
+			session_id="$(cat "$id_file")"
+			if [ -n "$session_class" ]; then
+				got_class="$(loginctl show-session "$session_id" --property=Class | cut -d = -f 2-)"
+				if [ "$got_class" != "$session_class" ]; then
+					systemctl stop "$unit_name" || true
+					rm -f "$id_file"
+					echo "tests.session: requested session class $session_class but got $got_class" >&2
+					exit 1
+				fi
+			fi
+			if [ -n "$session_type" ]; then
+				got_type="$(loginctl show-session "$session_id" --property=Type | cut -d = -f 2-)"
+				if [ "$got_type" != "$session_type" ]; then
+					systemctl stop "$unit_name" || true
+					rm -f "$id_file"
+					echo "tests.session: requested session type $session_type but got $got_type" >&2
+					exit 1
+				fi
+			fi
+
+			exit 0
+			;;
+		destroy-session)
+			# Destroy the session previously created with create-session. The
+			# unit name and ID file are derived from the -u and -l arguments in
+			# the same way, so the exact session can be found without
+			# enumerating anything.
+			if [ -z "$session_label" ]; then
+				session_suffix=""
+			else
+				if ! echo "$session_label" | grep -qE '^[a-zA-Z0-9_-]+$'; then
+					echo "tests.session: invalid session label $session_label" >&2
+					exit 1
+				fi
+				session_suffix="-$session_label"
+			fi
+			unit_name="tests.session-persist-$user$session_suffix.service"
+			id_file="/run/tests.session/$user$session_suffix.id"
+
+			systemctl stop "$unit_name" || true
+			systemctl reset-failed "$unit_name" || true
+			rm -f "$id_file"
 
 			exit 0
 			;;

--- a/tests/lib/tools/tests.session
+++ b/tests/lib/tools/tests.session
@@ -266,25 +266,6 @@ main() {
 			#
 			# The session ID is stored in /run/tests.session/<user>[-<label>].id
 			# so that destroy-session can later find and stop the exact session.
-			#
-			# Note: if the user has several concurrent display-eligible
-			# sessions (only classes user and greeter are ever
-			# display-eligible), "loginctl show-session auto" (systemd >=
-			# 245) resolves to "the caller's own session if they have one,
-			# otherwise their user's display session". The display election
-			# prefers class user over greeter, then graphical types
-			# (x11/wayland/mir) over tty over unspecified. Background sessions
-			# (and manager-class sessions on systemd >= 256, when they were
-			# introduced) are never display-eligible, so they cannot shadow
-			# the session created here.
-			#
-			# Note: the session created here is observed only by processes that
-			# are NOT themselves inside a logind session (e.g. a user service's
-			# ExecCondition, which runs outside any session scope and resolves
-			# "auto" via the user's elected display session). In contrast, a
-			# command run via "tests.session -u USER exec ..." always spawns its
-			# own separate, transient "background"-class session and never
-			# joins the session created here.
 			if [ -z "$user" ] || [ "$user" = "root" ] || echo "$user" | grep -q ','; then
 				echo "tests.session: invalid user, must be single non-root username: '$user'" >&2
 				exit 1

--- a/tests/lib/tools/tests.session
+++ b/tests/lib/tools/tests.session
@@ -142,6 +142,19 @@ main() {
 			;;
 		prepare)
 			# Try to enable linger for the selected user(s).
+			#
+			# Note: enabling linger starts user@UID.service, which runs through
+			# the "systemd-user" PAM stack. On systemd <= 255 pam_systemd
+			# deliberately creates no logind session for that PAM service (it
+			# only sets up XDG_RUNTIME_DIR); starting with systemd 256 (commit
+			# 4cb4e6cf6dce, "pam_systemd: register systemd user service manager
+			# as class='manager'") the user service manager registers a
+			# manager-class session ("manager-early" for root and other system
+			# users), and "loginctl list-sessions" grew a class column in the
+			# same release. Tests that count sessions must filter manager-class
+			# sessions out, e.g. with "grep -v manager"; on older systems the
+			# filter matches nothing. Manager-class sessions never take part in
+			# the display session election, see create-session for details.
 			for u in $(echo "$user" | tr ',' ' '); do
 				if ! loginctl enable-linger "$u"; then
 					echo "tests.session requires external fix for //github.com/systemd/systemd/issues/12401" >&2
@@ -254,21 +267,24 @@ main() {
 			# The session ID is stored in /run/tests.session/<user>[-<label>].id
 			# so that destroy-session can later find and stop the exact session.
 			#
-			# Note: if the user has several concurrent display-eligible sessions
-			# (e.g. classes user or greeter), "loginctl show-session auto"
-			# resolves to the session systemd-logind elects as the user's display
-			# session, preferring graphical types over tty over unspecified; the
-			# session class is not a factor in that election.
+			# Note: if the user has several concurrent display-eligible
+			# sessions (only classes user and greeter are ever
+			# display-eligible), "loginctl show-session auto" (systemd >=
+			# 245) resolves to "the caller's own session if they have one,
+			# otherwise their user's display session". The display election
+			# prefers class user over greeter, then graphical types
+			# (x11/wayland/mir) over tty over unspecified. Background sessions
+			# (and manager-class sessions on systemd >= 256, when they were
+			# introduced) are never display-eligible, so they cannot shadow
+			# the session created here.
 			#
 			# Note: the session created here is observed only by processes that
 			# are NOT themselves inside a logind session (e.g. a user service's
 			# ExecCondition, which runs outside any session scope and resolves
 			# "auto" via the user's elected display session). In contrast, a
 			# command run via "tests.session -u USER exec ..." always spawns its
-			# own separate, transient "background"-class session and never joins
-			# the session created here; background sessions are never
-			# display-eligible, so they cannot shadow this session in the
-			# display election.
+			# own separate, transient "background"-class session and never
+			# joins the session created here.
 			if [ -z "$user" ] || [ "$user" = "root" ] || echo "$user" | grep -q ','; then
 				echo "tests.session: invalid user, must be single non-root username: '$user'" >&2
 				exit 1

--- a/tests/lib/tools/tests.session
+++ b/tests/lib/tools/tests.session
@@ -174,6 +174,14 @@ main() {
 			exit 0
 			;;
 		restore)
+			# Defensively stop any persistent sessions created with
+			# create-session but not destroyed with destroy-session, so that
+			# they cannot leak into subsequent tests. Stopping the unit kills
+			# the session payload and thereby the session itself.
+			systemctl stop "tests.session-persist-*.service" 2>/dev/null || true
+			systemctl reset-failed "tests.session-persist-*.service" 2>/dev/null || true
+			rm -f /run/tests.session/*.id
+
 			# Disable linger for the selected user(s).
 			for u in $(echo "$user" | tr ',' ' '); do
 
@@ -277,7 +285,12 @@ main() {
 			unit_name="tests.session-persist-$user$session_suffix.service"
 			id_file="/run/tests.session/$user$session_suffix.id"
 
-			if systemctl is-active --quiet "$unit_name"; then
+			# A failed leftover unit also occupies the unit name, but
+			# is-active returns false for failed units, so check is-failed
+			# too in order to report the problem instead of failing below
+			# with a confusing "unit was already loaded" error from
+			# systemd-run.
+			if systemctl is-active --quiet "$unit_name" || systemctl is-failed --quiet "$unit_name"; then
 				echo "tests.session: session for user $user$session_suffix already exists, run destroy-session first" >&2
 				exit 1
 			fi
@@ -321,12 +334,24 @@ main() {
 
 			# Wait for the session to be registered, then verify that the
 			# requested class and type were honored by pam_systemd.
-			retry -n 10 --wait 1 test -s "$id_file"
+			if ! retry -n 10 --wait 1 test -s "$id_file"; then
+				# Stop and reset the unit so that its name is freed for a
+				# retry. A failed transient unit keeps occupying the name
+				# until reset-failed is called, even after being stopped.
+				systemctl stop "$unit_name" 2>/dev/null || true
+				systemctl reset-failed "$unit_name" 2>/dev/null || true
+				rm -f "$id_file"
+				echo "tests.session: timed out waiting for the session of user $user$session_suffix to be registered" >&2
+				exit 1
+			fi
 			session_id="$(cat "$id_file")"
 			if [ -n "$session_class" ]; then
 				got_class="$(loginctl show-session "$session_id" --property=Class | cut -d = -f 2-)"
 				if [ "$got_class" != "$session_class" ]; then
-					systemctl stop "$unit_name" || true
+					# Stop and reset the unit to free its name for a
+					# retry, see the comment above.
+					systemctl stop "$unit_name" 2>/dev/null || true
+					systemctl reset-failed "$unit_name" 2>/dev/null || true
 					rm -f "$id_file"
 					echo "tests.session: requested session class $session_class but got $got_class" >&2
 					exit 1
@@ -335,7 +360,10 @@ main() {
 			if [ -n "$session_type" ]; then
 				got_type="$(loginctl show-session "$session_id" --property=Type | cut -d = -f 2-)"
 				if [ "$got_type" != "$session_type" ]; then
-					systemctl stop "$unit_name" || true
+					# Stop and reset the unit to free its name for a
+					# retry, see the comment above.
+					systemctl stop "$unit_name" 2>/dev/null || true
+					systemctl reset-failed "$unit_name" 2>/dev/null || true
 					rm -f "$id_file"
 					echo "tests.session: requested session type $session_type but got $got_type" >&2
 					exit 1
@@ -365,8 +393,11 @@ main() {
 			unit_name="tests.session-persist-$user$session_suffix.service"
 			id_file="/run/tests.session/$user$session_suffix.id"
 
-			systemctl stop "$unit_name" || true
-			systemctl reset-failed "$unit_name" || true
+			# Best effort: the unit and its failure state may already be
+			# gone, e.g. when destroy-session is called more than once, so
+			# the systemctl noise is suppressed.
+			systemctl stop "$unit_name" 2>/dev/null || true
+			systemctl reset-failed "$unit_name" 2>/dev/null || true
 			rm -f "$id_file"
 
 			exit 0

--- a/tests/lib/tools/tests.session
+++ b/tests/lib/tools/tests.session
@@ -261,6 +261,10 @@ main() {
 			# the session created here; background sessions are never
 			# display-eligible, so they cannot shadow this session in the
 			# display election.
+			if [ -z "$user" ] || [ "$user" = "root" ] || echo "$user" | grep -q ','; then
+				echo "tests.session: invalid user, must be single non-root username: '$user'" >&2
+				exit 1
+			fi
 			if [ -z "$session_label" ]; then
 				session_suffix=""
 			else
@@ -345,6 +349,10 @@ main() {
 			# unit name and ID file are derived from the -u and -l arguments in
 			# the same way, so the exact session can be found without
 			# enumerating anything.
+			if [ -z "$user" ] || [ "$user" = "root" ] || echo "$user" | grep -q ','; then
+				echo "tests.session: invalid user, must be single non-root username: '$user'" >&2
+				exit 1
+			fi
 			if [ -z "$session_label" ]; then
 				session_suffix=""
 			else

--- a/tests/lib/tools/tests.session
+++ b/tests/lib/tools/tests.session
@@ -251,6 +251,16 @@ main() {
 			# resolves to the session systemd-logind elects as the user's display
 			# session, preferring graphical types over tty over unspecified; the
 			# session class is not a factor in that election.
+			#
+			# Note: the session created here is observed only by processes that
+			# are NOT themselves inside a logind session (e.g. a user service's
+			# ExecCondition, which runs outside any session scope and resolves
+			# "auto" via the user's elected display session). In contrast, a
+			# command run via "tests.session -u USER exec ..." always spawns its
+			# own separate, transient "background"-class session and never joins
+			# the session created here; background sessions are never
+			# display-eligible, so they cannot shadow this session in the
+			# display election.
 			if [ -z "$session_label" ]; then
 				session_suffix=""
 			else
@@ -265,16 +275,6 @@ main() {
 
 			if systemctl is-active --quiet "$unit_name"; then
 				echo "tests.session: session for user $user$session_suffix already exists, run destroy-session first" >&2
-				exit 1
-			fi
-
-			# check for --whitelist-environment; the requested session class and
-			# type must survive runuser's environment reset to reach pam_systemd
-			runuser_env_arg=
-			if runuser --help 2>&1 | grep -q whitelist-environment ; then
-				runuser_env_arg="-w XDG_SESSION_CLASS,XDG_SESSION_TYPE"
-			else
-				echo "tests.session: create-session requires runuser with --whitelist-environment support" >&2
 				exit 1
 			fi
 
@@ -293,6 +293,19 @@ main() {
 			touch "$id_file"
 			chown "$user:" "$id_file"
 
+			# The Environment= property places the requested session class and
+			# type in the environment of the runuser process itself. pam_systemd
+			# reads XDG_SESSION_CLASS/XDG_SESSION_TYPE via getenv() from the
+			# calling process when they are not set in the PAM environment, and
+			# runuser does not scrub its own environment before opening the PAM
+			# session, so this works even on runuser versions without
+			# --whitelist-environment support (e.g. Ubuntu Core 18).
+			#
+			# Note: unlike the exec path below, here we deliberately do not use
+			# "systemd-run --wait --pipe", which require systemd >= 253. This is a
+			# fire-and-forget transient service (we poll the ID file for readiness
+			# instead of waiting on stdio), so all the options used here predate
+			# systemd 237 and this works on the oldest supported systems.
 			# shellcheck disable=SC2086
 			systemd-run \
 			--system \
@@ -300,7 +313,7 @@ main() {
 			--unit="$unit_name" \
 			--description "tests.session persistent session for $user$session_suffix" \
 			${env_args:+--property "Environment=$env_args"} \
-			"$(command -v runuser)" $runuser_env_arg -l "$user" -c "echo \"\$XDG_SESSION_ID\" >\"$id_file\"; exec sleep infinity"
+			"$(command -v runuser)" -l "$user" -c "echo \"\$XDG_SESSION_ID\" >\"$id_file\"; exec sleep infinity"
 
 			# Wait for the session to be registered, then verify that the
 			# requested class and type were honored by pam_systemd.


### PR DESCRIPTION
The `tests.session -u <username> prepare` function enables linger and starts `default.target`, but it doesn't actually create a systemd session. But we need a real session in some situations, as in #17380 where we need services to run a program in `ExecCondition` which will look up the systemd session and decide whether to run based on its class.

This PR adds two new commands:

```
tests.session -u <username> create-session [-c <class>] [-t <type>] [-l <label>]
tests.session -u <username> destroy-session [-l <label>]
```

These allow callers to create and destroy systemd user sessions with a given class and type. The optional `label` argument allows a label to be appended to the default session name, so it's possible to manage multiple sessions for the same user at the same time.

The new subcommands should be used alongside `tests.session -u <username> prepare` and `tests.session -u <username> cleanup` in tests which require a real systemd user session to be present.

Cherry-picked from #17380

Tracked internally by: https://warthogs.atlassian.net/browse/SNAPDENG-37328