### PR TITLE
o/snapstate: fix undo of unlink-component after its snap revision was discarded

### DIFF
--- a/overlord/snapstate/handlers_components.go
+++ b/overlord/snapstate/handlers_components.go
@@ -654,6 +654,18 @@ func (m *SnapManager) undoUnlinkComponent(t *state.Task, _ *tomb.Tomb) (err erro
 		return err
 	}
 
+	// The snap revision this component belonged to may no longer be in the
+	// sequence. This happens when unlink-component ran as part of discarding an
+	// old revision (removeInactiveRevision) during a refresh, and the later
+	// discard-snap task (which has no undo handler) removed the whole revision
+	// from the sequence before a subsequent failure triggered the undo. In that
+	// case the revision, its files and its components are gone for good, so
+	// there is nothing to relink and the undo is a no-op.
+	if snapSt.Sequence.LastIndex(snapSup.Revision()) == -1 {
+		t.SetStatus(state.UndoneStatus)
+		return nil
+	}
+
 	if err := m.relinkComponent(
 		t, snapSt, snapSup.InstanceName(), snapSup.Revision()); err != nil {
 		return err

--- a/overlord/snapstate/handlers_components_link_test.go
+++ b/overlord/snapstate/handlers_components_link_test.go
@@ -21,6 +21,7 @@ package snapstate_test
 
 import (
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/snapcore/snapd/dirs"
@@ -518,4 +519,106 @@ func (s *linkCompSnapSuite) TestDoUnlinkThenUndoUnlinkComponent(c *C) {
 
 	s.testDoUnlinkThenUndoUnlinkComponent(c, snapName, snapRev,
 		compName, compRev, "unlink-component")
+}
+
+// TestUndoUnlinkComponentAfterSnapRevisionDiscarded reproduces a failure seen
+// when a refresh with components fails (e.g. in the configure hook) after the
+// cleanup of an old revision already ran. The old revision's components are
+// unlinked by unlink-component tasks (via removeInactiveRevision), and then
+// discard-snap (which has no undo handler) removes the whole old revision from
+// the sequence. When a later task fails, the undo of unlink-component must not
+// error out with "snap revision is not in the sequence": the revision is gone
+// for good, so the undo must be a no-op.
+//
+// This builds the real task chain that removeInactiveRevision produces
+// (clear-snap, unlink-component, discard-component, discard-snap) and runs the
+// real task handlers, so the revision is genuinely discarded by discard-snap
+// before the undo of unlink-component runs.
+func (s *linkCompSnapSuite) TestUndoUnlinkComponentAfterSnapRevisionDiscarded(c *C) {
+	const snapName = "mysnap"
+	const compName = "mycomp"
+	oldSnapRev := snap.R(1)
+	currentSnapRev := snap.R(2)
+	compRev := snap.R(7)
+
+	s.state.Lock()
+
+	// state with two revisions, the old one carrying the component
+	oldSI := &snap.SideInfo{RealName: snapName, Revision: oldSnapRev, SnapID: "some-snap-id"}
+	currentSI := &snap.SideInfo{RealName: snapName, Revision: currentSnapRev, SnapID: "some-snap-id"}
+	csi := snap.NewComponentSideInfo(naming.NewComponentRef(snapName, compName), compRev)
+	comps := []*sequence.ComponentState{sequence.NewComponentState(csi, snap.StandardComponent)}
+	snapstate.Set(s.state, snapName, &snapstate.SnapState{
+		Active:   true,
+		SnapType: "app",
+		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos(
+			[]*sequence.RevisionSideState{
+				sequence.NewRevisionSideState(oldSI, comps),
+				sequence.NewRevisionSideState(currentSI, nil),
+			}),
+		Current: currentSnapRev,
+	})
+
+	chg := s.state.NewChange("test change", "change desc")
+
+	// the tasks below mirror removeInactiveRevision for the old revision:
+	// clear-snap, then unlink-component + discard-component for each component,
+	// then discard-snap.
+	clearData := s.state.NewTask("clear-snap", "clear data for old revision")
+	clearData.Set("snap-setup", &snapstate.SnapSetup{SideInfo: oldSI})
+	chg.AddTask(clearData)
+
+	unlink := s.state.NewTask("unlink-component", "unlink old revision component")
+	unlink.Set("snap-setup-task", clearData.ID())
+	unlink.Set("component-setup", snapstate.NewComponentSetup(csi, snap.StandardComponent, ""))
+	unlink.WaitFor(clearData)
+	chg.AddTask(unlink)
+
+	discardComp := s.state.NewTask("discard-component", "discard old revision component")
+	discardComp.Set("snap-setup-task", clearData.ID())
+	discardComp.Set("component-setup-task", unlink.ID())
+	discardComp.WaitFor(unlink)
+	chg.AddTask(discardComp)
+
+	discardSnap := s.state.NewTask("discard-snap", "discard old revision")
+	discardSnap.Set("snap-setup-task", clearData.ID())
+	discardSnap.WaitFor(discardComp)
+	chg.AddTask(discardSnap)
+
+	// then something fails, provoking the undo of the whole change
+	terr := s.state.NewTask("error-trigger", "provoking undo")
+	terr.WaitFor(discardSnap)
+	chg.AddTask(terr)
+
+	s.state.Unlock()
+
+	for i := 0; i < 10; i++ {
+		s.se.Ensure()
+		s.se.Wait()
+	}
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// discard-snap really ran and removed the old revision from the sequence
+	var snapst snapstate.SnapState
+	c.Assert(snapstate.Get(s.state, snapName, &snapst), IsNil)
+	c.Check(snapst.Sequence.LastIndex(oldSnapRev), Equals, -1)
+	c.Check(snapst.Current, Equals, currentSnapRev)
+
+	// the change fails because of the error-trigger, but the undo of
+	// unlink-component must succeed (as a no-op) rather than error with
+	// "snap revision is not in the sequence"
+	err := chg.Err()
+	c.Assert(err, NotNil)
+	c.Check(strings.Contains(err.Error(), "is not in the sequence"), Equals, false,
+		Commentf("unexpected error: %v", err))
+
+	// the unlink-component task must have been undone cleanly
+	c.Check(unlink.Status(), Equals, state.UndoneStatus)
+
+	// the component symlink is not re-created: the old revision is gone
+	for _, op := range s.fakeBackend.ops {
+		c.Check(op.op, Not(Equals), "link-component")
+	}
 }

--- a/overlord/snapstate/sequence/sequence.go
+++ b/overlord/snapstate/sequence/sequence.go
@@ -25,6 +25,7 @@ package sequence
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/naming"
@@ -137,14 +138,16 @@ func (snapSeq *SnapSequence) LastIndex(revision snap.Revision) int {
 	return -1
 }
 
-var ErrSnapRevNotInSequence = errors.New("snap is not in the sequence")
+// ErrSnapRevNotInSequence is returned when an operation targets a snap
+// revision that is not present in the snap sequence.
+var ErrSnapRevNotInSequence = errors.New("snap revision is not in the sequence")
 
 // AddComponentForRevision adds a component to the last instance of snapRev in
 // the sequence.
 func (snapSeq *SnapSequence) AddComponentForRevision(snapRev snap.Revision, cs *ComponentState) error {
 	snapIdx := snapSeq.LastIndex(snapRev)
 	if snapIdx == -1 {
-		return ErrSnapRevNotInSequence
+		return fmt.Errorf("%w: %s", ErrSnapRevNotInSequence, snapRev)
 	}
 	revSt := snapSeq.Revisions[snapIdx]
 

--- a/overlord/snapstate/sequence/sequence_test.go
+++ b/overlord/snapstate/sequence/sequence_test.go
@@ -123,7 +123,9 @@ func (s *sequenceTestSuite) TestAddComponentForRevision(c *C) {
 	c.Assert(seq.AddComponentForRevision(snapRev, cs3), IsNil)
 	c.Assert(seq.Revisions[0].Components, DeepEquals, []*sequence.ComponentState{cs2, cs3})
 
-	c.Assert(seq.AddComponentForRevision(snap.R(2), cs3), Equals, sequence.ErrSnapRevNotInSequence)
+	err := seq.AddComponentForRevision(snap.R(2), cs3)
+	c.Assert(err, testutil.ErrorIs, sequence.ErrSnapRevNotInSequence)
+	c.Assert(err, ErrorMatches, "snap revision is not in the sequence: 2")
 }
 
 func (s *sequenceTestSuite) TestRemoveComponentForRevision(c *C) {


### PR DESCRIPTION
Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?