### PR TITLE
packaging: workaround dh_golang, drop prepare-debian-build-tree

### DIFF
--- a/packaging/debian-sid/rules
+++ b/packaging/debian-sid/rules
@@ -63,6 +63,16 @@ ifneq (,$(filter testkeys,$(DEB_BUILD_OPTIONS)))
 	TAGS+= withtestkeys
 endif
 
+# Export build tags via GOFLAGS so that dh_golang's "go list" call picks them
+# up. Without this, dh_golang fails because it calls "go list" without build
+# tags and hits packages that are excluded by nosecboot (e.g. secboot/keymgr,
+# which prepare-debian-build-tree used to strip). GOFLAGS applies to every go
+# command invocation, including the one inside dh_golang.
+comma := ,
+empty :=
+space := $(empty) $(empty)
+export GOFLAGS = -tags=$(subst $(space),$(comma),$(strip $(TAGS)))
+
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
 # /usr/lib/snapd/snap-{update-ns,gdbserver-shim} are always linked
@@ -159,9 +169,6 @@ override_dh_auto_build: snapd.defines.mk
 	$(file >data/info,$(data__info))
 	# Build golang bits
 	cp -a bootloader/assets/data _build/src/$(DH_GOPKG)/bootloader/assets
-
-	# Prepare the build tree by removing code not used for Debian builds
-	$(MAKE) -f packaging/snapd.mk prepare-debian-build-tree sourcedir=_build/src/$(DH_GOPKG) SNAPD_DEFINES_DIR=$(CURDIR)
 
 	# and build, we cannot use modules as packaging on Debian requires us to use
 	# dependencies from the distro, and this would require further updates to the

--- a/packaging/snapd.mk
+++ b/packaging/snapd.mk
@@ -95,35 +95,16 @@ endif
 EXTRA_GO_STATIC_LDFLAGS ?= -linkmode external -extldflags="$(GO_STATIC_EXTLDFLAG)" $(EXTRA_GO_LDFLAGS)
 
 # sourcedir is the path to the source directory tree (where the go source files are).
-# This is used by prepare-debian-build-tree to remove unnecessary code, and by
-# check-static-binaries to locate C binaries built by the autotools cmd/ build.
-# Can be set in snapd.defines.mk or on the make command line; defaults to $(CURDIR).
-# For Debian/dh-golang, this would be: sourcedir=_build/src/github.com/snapcore/snapd
+# This is used by check-static-binaries to locate C binaries built by the autotools
+# cmd/ build. Can be set in snapd.defines.mk or on the make command line; defaults
+# to $(CURDIR). For Debian/dh-golang, this would be:
+# sourcedir=_build/src/github.com/snapcore/snapd
 sourcedir ?= $(CURDIR)
 
 # NOTE: This *depends* on building out of tree. Some of the built binaries
 # conflict with directory names in the tree.
 .PHONY: all
 all: $(go_binaries)
-
-# Prepare the build tree by removing code that is not used in non-embedded builds.
-# This removes snap-bootstrap, snap-fde-keymgr, and secboot-related code that
-# is only needed for embedded systems and UC20+ builds. This could be somewhat
-# avoided if we had all the dependencies in Debian OR if dh-golang supported
-# build tags properly.
-.PHONY: prepare-debian-build-tree
-prepare-debian-build-tree:
-	# exclude certain parts that won't be used by debian
-	find $(sourcedir)/cmd/snap-bootstrap -name "*.go" 2>/dev/null | xargs -r rm -f
-	find $(sourcedir)/cmd/snap-fde-keymgr -name "*.go" 2>/dev/null | xargs -r rm -f
-	find $(sourcedir)/gadget/install -name "*.go" -not -name "params.go" -not -name "install_placeholder.go" -not -name "kernel.go" 2>/dev/null | xargs -r rm -f
-	# XXX: once dh-golang understands go build tags this would not be needed
-	find $(sourcedir)/secboot/ -name "*.go" 2>/dev/null | grep -E '(.*_sb(_test)?\.go|.*_tpm(_test)?\.go|secboot_hooks.go|auth_requestor.go|keymgr/)' | xargs -r rm -f
-	# Rename plainkey files to indicate they are secboot variants
-	if [ -f $(sourcedir)/secboot/keys/plainkey.go ]; then mv $(sourcedir)/secboot/keys/plainkey.go $(sourcedir)/secboot/keys/plainkey_sb.go; fi
-	if [ -f $(sourcedir)/secboot/keys/plainkey_test.go ]; then mv $(sourcedir)/secboot/keys/plainkey_test.go $(sourcedir)/secboot/keys/plainkey_sb_test.go; fi
-	find $(sourcedir)/secboot/keys/ -name "*.go" 2>/dev/null | grep -E '(.*_sb(_test)?\.go)' | xargs -r rm -f
-	find $(sourcedir)/boot/ -name "*.go" 2>/dev/null | grep -E '(.*_sb(_test)?\.go)' | xargs -r rm -f
 
 # FIXME: not all Go toolchains we build with support '-B gobuildid', replace a
 # random GNU build ID with something more predictable, use something similar to


### PR DESCRIPTION
Export build tags for dh_golang invocation, such that the tool will pass them to `go list` when computing metadata for filling `Built-Using` property of the deb artifacts.

Since we no longer need to mangle the source tree, we can safely drop `prepare-debian-build-tree`, since Sid packaging was the only place where it was used.
