### PR TITLE
tests: unit test spread run does not need to install deps or run golangci-lint

### DIFF
--- a/run-checks
+++ b/run-checks
@@ -561,7 +561,7 @@ if [ "$STATIC" = 1 ]; then
         exit 1
     fi
 
-    if gcil=$(command -v golangci-lint) || [ -z "${SKIP_GOLANGCI_LINT:-}" ]; then
+    if gcil=$(command -v golangci-lint) && [ -z "${SKIP_GOLANGCI_LINT:-}" ]; then
         echo ">> [Go] Checking golangci-lint"
         if echo "$gcil" | grep -q '/snap/bin/'; then
             # golangci-lint was installed from the snap

--- a/tests/unit/go/task.yaml
+++ b/tests/unit/go/task.yaml
@@ -80,6 +80,7 @@ execute: |
                 $PROXY_PARAM \
                 ${skip:-} \
                 SKIP_TESTS_FORMAT_CHECK=1 \
+                AUTO_INSTALL=0 \
                 IGNORE_MISSING=1 \
                 ./run-checks --static"
         else
@@ -89,6 +90,7 @@ execute: |
                 $PROXY_PARAM \
                 SKIP_COVERAGE=1 \
                 CC=$VARIANT \
+                AUTO_INSTALL=0 \
                 IGNORE_MISSING=1 \
                 ./run-checks --unit"
         fi
@@ -117,6 +119,7 @@ execute: |
                 $PROXY_PARAM \
                 ${skip:-} \
                 SKIP_TESTS_FORMAT_CHECK=1 \
+                AUTO_INSTALL=0 \
                 IGNORE_MISSING=1 \
                 ./run-checks --static" test
         else
@@ -126,6 +129,7 @@ execute: |
                 $PROXY_PARAM \
                 SKIP_COVERAGE=1 \
                 CC=$VARIANT \
+                AUTO_INSTALL=0 \
                 IGNORE_MISSING=1 \
                 ./run-checks --unit" test
         fi


### PR DESCRIPTION
Here is the failure:

```
>> [Go] Enabled golangci-lint linters: depguard,govet,ineffassign,misspell,modernize,nakedret,testpackage,unused
wrappers/binaries_test.go:1: : # github.com/snapcore/snapd/wrappers_test [github.com/snapcore/snapd/wrappers.test]
compile: writing output: write $WORK/b1500/_pkg_.a: disk quota exceeded (typecheck)
```

I don't think we need to run `golangci-lint` in the spread test. This updates `run-checks` to actually respect `SKIP_GOLANGCI_LINT`, and I also disabled installing the `run-checks` dependencies automatically.

I think this, and some of our other recent `/tmp` woes, might be related to https://github.com/systemd/systemd/pull/36010, but I haven't proved it.