### PR TITLE
o/snapstate: fix two bugs related to components 

### DIFF
--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -3566,6 +3566,13 @@ func (m *SnapManager) doDiscardSnap(t *state.Task, _ *tomb.Tomb) error {
 		if snapst.Current == snapsup.Revision() {
 			snapst.Current = newSeq[len(newSeq)-1].Snap.Revision
 		}
+
+		// the snap still has other revisions; keep the on-disk sequence file
+		// in sync with the removed revision. when no revisions are left the
+		// file is removed further below instead.
+		if err := updateSeqFileForSnap(snapst, snapsup.InstanceName()); err != nil {
+			return err
+		}
 	}
 
 	pb := NewTaskProgressAdapterUnlocked(t)

--- a/overlord/snapstate/handlers_components.go
+++ b/overlord/snapstate/handlers_components.go
@@ -418,6 +418,22 @@ func saveCurrentKernelModuleComponents(t *state.Task, snapsup *SnapSetup, snapst
 	return nil
 }
 
+// updateSeqFileForSnap rewrites the on-disk sequence file for the given snap
+// so that it stays consistent with the component information held in the
+// in-memory sequence. The sequence file is written for failover handling
+// (snap-repair) at snap link time, but component link/unlink handlers mutate
+// the sequence afterwards; without this the on-disk file would permanently
+// lack the components that were linked after the snap revision. The file is
+// only rewritten if it already exists, mirroring writeMigrationStatus, so that
+// we never create it for a snap whose link-snap has not run yet. State must be
+// locked by the caller.
+func updateSeqFileForSnap(snapst *SnapState, instanceName string) error {
+	if !osutil.FileExists(snap.SequenceFile(instanceName)) {
+		return nil
+	}
+	return writeSeqFile(instanceName, snapst)
+}
+
 func (m *SnapManager) doLinkComponent(t *state.Task, _ *tomb.Tomb) error {
 	// invariant: component is not in the state (unlink happens previously if necessary)
 	st := t.State()
@@ -468,6 +484,11 @@ func (m *SnapManager) doLinkComponent(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
+	// keep the on-disk sequence file in sync with the newly linked component
+	if err := updateSeqFileForSnap(snapSt, snapsup.InstanceName()); err != nil {
+		return err
+	}
+
 	// Finally, write the state
 	Set(st, snapsup.InstanceName(), snapSt)
 	// Make sure we won't be rerun
@@ -514,6 +535,11 @@ func (m *SnapManager) undoLinkComponent(t *state.Task, _ *tomb.Tomb) error {
 	snapSt.Sequence.RemoveComponentForRevision(snapInfo.Revision,
 		linkedComp.SideInfo.Component)
 
+	// keep the on-disk sequence file in sync with the removed component
+	if err := updateSeqFileForSnap(snapSt, snapsup.InstanceName()); err != nil {
+		return err
+	}
+
 	// Finally, write the state
 	Set(st, snapsup.InstanceName(), snapSt)
 	// Make sure we won't be rerun
@@ -551,6 +577,11 @@ func (m *SnapManager) doUnlinkCurrentComponent(t *state.Task, _ *tomb.Tomb) (err
 		return err
 	}
 
+	// keep the on-disk sequence file in sync with the removed component
+	if err := updateSeqFileForSnap(snapSt, snapInfo.InstanceName()); err != nil {
+		return err
+	}
+
 	// Finally, write the state
 	Set(st, snapInfo.InstanceName(), snapSt)
 	// Make sure we won't be rerun
@@ -575,6 +606,11 @@ func (m *SnapManager) doUnlinkComponent(t *state.Task, _ *tomb.Tomb) (err error)
 	// Remove component for the specified revision
 	if err := m.unlinkComponent(
 		t, snapSt, snapSup.InstanceName(), snapSup.Revision(), cref); err != nil {
+		return err
+	}
+
+	// keep the on-disk sequence file in sync with the removed component
+	if err := updateSeqFileForSnap(snapSt, snapSup.InstanceName()); err != nil {
 		return err
 	}
 
@@ -634,6 +670,11 @@ func (m *SnapManager) undoUnlinkCurrentComponent(t *state.Task, _ *tomb.Tomb) (e
 		return err
 	}
 
+	// keep the on-disk sequence file in sync with the relinked component
+	if err := updateSeqFileForSnap(snapSt, snapsup.InstanceName()); err != nil {
+		return err
+	}
+
 	// Finally, write the state
 	Set(st, snapsup.InstanceName(), snapSt)
 	// Make sure we won't be rerun
@@ -668,6 +709,11 @@ func (m *SnapManager) undoUnlinkComponent(t *state.Task, _ *tomb.Tomb) (err erro
 
 	if err := m.relinkComponent(
 		t, snapSt, snapSup.InstanceName(), snapSup.Revision()); err != nil {
+		return err
+	}
+
+	// keep the on-disk sequence file in sync with the relinked component
+	if err := updateSeqFileForSnap(snapSt, snapSup.InstanceName()); err != nil {
 		return err
 	}
 

--- a/overlord/snapstate/handlers_components.go
+++ b/overlord/snapstate/handlers_components.go
@@ -654,6 +654,18 @@ func (m *SnapManager) undoUnlinkComponent(t *state.Task, _ *tomb.Tomb) (err erro
 		return err
 	}
 
+	// The snap revision this component belonged to may no longer be in the
+	// sequence. This happens when unlink-component ran as part of discarding an
+	// old revision (removeInactiveRevision) during a refresh, and the later
+	// discard-snap task (which has no undo handler) removed the whole revision
+	// from the sequence before a subsequent failure triggered the undo. In that
+	// case the revision, its files and its components are gone for good, so
+	// there is nothing to relink and the undo is a no-op.
+	if snapSt.Sequence.LastIndex(snapSup.Revision()) == -1 {
+		t.SetStatus(state.UndoneStatus)
+		return nil
+	}
+
 	if err := m.relinkComponent(
 		t, snapSt, snapSup.InstanceName(), snapSup.Revision()); err != nil {
 		return err

--- a/overlord/snapstate/handlers_components_link_test.go
+++ b/overlord/snapstate/handlers_components_link_test.go
@@ -21,6 +21,7 @@ package snapstate_test
 
 import (
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/snapcore/snapd/dirs"
@@ -31,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/naming"
 	. "gopkg.in/check.v1"
+	"gopkg.in/tomb.v2"
 )
 
 type linkCompSnapSuite struct {
@@ -518,4 +520,105 @@ func (s *linkCompSnapSuite) TestDoUnlinkThenUndoUnlinkComponent(c *C) {
 
 	s.testDoUnlinkThenUndoUnlinkComponent(c, snapName, snapRev,
 		compName, compRev, "unlink-component")
+}
+
+// TestUndoUnlinkComponentAfterSnapRevisionDiscarded reproduces a failure seen
+// when a refresh with components fails (e.g. in the configure hook) after the
+// cleanup of an old revision already ran. The old revision's components are
+// unlinked by unlink-component tasks (via removeInactiveRevision), and then
+// discard-snap (which has no undo handler) removes the whole old revision from
+// the sequence. When a later task fails, the undo of unlink-component must not
+// error out with "snap revision is not in the sequence": the revision is gone
+// for good, so the undo must be a no-op.
+func (s *linkCompSnapSuite) TestUndoUnlinkComponentAfterSnapRevisionDiscarded(c *C) {
+	const snapName = "mysnap"
+	const compName = "mycomp"
+	oldSnapRev := snap.R(1)
+	currentSnapRev := snap.R(2)
+	compRev := snap.R(7)
+
+	// discardRevSim simulates doDiscardSnap removing the old revision from the
+	// sequence (and discarding its files), which has no undo handler.
+	s.runner.AddHandler("discard-rev-sim", func(t *state.Task, _ *tomb.Tomb) error {
+		st := t.State()
+		st.Lock()
+		defer st.Unlock()
+
+		var snapst snapstate.SnapState
+		if err := snapstate.Get(st, snapName, &snapst); err != nil {
+			return err
+		}
+		newSeq := snapst.Sequence.Revisions[:0]
+		for _, rss := range snapst.Sequence.Revisions {
+			if rss.Snap.Revision == oldSnapRev {
+				continue
+			}
+			newSeq = append(newSeq, rss)
+		}
+		snapst.Sequence.Revisions = newSeq
+		snapstate.Set(st, snapName, &snapst)
+		t.SetStatus(state.DoneStatus)
+		return nil
+	}, nil)
+
+	s.state.Lock()
+
+	// state with two revisions, the old one carrying the component
+	oldSI := &snap.SideInfo{RealName: snapName, Revision: oldSnapRev, SnapID: "some-snap-id"}
+	currentSI := &snap.SideInfo{RealName: snapName, Revision: currentSnapRev, SnapID: "some-snap-id"}
+	csi := snap.NewComponentSideInfo(naming.NewComponentRef(snapName, compName), compRev)
+	comps := []*sequence.ComponentState{sequence.NewComponentState(csi, snap.StandardComponent)}
+	snapstate.Set(s.state, snapName, &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos(
+			[]*sequence.RevisionSideState{
+				sequence.NewRevisionSideState(oldSI, comps),
+				sequence.NewRevisionSideState(currentSI, nil),
+			}),
+		Current: currentSnapRev,
+	})
+
+	// unlink-component for the old revision's component, as created by
+	// removeInactiveRevision (its snap-setup refers to the old revision)
+	unlink := s.state.NewTask("unlink-component", "task desc")
+	unlink.Set("component-setup", snapstate.NewComponentSetup(csi, snap.StandardComponent, ""))
+	unlink.Set("snap-setup", &snapstate.SnapSetup{SideInfo: oldSI})
+	chg := s.state.NewChange("test change", "change desc")
+	chg.AddTask(unlink)
+
+	// then the old revision is discarded (removing it from the sequence)
+	discard := s.state.NewTask("discard-rev-sim", "discarding old revision")
+	discard.WaitFor(unlink)
+	chg.AddTask(discard)
+
+	// then something fails, provoking the undo of the whole change
+	terr := s.state.NewTask("error-trigger", "provoking undo")
+	terr.WaitFor(discard)
+	chg.AddTask(terr)
+
+	s.state.Unlock()
+
+	for i := 0; i < 10; i++ {
+		s.se.Ensure()
+		s.se.Wait()
+	}
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// the change fails because of the error-trigger, but the undo of
+	// unlink-component must succeed (as a no-op) rather than error with
+	// "snap revision is not in the sequence"
+	err := chg.Err()
+	c.Assert(err, NotNil)
+	c.Check(strings.Contains(err.Error(), "is not in the sequence"), Equals, false,
+		Commentf("unexpected error: %v", err))
+
+	// the unlink-component task must have been undone cleanly
+	c.Check(unlink.Status(), Equals, state.UndoneStatus)
+
+	// the component symlink is not re-created: the old revision is gone
+	for _, op := range s.fakeBackend.ops {
+		c.Check(op.op, Not(Equals), "link-component")
+	}
 }

--- a/overlord/snapstate/handlers_components_link_test.go
+++ b/overlord/snapstate/handlers_components_link_test.go
@@ -20,6 +20,7 @@
 package snapstate_test
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -120,6 +121,54 @@ func (s *linkCompSnapSuite) TestDoLinkComponent(c *C) {
 	s.state.Unlock()
 
 	s.testDoLinkComponent(c, snapName, snapRev, []*snap.ComponentSideInfo{})
+}
+
+// TestDoLinkComponentUpdatesSeqFile verifies that linking a component updates
+// the on-disk sequence file, so that it stays consistent with the component
+// information held in the state (the sequence file is written at snap link
+// time, before components are linked).
+func (s *linkCompSnapSuite) TestDoLinkComponentUpdatesSeqFile(c *C) {
+	const snapName = "mysnap"
+	const compName = "mycomp"
+	snapRev := snap.R(1)
+	compRev := snap.R(7)
+
+	s.state.Lock()
+	// state does not contain the component yet
+	setStateWithOneSnap(s.state, snapName, snapRev)
+
+	// pretend that link-snap already wrote the sequence file (without
+	// components, as the component is not linked yet)
+	var snapst snapstate.SnapState
+	c.Assert(snapstate.Get(s.state, snapName, &snapst), IsNil)
+	c.Assert(snapstate.WriteSeqFile(snapName, &snapst), IsNil)
+
+	si := createTestSnapInfoForComponent(c, snapName, snapRev, compName)
+	ssu := createTestSnapSetup(si, snapstate.Flags{})
+
+	t := s.state.NewTask("link-component", "task desc")
+	cref := naming.NewComponentRef(snapName, compName)
+	csi := snap.NewComponentSideInfo(cref, compRev)
+	t.Set("component-setup", snapstate.NewComponentSetup(csi, snap.StandardComponent, ""))
+	t.Set("snap-setup", ssu)
+	chg := s.state.NewChange("test change", "change desc")
+	chg.AddTask(t)
+
+	s.state.Unlock()
+
+	s.se.Ensure()
+	s.se.Wait()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	c.Check(chg.Err(), IsNil)
+	c.Assert(t.Status(), Equals, state.DoneStatus)
+
+	// the on-disk sequence file must now contain the linked component
+	seqContent, err := os.ReadFile(snap.SequenceFile(snapName))
+	c.Assert(err, IsNil)
+	c.Check(string(seqContent), Equals, `{"sequence":[{"name":"mysnap","snap-id":"some-snap-id","revision":"1","components":[{"side-info":{"component":{"snap-name":"mysnap","component-name":"mycomp"},"revision":"7"},"type":"standard"}]}],"current":"1","migrated-hidden":false,"migrated-exposed-home":false}`)
 }
 
 func (s *linkCompSnapSuite) TestDoLinkComponentOtherCompPresent(c *C) {

--- a/overlord/snapstate/handlers_components_link_test.go
+++ b/overlord/snapstate/handlers_components_link_test.go
@@ -20,6 +20,7 @@
 package snapstate_test
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -165,10 +166,38 @@ func (s *linkCompSnapSuite) TestDoLinkComponentUpdatesSeqFile(c *C) {
 	c.Check(chg.Err(), IsNil)
 	c.Assert(t.Status(), Equals, state.DoneStatus)
 
-	// the on-disk sequence file must now contain the linked component
+	// the on-disk sequence file must now contain the linked component. we
+	// compare the unmarshaled content rather than the raw JSON so that the test
+	// does not depend on field ordering or other serialization details.
 	seqContent, err := os.ReadFile(snap.SequenceFile(snapName))
 	c.Assert(err, IsNil)
-	c.Check(string(seqContent), Equals, `{"sequence":[{"name":"mysnap","snap-id":"some-snap-id","revision":"1","components":[{"side-info":{"component":{"snap-name":"mysnap","component-name":"mycomp"},"revision":"7"},"type":"standard"}]}],"current":"1","migrated-hidden":false,"migrated-exposed-home":false}`)
+
+	var got map[string]any
+	c.Assert(json.Unmarshal(seqContent, &got), IsNil)
+	c.Check(got, DeepEquals, map[string]any{
+		"sequence": []any{
+			map[string]any{
+				"name":     "mysnap",
+				"snap-id":  "some-snap-id",
+				"revision": "1",
+				"components": []any{
+					map[string]any{
+						"side-info": map[string]any{
+							"component": map[string]any{
+								"snap-name":      "mysnap",
+								"component-name": "mycomp",
+							},
+							"revision": "7",
+						},
+						"type": "standard",
+					},
+				},
+			},
+		},
+		"current":               "1",
+		"migrated-hidden":       false,
+		"migrated-exposed-home": false,
+	})
 }
 
 func (s *linkCompSnapSuite) TestDoLinkComponentOtherCompPresent(c *C) {

--- a/overlord/snapstate/handlers_discard_test.go
+++ b/overlord/snapstate/handlers_discard_test.go
@@ -20,6 +20,7 @@
 package snapstate_test
 
 import (
+	"encoding/json"
 	"os"
 
 	. "gopkg.in/check.v1"
@@ -356,10 +357,26 @@ func (s *discardSnapSuite) TestDoDiscardSnapKeepsSeqFileForNonLastRevision(c *C)
 	c.Check(t.Status(), Equals, state.DoneStatus)
 	c.Check(seqFilePath, testutil.FilePresent)
 
-	// the discarded revision must no longer be present in the sequence file
+	// the discarded revision must no longer be present in the sequence file. we
+	// compare the unmarshaled content rather than the raw JSON so that the test
+	// does not depend on field ordering or other serialization details.
 	seqContent, err := os.ReadFile(seqFilePath)
 	c.Assert(err, IsNil)
-	c.Check(string(seqContent), Equals, `{"sequence":[{"name":"foo","snap-id":"","revision":"33"}],"current":"33","migrated-hidden":false,"migrated-exposed-home":false}`)
+
+	var got map[string]any
+	c.Assert(json.Unmarshal(seqContent, &got), IsNil)
+	c.Check(got, DeepEquals, map[string]any{
+		"sequence": []any{
+			map[string]any{
+				"name":     "foo",
+				"snap-id":  "",
+				"revision": "33",
+			},
+		},
+		"current":               "33",
+		"migrated-hidden":       false,
+		"migrated-exposed-home": false,
+	})
 }
 
 func (s *discardSnapSuite) TestDoDiscardSnapNoErrorIfSeqFileMissing(c *C) {

--- a/overlord/snapstate/handlers_discard_test.go
+++ b/overlord/snapstate/handlers_discard_test.go
@@ -355,6 +355,11 @@ func (s *discardSnapSuite) TestDoDiscardSnapKeepsSeqFileForNonLastRevision(c *C)
 	defer s.state.Unlock()
 	c.Check(t.Status(), Equals, state.DoneStatus)
 	c.Check(seqFilePath, testutil.FilePresent)
+
+	// the discarded revision must no longer be present in the sequence file
+	seqContent, err := os.ReadFile(seqFilePath)
+	c.Assert(err, IsNil)
+	c.Check(string(seqContent), Equals, `{"sequence":[{"name":"foo","snap-id":"","revision":"33"}],"current":"33","migrated-hidden":false,"migrated-exposed-home":false}`)
 }
 
 func (s *discardSnapSuite) TestDoDiscardSnapNoErrorIfSeqFileMissing(c *C) {

--- a/overlord/snapstate/sequence/sequence.go
+++ b/overlord/snapstate/sequence/sequence.go
@@ -25,6 +25,7 @@ package sequence
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/naming"
@@ -137,14 +138,16 @@ func (snapSeq *SnapSequence) LastIndex(revision snap.Revision) int {
 	return -1
 }
 
-var ErrSnapRevNotInSequence = errors.New("snap is not in the sequence")
+// ErrSnapRevNotInSequence is returned when an operation targets a snap
+// revision that is not present in the snap sequence.
+var ErrSnapRevNotInSequence = errors.New("snap revision is not in the sequence")
 
 // AddComponentForRevision adds a component to the last instance of snapRev in
 // the sequence.
 func (snapSeq *SnapSequence) AddComponentForRevision(snapRev snap.Revision, cs *ComponentState) error {
 	snapIdx := snapSeq.LastIndex(snapRev)
 	if snapIdx == -1 {
-		return ErrSnapRevNotInSequence
+		return fmt.Errorf("%w: %s", ErrSnapRevNotInSequence, snapRev)
 	}
 	revSt := snapSeq.Revisions[snapIdx]
 

--- a/overlord/snapstate/sequence/sequence_test.go
+++ b/overlord/snapstate/sequence/sequence_test.go
@@ -123,7 +123,9 @@ func (s *sequenceTestSuite) TestAddComponentForRevision(c *C) {
 	c.Assert(seq.AddComponentForRevision(snapRev, cs3), IsNil)
 	c.Assert(seq.Revisions[0].Components, DeepEquals, []*sequence.ComponentState{cs2, cs3})
 
-	c.Assert(seq.AddComponentForRevision(snap.R(2), cs3), Equals, sequence.ErrSnapRevNotInSequence)
+	err := seq.AddComponentForRevision(snap.R(2), cs3)
+	c.Assert(err, testutil.ErrorIs, sequence.ErrSnapRevNotInSequence)
+	c.Assert(err, ErrorMatches, "snap revision is not in the sequence: 2")
 }
 
 func (s *sequenceTestSuite) TestRemoveComponentForRevision(c *C) {

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -16441,6 +16441,175 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
 	c.Assert(snapst.Sequence.Revisions[0], DeepEquals, seq.Revisions[0])
 }
 
+// TestUpdateWithComponentsBackToPrevRevisionUndo exercises the undo path of a
+// refresh that moves back to a snap revision that is already present in the
+// sequence and that carries extra components which must be unlinked. The
+// undo of unlink-component must not fail with "snap revision is not in the
+// sequence".
+func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevisionUndo(c *C) {
+	const (
+		snapName = "kernel-snap-with-components"
+		snapID   = "kernel-snap-with-components-id"
+		channel  = "channel-for-components-only-component-refresh"
+	)
+
+	r := snapstatetest.MockDeviceModel(MakeModel20("pc", map[string]any{"base": "core24"}))
+	defer r()
+
+	components := []string{"standard-component", "kernel-modules-component"}
+
+	currentSnapRev := snap.R(11)
+	prevSnapRev := snap.R(7)
+
+	sort.Strings(components)
+
+	currentSI := snap.SideInfo{
+		RealName: snapName,
+		Revision: currentSnapRev,
+		SnapID:   snapID,
+		Channel:  channel,
+	}
+	snaptest.MockSnap(c, fmt.Sprintf("name: %s\ntype: kernel\n", snapName), &currentSI)
+
+	restore := snapstate.MockRevisionDate(nil)
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	prevSI := snap.SideInfo{
+		RealName: snapName,
+		Revision: prevSnapRev,
+		SnapID:   snapID,
+		Channel:  channel,
+	}
+
+	otherSI := snap.SideInfo{
+		RealName: snapName,
+		Revision: snap.R(99),
+		SnapID:   snapID,
+		Channel:  channel,
+	}
+
+	seq := snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{&otherSI, &prevSI, &currentSI})
+
+	for i, comp := range components {
+		prevCsi := snap.ComponentSideInfo{
+			Component: naming.NewComponentRef(snapName, comp),
+			Revision:  snap.R(i + 1),
+		}
+		err := seq.AddComponentForRevision(prevSnapRev, &sequence.ComponentState{
+			SideInfo: &prevCsi,
+			CompType: componentNameToType(c, comp),
+		})
+		c.Assert(err, IsNil)
+
+		currentCsi := snap.ComponentSideInfo{
+			Component: naming.NewComponentRef(snapName, comp),
+			Revision:  snap.R(i + 3),
+		}
+		err = seq.AddComponentForRevision(currentSnapRev, &sequence.ComponentState{
+			SideInfo: &currentCsi,
+			CompType: componentNameToType(c, comp),
+		})
+		c.Assert(err, IsNil)
+	}
+
+	availableComponents := make([]string, len(components))
+	copy(availableComponents, components)
+	availableComponents = append(availableComponents, "standard-component-extra")
+
+	// an extra component installed only for the revision we are moving to; it
+	// will be unlinked by an unlink-component task and then relinked on undo.
+	extraCsi := snap.ComponentSideInfo{
+		Component: naming.NewComponentRef(snapName, "standard-component-extra"),
+		Revision:  snap.R(len(availableComponents) + 1),
+	}
+	err := seq.AddComponentForRevision(prevSnapRev, &sequence.ComponentState{
+		SideInfo: &extraCsi,
+		CompType: componentNameToType(c, extraCsi.Component.ComponentName),
+	})
+	c.Assert(err, IsNil)
+
+	s.fakeStore.snapResourcesFn = func(info *snap.Info) []store.SnapResourceResult {
+		c.Assert(info.InstanceName(), DeepEquals, snapName)
+		var results []store.SnapResourceResult
+		for i, compName := range availableComponents {
+			results = append(results, store.SnapResourceResult{
+				DownloadInfo: snap.DownloadInfo{
+					DownloadURL: "http://example.com/" + compName,
+				},
+				Name:      compName,
+				Revision:  i + 2,
+				Type:      fmt.Sprintf("component/%s", componentNameToType(c, compName)),
+				Version:   "1.0",
+				CreatedAt: "2024-01-01T00:00:00Z",
+			})
+		}
+		return results
+	}
+
+	s.AddCleanup(snapstate.MockReadComponentInfo(func(
+		compMntDir string, info *snap.Info, csi *snap.ComponentSideInfo,
+	) (*snap.ComponentInfo, error) {
+		return &snap.ComponentInfo{
+			Component:         csi.Component,
+			Type:              componentNameToType(c, csi.Component.ComponentName),
+			CompVersion:       "1.0",
+			ComponentSideInfo: *csi,
+		}, nil
+	}))
+
+	snapstate.Set(s.state, snapName, &snapstate.SnapState{
+		Active:          true,
+		Sequence:        seq,
+		Current:         currentSI.Revision,
+		SnapType:        "kernel",
+		TrackingChannel: channel,
+	})
+
+	ts, err := snapstate.Update(s.state, snapName, &snapstate.RevisionOptions{
+		Revision: prevSnapRev,
+	}, s.user.ID, snapstate.Flags{})
+	c.Assert(err, IsNil)
+
+	chg := s.state.NewChange("refresh", "refresh a snap")
+	chg.AddAll(ts)
+
+	// an unlink-component task must be present for the extra component,
+	// otherwise this test is not exercising the undo we care about.
+	var hasUnlinkComponent bool
+	for _, t := range ts.Tasks() {
+		if t.Kind() == "unlink-component" {
+			hasUnlinkComponent = true
+		}
+	}
+	c.Assert(hasUnlinkComponent, Equals, true, Commentf("change tasks:\n%s", printTasks(ts.Tasks())))
+
+	last := lastWithLane(ts.Tasks())
+	c.Assert(last, NotNil)
+
+	terr := s.state.NewTask("error-trigger", "provoking total undo")
+	terr.WaitFor(last)
+	terr.JoinLane(last.Lanes()[0])
+	chg.AddTask(terr)
+
+	s.settle(c)
+
+	err = chg.Err()
+	c.Assert(err, NotNil, Commentf("change tasks:\n%s", printTasks(chg.Tasks())))
+	// the undo of unlink-component must not fail with an internal error about
+	// the snap revision missing from the sequence
+	c.Check(err.Error(), Not(testutil.Contains), "is not in the sequence",
+		Commentf("change tasks:\n%s", printTasks(chg.Tasks())))
+
+	// the system must be back to the original current revision, with the
+	// original sequence restored
+	var snapst snapstate.SnapState
+	c.Assert(snapstate.Get(s.state, snapName, &snapst), IsNil)
+	c.Check(snapst.Current, Equals, currentSnapRev)
+}
+
 func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevisionAlreadyPresent(c *C) {
 	s.testUpdateWithComponentsBackToPrevRevisionAlreadyPresent(c, false)
 }

--- a/tests/main/component-failing-configure-refresh/comp-one/meta/component.yaml
+++ b/tests/main/component-failing-configure-refresh/comp-one/meta/component.yaml
@@ -1,0 +1,5 @@
+component: test-snap-comp-conf+comp-one
+type: standard
+version: '1.0'
+summary: test component
+description: test component

--- a/tests/main/component-failing-configure-refresh/comp-two/meta/component.yaml
+++ b/tests/main/component-failing-configure-refresh/comp-two/meta/component.yaml
@@ -1,0 +1,5 @@
+component: test-snap-comp-conf+comp-two
+type: standard
+version: '1.0'
+summary: test component
+description: test component

--- a/tests/main/component-failing-configure-refresh/task.yaml
+++ b/tests/main/component-failing-configure-refresh/task.yaml
@@ -1,0 +1,132 @@
+summary: Test undo of a component refresh that discards an old revision when the configure hook fails
+
+details: |
+  This test is a regression test for two bugs that were triggered when
+  refreshing a snap that has components and a snap-wide configure hook, and the
+  configure hook fails.
+
+  Face 1: when the refresh also garbage-collects an old snap revision in the
+  same change, the old revision's components are unlinked (unlink-component) and
+  then the old revision is removed from the sequence by discard-snap (which has
+  no undo handler). When the configure hook then fails, the undo of
+  unlink-component used to fail with "internal error while undo unlink
+  component: snap revision is not in the sequence", leaving the state
+  inconsistent. The undo must now be a clean no-op.
+
+  Face 2: the on-disk sequence file (/var/lib/snapd/sequence/<snap>.json) is
+  written by link-snap before the components are linked, and used to never be
+  updated afterwards, so it lacked the components of the freshly installed
+  revision. It must now record them.
+
+systems: [ubuntu-16.04-64, ubuntu-18.04-64, ubuntu-2*, ubuntu-core-*-64*, fedora-*]
+
+# the failure/undo paths here can be slow under load
+kill-timeout: 5m
+
+environment:
+  SNAP_NAME: test-snap-comp-conf
+  SEQ_FILE: /var/lib/snapd/sequence/test-snap-comp-conf.json
+
+prepare: |
+  snap pack test-snap
+  snap pack comp-one
+  snap pack comp-two
+
+restore: |
+  snap unset system refresh.retain
+  if snap list "$SNAP_NAME" 2>/dev/null; then
+    snap remove --purge "$SNAP_NAME"
+  fi
+  rm -f test-snap-comp-conf_*.snap test-snap-comp-conf+*.comp install.err tasks.out change.out
+
+execute: |
+  # keep at most 2 revisions so that the third install discards the oldest one
+  snap set system refresh.retain=2
+
+  echo "Install the snap with its components (revision x1)"
+  snap install --dangerous \
+    ./test-snap-comp-conf_1.0_all.snap \
+    ./test-snap-comp-conf+comp-one_1.0.comp \
+    ./test-snap-comp-conf+comp-two_1.0.comp
+
+  snap list "$SNAP_NAME" | awk 'NR != 1 { print $3 }' | MATCH x1
+  snap run "$SNAP_NAME" comp-one
+  snap run "$SNAP_NAME" comp-two
+
+  echo "Face 2: the sequence file records the components for the current revision"
+  test -f "$SEQ_FILE"
+  grep -q '"revision":"x1"' "$SEQ_FILE"
+  grep -q '"component-name":"comp-one"' "$SEQ_FILE"
+  grep -q '"component-name":"comp-two"' "$SEQ_FILE"
+
+  echo "Refresh to revision x2 (configure hook succeeds)"
+  snap install --dangerous \
+    ./test-snap-comp-conf_1.0_all.snap \
+    ./test-snap-comp-conf+comp-one_1.0.comp \
+    ./test-snap-comp-conf+comp-two_1.0.comp
+
+  snap list "$SNAP_NAME" | awk 'NR != 1 { print $3 }' | MATCH x2
+
+  echo "Face 2: after the refresh the sequence file records components for x2"
+  grep -q '"revision":"x2"' "$SEQ_FILE"
+  grep -q '"component-name":"comp-one"' "$SEQ_FILE"
+  grep -q '"component-name":"comp-two"' "$SEQ_FILE"
+
+  echo "Make the configure hook fail on the next refresh"
+  # a marker file is used (not a config option) because setting a config option
+  # would itself run the configure hook and fail immediately. $SNAP_COMMON is
+  # shared across all revisions, so the new revision's configure hook sees it.
+  mkdir -p "/var/snap/$SNAP_NAME/common"
+  touch "/var/snap/$SNAP_NAME/common/fail-configure"
+
+  echo "Refresh to revision x3; the old x1 is discarded in the same change and the configure hook fails"
+  if snap install --dangerous \
+    ./test-snap-comp-conf_1.0_all.snap \
+    ./test-snap-comp-conf+comp-one_1.0.comp \
+    ./test-snap-comp-conf+comp-two_1.0.comp 2> install.err; then
+      echo "expected the refresh to fail due to the failing configure hook"
+      exit 1
+  fi
+
+  echo "Face 1: the failure is the configure hook, not an internal undo error"
+  not grep -q "is not in the sequence" install.err
+
+  echo "Face 1: the change settles to Error instead of getting stuck in the undo"
+  # pick the most recent change for this snap that is in Error state
+  change="$(snap changes | awk -v n="$SNAP_NAME" '$2 == "Error" && $0 ~ n { print $1; exit }')"
+  test -n "$change"
+  snap tasks "$change" > tasks.out
+  grep -q "Run configure hook" tasks.out
+  # no task must be left in Doing/Undoing state once the change has settled
+  not grep -qE "^(Doing|Undoing)" tasks.out
+  # the task that failed is the configure hook
+  grep "Run configure hook" tasks.out | MATCH "^Error"
+
+  echo "Face 1: the undo of the discarded revision's unlink-component is a clean no-op"
+  # the task summary for unlinking a component is "Unlink component ...". none
+  # of these may be in Error state: the discarded old revision is no longer in
+  # the sequence, and undoing its unlink must be a no-op, not an error.
+  if grep "Unlink component" tasks.out | grep -q "^Error"; then
+      echo "an unlink-component task errored during undo:"
+      grep "Unlink component" tasks.out
+      exit 1
+  fi
+
+  echo "Face 1: the change error mentions the configure hook, not the internal undo error"
+  # the change error (from snap change) must point at the configure hook and
+  # must not mention the internal "not in the sequence" undo error. the hook's
+  # own output lives in the task log, which snap change folds away, so we only
+  # assert on the error summary here.
+  snap change "$change" > change.out
+  not grep -q "is not in the sequence" change.out
+  grep -q "run hook \"configure\"" change.out
+
+  echo "The snap was rolled back to x2 with its components intact"
+  snap list "$SNAP_NAME" | awk 'NR != 1 { print $3 }' | MATCH x2
+  snap run "$SNAP_NAME" comp-one
+  snap run "$SNAP_NAME" comp-two
+
+  echo "Face 2: the sequence file still matches the in-memory state after the rollback"
+  grep -q '"revision":"x2"' "$SEQ_FILE"
+  grep -q '"component-name":"comp-one"' "$SEQ_FILE"
+  grep -q '"component-name":"comp-two"' "$SEQ_FILE"

--- a/tests/main/component-failing-configure-refresh/test-snap/meta/hooks/configure
+++ b/tests/main/component-failing-configure-refresh/test-snap/meta/hooks/configure
@@ -1,0 +1,14 @@
+#!/bin/sh -e
+
+# when the marker file "$SNAP_COMMON/fail-configure" exists, this hook fails.
+# this is used to simulate a snap whose configure hook fails during a refresh.
+# a marker file is used (instead of a configuration option) because setting a
+# configuration option would itself run this hook and fail immediately.
+# $SNAP_COMMON is shared across all revisions of the snap, so the hook of the
+# revision being refreshed to sees the marker created before the refresh.
+if [ -e "$SNAP_COMMON/fail-configure" ]; then
+    echo "configure hook failing as requested"
+    exit 1
+fi
+
+exit 0

--- a/tests/main/component-failing-configure-refresh/test-snap/meta/snap.yaml
+++ b/tests/main/component-failing-configure-refresh/test-snap/meta/snap.yaml
@@ -1,0 +1,24 @@
+name: test-snap-comp-conf
+version: '1.0'
+summary: A snap with components and a configure hook
+description: |
+  A snap with components and a configure hook whose failure can be
+  triggered via a configuration option, used to test the undo path of a
+  refresh that discards an old revision.
+architectures:
+- all
+base: core24
+confinement: strict
+grade: stable
+apps:
+  test-snap-comp-conf:
+    command: test
+components:
+  comp-one:
+    summary: test component
+    description: test component
+    type: standard
+  comp-two:
+    summary: test component
+    description: test component
+    type: standard

--- a/tests/main/component-failing-configure-refresh/test-snap/test
+++ b/tests/main/component-failing-configure-refresh/test-snap/test
@@ -1,0 +1,13 @@
+#!/bin/sh -e
+
+if [ $# -ne 1 ]; then
+    echo "pass in a component name to check if it is installed"
+    exit 1
+fi
+
+if [ ! -f "/snap/${SNAP_NAME}/components/${SNAP_REVISION}/${1}/meta/component.yaml" ]; then
+    echo "component ${1} is not installed!"
+    exit 1
+fi
+
+echo "component ${1} is installed"


### PR DESCRIPTION
This came out of a debug session after I noticed the bug on my system earlier today. There are two unrelated issues: one is that a snap with components is refreshed, where one old revision is being garbage collected, the incoming revision has a configure hook that fails. We then attempt to re-link the components from the garbage collected snap revision which fails.

The second issue was discovered by accident when looking at sequences. The state.json file for the snap had a correct sequence (with revisions and components) while the standalone sequence file had the correct revision but components for the last revision were lost.

There's also a drive-by change that fixes confusing wording of an error message that used to suggest that a snap is not found while it was that a snap _revision_ is not really found.

I'm working on a spread test so this is still marked as draft.