### PR TITLE
many: graduate quota-groups

### DIFF
--- a/daemon/api_general_test.go
+++ b/daemon/api_general_test.go
@@ -54,7 +54,6 @@ import (
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/sandbox"
 	"github.com/snapcore/snapd/snap"
-	"github.com/snapcore/snapd/systemd"
 )
 
 var _ = check.Suite(&generalSuite{})
@@ -109,7 +108,8 @@ func (s *generalSuite) TestSysInfo(c *check.C) {
 	req, err := http.NewRequest("GET", "/v2/system-info", nil)
 	c.Assert(err, check.IsNil)
 
-	restore := release.MockReleaseInfo(&release.OS{ID: "distro-id", VersionID: "1.2"})
+	// use Ubuntu 14.04 so UserDaemons is unsupported
+	restore := release.MockReleaseInfo(&release.OS{ID: "ubuntu", VersionID: "14.04"})
 	defer restore()
 	restore = release.MockOnClassic(true)
 	defer restore()
@@ -125,10 +125,6 @@ func (s *generalSuite) TestSysInfo(c *check.C) {
 
 	restore = daemon.MockSystemdVirt("magic")
 	defer restore()
-	// Set systemd version <230 so QuotaGroups feature unsupported
-	restore = systemd.MockSystemdVersion(229, nil)
-	defer restore()
-
 	buildID := "this-is-my-build-id"
 	restore = daemon.MockBuildID(buildID)
 	defer restore()
@@ -143,7 +139,7 @@ func (s *generalSuite) TestSysInfo(c *check.C) {
 	tr.Set("core", "refresh.schedule", "00:00-9:00/12:00-13:00")
 	tr.Set("core", "refresh.timer", "8:00~9:00/2")
 	tr.Set("core", "experimental.parallel-instances", "false")
-	tr.Set("core", "experimental.quota-groups", "true")
+	tr.Set("core", "experimental.user-daemons", "true")
 	tr.Commit()
 	st.Unlock()
 
@@ -158,8 +154,8 @@ func (s *generalSuite) TestSysInfo(c *check.C) {
 		"series":  "16",
 		"version": "42b1",
 		"os-release": map[string]any{
-			"id":         "distro-id",
-			"version-id": "1.2",
+			"id":         "ubuntu",
+			"version-id": "14.04",
 		},
 		"build-id":   buildID,
 		"on-classic": true,
@@ -208,17 +204,17 @@ func (s *generalSuite) TestSysInfo(c *check.C) {
 	_, exists = parallelInstancesInfo["unsupported-reason"]
 	c.Check(exists, check.Equals, false)
 	c.Check(parallelInstancesInfo["enabled"], check.Equals, false)
-	// Ensure that QuotaGroups exists and is a feature.FeatureInfo
-	quotaGroupsInfoRaw, exists := featuresAll[features.QuotaGroups.String()]
+	// ensure that UserDaemons exists and is a feature.FeatureInfo.
+	userDaemonsInfoRaw, exists := featuresAll[features.UserDaemons.String()]
 	c.Assert(exists, check.Equals, true)
-	quotaGroupsInfo, ok := quotaGroupsInfoRaw.(map[string]any)
+	userDaemonsInfo, ok := userDaemonsInfoRaw.(map[string]any)
 	c.Assert(ok, check.Equals, true)
-	// Ensure that QuotaGroups is unsupported but enabled
-	c.Check(quotaGroupsInfo["supported"], check.Equals, false)
-	unsupportedReason, exists := quotaGroupsInfo["unsupported-reason"]
+	// ensure that UserDaemons is unsupported but enabled.
+	c.Check(userDaemonsInfo["supported"], check.Equals, false)
+	unsupportedReason, exists := userDaemonsInfo["unsupported-reason"]
 	c.Check(exists, check.Equals, true)
 	c.Check(unsupportedReason, check.Not(check.Equals), "")
-	c.Check(quotaGroupsInfo["enabled"], check.Equals, true)
+	c.Check(userDaemonsInfo["enabled"], check.Equals, true)
 }
 
 func (s *generalSuite) TestSysInfoLegacyRefresh(c *check.C) {
@@ -332,10 +328,6 @@ func (s *generalSuite) testSysInfoBinOrigin(c *check.C, exp string, expErr strin
 
 	restore = daemon.MockSystemdVirt("magic")
 	defer restore()
-	// Set systemd version <230 so QuotaGroups feature unsupported
-	restore = systemd.MockSystemdVersion(229, nil)
-	defer restore()
-
 	buildID := "this-is-my-build-id"
 	restore = daemon.MockBuildID(buildID)
 	defer restore()

--- a/features/features.go
+++ b/features/features.go
@@ -28,7 +28,6 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/sandbox/apparmor"
-	"github.com/snapcore/snapd/systemd"
 )
 
 // SnapdFeature is a named feature that may be on or off.
@@ -53,11 +52,6 @@ const (
 	CheckDiskSpaceRefresh
 	// GateAutoRefreshHook enables refresh control from snaps via gate-auto-refresh hook.
 	GateAutoRefreshHook
-	// QuotaGroups enables any current experimental features related to the Quota Groups API, on top of the features
-	// already graduated past experimental:
-	//  * journal quotas are still experimental
-	// while guota groups creation and management and memory, cpu, quotas are no longer experimental.
-	QuotaGroups
 	// RefreshAppAwarenessUX enables experimental UX improvements for refresh-app-awareness.
 	RefreshAppAwarenessUX
 	// Confdb enables experimental configuration based on confdb and views.
@@ -110,8 +104,6 @@ var featureNames = map[SnapdFeature]string{
 
 	GateAutoRefreshHook: "gate-auto-refresh-hook",
 
-	QuotaGroups: "quota-groups",
-
 	RefreshAppAwarenessUX: "refresh-app-awareness-ux",
 
 	Confdb:        "confdb",
@@ -130,7 +122,6 @@ var featureNames = map[SnapdFeature]string{
 
 // featuresEnabledWhenUnset contains a set of features that are enabled when not explicitly configured.
 var featuresEnabledWhenUnset = map[SnapdFeature]bool{
-	QuotaGroups:           true,
 	RefreshAppAwarenessUX: true,
 }
 
@@ -154,6 +145,7 @@ var featuresGraduated = map[string]bool{
 	"classic-preserves-xdg-runtime-dir": true,
 	"refresh-app-awareness":             true,
 	"dbus-activation":                   true,
+	"quota-groups":                      true,
 }
 
 var (
@@ -165,13 +157,6 @@ var (
 // with a reason why the feature is unsupported. If a function has no callback
 // defined, it should be assumed to be supported.
 var featuresSupportedCallbacks = map[SnapdFeature]func() (bool, string){
-	// QuotaGroups requires systemd version 230 or higher
-	QuotaGroups: func() (bool, string) {
-		if err := systemd.EnsureAtLeast(230); err != nil {
-			return false, err.Error()
-		}
-		return true, ""
-	},
 	// UserDaemons requires user units
 	UserDaemons: func() (bool, string) {
 		if !releaseSystemctlSupportsUserUnits() {

--- a/features/features_test.go
+++ b/features/features_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/state"
-	"github.com/snapcore/snapd/systemd"
 )
 
 func Test(t *testing.T) { TestingT(t) }
@@ -54,7 +53,6 @@ func (*featureSuite) TestName(c *C) {
 	check(features.CheckDiskSpaceRefresh, "check-disk-space-refresh")
 	check(features.CheckDiskSpaceRemove, "check-disk-space-remove")
 	check(features.GateAutoRefreshHook, "gate-auto-refresh-hook")
-	check(features.QuotaGroups, "quota-groups")
 	check(features.RefreshAppAwarenessUX, "refresh-app-awareness-ux")
 	check(features.Confdb, "confdb")
 	check(features.ConfdbControl, "confdb-control")
@@ -94,7 +92,6 @@ func (*featureSuite) TestIsExported(c *C) {
 	check(features.CheckDiskSpaceRefresh, false)
 	check(features.CheckDiskSpaceRemove, false)
 	check(features.GateAutoRefreshHook, false)
-	check(features.QuotaGroups, false)
 	check(features.RefreshAppAwarenessUX, true)
 	check(features.Confdb, true)
 	check(features.ConfdbControl, false)
@@ -115,24 +112,8 @@ func (*featureSuite) TestIsGraduated(c *C) {
 	for _, feature := range graduated {
 		c.Check(features.IsGraduated(feature), Equals, true)
 	}
+	c.Check(features.IsGraduated("quota-groups"), Equals, true)
 	c.Check(features.IsGraduated("other-feature"), Equals, false)
-}
-
-func (*featureSuite) TestQuotaGroupsSupportedCallback(c *C) {
-	callback, exists := features.FeaturesSupportedCallbacks[features.QuotaGroups]
-	c.Assert(exists, Equals, true)
-
-	restore1 := systemd.MockSystemdVersion(229, nil)
-	defer restore1()
-	supported, reason := callback()
-	c.Check(supported, Equals, false)
-	c.Check(reason, Matches, "systemd version 229 is too old.*")
-
-	restore2 := systemd.MockSystemdVersion(230, nil)
-	defer restore2()
-	supported, reason = callback()
-	c.Check(supported, Equals, true)
-	c.Check(reason, Equals, "")
 }
 
 func (*featureSuite) TestUserDaemonsSupportedCallback(c *C) {
@@ -229,7 +210,6 @@ func (*featureSuite) TestIsEnabledWhenUnset(c *C) {
 	check(features.CheckDiskSpaceRefresh, false)
 	check(features.CheckDiskSpaceRemove, false)
 	check(features.GateAutoRefreshHook, false)
-	check(features.QuotaGroups, true)
 	check(features.RefreshAppAwarenessUX, true)
 	check(features.Confdb, false)
 	check(features.AppArmorPrompting, false)

--- a/overlord/configstate/configcore/runwithstate_test.go
+++ b/overlord/configstate/configcore/runwithstate_test.go
@@ -112,7 +112,7 @@ func (r *graduatedSuite) TestConfigureDefaultEnabledExperimentalFeature(c *C) {
 	task := r.state.NewTask("configure", "configure")
 	tr := configcore.NewRunTransaction(config.NewTransaction(r.state), task)
 
-	c.Assert(tr.Set("core", "experimental.quota-groups", true), IsNil)
+	c.Assert(tr.Set("core", "experimental.refresh-app-awareness-ux", true), IsNil)
 
 	r.state.Unlock()
 	c.Assert(configcore.Run(coreDev, tr), IsNil)
@@ -120,10 +120,10 @@ func (r *graduatedSuite) TestConfigureDefaultEnabledExperimentalFeature(c *C) {
 
 	tr.Commit()
 
-	msg := "feature quota-groups is enabled by default and will be permanently enabled in a future release"
+	msg := "feature refresh-app-awareness-ux is enabled by default and will be permanently enabled in a future release"
 
 	var enabled bool
-	err := tr.Get("core", "experimental.quota-groups", &enabled)
+	err := tr.Get("core", "experimental.refresh-app-awareness-ux", &enabled)
 	c.Check(err, IsNil)
 	c.Check(enabled, Equals, true)
 

--- a/overlord/ifacestate/handlers_test.go
+++ b/overlord/ifacestate/handlers_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/mount"
-	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/servicestate/servicestatetest"
@@ -206,12 +205,6 @@ func (s *handlersSuite) TestBuildConfinementOptionsWithLogNamespace(c *C) {
 
 	m := ifacestate.NewInterfaceManagerWithAppArmorPrompting(false)
 
-	// journal quota is still experimental, so we must enable the experimental
-	// quota-groups option
-	tr := config.NewTransaction(s.st)
-	tr.Set("core", "experimental.quota-groups", true)
-	tr.Commit()
-
 	snapInfo := mockInstalledSnap(c, s.st, snapAyaml)
 
 	// Create a new quota group with a journal quota
@@ -235,10 +228,6 @@ func (s *handlersSuite) TestBuildConfinementOptionsWithLogNamespaceMountProfileC
 	defer s.st.Unlock()
 
 	m := ifacestate.NewInterfaceManagerWithAppArmorPrompting(false)
-
-	tr := config.NewTransaction(s.st)
-	tr.Set("core", "experimental.quota-groups", true)
-	tr.Commit()
 
 	snapInfo := mockInstalledSnap(c, s.st, snapAyaml)
 	err := servicestatetest.MockQuotaInState(s.st, "foo", "", []string{snapInfo.InstanceName()}, nil, quota.NewResourcesBuilder().WithJournalNamespace().Build())

--- a/overlord/servicestate/quota_control.go
+++ b/overlord/servicestate/quota_control.go
@@ -24,9 +24,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/snapcore/snapd/features"
 	"github.com/snapcore/snapd/i18n"
-	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/servicestate/internal"
 	"github.com/snapcore/snapd/overlord/snapstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -75,18 +73,6 @@ func quotaGroupsAvailable(st *state.State) error {
 	return nil
 }
 
-func isExperimentalQuotasAvailable(st *state.State, quotaName string) error {
-	tr := config.NewTransaction(st)
-	status, err := features.Flag(tr, features.QuotaGroups)
-	if err != nil && !config.IsNoOption(err) {
-		return err
-	}
-	if !status {
-		return fmt.Errorf("%s quota options are experimental - test it by setting 'experimental.quota-groups' to true", quotaName)
-	}
-	return nil
-}
-
 func verifyQuotaRequirements(st *state.State, resourceLimits quota.Resources) error {
 	// validate quotas in general are available
 	if err := quotaGroupsAvailable(st); err != nil {
@@ -112,11 +98,6 @@ func verifyQuotaRequirements(st *state.State, resourceLimits quota.Resources) er
 	if resourceLimits.Journal != nil {
 		if err := systemd.EnsureAtLeast(245); err != nil {
 			return fmt.Errorf("cannot use journal quota with incompatible systemd: %v", err)
-		}
-
-		// To use journal quotas, the quota-group experimental features must be enabled.
-		if err := isExperimentalQuotasAvailable(st, "journal"); err != nil {
-			return err
 		}
 	}
 	return nil

--- a/overlord/servicestate/quota_control_test.go
+++ b/overlord/servicestate/quota_control_test.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/gadget/quantity"
-	"github.com/snapcore/snapd/overlord/configstate/config"
 	"github.com/snapcore/snapd/overlord/servicestate"
 	"github.com/snapcore/snapd/overlord/servicestate/internal"
 	"github.com/snapcore/snapd/overlord/servicestate/servicestatetest"
@@ -288,23 +287,6 @@ func checkQuotaControlTasks(c *C, tasks []*state.Task, expAction *servicestate.Q
 	c.Assert(qcs[0], DeepEquals, expAction)
 }
 
-func (s *quotaControlSuite) TestCreateQuotaExperimentalNotEnabled(c *C) {
-	// Test experimental quota group features that should not be enabled when
-	// quota-groups feature is disabled
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	tr := config.NewTransaction(s.state)
-	tr.Set("core", "experimental.quota-groups", false)
-	tr.Commit()
-
-	// Journal Quota is experimental, must give an error
-	_, err := servicestate.CreateQuota(s.state, "foo", servicestate.CreateQuotaOptions{
-		ResourceLimits: quota.NewResourcesBuilder().WithJournalNamespace().Build(),
-	})
-	c.Assert(err, ErrorMatches, `journal quota options are experimental - test it by setting 'experimental.quota-groups' to true`)
-}
-
 func (s *quotaControlSuite) TestCreateQuotaSystemdTooOld(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -351,28 +333,9 @@ func (s *quotaControlSuite) TestCreateQuotaPerQuotaSystemdTooOld(c *C) {
 	}
 }
 
-func (s *quotaControlSuite) TestCreateQuotaJournalNotEnabled(c *C) {
+func (s *quotaControlSuite) TestCreateQuotaJournal(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
-
-	tr := config.NewTransaction(s.state)
-	tr.Set("core", "experimental.quota-groups", false)
-	tr.Commit()
-
-	quotaConstraints := quota.NewResourcesBuilder().WithJournalNamespace().Build()
-	_, err := servicestate.CreateQuota(s.state, "foo", servicestate.CreateQuotaOptions{
-		ResourceLimits: quotaConstraints,
-	})
-	c.Assert(err, ErrorMatches, `journal quota options are experimental - test it by setting 'experimental.quota-groups' to true`)
-}
-
-func (s *quotaControlSuite) TestCreateQuotaJournalEnabled(c *C) {
-	s.state.Lock()
-	defer s.state.Unlock()
-
-	tr := config.NewTransaction(s.state)
-	tr.Set("core", "experimental.quota-groups", true)
-	tr.Commit()
 
 	quotaConstraints := quota.NewResourcesBuilder().WithJournalNamespace().Build()
 	_, err := servicestate.CreateQuota(s.state, "foo", servicestate.CreateQuotaOptions{
@@ -798,23 +761,6 @@ func (s *quotaControlSuite) TestEnsureSnapAbsentFromQuotaGroup(c *C) {
 	// is not in any quota group
 	err = servicestate.EnsureSnapAbsentFromQuota(s.state, "test-snap33333")
 	c.Assert(err, IsNil)
-}
-
-func (s *quotaControlSuite) TestUpdateQuotaGroupExperimentalNotEnabled(c *C) {
-	// Test experimental quota group features that should not be enabled when
-	// quota-groups feature is disabled
-	s.state.Lock()
-	defer s.state.Unlock()
-	tr := config.NewTransaction(s.state)
-	tr.Set("core", "experimental.quota-groups", false)
-	tr.Commit()
-
-	// Journal Quotas is experimental, must give an error
-	opts := servicestate.UpdateQuotaOptions{
-		NewResourceLimits: quota.NewResourcesBuilder().WithJournalNamespace().Build(),
-	}
-	_, err := servicestate.UpdateQuota(s.state, "foo", opts)
-	c.Assert(err, ErrorMatches, `journal quota options are experimental - test it by setting 'experimental.quota-groups' to true`)
 }
 
 func (s *quotaControlSuite) TestUpdateQuotaPrecond(c *C) {
@@ -1305,10 +1251,6 @@ func (s *quotaControlSuite) TestAddSnapServicesToQuotaJournalGroupQuotaFail(c *C
 	st.Lock()
 	defer st.Unlock()
 
-	tr := config.NewTransaction(s.state)
-	tr.Set("core", "experimental.journal-quota", true)
-	tr.Commit()
-
 	// setup test-snap
 	snapstate.Set(s.state, "test-snap", s.testSnapState)
 	snaptest.MockSnapCurrent(c, testYaml, s.testSnapSideInfo)
@@ -1326,10 +1268,6 @@ func (s *quotaControlSuite) TestAddJournalQuotaToGroupWithServicesFail(c *C) {
 	st := s.state
 	st.Lock()
 	defer st.Unlock()
-
-	tr := config.NewTransaction(s.state)
-	tr.Set("core", "experimental.quota-groups", true)
-	tr.Commit()
 
 	// setup test-snap
 	snapstate.Set(s.state, "test-snap", s.testSnapState)

--- a/tests/core/persistent-journal-namespace/task.yaml
+++ b/tests/core/persistent-journal-namespace/task.yaml
@@ -18,8 +18,6 @@ systems:
 
 prepare: |
   "$TESTSTOOLS"/snaps-state install-local test-snapd-journal-quota
-  snap set system experimental.quota-groups=true
-  tests.cleanup defer snap unset system experimental.quota-groups
 
 restore: |
   # Stop test service and cleanup

--- a/tests/main/graduated-experimental-flags/task.yaml
+++ b/tests/main/graduated-experimental-flags/task.yaml
@@ -7,7 +7,7 @@ details: |
     on snapd startup.
 
 execute: |
-    default_enabled_feature=quota-groups
+    default_enabled_feature=refresh-app-awareness-ux
     default_enabled_message="feature ${default_enabled_feature} is enabled by default and will be permanently enabled in a future release"
 
     echo "Check that setting a default-enabled experimental feature succeeds"
@@ -16,7 +16,7 @@ execute: |
     snap warnings | tr '\n' ' ' | tr -s ' ' | MATCH "${default_enabled_message}"
 
     echo "Check that the default-enabled flag is still persisted"
-    gojq '.data.config.core.experimental."quota-groups"' /var/lib/snapd/state.json | MATCH "true"
+    gojq '.data.config.core.experimental."refresh-app-awareness-ux"' /var/lib/snapd/state.json | MATCH "true"
 
     snap okay
 
@@ -25,7 +25,7 @@ execute: |
     snap tasks --last=configure-snap | MATCH "${default_enabled_message}"
 
     echo "Check that the default-enabled false value is still persisted"
-    gojq '.data.config.core.experimental."quota-groups"' /var/lib/snapd/state.json | MATCH "false"
+    gojq '.data.config.core.experimental."refresh-app-awareness-ux"' /var/lib/snapd/state.json | MATCH "false"
 
     feature=robust-mount-namespace-updates
     message="feature ${feature} is no longer experimental and is always enabled"

--- a/tests/main/snap-logs-journal/task.yaml
+++ b/tests/main/snap-logs-journal/task.yaml
@@ -14,8 +14,6 @@ systems:
 prepare: |
   "$TESTSTOOLS"/snaps-state install-local test-snapd-journal-quota
   tests.cleanup defer snap remove --purge test-snapd-journal-quota
-  snap set system experimental.quota-groups=true
-  tests.cleanup defer snap unset system experimental.quota-groups
 
 restore: |
   echo "Stopping the service"

--- a/tests/main/snap-quota-journal/task.yaml
+++ b/tests/main/snap-quota-journal/task.yaml
@@ -15,8 +15,6 @@ systems:
 
 prepare: |
   "$TESTSTOOLS"/snaps-state install-local test-snapd-journal-quota
-  snap set system experimental.quota-groups=true
-  tests.cleanup defer snap unset system experimental.quota-groups
 
 restore: |
   snap remove-quota group-one || true

--- a/tests/main/snap-quota-services/task.yaml
+++ b/tests/main/snap-quota-services/task.yaml
@@ -20,8 +20,6 @@ systems:
 prepare: |
   snap install test-snapd-stressd --edge --devmode
   tests.cleanup defer snap remove --purge test-snapd-stressd
-  snap set system experimental.quota-groups=true
-  tests.cleanup defer snap unset system experimental.quota-groups
 
 execute: |
   # Create the top level snap group with a memory limit. test-snapd-stressd


### PR DESCRIPTION
This feature was default-enabled in 2.77, we should graduate it in 2.78.