### PR TITLE
many: make unit tests pass as root

### DIFF
--- a/asserts/fsbackstore_test.go
+++ b/asserts/fsbackstore_test.go
@@ -52,6 +52,9 @@ func (fsbss *fsBackstoreSuite) TestOpenOK(c *C) {
 }
 
 func (fsbss *fsBackstoreSuite) TestOpenCreateFail(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
 	parent := filepath.Join(c.MkDir(), "var")
 	topDir := filepath.Join(parent, "asserts-db")
 	// make it not writable

--- a/asserts/fsbackstore_test.go
+++ b/asserts/fsbackstore_test.go
@@ -53,7 +53,7 @@ func (fsbss *fsBackstoreSuite) TestOpenOK(c *C) {
 
 func (fsbss *fsBackstoreSuite) TestOpenCreateFail(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root bypasses directory write permissions)")
 	}
 	parent := filepath.Join(c.MkDir(), "var")
 	topDir := filepath.Join(parent, "asserts-db")

--- a/cmd/snap-repair/cmd_show_test.go
+++ b/cmd/snap-repair/cmd_show_test.go
@@ -123,7 +123,7 @@ output:
 
 func (r *repairSuite) TestShowRepairSingleUnreadableOutput(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root can read files regardless of mode)")
 	}
 	makeMockRepairState(c)
 	scriptPath := filepath.Join(dirs.SnapRepairRunDir, "canonical/1", "r3.retry")

--- a/cmd/snap-repair/cmd_show_test.go
+++ b/cmd/snap-repair/cmd_show_test.go
@@ -122,6 +122,9 @@ output:
 }
 
 func (r *repairSuite) TestShowRepairSingleUnreadableOutput(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
 	makeMockRepairState(c)
 	scriptPath := filepath.Join(dirs.SnapRepairRunDir, "canonical/1", "r3.retry")
 	err := os.Chmod(scriptPath, 0000)

--- a/cmd/snap-repair/runner_test.go
+++ b/cmd/snap-repair/runner_test.go
@@ -2332,7 +2332,7 @@ func (s *runner20Suite) TestLoadStateInitDeviceInfoModeenvInvalidContent(c *C) {
 
 func (s *runner20Suite) TestLoadStateInitDeviceInfoModeenvIncorrectPermissions(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root can read files regardless of mode)")
 	}
 	runner := repair.NewRunner()
 

--- a/cmd/snap-repair/runner_test.go
+++ b/cmd/snap-repair/runner_test.go
@@ -2331,6 +2331,9 @@ func (s *runner20Suite) TestLoadStateInitDeviceInfoModeenvInvalidContent(c *C) {
 }
 
 func (s *runner20Suite) TestLoadStateInitDeviceInfoModeenvIncorrectPermissions(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
 	runner := repair.NewRunner()
 
 	err := os.Chmod(dirs.SnapModeenvFile, 0300)

--- a/cmd/snapd/cli/cmd_services_test.go
+++ b/cmd/snapd/cli/cmd_services_test.go
@@ -506,11 +506,16 @@ func (s *appOpSuite) TestAppStatusInvalidUserGlobalSwitches(c *check.C) {
 
 func (s *appOpSuite) TestAppStatusNoServices(c *check.C) {
 	n := 0
+	var hasGlobal bool
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		switch n {
-		case 0:
+		case 0, 1:
 			c.Check(r.URL.Path, check.Equals, "/v2/apps")
-			c.Check(r.URL.Query(), check.HasLen, 1)
+			if hasGlobal {
+				c.Check(r.URL.Query(), check.HasLen, 2)
+			} else {
+				c.Check(r.URL.Query(), check.HasLen, 1)
+			}
 			c.Check(r.URL.Query().Get("select"), check.Equals, "service")
 			c.Check(r.Method, check.Equals, "GET")
 			w.WriteHeader(200)
@@ -522,17 +527,36 @@ func (s *appOpSuite) TestAppStatusNoServices(c *check.C) {
 				"status-code": 200,
 			})
 		default:
-			c.Fatalf("expected to get 1 requests, now on %d", n+1)
+			c.Fatalf("expected to get 2 requests, now on %d", n+1)
 		}
+
 		n++
 	})
-	rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"services"})
-	c.Assert(err, check.IsNil)
-	c.Assert(rest, check.HasLen, 0)
-	c.Check(s.Stdout(), check.Equals, "")
-	c.Check(s.Stderr(), check.Equals, "There are no services provided by installed snaps.\n")
-	// ensure that the fake server api was actually hit
-	c.Check(n, check.Equals, 1)
+
+	tests := []string {"0", "1337"}
+	var testsRun int
+	for _, uid := range tests {
+		testsRun++
+		s.stdout.Reset()
+		s.stderr.Reset()
+		hasGlobal = uid == "0"
+		r := snap.MockUserCurrent(func() (*user.User, error) {
+			return &user.User{
+				Uid: uid,
+			}, nil
+		})
+
+		rest, err := snap.Parser(snap.Client()).ParseArgs([]string{"services"})
+		c.Assert(err, check.IsNil)
+		c.Assert(rest, check.HasLen, 0)
+		c.Check(s.Stdout(), check.Equals, "")
+		c.Check(s.Stderr(), check.Equals, "There are no services provided by installed snaps.\n")
+		// ensure that the fake server api was actually hit
+		c.Check(n, check.Equals, testsRun)
+
+		// restore the user mock
+		r()
+	}
 }
 
 func (s *appOpSuite) TestLogsCommand(c *check.C) {

--- a/cmd/snapd/cli/cmd_services_test.go
+++ b/cmd/snapd/cli/cmd_services_test.go
@@ -533,7 +533,7 @@ func (s *appOpSuite) TestAppStatusNoServices(c *check.C) {
 		n++
 	})
 
