### PR TITLE
tests: fix stale debian symlink in spread setup

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -241,7 +241,7 @@ parts:
       - xz-utils
     override-pull: |
       craftctl default
-      ln -sf packaging/ubuntu-16.04 debian
+      ln -sfn packaging/ubuntu-16.04 debian
       # set version, this needs dpkg-parsechangelog (from dpkg-dev) and git
       VERSION="$(./mkversion.sh --output-only)"
 

--- a/spread.yaml
+++ b/spread.yaml
@@ -2098,7 +2098,7 @@ suites:
             SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
             case "$SNAP_MOUNT_DIR" in
                 /var/lib/snapd/snap)
-                    ln -sf "$SNAP_MOUNT_DIR" /snap
+                    ln -sfn "$SNAP_MOUNT_DIR" /snap
                     tests.cleanup defer rm -f /snap
                     ;;
             esac

--- a/tests/lib/prepare-restore.sh
+++ b/tests/lib/prepare-restore.sh
@@ -376,22 +376,24 @@ prepare_project() {
         fi
     fi
 
-    # set up debian symlink as needed
+    # set up debian symlink as needed. Use "ln -sfn" so that an existing symlink
+    # is replaced rather than dereferenced, which would create a nested symlink
+    # inside it and leave the stale packaging in place.
     if os.query is-trusty; then
         # no packaging setup for 14.04, we're no longer building the packages in
         # CI
         :
     elif os.query is-ubuntu-ge 26.04; then
-        ln -sf packaging/ubuntu-26.04 debian
+        ln -sfn packaging/ubuntu-26.04 debian
     elif os.query is-ubuntu; then
         # TODO generate packaging appropriate for a given ubuntu release
-        ln -sf packaging/ubuntu-16.04 debian
+        ln -sfn packaging/ubuntu-16.04 debian
     elif os.query is-debian sid ; then
         # debian sid has special packaging
-        ln -sf packaging/debian-sid debian
+        ln -sfn packaging/debian-sid debian
     elif os.query is-debian; then
         # TODO debian reuses ubuntu 16.04 packaging
-        ln -sf packaging/ubuntu-16.04 debian
+        ln -sfn packaging/ubuntu-16.04 debian
     fi
 
     if os.query is-trusty; then

--- a/tests/main/classic-confinement-perms/task.yaml
+++ b/tests/main/classic-confinement-perms/task.yaml
@@ -15,7 +15,7 @@ prepare: |
     SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
     if [ "$SNAP_MOUNT_DIR" = "/var/lib/snapd/snap" ] && [ ! -L /snap ]; then
         # set up classic execution support
-        ln -sf "$SNAP_MOUNT_DIR" /snap
+        ln -sfn "$SNAP_MOUNT_DIR" /snap
         tests.cleanup defer rm -f /snap
     fi
     # owned by root

--- a/tests/main/classic-confinement/task.yaml
+++ b/tests/main/classic-confinement/task.yaml
@@ -17,7 +17,7 @@ prepare: |
     SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
     if [ "$SNAP_MOUNT_DIR" = "/var/lib/snapd/snap" ] && [ ! -L /snap ]; then
         # set up classic execution support
-        ln -sf "$SNAP_MOUNT_DIR" /snap
+        ln -sfn "$SNAP_MOUNT_DIR" /snap
         tests.cleanup defer rm -f /snap
     fi
 

--- a/tests/main/command-chain/task.yaml
+++ b/tests/main/command-chain/task.yaml
@@ -28,7 +28,7 @@ prepare: |
     if [ "$SNAP_REEXEC" = "1" ] && [ "$SNAP_MOUNT_DIR" != "/snap" ] && [ ! -L /snap ]; then
         # reexec expects to find the snapd snap under /snap, enable it to do so
         # on distros using /var/lib/snapd/snap
-        ln -sf "$SNAP_MOUNT_DIR" /snap
+        ln -sfn "$SNAP_MOUNT_DIR" /snap
         tests.cleanup defer rm -f /snap
     fi
 

--- a/tests/main/confinement-classic/task.yaml
+++ b/tests/main/confinement-classic/task.yaml
@@ -12,7 +12,7 @@ prepare: |
     SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
     if [ "$SNAP_MOUNT_DIR" = "/var/lib/snapd/snap" ] && [ ! -L /snap ]; then
         # set up classic execution support
-        ln -sf "$SNAP_MOUNT_DIR" /snap
+        ln -sfn "$SNAP_MOUNT_DIR" /snap
         tests.cleanup defer rm -f /snap
     fi
 

--- a/tests/main/install-sideload/task.yaml
+++ b/tests/main/install-sideload/task.yaml
@@ -26,7 +26,7 @@ prepare: |
     if [ "$SNAP_REEXEC" = "1" ] && [ "$SNAP_MOUNT_DIR" != "/snap" ] && [ ! -L /snap ]; then
         # reexec expects to find the snapd snap under /snap, enable it to do so
         # on distros using /var/lib/snapd/snap
-        ln -sf "$SNAP_MOUNT_DIR" /snap
+        ln -sfn "$SNAP_MOUNT_DIR" /snap
         tests.cleanup defer rm -f /snap
     fi
 

--- a/tests/main/interfaces-classic-content-slot/task.yaml
+++ b/tests/main/interfaces-classic-content-slot/task.yaml
@@ -20,7 +20,7 @@ prepare: |
     SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
     if [ "$SNAP_MOUNT_DIR" = "/var/lib/snapd/snap" ] && [ ! -L /snap ]; then
         # set up classic execution support
-        ln -sf "$SNAP_MOUNT_DIR" /snap
+        ln -sfn "$SNAP_MOUNT_DIR" /snap
         tests.cleanup defer rm -f /snap
     fi
 

--- a/tests/main/multi-entry/task.yaml
+++ b/tests/main/multi-entry/task.yaml
@@ -40,7 +40,7 @@ prepare: |
 
     if [ "$SNAP_MOUNT_DIR" = "/var/lib/snapd/snap" ] && [ ! -L /snap ]; then
         # set up classic execution support
-        ln -sf "$SNAP_MOUNT_DIR" /snap
+        ln -sfn "$SNAP_MOUNT_DIR" /snap
         tests.cleanup defer rm -f /snap
     fi
 

--- a/tests/main/parallel-install-classic/task.yaml
+++ b/tests/main/parallel-install-classic/task.yaml
@@ -35,7 +35,7 @@ prepare: |
     SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
     if [ "$SNAP_MOUNT_DIR" = "/var/lib/snapd/snap" ] && [ ! -L /snap ]; then
         # set up classic execution support
-        ln -sf "$SNAP_MOUNT_DIR" /snap
+        ln -sfn "$SNAP_MOUNT_DIR" /snap
         tests.cleanup defer rm -f /snap
     fi
 

--- a/tests/main/parallel-install-remove-after/task.yaml
+++ b/tests/main/parallel-install-remove-after/task.yaml
@@ -9,7 +9,7 @@ prepare: |
     SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
     if [ "$SNAP_MOUNT_DIR" = "/var/lib/snapd/snap" ] && [ ! -L /snap ]; then
         # set up classic execution support
-        ln -sf "$SNAP_MOUNT_DIR" /snap
+        ln -sfn "$SNAP_MOUNT_DIR" /snap
         tests.cleanup defer rm -f /snap
     fi
 

--- a/tests/main/refresh-classic/task.yaml
+++ b/tests/main/refresh-classic/task.yaml
@@ -11,7 +11,7 @@ prepare: |
     SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
     if [ "$SNAP_MOUNT_DIR" = "/var/lib/snapd/snap" ] && [ ! -L /snap ]; then
         # set up classic execution support
-        ln -sf "$SNAP_MOUNT_DIR" /snap
+        ln -sfn "$SNAP_MOUNT_DIR" /snap
         tests.cleanup defer rm -f /snap
     fi
 

--- a/tests/main/security-device-cgroups-classic/task.yaml
+++ b/tests/main/security-device-cgroups-classic/task.yaml
@@ -19,7 +19,7 @@ prepare: |
     SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
     if [ "$SNAP_MOUNT_DIR" = "/var/lib/snapd/snap" ] && [ ! -L /snap ]; then
         # set up classic execution support
-        ln -sf "$SNAP_MOUNT_DIR" /snap
+        ln -sfn "$SNAP_MOUNT_DIR" /snap
         tests.cleanup defer rm -f /snap
     fi
 

--- a/tests/main/security-group-policy/task.yaml
+++ b/tests/main/security-group-policy/task.yaml
@@ -33,7 +33,7 @@ prepare: |
     SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
     if [ "$SNAP_MOUNT_DIR" = "/var/lib/snapd/snap" ] && [ ! -L /snap ]; then
         # set up classic execution support
-        ln -sf "$SNAP_MOUNT_DIR" /snap
+        ln -sfn "$SNAP_MOUNT_DIR" /snap
         tests.cleanup defer rm -f /snap
     fi
 

--- a/tests/main/selinux-classic-confinement/task.yaml
+++ b/tests/main/selinux-classic-confinement/task.yaml
@@ -22,7 +22,7 @@ prepare: |
     SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
     if [ "$SNAP_MOUNT_DIR" = "/var/lib/snapd/snap" ] && [ ! -L /snap ]; then
         # set up classic execution support
-        ln -sf "$SNAP_MOUNT_DIR" /snap
+        ln -sfn "$SNAP_MOUNT_DIR" /snap
         tests.cleanup defer rm -f /snap
     fi
 

--- a/tests/main/services-socket-activation/task.yaml
+++ b/tests/main/services-socket-activation/task.yaml
@@ -21,7 +21,7 @@ prepare: |
                 # although classic snaps do not work out of the box on fedora,
                 # we still want to verify if the basics do work if the user
                 # symlinks /snap to $SNAP_MOUNT_DIR themselves
-                ln -sf "$SNAP_MOUNT_DIR" /snap
+                ln -sfn "$SNAP_MOUNT_DIR" /snap
                 tests.cleanup defer rm -f /snap
             fi
             "$TESTSTOOLS"/snaps-state install-local socket-activation-classic --classic

--- a/tests/main/snap-routine-file-access/task.yaml
+++ b/tests/main/snap-routine-file-access/task.yaml
@@ -32,7 +32,7 @@ prepare: |
     SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
     if [ "$SNAP_MOUNT_DIR" = "/var/lib/snapd/snap" ] && [ ! -L /snap ]; then
         # set up classic execution support
-        ln -sf "$SNAP_MOUNT_DIR" /snap
+        ln -sfn "$SNAP_MOUNT_DIR" /snap
         tests.cleanup defer rm -f /snap
     fi
 

--- a/tests/main/snap-run-hook/task.yaml
+++ b/tests/main/snap-run-hook/task.yaml
@@ -22,7 +22,7 @@ prepare: |
     if [ "$SNAP_REEXEC" = "1" ] && [ "$SNAP_MOUNT_DIR" != "/snap" ] && [ ! -L /snap ]; then
         # reexec expects to find the snapd snap under /snap, enable it to do so
         # on distros using /var/lib/snapd/snap
-        ln -sf "$SNAP_MOUNT_DIR" /snap
+        ln -sfn "$SNAP_MOUNT_DIR" /snap
         tests.cleanup defer rm -f /snap
     fi
 

--- a/tests/main/snapd-snap/task.yaml
+++ b/tests/main/snapd-snap/task.yaml
@@ -56,7 +56,7 @@ prepare: |
     SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
     if [ "$SNAP_MOUNT_DIR" = "/var/lib/snapd/snap" ] && [ ! -L /snap ]; then
         # set up classic execution support
-        ln -sf "$SNAP_MOUNT_DIR" /snap
+        ln -sfn "$SNAP_MOUNT_DIR" /snap
         tests.cleanup defer rm -f /snap
     fi
 

--- a/tests/main/writable-areas/task.yaml
+++ b/tests/main/writable-areas/task.yaml
@@ -23,7 +23,7 @@ prepare: |
     if [ "$SNAP_REEXEC" = "1" ] && [ "$SNAP_MOUNT_DIR" != "/snap" ] && [ ! -L /snap ]; then
         # reexec expects to find the snapd snap under /snap, enable it to do so
         # on distros using /var/lib/snapd/snap
-        ln -sf "$SNAP_MOUNT_DIR" /snap
+        ln -sfn "$SNAP_MOUNT_DIR" /snap
         tests.cleanup defer rm -f /snap
     fi
 

--- a/tests/regression/lp-1910456/task.yaml
+++ b/tests/regression/lp-1910456/task.yaml
@@ -31,7 +31,7 @@ prepare: |
         SNAP_MOUNT_DIR="$(os.paths snap-mount-dir)"
         if [ "$SNAP_MOUNT_DIR" = "/var/lib/snapd/snap" ] && [ ! -L /snap ]; then
             # set up classic execution support
-            ln -sf "$SNAP_MOUNT_DIR" /snap
+            ln -sfn "$SNAP_MOUNT_DIR" /snap
             tests.cleanup defer rm -f /snap
         fi
 


### PR DESCRIPTION
The debian symlink was setup with the force flag to overwrite any stale packaging. However, it was missing a `-n` flag to prevent dereferencing the existing target, so it would dereference debian/ (instead of removing it) and then create a new packaging link inside it. As a consequence, the deb was created with the wrong packaging script. In the nsswitch spike this meant building a deb with a missing dependency and proxy.
```
$ ls -l $PROJECT_PATH/debian
lrwxrwxrwx 1 test test 22 Feb 18 11:17 /home/gopath/src/github.com/snapcore/snapd/debian -> packaging/ubuntu-16.04
$ ls -l $PROJECT_PATH/debian/ubuntu-26.04
lrwxrwxrwx 1 test test 22 Aug 18 10:41 /home/gopath/src/github.com/snapcore/snapd/debian/ubuntu-26.04 -> packaging/ubuntu-26.04
```
