### PR TITLE
tests: retry check for no bpf progs in tests/main/cgroup-devices-v2

### DIFF
--- a/tests/main/cgroup-devices-v2/task.yaml
+++ b/tests/main/cgroup-devices-v2/task.yaml
@@ -103,7 +103,10 @@ execute: |
     # (also wait until systemd cleans up the cgroup)
     retry -n 10 test ! -e "/sys/fs/cgroup/$testshcgroup"
     echo "Verify there continue to be no snap BPF programs"
-    test -z "$(dump_cgroup_device_progs)"
+    # retry as the kernel may not immediately free BPF programs after cgroup dir removal
+    export -f dump_cgroup_device_progs
+    # shellcheck disable=SC2016
+    retry -n 10 bash -c 'test -z "$(dump_cgroup_device_progs)"'
 
     # dump the map
     bpftool map dump pinned /sys/fs/bpf/snap/snap_test-snapd-service_sh > device-access.map-app


### PR DESCRIPTION
Retries the check for no bpf programs as the kernel may not immediately free bpf programs after cgroup dir removal:

When a cgroup is removed, the directory vanishes from /sys/fs/cgroup/ while bpf programs attached to it remain visible in `bpftool` due to a delayed, asynchronous kernel cleanup process. This occurs because [kernfs_remove](https://github.com/torvalds/linux/blob/bd5f485f3f026225b86573e559af0b7254ef4184/kernel/cgroup/cgroup.c#L6284)  removes the directory instantly from VFS, while the bpf reference counter (refcnt) is only marked for destruction via [percpu_ref_kill](https://github.com/torvalds/linux/blob/bd5f485f3f026225b86573e559af0b7254ef4184/kernel/bpf/cgroup.c#L245) and awaits the queued final cleanup by [cgroup_bpf_release_fn](https://github.com/torvalds/linux/blob/bd5f485f3f026225b86573e559af0b7254ef4184/kernel/bpf/cgroup.c#L382). Consequently, a race window exists where `bpftool` still lists programs, even though the cgroup path is gone, until the asynchronous `cgroup_bpf_release_fn` completes.

[Example Failure](https://github.com/canonical/snapd/actions/runs/32250941282/job/96076146175?pr=17481#step:25:2062)