### PR TITLE
tests: fix json error assertions for Go 1.27

### DIFF
--- a/daemon/api_prompting_test.go
+++ b/daemon/api_prompting_test.go
@@ -1302,7 +1302,7 @@ func (s *promptingSuite) TestPostPromptErrors(c *C) {
 	rspe = s.errorReq(c, req, nil, actionIsExpected)
 	c.Check(rspe.Status, Equals, 400)
 	c.Check(rspe.Kind, Equals, client.ErrorKind(""))
-	c.Check(rspe.Message, Matches, "cannot decode request body into prompt reply:.*cannot unmarshal number into Go struct field.*")
+	c.Check(rspe.Message, Matches, "cannot decode request body into prompt reply:.*cannot unmarshal number into.*")
 
 	// Invalid outcome (action) or lifespan
 	for _, testCase := range []struct {

--- a/interfaces/prompting/patterns/patterns_test.go
+++ b/interfaces/prompting/patterns/patterns_test.go
@@ -376,7 +376,7 @@ func (s *patternsSuite) TestPathPatternUnmarshalJSONUnhappy(c *C) {
 		},
 		{
 			[]byte{'"', 0x00, '"'},
-			`invalid character '\\x00' in string literal`,
+			`invalid character '\\x00' in string.*`,
 		},
 	} {
 		pathPattern := patterns.PathPattern{}

--- a/jsonutil/safejson/safejson_test.go
+++ b/jsonutil/safejson/safejson_test.go
@@ -86,11 +86,11 @@ func (escapeSuite) TestBadStrings(c *check.C) {
 
 	table := map[string][][]byte{
 		// these are from json itself (so we're not checking them):
-		"invalid character '.+' in string literal":     cc0,
-		"invalid character '.+' in string escape code": badesc,
-		`invalid character '.+' in \\u .*`:             {[]byte(`"\u02"`), []byte(`"\u02zz"`)},
-		"invalid character '\"' after top-level value": {[]byte(`"""`)},
-		"unexpected end of JSON input":                 {[]byte(`"\"`)},
+		"invalid character '.+' in string.*":                                                                cc0,
+		"(invalid character '.+' in string escape code|invalid escape sequence .+ in string)":               badesc,
+		`(invalid character '.+' in \\u hexadecimal character escape|invalid escape sequence .+ in string)`: {[]byte(`"\u02"`), []byte(`"\u02zz"`)},
+		"invalid character '\"' after top-level value":                                                      {[]byte(`"""`)},
+		"unexpected end of JSON input":                                                                      {[]byte(`"\"`)},
 	}
 
 	for e, js := range table {

--- a/overlord/devicestate/devicestate_test.go
+++ b/overlord/devicestate/devicestate_test.go
@@ -2075,7 +2075,7 @@ func (s *deviceMgrSuite) TestRunFDESetupHookErrorResult(c *C) {
 	st.Lock()
 	_, err := devicestate.DeviceManagerRunFDESetupHook(s.mgr, req)
 	st.Unlock()
-	c.Assert(err, ErrorMatches, `cannot get result from fde-setup hook "op": cannot unmarshal context value for "fde-setup-result": illegal base64 data at input byte 3`)
+	c.Assert(err, ErrorMatches, `cannot get result from fde-setup hook "op": cannot unmarshal context value for "fde-setup-result": .*illegal base64 data at input byte 3`)
 }
 
 type startOfOperationTimeSuite struct {

--- a/overlord/install/install_test.go
+++ b/overlord/install/install_test.go
@@ -1654,9 +1654,9 @@ func (s *installSuite) TestInstallCheckEncryptedFDEHook(c *C) {
 		{`{"features":["a"]}`, "", device.EncryptionTypeLUKS},
 		{`{"features":["a","b"]}`, "", device.EncryptionTypeLUKS},
 		// features must be list of strings
-		{`{"features":[1]}`, `cannot parse hook output ".*": json: cannot unmarshal number into Go struct.*`, device.EncryptionTypeNone},
-		{`{"features":1}`, `cannot parse hook output ".*": json: cannot unmarshal number into Go struct.*`, device.EncryptionTypeNone},
-		{`{"features":"1"}`, `cannot parse hook output ".*": json: cannot unmarshal string into Go struct.*`, device.EncryptionTypeNone},
+		{`{"features":[1]}`, `cannot parse hook output ".*": json: cannot unmarshal number into.*`, device.EncryptionTypeNone},
+		{`{"features":1}`, `cannot parse hook output ".*": json: cannot unmarshal number into.*`, device.EncryptionTypeNone},
+		{`{"features":"1"}`, `cannot parse hook output ".*": json: cannot unmarshal string into.*`, device.EncryptionTypeNone},
 		// valid and uses ice
 		{`{"features":["a","inline-crypto-engine","b"]}`, "", device.EncryptionTypeLUKSWithICE},
 	} {

--- a/usersession/client/client_test.go
+++ b/usersession/client/client_test.go
@@ -665,7 +665,7 @@ func (s *clientSuite) TestServiceStatusWrongResultType(c *C) {
 	})
 	_, failures, err := s.cli.ServiceStatus(context.Background(), []string{"snap.foo.service"})
 	c.Check(failures, DeepEquals, map[int][]client.ServiceFailure{})
-	c.Check(err, ErrorMatches, `json: cannot unmarshal string into Go value of type client.ServiceUnitStatus`)
+	c.Check(err, ErrorMatches, `json: cannot unmarshal string into .* of type client.ServiceUnitStatus`)
 }
 
 func (s *clientSuite) TestServiceStatusFailure(c *C) {


### PR DESCRIPTION
## Summary

Go 1.27's `encoding/json` changed several error message formats, which breaks 6 test assertions:

| old (<=1.26) | new (1.27) |
|---|---|
| `cannot unmarshal number into Go struct field T.x of type int` | `cannot unmarshal number into .x of type int` |
| `invalid character 'q' in string escape code` | ``invalid escape sequence `\q` in string`` |
| `invalid character 'z' in \u hexadecimal character escape` | ``invalid escape sequence `\u02zz` in string`` |
| `invalid character '\x00' in string literal` | `invalid character '\x00' in string` |
| `json: cannot unmarshal string into Go value of type T` | `json: cannot unmarshal string into . of type T` |
| `illegal base64 data at input byte 3` | wrapped with a prefix (`.*illegal base64 data at input byte 3`) |

## What this PR does

Relaxes the assertions in 6 test files so they match **both** the Go 1.26 and Go 1.27 message formats (substring/alternation patterns instead of exact old strings). No production code changes.

## Verification

- Exact error strings compared against `go1.26.5` and `go1.27rc3` (official tarballs) — every relaxed pattern was regex-checked to full-match both variants.
- All affected snapd test packages build and pass under go1.27rc3 (verified via a full package build/test cycle against the 1.27 toolchain).

Context: found while test-rebuilding Ubuntu's golang-defaults reverse-dependencies against Go 1.27 ahead of the archive transition (go1.27 regression sweep).