### PR TITLE
 .github/workflows: update TODO for gocover-cobertura to TODO:GOVERSION

### DIFF
--- a/.github/workflows/weekly-static-analysis.yaml
+++ b/.github/workflows/weekly-static-analysis.yaml
@@ -78,8 +78,7 @@ jobs:
 
     - name: Test Go with coverage
       run: |
-        # gocover-cobertura was updated May 2026, changes break coverage reporting
-        # TODO: Triage work needed to update to newest version of gocover-cobertura
+        # TODO:GOVERSION gocover-cobertura=v.1.5.0 needs Go>=v1.25.0
         # (https://github.com/boumenot/gocover-cobertura/releases#release-v1.5.0)
         go install github.com/boumenot/gocover-cobertura@v1.4.0
 


### PR DESCRIPTION
Gocover-cobertura update requires Go>=1.25.0, but we are at Go=1.18.

SNAPDENG-37267