-	tests := []string {"0", "1337"}
+	tests := []string{"0", "1337"}
 	var testsRun int
 	for _, uid := range tests {
 		testsRun++

--- a/cmd/snapd/cli/error.go
+++ b/cmd/snapd/cli/error.go
@@ -34,7 +34,6 @@ import (
 	"github.com/snapcore/snapd/i18n"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
-	"github.com/snapcore/snapd/osutil/user"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/channel"
 	"github.com/snapcore/snapd/strutil"
@@ -250,7 +249,7 @@ If you understand and want to proceed repeat the command including --classic.
 		msg = i18n.G(`snap %q is not compatible with --classic`)
 	case client.ErrorKindLoginRequired:
 		usesSnapName = false
-		u, _ := user.Current()
+		u, _ := userCurrent()
 		if u != nil && u.Username == "root" {
 			// TRANSLATORS: %s is an error message (e.g. “cannot yadda yadda: permission denied”)
 			msg = fmt.Sprintf(i18n.G(`%s (see 'snap help login')`), err.Message)

--- a/cmd/snapd/cli/main_test.go
+++ b/cmd/snapd/cli/main_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/kcmdline"
+	"github.com/snapcore/snapd/osutil/user"
 	"github.com/snapcore/snapd/snapdenv"
 	"github.com/snapcore/snapd/snapdtool"
 	"github.com/snapcore/snapd/testutil"
@@ -218,6 +219,11 @@ func (s *SnapSuite) TestErrorResult(c *C) {
 }
 
 func (s *SnapSuite) TestAccessDeniedHint(c *C) {
+	r := snap.MockUserCurrent(func() (*user.User, error) {
+		return &user.User{Username: "user"}, nil
+	})
+	defer r()
+
 	s.RedirectClientToTestServer(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, `{"type": "error", "result": {"message": "access denied", "kind": "login-required"}, "status-code": 401}`)
 	})

--- a/cmd/snapd/tool/snap-preseed/preseed_classic_test.go
+++ b/cmd/snapd/tool/snap-preseed/preseed_classic_test.go
@@ -200,6 +200,16 @@ func (s *startPreseedSuite) TestLabelWithoutHybrid(c *C) {
 }
 
 func (s *startPreseedSuite) TestReadInfoValidity(c *C) {
+	restore := snap_preseed.MockOsGetuid(func() int {
+		return 0
+	})
+	defer restore()
+
+	restorePreseed := snap_preseed.MockPreseedClassic(func(dir string) error {
+		return nil
+	})
+	defer restorePreseed()
+
 	var called bool
 	inf := &snap.Info{
 		BadInterfaces: make(map[string]string),
@@ -214,7 +224,7 @@ func (s *startPreseedSuite) TestReadInfoValidity(c *C) {
 
 	parser := testParser(c)
 	tmpDir := c.MkDir()
-	_ = snap_preseed.Run(parser, []string{tmpDir})
+	c.Assert(snap_preseed.Run(parser, []string{tmpDir}), IsNil)
 
 	// real sanitize method should be set after Run()
 	snap.SanitizePlugsSlots(inf)

--- a/desktop/portal/launcher_test.go
+++ b/desktop/portal/launcher_test.go
@@ -158,6 +158,9 @@ func (s *portalSuite) TestOpenMissingFile(c *C) {
 }
 
 func (s *portalSuite) TestOpenUnreadableFile(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
 	path := filepath.Join(c.MkDir(), "test.txt")
 	c.Assert(os.WriteFile(path, []byte("hello world"), 0644), IsNil)
 	c.Assert(os.Chmod(path, 0), IsNil)

--- a/desktop/portal/launcher_test.go
+++ b/desktop/portal/launcher_test.go
@@ -159,7 +159,7 @@ func (s *portalSuite) TestOpenMissingFile(c *C) {
 
 func (s *portalSuite) TestOpenUnreadableFile(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root can read files regardless of mode)")
 	}
 	path := filepath.Join(c.MkDir(), "test.txt")
 	c.Assert(os.WriteFile(path, []byte("hello world"), 0644), IsNil)

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -2081,13 +2081,17 @@ func (s *imageSuite) TestCannotCreateGadgetUnpackDir(c *C) {
 	fn := filepath.Join(c.MkDir(), "model.assertion")
 	err := os.WriteFile(fn, asserts.Encode(s.model), 0644)
 	c.Assert(err, IsNil)
+	prepareDir := filepath.Join(c.MkDir(), "no-where")
+	err = os.WriteFile(prepareDir, nil, 0644)
+	c.Assert(err, IsNil)
 
 	err = image.Prepare(&image.Options{
 		ModelFile:  fn,
 		Channel:    "stable",
-		PrepareDir: "/no-where",
+		PrepareDir: prepareDir,
 	})
-	c.Assert(err, ErrorMatches, `cannot create unpack dir "/no-where/gadget": mkdir .*`)
+	gadgetUnpackDir := filepath.Join(prepareDir, "gadget")
+	c.Assert(err, ErrorMatches, fmt.Sprintf(`cannot create unpack dir %q: mkdir %s: not a directory`, gadgetUnpackDir, prepareDir))
 }
 
 func (s *imageSuite) TestNoLocalParallelSnapInstances(c *C) {

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -2808,7 +2808,7 @@ func (s *imageSuite) TestSetupSeedMissingContentProvider(c *C) {
 
 func (s *imageSuite) TestSetupSeedClassic(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root-owned files do not trigger the ownership warning)")
 	}
 	restore := image.MockTrusted(s.StoreSigning.Trusted)
 	defer restore()
@@ -3056,7 +3056,7 @@ func (s *imageSuite) TestSetupSeedClassicWithLocalClassicSnap(c *C) {
 
 func (s *imageSuite) TestSetupSeedClassicSnapdOnly(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root-owned files do not trigger the ownership warning)")
 	}
 	restore := image.MockTrusted(s.StoreSigning.Trusted)
 	defer restore()

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -2803,6 +2803,9 @@ func (s *imageSuite) TestSetupSeedMissingContentProvider(c *C) {
 }
 
 func (s *imageSuite) TestSetupSeedClassic(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
 	restore := image.MockTrusted(s.StoreSigning.Trusted)
 	defer restore()
 
@@ -3048,6 +3051,9 @@ func (s *imageSuite) TestSetupSeedClassicWithLocalClassicSnap(c *C) {
 }
 
 func (s *imageSuite) TestSetupSeedClassicSnapdOnly(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
 	restore := image.MockTrusted(s.StoreSigning.Trusted)
 	defer restore()
 

--- a/interfaces/builtin/polkit_test.go
+++ b/interfaces/builtin/polkit_test.go
@@ -417,7 +417,7 @@ plugs:
 
 func (s *polkitInterfaceSuite) TestSanitizePlugPolicyDirNotWritable(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root bypasses directory writability checks)")
 	}
 
 	_, plugInfo := mockPolkitPolicyConnectedPlug(c)
@@ -430,7 +430,7 @@ func (s *polkitInterfaceSuite) TestSanitizePlugPolicyDirNotWritable(c *C) {
 
 func (s *polkitInterfaceSuite) TestSanitizePlugRuleDirNotWritable(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root bypasses directory writability checks)")
 	}
 
 	_, plugInfo := mockPolkitRuleConnectedPlug(c, "hash")

--- a/interfaces/builtin/polkit_test.go
+++ b/interfaces/builtin/polkit_test.go
@@ -416,6 +416,10 @@ plugs:
 }
 
 func (s *polkitInterfaceSuite) TestSanitizePlugPolicyDirNotWritable(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
+
 	_, plugInfo := mockPolkitPolicyConnectedPlug(c)
 
 	// Actions directory is not writable.
@@ -425,6 +429,10 @@ func (s *polkitInterfaceSuite) TestSanitizePlugPolicyDirNotWritable(c *C) {
 }
 
 func (s *polkitInterfaceSuite) TestSanitizePlugRuleDirNotWritable(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
+
 	_, plugInfo := mockPolkitRuleConnectedPlug(c, "hash")
 
 	// Rules directory is not writable.
@@ -589,9 +597,11 @@ func (s *polkitInterfaceSuite) TestPolkitPoliciesSupported(c *C) {
 	c.Assert(os.Chmod(s.daemonPath1, 0o700), IsNil)
 	c.Assert(os.Chmod(s.daemonPath2, 0o700), IsNil)
 
-	// Actions directory is not writable so polkit policies are not supported.
-	c.Assert(os.Chmod(dirs.SnapPolkitPolicyDir, 0o500), IsNil)
-	c.Check(interfaces.StaticInfoOf(s.iface).ImplicitOnCore, Equals, false)
+	if os.Geteuid() != 0 {
+		// Actions directory is not writable so polkit policies are not supported.
+		c.Assert(os.Chmod(dirs.SnapPolkitPolicyDir, 0o500), IsNil)
+		c.Check(interfaces.StaticInfoOf(s.iface).ImplicitOnCore, Equals, false)
+	}
 
 	// Actions directory is writable so polkit policies are supported.
 	c.Assert(os.Chmod(dirs.SnapPolkitPolicyDir, 0o700), IsNil)
@@ -623,9 +633,11 @@ func (s *polkitInterfaceSuite) TestPolkitRulesSupported(c *C) {
 	c.Assert(os.Chmod(s.daemonPath1, 0o700), IsNil)
 	c.Assert(os.Chmod(s.daemonPath2, 0o700), IsNil)
 
-	// Rules directory is not writable so polkit rules are not supported.
-	c.Assert(os.Chmod(dirs.SnapPolkitRuleDir, 0o500), IsNil)
-	c.Check(interfaces.StaticInfoOf(s.iface).ImplicitOnCore, Equals, false)
+	if os.Geteuid() != 0 {
+		// Rules directory is not writable so polkit rules are not supported.
+		c.Assert(os.Chmod(dirs.SnapPolkitRuleDir, 0o500), IsNil)
+		c.Check(interfaces.StaticInfoOf(s.iface).ImplicitOnCore, Equals, false)
+	}
 
 	// Rules directory is writable so polkit rules are supported.
 	c.Assert(os.Chmod(dirs.SnapPolkitRuleDir, 0o700), IsNil)

--- a/interfaces/builtin/udisks2_test.go
+++ b/interfaces/builtin/udisks2_test.go
@@ -324,6 +324,9 @@ func (s *UDisks2InterfaceSuite) TestUDevSpecFileDoesNotExist(c *C) {
 }
 
 func (s *UDisks2InterfaceSuite) TestUDevSpecFileCannotOpen(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
 	producerDir := s.slotInfoWithUdevFile.Snap.MountDir()
 	c.Assert(os.WriteFile(filepath.Join(producerDir, "non-readable"), []byte(""), 0222), IsNil)
 	yaml := fmt.Sprintf(udisks2WithUdevFileProducerYamlTemplate, "non-readable")

--- a/interfaces/builtin/udisks2_test.go
+++ b/interfaces/builtin/udisks2_test.go
@@ -325,7 +325,7 @@ func (s *UDisks2InterfaceSuite) TestUDevSpecFileDoesNotExist(c *C) {
 
 func (s *UDisks2InterfaceSuite) TestUDevSpecFileCannotOpen(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root can read files regardless of mode)")
 	}
 	producerDir := s.slotInfoWithUdevFile.Snap.MountDir()
 	c.Assert(os.WriteFile(filepath.Join(producerDir, "non-readable"), []byte(""), 0222), IsNil)

--- a/interfaces/prompting/requestrules/requestrules_test.go
+++ b/interfaces/prompting/requestrules/requestrules_test.go
@@ -314,7 +314,7 @@ func sortSliceParams(list []*noticeInfo) ([]*noticeInfo, func(i, j int) bool) {
 
 func (s *requestrulesSuite) TestLoadErrorOpen(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root can read files regardless of mode)")
 	}
 
 	dbPath := s.prepDBPath(c)
@@ -869,7 +869,7 @@ func (s *requestrulesSuite) TestCloseRepeatedly(c *C) {
 
 func (s *requestrulesSuite) TestCloseErrors(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root bypasses directory write permissions)")
 	}
 
 	rdb, err := requestrules.New(s.defaultNotifyRule)
@@ -1211,7 +1211,7 @@ func (s *requestrulesSuite) TestAddRuleRemoveRuleDuplicateVariants(c *C) {
 
 func (s *requestrulesSuite) TestAddRuleErrors(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root bypasses directory write permissions)")
 	}
 
 	rdb, err := requestrules.New(s.defaultNotifyRule)
@@ -2618,7 +2618,7 @@ func (s *requestrulesSuite) testRemoveRule(c *C, rdb *requestrules.RuleDB, rule 
 
 func (s *requestrulesSuite) TestRemoveRuleErrors(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root bypasses directory write permissions)")
 	}
 
 	rdb, err := requestrules.New(s.defaultNotifyRule)
@@ -2741,7 +2741,7 @@ func (s *requestrulesSuite) TestRemoveRulesForSnapInterface(c *C) {
 
 func (s *requestrulesSuite) TestRemoveRulesForSnapInterfaceErrors(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root bypasses directory write permissions)")
 	}
 
 	dbPath := filepath.Join(dirs.SnapInterfacesRequestsStateDir, "request-rules.json")
@@ -3080,7 +3080,7 @@ func (s *requestrulesSuite) TestPatchRule(c *C) {
 
 func (s *requestrulesSuite) TestPatchRuleErrors(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root bypasses directory write permissions)")
 	}
 
 	rdb, err := requestrules.New(s.defaultNotifyRule)

--- a/interfaces/prompting/requestrules/requestrules_test.go
+++ b/interfaces/prompting/requestrules/requestrules_test.go
@@ -313,6 +313,10 @@ func sortSliceParams(list []*noticeInfo) ([]*noticeInfo, func(i, j int) bool) {
 }
 
 func (s *requestrulesSuite) TestLoadErrorOpen(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
+
 	dbPath := s.prepDBPath(c)
 	// Create unreadable DB file to cause open failure
 	f, err := os.Create(dbPath)
@@ -864,6 +868,10 @@ func (s *requestrulesSuite) TestCloseRepeatedly(c *C) {
 }
 
 func (s *requestrulesSuite) TestCloseErrors(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
+
 	rdb, err := requestrules.New(s.defaultNotifyRule)
 	c.Assert(err, IsNil)
 
@@ -1202,6 +1210,10 @@ func (s *requestrulesSuite) TestAddRuleRemoveRuleDuplicateVariants(c *C) {
 }
 
 func (s *requestrulesSuite) TestAddRuleErrors(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
+
 	rdb, err := requestrules.New(s.defaultNotifyRule)
 	c.Assert(err, IsNil)
 
@@ -2605,6 +2617,10 @@ func (s *requestrulesSuite) testRemoveRule(c *C, rdb *requestrules.RuleDB, rule 
 }
 
 func (s *requestrulesSuite) TestRemoveRuleErrors(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
+
 	rdb, err := requestrules.New(s.defaultNotifyRule)
 	c.Assert(err, IsNil)
 
@@ -2724,6 +2740,10 @@ func (s *requestrulesSuite) TestRemoveRulesForSnapInterface(c *C) {
 }
 
 func (s *requestrulesSuite) TestRemoveRulesForSnapInterfaceErrors(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
+
 	dbPath := filepath.Join(dirs.SnapInterfacesRequestsStateDir, "request-rules.json")
 
 	rdb, err := requestrules.New(s.defaultNotifyRule)
@@ -3059,6 +3079,10 @@ func (s *requestrulesSuite) TestPatchRule(c *C) {
 }
 
 func (s *requestrulesSuite) TestPatchRuleErrors(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
+
 	rdb, err := requestrules.New(s.defaultNotifyRule)
 	c.Assert(err, IsNil)
 

--- a/interfaces/seccomp/backend_test.go
+++ b/interfaces/seccomp/backend_test.go
@@ -1071,6 +1071,9 @@ func (s *backendSuite) TestParallelCompileError(c *C) {
 }
 
 func (s *backendSuite) TestParallelCompileRemovesFirst(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
 	err := os.MkdirAll(dirs.SnapSeccompDir, 0755)
 	c.Assert(err, IsNil)
 	err = os.WriteFile(filepath.Join(dirs.SnapSeccompDir, "profile-001.bin2"), nil, 0755)

--- a/interfaces/seccomp/backend_test.go
+++ b/interfaces/seccomp/backend_test.go
@@ -1072,7 +1072,7 @@ func (s *backendSuite) TestParallelCompileError(c *C) {
 
 func (s *backendSuite) TestParallelCompileRemovesFirst(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root can remove files from read-only directories)")
 	}
 	err := os.MkdirAll(dirs.SnapSeccompDir, 0755)
 	c.Assert(err, IsNil)

--- a/osutil/cp_test.go
+++ b/osutil/cp_test.go
@@ -344,7 +344,7 @@ func (s *cpSuite) TestAtomicWriteFileCopySymlinks(c *C) {
 
 func (s *cpSuite) TestAtomicWriteFileCopyErrReal(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root bypasses directory write permissions)")
 	}
 	err := osutil.AtomicWriteFileCopy(s.f2, filepath.Join(s.dir, "random-file"), 0)
 	c.Assert(err, ErrorMatches, "unable to open source file .*/random-file: open .* no such file or directory")

--- a/osutil/fshelpers_test.go
+++ b/osutil/fshelpers_test.go
@@ -35,7 +35,7 @@ var _ = Suite(&fshelpersSuite{})
 
 func (s *fshelpersSuite) TestSelfOwnedFile(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (files created by root are owned by root)")
 	}
 	name := filepath.Join(c.MkDir(), "testownedfile")
 	err := os.WriteFile(name, nil, 0644)

--- a/osutil/io_test.go
+++ b/osutil/io_test.go
@@ -76,7 +76,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFileOverwrite(c *C) {
 
 func (ts *AtomicWriteTestSuite) TestAtomicWriteFileSymlinkNoFollow(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root bypasses directory write permissions)")
 	}
 	tmpdir := c.MkDir()
 	rodir := filepath.Join(tmpdir, "ro")
@@ -112,7 +112,7 @@ func (ts *AtomicWriteTestSuite) TestAtomicWriteFileAsteriskInBasenameError(c *C)
 
 func (ts *AtomicWriteTestSuite) TestAtomicWriteFileTmpFileCreateError(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root bypasses directory write permissions)")
 	}
 	tmpdir := c.MkDir()
 
@@ -296,7 +296,7 @@ var _ = Suite(&AtomicSymlinkTestSuite{})
 
 func (ts *AtomicSymlinkTestSuite) TestAtomicSymlink(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root bypasses directory write permissions)")
 	}
 	mustReadSymlink := func(p, exp string) {
 		target, err := os.Readlink(p)
@@ -391,7 +391,7 @@ var _ = Suite(&AtomicLinkTestSuite{})
 
 func (ts *AtomicLinkTestSuite) TestAtomicLink(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root bypasses directory write permissions)")
 	}
 	mustReadLink := func(target, link string) {
 		match, err := osutil.ComparePathsByDeviceInode(target, link)
@@ -485,7 +485,7 @@ var _ = Suite(&AtomicRenameTestSuite{})
 
 func (ts *AtomicRenameTestSuite) TestAtomicRenameFile(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root bypasses directory write permissions)")
 	}
 	d := c.MkDir()
 

--- a/osutil/mountinfo_linux_test.go
+++ b/osutil/mountinfo_linux_test.go
@@ -239,7 +239,7 @@ func (s *mountinfoSuite) TestLoadMountInfo2(c *C) {
 // Test that trying to load mountinfo without permissions reports an error.
 func (s *mountinfoSuite) TestLoadMountInfo3(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root can read files regardless of mode)")
 	}
 	fname := filepath.Join(c.MkDir(), "mountinfo")
 	err := os.WriteFile(fname, []byte(mountInfoSample), 0644)

--- a/osutil/stat_test.go
+++ b/osutil/stat_test.go
@@ -148,7 +148,7 @@ func makeTestPathInDir(c *C, dir, path string, mode os.FileMode) string {
 
 func (ts *StatTestSuite) TestIsWritableDir(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root bypasses file permission checks)")
 	}
 	for _, t := range []struct {
 		path       string
@@ -199,7 +199,7 @@ func (ts *StatTestSuite) TestIsDirNotExist(c *C) {
 
 func (ts *StatTestSuite) TestDirExists(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root bypasses directory traversal permissions)")
 	}
 	for _, t := range []struct {
 		make   string

--- a/osutil/syncdir_test.go
+++ b/osutil/syncdir_test.go
@@ -224,7 +224,7 @@ func (s *EnsureDirStateSuite) TestReportsAbnormalPatterns(c *C) {
 
 func (s *EnsureDirStateSuite) TestRemovesAllManagedFilesOnError(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root can read directories regardless of mode)")
 	}
 	// Create a "prior.snap" file
 	prior := filepath.Join(s.dir, "prior.snap")

--- a/overlord/configstate/configcore/motd_test.go
+++ b/overlord/configstate/configcore/motd_test.go
@@ -213,7 +213,7 @@ func (s *motdSuite) TestHandleMotdConfigurationSetWritableFileDoesNotExist(c *C)
 
 func (s *motdSuite) TestHandleMotdConfigurationSetMkdirAllError(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root bypasses directory write permissions)")
 	}
 
 	// Mock os.MkdirAll(/etc/motd.d) to return an error
@@ -231,7 +231,7 @@ func (s *motdSuite) TestHandleMotdConfigurationSetMkdirAllError(c *C) {
 
 func (s *motdSuite) TestHandleMotdConfigurationSetAtomicWriteFileError(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root bypasses directory write permissions)")
 	}
 
 	// First add the writable file
@@ -283,7 +283,7 @@ func (s *motdSuite) TestHandleMotdConfigurationUnsetWritableFileExists(c *C) {
 
 func (s *motdSuite) TestHandleMotdConfigurationUnsetWritableFileRemoveError(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root can remove files from read-only directories)")
 	}
 
 	// First add the writable file
@@ -330,7 +330,7 @@ func (s *motdSuite) TestHandleMotdConfigurationUnsetWritableFileDoesNotExist(c *
 
 func (s *motdSuite) TestHandleMotdConfigurationGetMotdFromSystemReadError(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root can read files regardless of mode)")
 	}
 
 	// Mock os.ReadFile(s.readonlyFilePath) to return an error
@@ -499,7 +499,7 @@ func (s *motdSuite) TestGetMotdFromSystemWritable(c *C) {
 
 func (s *motdSuite) TestGetMotdFromSystemReadError(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root can read files regardless of mode)")
 	}
 
 	s.state.Lock()

--- a/overlord/configstate/configcore/motd_test.go
+++ b/overlord/configstate/configcore/motd_test.go
@@ -212,6 +212,10 @@ func (s *motdSuite) TestHandleMotdConfigurationSetWritableFileDoesNotExist(c *C)
 }
 
 func (s *motdSuite) TestHandleMotdConfigurationSetMkdirAllError(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
+
 	// Mock os.MkdirAll(/etc/motd.d) to return an error
 	os.MkdirAll(filepath.Dir(s.writableDirPath), 0555)
 
@@ -226,6 +230,10 @@ func (s *motdSuite) TestHandleMotdConfigurationSetMkdirAllError(c *C) {
 }
 
 func (s *motdSuite) TestHandleMotdConfigurationSetAtomicWriteFileError(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
+
 	// First add the writable file
 	err := os.MkdirAll(s.writableDirPath, 0755)
 	c.Assert(err, IsNil)
@@ -274,6 +282,10 @@ func (s *motdSuite) TestHandleMotdConfigurationUnsetWritableFileExists(c *C) {
 }
 
 func (s *motdSuite) TestHandleMotdConfigurationUnsetWritableFileRemoveError(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
+
 	// First add the writable file
 	err := os.MkdirAll(s.writableDirPath, 0755)
 	c.Assert(err, IsNil)
@@ -317,6 +329,10 @@ func (s *motdSuite) TestHandleMotdConfigurationUnsetWritableFileDoesNotExist(c *
 }
 
 func (s *motdSuite) TestHandleMotdConfigurationGetMotdFromSystemReadError(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
+
 	// Mock os.ReadFile(s.readonlyFilePath) to return an error
 	os.Chmod(s.readonlyFilePath, 0000)
 	defer os.Chmod(s.readonlyFilePath, 0444)
@@ -482,6 +498,10 @@ func (s *motdSuite) TestGetMotdFromSystemWritable(c *C) {
 }
 
 func (s *motdSuite) TestGetMotdFromSystemReadError(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
+
 	s.state.Lock()
 	defer s.state.Unlock()
 

--- a/overlord/ifacestate/apparmorprompting/prompting_test.go
+++ b/overlord/ifacestate/apparmorprompting/prompting_test.go
@@ -120,7 +120,7 @@ func (s *apparmorpromptingSuite) TestNewErrorListener(c *C) {
 
 func (s *apparmorpromptingSuite) TestNewErrorPromptDB(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root bypasses directory write permissions)")
 	}
 
 	_, reqChan, restore := apparmorprompting.MockListener()
@@ -153,7 +153,7 @@ func checkListenerClosed(c *C, reqChan <-chan *prompting.Request) {
 
 func (s *apparmorpromptingSuite) TestNewErrorRuleDB(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root bypasses directory write permissions)")
 	}
 
 	_, reqChan, restore := apparmorprompting.MockListener()

--- a/overlord/ifacestate/apparmorprompting/prompting_test.go
+++ b/overlord/ifacestate/apparmorprompting/prompting_test.go
@@ -119,6 +119,10 @@ func (s *apparmorpromptingSuite) TestNewErrorListener(c *C) {
 }
 
 func (s *apparmorpromptingSuite) TestNewErrorPromptDB(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
+
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 
@@ -148,6 +152,10 @@ func checkListenerClosed(c *C, reqChan <-chan *prompting.Request) {
 }
 
 func (s *apparmorpromptingSuite) TestNewErrorRuleDB(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
+
 	_, reqChan, restore := apparmorprompting.MockListener()
 	defer restore()
 

--- a/overlord/snapshotstate/backend/backend_test.go
+++ b/overlord/snapshotstate/backend/backend_test.go
@@ -593,7 +593,7 @@ func (s *snapshotSuite) TestAddDirToZipTarFails(c *check.C) {
 	var buf bytes.Buffer
 	z := zip.NewWriter(&buf)
 	savingUserData := false
-	c.Assert(backend.AddSnapDirToZip(ctx, &client.Snapshot{Revision: rev}, z, "", "an/entry", s.root, savingUserData, nil), check.ErrorMatches, ".* context canceled")
+	c.Assert(backend.AddSnapDirToZip(ctx, &client.Snapshot{Revision: rev}, z, "root", "an/entry", s.root, savingUserData, nil), check.ErrorMatches, ".* context canceled")
 }
 
 func (s *snapshotSuite) TestAddDirToZip(c *check.C) {
@@ -610,7 +610,7 @@ func (s *snapshotSuite) TestAddDirToZip(c *check.C) {
 		Revision: rev,
 	}
 	savingUserData := false
-	c.Assert(backend.AddSnapDirToZip(context.Background(), snapshot, z, "", "an/entry", s.root, savingUserData, nil), check.IsNil)
+	c.Assert(backend.AddSnapDirToZip(context.Background(), snapshot, z, "root", "an/entry", s.root, savingUserData, nil), check.IsNil)
 	z.Close() // write out the central directory
 
 	c.Check(snapshot.SHA3_384, check.HasLen, 1)
@@ -1103,6 +1103,10 @@ func (s *snapshotSuite) TestImportCheckError(c *check.C) {
 }
 
 func (s *snapshotSuite) TestImportDuplicated(c *check.C) {
+	if os.Geteuid() == 0 {
+		c.Skip("this test cannot run as root (runuser will fail)")
+	}
+
 	err := os.MkdirAll(dirs.SnapshotsDir, 0755)
 	c.Assert(err, check.IsNil)
 
@@ -1132,6 +1136,10 @@ func (s *snapshotSuite) TestImportDuplicated(c *check.C) {
 }
 
 func (s *snapshotSuite) TestImportExportRoundtrip(c *check.C) {
+	if os.Geteuid() == 0 {
+		c.Skip("this test cannot run as root (runuser will fail)")
+	}
+
 	err := os.MkdirAll(dirs.SnapshotsDir, 0755)
 	c.Assert(err, check.IsNil)
 
@@ -1292,6 +1300,10 @@ func (s *snapshotSuite) TestEstimateSnapshotSizeNotDataDirs(c *check.C) {
 }
 
 func (s *snapshotSuite) TestExportTwice(c *check.C) {
+	if os.Geteuid() == 0 {
+		c.Skip("this test cannot run as root (runuser will fail)")
+	}
+
 	// use mocking done in snapshotSuite.SetUpTest
 	info := &snap.Info{
 		SideInfo: snap.SideInfo{
@@ -1659,6 +1671,10 @@ func (s *snapshotSuite) TestMultiErrorCycle(c *check.C) {
 }
 
 func (s *snapshotSuite) TestSnapshotExportContentHash(c *check.C) {
+	if os.Geteuid() == 0 {
+		c.Skip("this test cannot run as root (runuser will fail)")
+	}
+
 	ctx := context.TODO()
 	info := &snap.Info{
 		SideInfo: snap.SideInfo{

--- a/overlord/snapstate/backend/copydata_test.go
+++ b/overlord/snapstate/backend/copydata_test.go
@@ -213,6 +213,9 @@ func (s *copydataSuite) testCopyDataMulti(c *C, snapDir string, opts *dirs.SnapD
 }
 
 func (s *copydataSuite) TestCopyDataBails(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
 
 	v1 := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
 	c.Assert(s.be.CopySnapData(v1, nil, nil, progress.Null), IsNil)
@@ -558,6 +561,10 @@ func (s *copydataSuite) TestCopyDataCopyFailure(c *C) {
 }
 
 func (s *copydataSuite) TestCopyDataPartialFailure(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
+
 	v1 := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
 
 	s.populateData(c, snap.R(10))

--- a/overlord/snapstate/backend/copydata_test.go
+++ b/overlord/snapstate/backend/copydata_test.go
@@ -214,7 +214,7 @@ func (s *copydataSuite) testCopyDataMulti(c *C, snapDir string, opts *dirs.SnapD
 
 func (s *copydataSuite) TestCopyDataBails(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root bypasses directory write permissions)")
 	}
 
 	v1 := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})
@@ -562,7 +562,7 @@ func (s *copydataSuite) TestCopyDataCopyFailure(c *C) {
 
 func (s *copydataSuite) TestCopyDataPartialFailure(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root bypasses directory write permissions)")
 	}
 
 	v1 := snaptest.MockSnap(c, helloYaml1, &snap.SideInfo{Revision: snap.R(10)})

--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -708,14 +708,14 @@ func (s *linkCleanupSuite) testLinkCleanupDirOnFail(c *C, dir string) {
 
 func (s *linkCleanupSuite) TestLinkCleanupOnDesktopFail(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root bypasses directory write permissions)")
 	}
 	s.testLinkCleanupDirOnFail(c, dirs.SnapDesktopFilesDir)
 }
 
 func (s *linkCleanupSuite) TestLinkCleanupOnBinariesFail(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root bypasses directory write permissions)")
 	}
 	// this one is the trivial case _as the code stands today_,
 	// but nothing guarantees that ordering.
@@ -724,28 +724,28 @@ func (s *linkCleanupSuite) TestLinkCleanupOnBinariesFail(c *C) {
 
 func (s *linkCleanupSuite) TestLinkCleanupOnServicesFail(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root bypasses directory write permissions)")
 	}
 	s.testLinkCleanupDirOnFail(c, dirs.SnapServicesDir)
 }
 
 func (s *linkCleanupSuite) TestLinkCleanupOnMountDirFail(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root bypasses directory write permissions)")
 	}
 	s.testLinkCleanupDirOnFail(c, filepath.Dir(s.info.MountDir()))
 }
 
 func (s *linkCleanupSuite) TestLinkCleanupOnDBusSystemFail(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root bypasses directory write permissions)")
 	}
 	s.testLinkCleanupDirOnFail(c, dirs.SnapDBusSystemServicesDir)
 }
 
 func (s *linkCleanupSuite) TestLinkCleanupOnDBusSessionFail(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root bypasses directory write permissions)")
 	}
 	s.testLinkCleanupDirOnFail(c, dirs.SnapDBusSessionServicesDir)
 }
@@ -768,7 +768,7 @@ func (s *linkCleanupSuite) TestLinkCleanupOnSystemctlFail(c *C) {
 
 func (s *linkCleanupSuite) TestLinkCleansUpDataDirAndSymlinksOnSymlinkFail(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root bypasses directory write permissions)")
 	}
 
 	// validity check
@@ -851,7 +851,7 @@ func (s *linkCleanupSuite) testLinkCleanupFailedSnapdSnapOnCorePastWrappers(c *C
 
 func (s *linkCleanupSuite) TestLinkCleanupFailedSnapdSnapFirstInstallOnCore(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root bypasses directory write permissions)")
 	}
 
 	// test failure mode when snapd is first installed, its units were
@@ -864,7 +864,7 @@ func (s *linkCleanupSuite) TestLinkCleanupFailedSnapdSnapFirstInstallOnCore(c *C
 
 func (s *linkCleanupSuite) TestLinkCleanupFailedSnapdSnapNonFirstInstallOnCore(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root bypasses directory write permissions)")
 	}
 
 	// test failure mode when a new revision of snapd is installed, its was

--- a/overlord/snapstate/backend/link_test.go
+++ b/overlord/snapstate/backend/link_test.go
@@ -707,28 +707,46 @@ func (s *linkCleanupSuite) testLinkCleanupDirOnFail(c *C, dir string) {
 }
 
 func (s *linkCleanupSuite) TestLinkCleanupOnDesktopFail(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
 	s.testLinkCleanupDirOnFail(c, dirs.SnapDesktopFilesDir)
 }
 
 func (s *linkCleanupSuite) TestLinkCleanupOnBinariesFail(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
 	// this one is the trivial case _as the code stands today_,
 	// but nothing guarantees that ordering.
 	s.testLinkCleanupDirOnFail(c, dirs.SnapBinariesDir)
 }
 
 func (s *linkCleanupSuite) TestLinkCleanupOnServicesFail(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
 	s.testLinkCleanupDirOnFail(c, dirs.SnapServicesDir)
 }
 
 func (s *linkCleanupSuite) TestLinkCleanupOnMountDirFail(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
 	s.testLinkCleanupDirOnFail(c, filepath.Dir(s.info.MountDir()))
 }
 
 func (s *linkCleanupSuite) TestLinkCleanupOnDBusSystemFail(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
 	s.testLinkCleanupDirOnFail(c, dirs.SnapDBusSystemServicesDir)
 }
 
 func (s *linkCleanupSuite) TestLinkCleanupOnDBusSessionFail(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
 	s.testLinkCleanupDirOnFail(c, dirs.SnapDBusSessionServicesDir)
 }
 
@@ -749,6 +767,10 @@ func (s *linkCleanupSuite) TestLinkCleanupOnSystemctlFail(c *C) {
 }
 
 func (s *linkCleanupSuite) TestLinkCleansUpDataDirAndSymlinksOnSymlinkFail(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
+
 	// validity check
 	c.Assert(s.info.DataDir(), testutil.FileAbsent)
 
@@ -828,6 +850,10 @@ func (s *linkCleanupSuite) testLinkCleanupFailedSnapdSnapOnCorePastWrappers(c *C
 }
 
 func (s *linkCleanupSuite) TestLinkCleanupFailedSnapdSnapFirstInstallOnCore(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
+
 	// test failure mode when snapd is first installed, its units were
 	// correctly written and corresponding services were started, but
 	// current symlink failed
@@ -837,6 +863,10 @@ func (s *linkCleanupSuite) TestLinkCleanupFailedSnapdSnapFirstInstallOnCore(c *C
 }
 
 func (s *linkCleanupSuite) TestLinkCleanupFailedSnapdSnapNonFirstInstallOnCore(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
+
 	// test failure mode when a new revision of snapd is installed, its was
 	// units were correctly written and corresponding services were started,
 	// but current symlink failed

--- a/overlord/snapstate/backend/snapdata_test.go
+++ b/overlord/snapstate/backend/snapdata_test.go
@@ -309,7 +309,7 @@ func (s *snapdataSuite) TestRemoveSnapDataDirWithUnexpectedFiles(c *C) {
 
 func (s *snapdataSuite) TestRemoveSnapDataDirEnotemptyWithReadDirError(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root can read directories regardless of mode)")
 	}
 
 	baseDataDir := filepath.Join(dirs.GlobalRootDir, "home", "users", "snap", "hello")
@@ -328,7 +328,7 @@ func (s *snapdataSuite) TestRemoveSnapDataDirEnotemptyWithReadDirError(c *C) {
 
 func (s *snapdataSuite) TestRemoveSnapDataDirErrorNotEnotempty(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root can remove directories from read-only parents)")
 	}
 
 	parentDir := filepath.Join(dirs.GlobalRootDir, "home", "users", "snap")
@@ -346,7 +346,7 @@ func (s *snapdataSuite) TestRemoveSnapDataDirErrorNotEnotempty(c *C) {
 
 func (s *snapdataSuite) TestRemoveSnapDataDirCurrentSymlinkRemovalFails(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root can remove files from read-only directories)")
 	}
 
 	baseDataDir := filepath.Join(dirs.GlobalRootDir, "home", "users", "snap", "hello")

--- a/overlord/snapstate/backend/snapdata_test.go
+++ b/overlord/snapstate/backend/snapdata_test.go
@@ -308,6 +308,10 @@ func (s *snapdataSuite) TestRemoveSnapDataDirWithUnexpectedFiles(c *C) {
 }
 
 func (s *snapdataSuite) TestRemoveSnapDataDirEnotemptyWithReadDirError(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
+
 	baseDataDir := filepath.Join(dirs.GlobalRootDir, "home", "users", "snap", "hello")
 	c.Assert(os.MkdirAll(baseDataDir, 0755), IsNil)
 	// unexpected folder to make removal fail with ENOTEMPTY
@@ -323,6 +327,10 @@ func (s *snapdataSuite) TestRemoveSnapDataDirEnotemptyWithReadDirError(c *C) {
 }
 
 func (s *snapdataSuite) TestRemoveSnapDataDirErrorNotEnotempty(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
+
 	parentDir := filepath.Join(dirs.GlobalRootDir, "home", "users", "snap")
 	baseDataDir := filepath.Join(parentDir, "hello")
 	c.Assert(os.MkdirAll(baseDataDir, 0755), IsNil)
@@ -337,6 +345,10 @@ func (s *snapdataSuite) TestRemoveSnapDataDirErrorNotEnotempty(c *C) {
 }
 
 func (s *snapdataSuite) TestRemoveSnapDataDirCurrentSymlinkRemovalFails(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
+
 	baseDataDir := filepath.Join(dirs.GlobalRootDir, "home", "users", "snap", "hello")
 	c.Assert(os.MkdirAll(baseDataDir, 0755), IsNil)
 	// create the current symlink

--- a/overlord/snapstate/handlers_discard_test.go
+++ b/overlord/snapstate/handlers_discard_test.go
@@ -386,6 +386,10 @@ func (s *discardSnapSuite) TestDoDiscardSnapNoErrorIfSeqFileMissing(c *C) {
 }
 
 func (s *discardSnapSuite) TestDoDiscardSnapErrorOnSeqFileRemovalFailure(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
+
 	s.state.Lock()
 	snapst := &snapstate.SnapState{
 		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{

--- a/overlord/snapstate/handlers_discard_test.go
+++ b/overlord/snapstate/handlers_discard_test.go
@@ -387,7 +387,7 @@ func (s *discardSnapSuite) TestDoDiscardSnapNoErrorIfSeqFileMissing(c *C) {
 
 func (s *discardSnapSuite) TestDoDiscardSnapErrorOnSeqFileRemovalFailure(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root can remove files from read-only directories)")
 	}
 
 	s.state.Lock()

--- a/overlord/snapstate/handlers_error_test.go
+++ b/overlord/snapstate/handlers_error_test.go
@@ -136,6 +136,10 @@ func (s *killSnapAppsErrorSuite) TestDoKillSnapAppsErrorNoTaskSnapSetup(c *C) {
 }
 
 func (s *killSnapAppsErrorSuite) TestDoKillSnapAppsErrorSnapOpenLock(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
+
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -244,6 +248,10 @@ func (s *killSnapAppsErrorSuite) TestDoKillSnapAppsErrorKillReasonUnmarshal(c *C
 }
 
 func (s *killSnapAppsErrorSuite) TestDoKillSnapAppsErrorInhibitLockWithHint(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
+
 	s.state.Lock()
 	defer s.state.Unlock()
 

--- a/overlord/snapstate/handlers_error_test.go
+++ b/overlord/snapstate/handlers_error_test.go
@@ -137,7 +137,7 @@ func (s *killSnapAppsErrorSuite) TestDoKillSnapAppsErrorNoTaskSnapSetup(c *C) {
 
 func (s *killSnapAppsErrorSuite) TestDoKillSnapAppsErrorSnapOpenLock(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root bypasses directory write permissions)")
 	}
 
 	s.state.Lock()
@@ -249,7 +249,7 @@ func (s *killSnapAppsErrorSuite) TestDoKillSnapAppsErrorKillReasonUnmarshal(c *C
 
 func (s *killSnapAppsErrorSuite) TestDoKillSnapAppsErrorInhibitLockWithHint(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root bypasses directory write permissions)")
 	}
 
 	s.state.Lock()

--- a/sandbox/apparmor/process_test.go
+++ b/sandbox/apparmor/process_test.go
@@ -74,6 +74,10 @@ func (s *apparmorSuite) TestSnapAppFromPidNewKernelPath(c *C) {
 }
 
 func (s *apparmorSuite) TestSnapAppFromPid(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
+
 	// When no /proc/$pid/attr/current exists, assume unconfined
 	_, _, _, err := apparmor.SnapAppFromPid(42)
 	c.Check(err, ErrorMatches, `security label "unconfined" does not belong to a snap`)

--- a/sandbox/apparmor/process_test.go
+++ b/sandbox/apparmor/process_test.go
@@ -75,7 +75,7 @@ func (s *apparmorSuite) TestSnapAppFromPidNewKernelPath(c *C) {
 
 func (s *apparmorSuite) TestSnapAppFromPid(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root can read files regardless of mode)")
 	}
 
 	// When no /proc/$pid/attr/current exists, assume unconfined

--- a/sandbox/apparmor/profile_test.go
+++ b/sandbox/apparmor/profile_test.go
@@ -663,6 +663,10 @@ func (s *appArmorSuite) TestSetupSnapConfineGeneratedPolicyError2(c *C) {
 
 // Test behavior when EnsureDirState fails
 func (s *appArmorSuite) TestSetupSnapConfineGeneratedPolicyError3(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
+
 	dirs.SetRootDir(c.MkDir())
 	defer dirs.SetRootDir("")
 

--- a/sandbox/apparmor/profile_test.go
+++ b/sandbox/apparmor/profile_test.go
@@ -664,7 +664,7 @@ func (s *appArmorSuite) TestSetupSnapConfineGeneratedPolicyError2(c *C) {
 // Test behavior when EnsureDirState fails
 func (s *appArmorSuite) TestSetupSnapConfineGeneratedPolicyError3(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root can remove files from read-only directories)")
 	}
 
 	dirs.SetRootDir(c.MkDir())

--- a/sandbox/selinux/selinux_linux_test.go
+++ b/sandbox/selinux/selinux_linux_test.go
@@ -128,7 +128,7 @@ func (s *selinuxSuite) TestIsEnforcingFailGarbage(c *check.C) {
 
 func (s *selinuxSuite) TestIsEnforcingFailOther(c *check.C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root can read files regardless of mode)")
 	}
 
 	dir := c.MkDir()

--- a/sandbox/selinux/selinux_linux_test.go
+++ b/sandbox/selinux/selinux_linux_test.go
@@ -127,6 +127,10 @@ func (s *selinuxSuite) TestIsEnforcingFailGarbage(c *check.C) {
 }
 
 func (s *selinuxSuite) TestIsEnforcingFailOther(c *check.C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
+
 	dir := c.MkDir()
 	miLine := fmt.Sprintf("41 19 0:18 / %s rw,relatime shared:20 - selinuxfs selinuxfs rw\n", dir)
 	restore := osutil.MockMountInfo(miLine)

--- a/secboot/secboot_sb_test.go
+++ b/secboot/secboot_sb_test.go
@@ -4760,6 +4760,10 @@ func (s *secbootSuite) TestGetPrimaryKeyFallbackFile(c *C) {
 }
 
 func (s *secbootSuite) TestGetPrimaryKeyError(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
+
 	defer secboot.MockDisksDevlinks(func(node string) ([]string, error) {
 		switch node {
 		case "/dev/test/device1":

--- a/secboot/secboot_sb_test.go
+++ b/secboot/secboot_sb_test.go
@@ -4761,7 +4761,7 @@ func (s *secbootSuite) TestGetPrimaryKeyFallbackFile(c *C) {
 
 func (s *secbootSuite) TestGetPrimaryKeyError(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root can read files regardless of mode)")
 	}
 
 	defer secboot.MockDisksDevlinks(func(node string) ([]string, error) {

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -3068,7 +3068,7 @@ func (s *seed20Suite) TestLoadAutoImportAssertionGradeDangerousAutoImportAsserti
 
 func (s *seed20Suite) TestLoadAutoImportAssertionGradeDangerousAutoImportAssertionErrFilePerm(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root can read files regardless of mode)")
 	}
 
 	// dangerous grade, system user assertion with wrong file permissions

--- a/seed/seed20_test.go
+++ b/seed/seed20_test.go
@@ -3067,6 +3067,10 @@ func (s *seed20Suite) TestLoadAutoImportAssertionGradeDangerousAutoImportAsserti
 }
 
 func (s *seed20Suite) TestLoadAutoImportAssertionGradeDangerousAutoImportAssertionErrFilePerm(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
+
 	// dangerous grade, system user assertion with wrong file permissions
 	s.testLoadAutoImportAssertion(c, asserts.ModelDangerous, valid, 0222, s.commitTo, fmt.Errorf(".* permission denied"))
 }

--- a/syscheck/apparmor_lxd_test.go
+++ b/syscheck/apparmor_lxd_test.go
@@ -30,7 +30,7 @@ import (
 
 func (s *syscheckSuite) TestCheckApparmorUsable(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root can read files regardless of mode)")
 	}
 
 	epermProfilePath := filepath.Join(c.MkDir(), "profiles")

--- a/syscheck/apparmor_lxd_test.go
+++ b/syscheck/apparmor_lxd_test.go
@@ -29,6 +29,10 @@ import (
 )
 
 func (s *syscheckSuite) TestCheckApparmorUsable(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
+
 	epermProfilePath := filepath.Join(c.MkDir(), "profiles")
 	restore := syscheck.MockAppArmorProfilesPath(epermProfilePath)
 	defer restore()

--- a/testutil/exec_test.go
+++ b/testutil/exec_test.go
@@ -118,6 +118,10 @@ func (s *mockCommandSuite) TestMockNoShellchecksWhenNotAvailable(c *check.C) {
 }
 
 func (s *mockCommandSuite) TestMockCreateAbsPathDir(c *check.C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
+
 	// this is an absolute path
 	dir := c.MkDir()
 

--- a/testutil/exec_test.go
+++ b/testutil/exec_test.go
@@ -119,7 +119,7 @@ func (s *mockCommandSuite) TestMockNoShellchecksWhenNotAvailable(c *check.C) {
 
 func (s *mockCommandSuite) TestMockCreateAbsPathDir(c *check.C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root bypasses directory write permissions)")
 	}
 
 	// this is an absolute path

--- a/usersession/xdgopenproxy/userd_launcher_test.go
+++ b/usersession/xdgopenproxy/userd_launcher_test.go
@@ -121,7 +121,7 @@ func (s *userdSuite) TestOpenMissingFile(c *C) {
 
 func (s *userdSuite) TestOpenUnreadableFile(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root can read files regardless of mode)")
 	}
 	launcher := &xdgopenproxy.UserdLauncher{}
 

--- a/usersession/xdgopenproxy/userd_launcher_test.go
+++ b/usersession/xdgopenproxy/userd_launcher_test.go
@@ -120,6 +120,9 @@ func (s *userdSuite) TestOpenMissingFile(c *C) {
 }
 
 func (s *userdSuite) TestOpenUnreadableFile(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
 	launcher := &xdgopenproxy.UserdLauncher{}
 
 	path := filepath.Join(c.MkDir(), "test.txt")

--- a/wrappers/binaries_test.go
+++ b/wrappers/binaries_test.go
@@ -127,7 +127,7 @@ func (s *binariesTestSuite) prepareReadOnlyLegacyDir(c *C) {
 
 func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveReadOnlyLegacyDir(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root can remove files from read-only directories)")
 	}
 
 	s.prepareReadOnlyLegacyDir(c)
@@ -136,7 +136,7 @@ func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveReadOnlyLegacyDir(c *C) 
 
 func (s *binariesTestSuite) TestEnsureSnapBinariesAndRemoveReadOnlyLegacyDir(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root can remove files from read-only directories)")
 	}
 
 	s.prepareReadOnlyLegacyDir(c)

--- a/wrappers/binaries_test.go
+++ b/wrappers/binaries_test.go
@@ -126,11 +126,19 @@ func (s *binariesTestSuite) prepareReadOnlyLegacyDir(c *C) {
 }
 
 func (s *binariesTestSuite) TestAddSnapBinariesAndRemoveReadOnlyLegacyDir(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
+
 	s.prepareReadOnlyLegacyDir(c)
 	s.testAddSnapBinariesAndRemove(c, true, true)
 }
 
 func (s *binariesTestSuite) TestEnsureSnapBinariesAndRemoveReadOnlyLegacyDir(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
+
 	s.prepareReadOnlyLegacyDir(c)
 	s.testEnsureSnapBinariesAndRemove(c, true, true)
 }

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -1780,6 +1780,10 @@ TasksAccounting=true
 }
 
 func (s *servicesTestSuite) TestEnsureSnapServiceEnsureError(c *C) {
+	if os.Geteuid() == 0 {
+		c.Skip("cannot run test as root")
+	}
+
 	info := snaptest.MockSnap(c, packageHello, &snap.SideInfo{Revision: snap.R(12)})
 	svcFileDir := filepath.Join(dirs.GlobalRootDir, "/etc/systemd/system")
 

--- a/wrappers/services_test.go
+++ b/wrappers/services_test.go
@@ -1781,7 +1781,7 @@ TasksAccounting=true
 
 func (s *servicesTestSuite) TestEnsureSnapServiceEnsureError(c *C) {
 	if os.Geteuid() == 0 {
-		c.Skip("cannot run test as root")
+		c.Skip("this test cannot run as root (root bypasses directory write permissions)")
 	}
 
 	info := snaptest.MockSnap(c, packageHello, &snap.SideInfo{Revision: snap.R(12)})


### PR DESCRIPTION
Make sure all unit tests pass when run as root. In some cases, this means skipping tests when the EUID is 0, but in other cases, improved mocking resolves the issue and improves test quality along the way.

Inspired by #17458, let's just fix the issue so we can run snapd unit tests properly as root.

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-37334