### PR TITLE
tests: cleanup root user snap data on Ubuntu Core systems

### DIFF
--- a/tests/lib/reset.sh
+++ b/tests/lib/reset.sh
@@ -166,7 +166,7 @@ reset_all_snap() {
     # ensure we have the same state as initially
     systemctl stop snapd.service snapd.socket
     restore_snapd_state
-    rm -rf /root/.snap
+    rm -rf /root/.snap /root/snap
     rm -rf /tmp/snap-private-tmp/snap.*
     if [ "$1" != "--keep-stopped" ]; then
         systemctl start snapd.service snapd.socket


### PR DESCRIPTION
We should cleanup `/root/snap` in addition to the existing cleanup of `/root/.snap` on UC systems to have a clean test environment.

Observed that the failure in [Error executing openstack:ubuntu-core-24-64:tests/main/install-store-laaaarge](https://github.com/canonical/snapd/actions/runs/32250941282/job/96076145890?pr=17481#step:25:807) is due to some other test's unfinished cleanup/removal of `test-snapd-sh` snap data. That test installs the snap from stable channel (rev 2) and the remnants are for rev 7, which has to be from some other test that installed the snap from edge channel.

```
+ snap install test-snapd-sh
test-snapd-sh 1.0 from Test snaps (test-snaps-canonical) installed
+ snap remove test-snapd-sh
error: cannot perform the following tasks:
- Remove data for snap "test-snapd-sh" (2) (failed to remove snap "test-snapd-sh" base directory: remove /root/snap/test-snapd-sh: directory not empty
dir contents: [7])
```