### PR TITLE
secboot: allow sealing with hooks with multiple models

### DIFF
--- a/overlord/fdestate/backend/seal.go
+++ b/overlord/fdestate/backend/seal.go
@@ -47,7 +47,7 @@ type InitialFDEState interface {
 	UpdatePCRHandle(role string, pcrHandle uint32) error
 }
 
-func runKeySealRequests(key secboot.BootstrappedContainer, useTokens bool) []secboot.SealKeyRequest {
+func runKeySealRequests(key secboot.BootstrappedContainer, useTokens bool, models []secboot.ModelForSealing) []secboot.SealKeyRequest {
 	var keyFile string
 	if !useTokens {
 		keyFile = device.DataSealedKeyUnder(boot.InitramfsBootEncryptionKeyDir)
@@ -59,11 +59,12 @@ func runKeySealRequests(key secboot.BootstrappedContainer, useTokens bool) []sec
 			SlotName:              "default",
 			KeyFile:               keyFile,
 			BootModes:             []string{"run", "recover"},
+			Models:                models,
 		},
 	}
 }
 
-func fallbackKeySealRequests(key, saveKey secboot.BootstrappedContainer, factoryResetKeyPath bool, useTokens bool) []secboot.SealKeyRequest {
+func fallbackKeySealRequests(key, saveKey secboot.BootstrappedContainer, factoryResetKeyPath bool, useTokens bool, models []secboot.ModelForSealing) []secboot.SealKeyRequest {
 	var dataFallbackKey, saveFallbackKey string
 	if !useTokens {
 		dataFallbackKey = device.FallbackDataSealedKeyUnder(boot.InitramfsSeedEncryptionKeyDir)
@@ -85,6 +86,7 @@ func fallbackKeySealRequests(key, saveKey secboot.BootstrappedContainer, factory
 			SlotName:              "default-fallback",
 			KeyFile:               dataFallbackKey,
 			BootModes:             []string{"recover"},
+			Models:                models,
 		},
 		{
 			BootstrappedContainer: saveKey,
@@ -92,6 +94,7 @@ func fallbackKeySealRequests(key, saveKey secboot.BootstrappedContainer, factory
 			SlotName:              "default-fallback",
 			KeyFile:               saveFallbackKey,
 			BootModes:             []string{"recover", "factory-reset"},
+			Models:                models,
 		},
 	}
 }
@@ -144,7 +147,7 @@ func sealRunObjectKeys(
 	// path only unseals one object because unsealing is expensive.
 	// Furthermore, the run object key is stored on ubuntu-boot so that we do not
 	// need to continually write/read keys from ubuntu-seed.
-	primaryKey, pcrProfile, err := secbootSealKeys(runKeySealRequests(key, useTokens), sealKeyParams)
+	primaryKey, pcrProfile, err := secbootSealKeys(runKeySealRequests(key, useTokens, nil), sealKeyParams)
 	if err != nil {
 		return nil, fmt.Errorf("cannot seal the encryption keys: %v", err)
 	}
@@ -204,7 +207,7 @@ func sealFallbackObjectKeys(
 	// The fallback object contains the ubuntu-data and ubuntu-save keys. The
 	// key files are stored on ubuntu-seed, separate from ubuntu-data so they
 	// can be used if ubuntu-data and ubuntu-boot are corrupted or unavailable.
-	_, pcrProfile, err := secbootSealKeys(fallbackKeySealRequests(key, saveKey, factoryResetKeyPath, useTokens), sealKeyParams)
+	_, pcrProfile, err := secbootSealKeys(fallbackKeySealRequests(key, saveKey, factoryResetKeyPath, useTokens, nil), sealKeyParams)
 	if err != nil {
 		return fmt.Errorf("cannot seal the fallback encryption keys: %v", err)
 	}
@@ -241,16 +244,24 @@ func sealKeyForBootChainsHook(method device.SealingMethod, key, saveKey secboot.
 		sealingParams.AuxKeyFile = filepath.Join(boot.InstallHostFDESaveDir, "aux-key")
 	}
 
-	var models []secboot.ModelForSealing
+	var runModels []secboot.ModelForSealing
+	var runRecoverModels []secboot.ModelForSealing
+	var recoverModels []secboot.ModelForSealing
+
 	for _, runChain := range params.RunModeBootChains {
-		sealingParams.Model = runChain.ModelForSealing()
-		models = append(models, runChain.ModelForSealing())
-		// We assume that factory-reset/installation/reprovision always reseal with one unique model.
-		// FIMXE: for reprovision, we might need to actually clean up the modeenv.
-		break
+		runModels = append(runModels, runChain.ModelForSealing())
+		runRecoverModels = append(runRecoverModels, runChain.ModelForSealing())
 	}
 
-	skrs := append(runKeySealRequests(key, params.UseTokens), fallbackKeySealRequests(key, saveKey, params.LegacyFactoryResetKeyPath, params.UseTokens)...)
+	for _, runRecoverChain := range params.RecoveryBootChainsForRunKey {
+		runRecoverModels = append(runRecoverModels, runRecoverChain.ModelForSealing())
+	}
+
+	for _, recoverChain := range params.RecoveryBootChains {
+		recoverModels = append(recoverModels, recoverChain.ModelForSealing())
+	}
+
+	skrs := append(runKeySealRequests(key, params.UseTokens, runRecoverModels), fallbackKeySealRequests(key, saveKey, params.LegacyFactoryResetKeyPath, params.UseTokens, recoverModels)...)
 	if err := secbootSealKeysWithProtector(params.KeyProtectorFactory, skrs, &sealingParams); err != nil {
 		return err
 	}
@@ -272,13 +283,13 @@ func sealKeyForBootChainsHook(method device.SealingMethod, key, saveKey secboot.
 	}
 
 	if fdeState != nil {
-		if err := fdeState.UpdateParameters("run+recover", "all", []string{"run", "recover"}, models, nil); err != nil {
+		if err := fdeState.UpdateParameters("run+recover", "all", []string{"run", "recover"}, runModels, nil); err != nil {
 			return err
 		}
-		if err := fdeState.UpdateParameters("recover", "ubuntu-save", []string{"recover", "factory-reset"}, models, nil); err != nil {
+		if err := fdeState.UpdateParameters("recover", "ubuntu-save", []string{"recover", "factory-reset"}, runRecoverModels, nil); err != nil {
 			return err
 		}
-		if err := fdeState.UpdateParameters("recover", "ubuntu-data", []string{"recover"}, models, nil); err != nil {
+		if err := fdeState.UpdateParameters("recover", "ubuntu-data", []string{"recover"}, recoverModels, nil); err != nil {
 			return err
 		}
 	}

--- a/overlord/fdestate/backend/seal_test.go
+++ b/overlord/fdestate/backend/seal_test.go
@@ -567,6 +567,7 @@ func (s *sealSuite) TestSealKeyForBootChains(c *C) {
 
 func (s *sealSuite) testSealToModeenvWithFdeHookHappy(c *C, useTokens bool) {
 	model := boottest.MakeMockUC20Model()
+	model2 := boottest.MakeMockUC20Model(map[string]any{"model": "my-model-uc20-other"})
 
 	n := 0
 	var runFDESetupHookReqs []*fde.SetupRequest
@@ -591,8 +592,6 @@ func (s *sealSuite) testSealToModeenvWithFdeHookHappy(c *C, useTokens bool) {
 	savedTokens := make(map[string][]byte)
 	restore := fdeBackend.MockSecbootSealKeysWithProtector(func(kf secboot.KeyProtectorFactory, keys []secboot.SealKeyRequest, params *secboot.SealKeysWithFDESetupHookParams) error {
 		c.Check(kf, Equals, mockFactory)
-		c.Check(params.Model.Model(), Equals, model.Model())
-		c.Check(params.Model.Model(), Equals, model.Model())
 		if useTokens {
 			c.Check(params.AuxKeyFile, Equals, "")
 		} else {
@@ -624,6 +623,18 @@ func (s *sealSuite) testSealToModeenvWithFdeHookHappy(c *C, useTokens bool) {
 				}
 				savedTokens[fmt.Sprintf("%s/%s", container, skr.SlotName)] = out
 			}
+
+			switch skr.SlotName {
+			case "default":
+				c.Assert(skr.Models, HasLen, 1)
+				c.Check(skr.Models[0].Model(), Equals, model.Model())
+			case "default-fallback":
+				c.Assert(skr.Models, HasLen, 2)
+				c.Check(skr.Models[0].Model(), Equals, model.Model())
+				c.Check(skr.Models[1].Model(), Equals, model2.Model())
+			default:
+				c.Errorf("unexpected slot name")
+			}
 		}
 		return nil
 	})
@@ -647,6 +658,13 @@ func (s *sealSuite) testSealToModeenvWithFdeHookHappy(c *C, useTokens bool) {
 				Classic:        model.Classic(),
 				Grade:          model.Grade(),
 				ModelSignKeyID: model.SignKeyID(),
+			},
+			{
+				BrandID:        model2.BrandID(),
+				Model:          model2.Model(),
+				Classic:        model2.Classic(),
+				Grade:          model2.Grade(),
+				ModelSignKeyID: model2.SignKeyID(),
 			},
 		},
 		RoleToBlName: nil,

--- a/secboot/export_sb_test.go
+++ b/secboot/export_sb_test.go
@@ -607,3 +607,7 @@ func MockTPMResetDictionaryAttackLock(f func(tpm *sb_tpm2.Connection, lockoutAut
 func MockSbKeyDataRecoverKeys(f func(d *sb.KeyData) (sb.DiskUnlockKey, sb.PrimaryKey, error)) (restore func()) {
 	return testutil.Mock(&sbKeyDataRecoverKeys, f)
 }
+
+func MockSbHooksNewProtectedKey(f func(rand io.Reader, params *sb_hooks.KeyParams) (protectedKey *sb.KeyData, primaryKeyOut sb.PrimaryKey, unlockKey sb.DiskUnlockKey, err error)) (restore func()) {
+	return testutil.Mock(&sbHooksNewProtectedKey, f)
+}

--- a/secboot/secboot.go
+++ b/secboot/secboot.go
@@ -89,6 +89,8 @@ type SealKeyRequest struct {
 	KeyFile string
 	// The boot modes allowed (i.e. snapd_recovery_mode kernel parameter)
 	BootModes []string
+	// Initial model to bind sealed keys to.
+	Models []ModelForSealing
 }
 
 // ModelForSealing provides information about the model for use in the context
@@ -181,8 +183,6 @@ type SealKeysParams struct {
 }
 
 type SealKeysWithFDESetupHookParams struct {
-	// Initial model to bind sealed keys to.
-	Model ModelForSealing
 	// The path to the aux key file (if empty the key will not be
 	// saved)
 	AuxKeyFile string

--- a/secboot/secboot_hooks.go
+++ b/secboot/secboot_hooks.go
@@ -42,6 +42,7 @@ var sbSetModel = sb_scope.SetModel
 var sbSetBootMode = sb_scope.SetBootMode
 var sbSetKeyRevealer = sb_hooks.SetKeyRevealer
 var sbWithExternalUnlockKey = sb.WithExternalUnlockKey
+var sbHooksNewProtectedKey = sb_hooks.NewProtectedKey
 
 // taggedHandle wraps a raw handle from a secboot hook and adds a method field.
 // This field is used to route the handle to the correct [sb_hooks.KeyRevealer].
@@ -167,13 +168,16 @@ func SealKeysWithProtector(kpf KeyProtectorFactory, keys []SealKeyRequest, param
 		flags := sb_hooks.KeyProtectorNoAEAD
 		sb_hooks.SetKeyProtector(protector, flags)
 
-		protectedKey, primaryKeyOut, unlockKey, err := sb_hooks.NewProtectedKey(rand.Reader, &sb_hooks.KeyParams{
-			PrimaryKey: primaryKey,
-			Role:       skr.KeyName,
-			AuthorizedSnapModels: []sb.SnapModel{
-				params.Model,
-			},
-			AuthorizedBootModes: skr.BootModes,
+		var sbModels []sb.SnapModel
+		for _, model := range skr.Models {
+			sbModels = append(sbModels, model)
+		}
+
+		protectedKey, primaryKeyOut, unlockKey, err := sbHooksNewProtectedKey(rand.Reader, &sb_hooks.KeyParams{
+			PrimaryKey:           primaryKey,
+			Role:                 skr.KeyName,
+			AuthorizedSnapModels: sbModels,
+			AuthorizedBootModes:  skr.BootModes,
 		})
 		if err != nil {
 			return err

--- a/secboot/secboot_sb_test.go
+++ b/secboot/secboot_sb_test.go
@@ -2534,19 +2534,51 @@ func (s *secbootSuite) testSealKeysWithProtectorHappy(c *C, useKeyFiles bool) {
 	tmpDir := c.MkDir()
 	auxKeyFn := filepath.Join(tmpDir, "aux-key")
 	params := secboot.SealKeysWithFDESetupHookParams{
-		Model:      fakeModel,
 		AuxKeyFile: auxKeyFn,
 	}
 	containerA := secboot.CreateMockBootstrappedContainer()
 	containerB := secboot.CreateMockBootstrappedContainer()
+
 	myKeys := []secboot.SealKeyRequest{
-		{BootstrappedContainer: containerA, KeyName: "key1", SlotName: "foo1"},
-		{BootstrappedContainer: containerB, KeyName: "key2", SlotName: "foo2"},
+		{
+			BootstrappedContainer: containerA,
+			KeyName:               "key1",
+			SlotName:              "foo1",
+			Models: []secboot.ModelForSealing{
+				&testModel{
+					name: "model1",
+				},
+			},
+		},
+		{
+			BootstrappedContainer: containerB,
+			KeyName:               "key2",
+			SlotName:              "foo2",
+			Models: []secboot.ModelForSealing{
+				&testModel{
+					name: "model2",
+				},
+			},
+		},
 	}
 	if useKeyFiles {
 		myKeys[0].KeyFile = filepath.Join(tmpDir, "key-file-1")
 		myKeys[1].KeyFile = filepath.Join(tmpDir, "key-file-2")
 	}
+
+	defer secboot.MockSbHooksNewProtectedKey(func(rand io.Reader, params *sb_hooks.KeyParams) (protectedKey *sb.KeyData, primaryKeyOut sb.PrimaryKey, unlockKey sb.DiskUnlockKey, err error) {
+		switch params.Role {
+		case "key1":
+			c.Assert(params.AuthorizedSnapModels, HasLen, 1)
+			c.Check(params.AuthorizedSnapModels[0].Model(), Equals, "model1")
+		case "key2":
+			c.Assert(params.AuthorizedSnapModels, HasLen, 1)
+			c.Check(params.AuthorizedSnapModels[0].Model(), Equals, "model2")
+		default:
+			c.Errorf("unexpected call")
+		}
+		return sb_hooks.NewProtectedKey(rand, params)
+	})()
 
 	factory := secboot.FDESetupHookKeyProtectorFactory(runFDESetupHook)
 	err := secboot.SealKeysWithProtector(factory, myKeys, &params)
@@ -2670,7 +2702,6 @@ func (s *secbootSuite) sealKeysWithOPTEE(c *C) (key []byte, keyPath string) {
 
 	root := c.MkDir()
 	params := secboot.SealKeysWithFDESetupHookParams{
-		Model:      fakeModel,
 		AuxKeyFile: filepath.Join(root, "aux-key"),
 	}
 	container := secboot.CreateMockBootstrappedContainer()


### PR DESCRIPTION
Sealing keys was done by installation/factory-reset that was expecting only one model. But during reprovision, the system may have multiple models instead.
