### PR TITLE
o/snapstate: keep the on-disk sequence file in sync with component changes

### DIFF
--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -3566,6 +3566,13 @@ func (m *SnapManager) doDiscardSnap(t *state.Task, _ *tomb.Tomb) error {
 		if snapst.Current == snapsup.Revision() {
 			snapst.Current = newSeq[len(newSeq)-1].Snap.Revision
 		}
+
+		// the snap still has other revisions; keep the on-disk sequence file
+		// in sync with the removed revision. when no revisions are left the
+		// file is removed further below instead.
+		if err := updateSeqFileForSnap(snapst, snapsup.InstanceName()); err != nil {
+			return err
+		}
 	}
 
 	pb := NewTaskProgressAdapterUnlocked(t)

--- a/overlord/snapstate/handlers_components.go
+++ b/overlord/snapstate/handlers_components.go
@@ -418,6 +418,22 @@ func saveCurrentKernelModuleComponents(t *state.Task, snapsup *SnapSetup, snapst
 	return nil
 }
 
+// updateSeqFileForSnap rewrites the on-disk sequence file for the given snap
+// so that it stays consistent with the component information held in the
+// in-memory sequence. The sequence file is written for failover handling
+// (snap-repair) at snap link time, but component link/unlink handlers mutate
+// the sequence afterwards; without this the on-disk file would permanently
+// lack the components that were linked after the snap revision. The file is
+// only rewritten if it already exists, mirroring writeMigrationStatus, so that
+// we never create it for a snap whose link-snap has not run yet. State must be
+// locked by the caller.
+func updateSeqFileForSnap(snapst *SnapState, instanceName string) error {
+	if !osutil.FileExists(snap.SequenceFile(instanceName)) {
+		return nil
+	}
+	return writeSeqFile(instanceName, snapst)
+}
+
 func (m *SnapManager) doLinkComponent(t *state.Task, _ *tomb.Tomb) error {
 	// invariant: component is not in the state (unlink happens previously if necessary)
 	st := t.State()
@@ -468,6 +484,11 @@ func (m *SnapManager) doLinkComponent(t *state.Task, _ *tomb.Tomb) error {
 		return err
 	}
 
+	// keep the on-disk sequence file in sync with the newly linked component
+	if err := updateSeqFileForSnap(snapSt, snapsup.InstanceName()); err != nil {
+		return err
+	}
+
 	// Finally, write the state
 	Set(st, snapsup.InstanceName(), snapSt)
 	// Make sure we won't be rerun
@@ -514,6 +535,11 @@ func (m *SnapManager) undoLinkComponent(t *state.Task, _ *tomb.Tomb) error {
 	snapSt.Sequence.RemoveComponentForRevision(snapInfo.Revision,
 		linkedComp.SideInfo.Component)
 
+	// keep the on-disk sequence file in sync with the removed component
+	if err := updateSeqFileForSnap(snapSt, snapsup.InstanceName()); err != nil {
+		return err
+	}
+
 	// Finally, write the state
 	Set(st, snapsup.InstanceName(), snapSt)
 	// Make sure we won't be rerun
@@ -551,6 +577,11 @@ func (m *SnapManager) doUnlinkCurrentComponent(t *state.Task, _ *tomb.Tomb) (err
 		return err
 	}
 
+	// keep the on-disk sequence file in sync with the removed component
+	if err := updateSeqFileForSnap(snapSt, snapInfo.InstanceName()); err != nil {
+		return err
+	}
+
 	// Finally, write the state
 	Set(st, snapInfo.InstanceName(), snapSt)
 	// Make sure we won't be rerun
@@ -575,6 +606,11 @@ func (m *SnapManager) doUnlinkComponent(t *state.Task, _ *tomb.Tomb) (err error)
 	// Remove component for the specified revision
 	if err := m.unlinkComponent(
 		t, snapSt, snapSup.InstanceName(), snapSup.Revision(), cref); err != nil {
+		return err
+	}
+
+	// keep the on-disk sequence file in sync with the removed component
+	if err := updateSeqFileForSnap(snapSt, snapSup.InstanceName()); err != nil {
 		return err
 	}
 
@@ -634,6 +670,11 @@ func (m *SnapManager) undoUnlinkCurrentComponent(t *state.Task, _ *tomb.Tomb) (e
 		return err
 	}
 
+	// keep the on-disk sequence file in sync with the relinked component
+	if err := updateSeqFileForSnap(snapSt, snapsup.InstanceName()); err != nil {
+		return err
+	}
+
 	// Finally, write the state
 	Set(st, snapsup.InstanceName(), snapSt)
 	// Make sure we won't be rerun
@@ -668,6 +709,11 @@ func (m *SnapManager) undoUnlinkComponent(t *state.Task, _ *tomb.Tomb) (err erro
 
 	if err := m.relinkComponent(
 		t, snapSt, snapSup.InstanceName(), snapSup.Revision()); err != nil {
+		return err
+	}
+
+	// keep the on-disk sequence file in sync with the relinked component
+	if err := updateSeqFileForSnap(snapSt, snapSup.InstanceName()); err != nil {
 		return err
 	}
 

--- a/overlord/snapstate/handlers_components.go
+++ b/overlord/snapstate/handlers_components.go
@@ -654,6 +654,18 @@ func (m *SnapManager) undoUnlinkComponent(t *state.Task, _ *tomb.Tomb) (err erro
 		return err
 	}
 
+	// The snap revision this component belonged to may no longer be in the
+	// sequence. This happens when unlink-component ran as part of discarding an
+	// old revision (removeInactiveRevision) during a refresh, and the later
+	// discard-snap task (which has no undo handler) removed the whole revision
+	// from the sequence before a subsequent failure triggered the undo. In that
+	// case the revision, its files and its components are gone for good, so
+	// there is nothing to relink and the undo is a no-op.
+	if snapSt.Sequence.LastIndex(snapSup.Revision()) == -1 {
+		t.SetStatus(state.UndoneStatus)
+		return nil
+	}
+
 	if err := m.relinkComponent(
 		t, snapSt, snapSup.InstanceName(), snapSup.Revision()); err != nil {
 		return err

--- a/overlord/snapstate/handlers_components_link_test.go
+++ b/overlord/snapstate/handlers_components_link_test.go
@@ -21,6 +21,7 @@ package snapstate_test
 
 import (
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/snapcore/snapd/dirs"
@@ -518,4 +519,106 @@ func (s *linkCompSnapSuite) TestDoUnlinkThenUndoUnlinkComponent(c *C) {
 
 	s.testDoUnlinkThenUndoUnlinkComponent(c, snapName, snapRev,
 		compName, compRev, "unlink-component")
+}
+
+// TestUndoUnlinkComponentAfterSnapRevisionDiscarded reproduces a failure seen
+// when a refresh with components fails (e.g. in the configure hook) after the
+// cleanup of an old revision already ran. The old revision's components are
+// unlinked by unlink-component tasks (via removeInactiveRevision), and then
+// discard-snap (which has no undo handler) removes the whole old revision from
+// the sequence. When a later task fails, the undo of unlink-component must not
+// error out with "snap revision is not in the sequence": the revision is gone
+// for good, so the undo must be a no-op.
+//
+// This builds the real task chain that removeInactiveRevision produces
+// (clear-snap, unlink-component, discard-component, discard-snap) and runs the
+// real task handlers, so the revision is genuinely discarded by discard-snap
+// before the undo of unlink-component runs.
+func (s *linkCompSnapSuite) TestUndoUnlinkComponentAfterSnapRevisionDiscarded(c *C) {
+	const snapName = "mysnap"
+	const compName = "mycomp"
+	oldSnapRev := snap.R(1)
+	currentSnapRev := snap.R(2)
+	compRev := snap.R(7)
+
+	s.state.Lock()
+
+	// state with two revisions, the old one carrying the component
+	oldSI := &snap.SideInfo{RealName: snapName, Revision: oldSnapRev, SnapID: "some-snap-id"}
+	currentSI := &snap.SideInfo{RealName: snapName, Revision: currentSnapRev, SnapID: "some-snap-id"}
+	csi := snap.NewComponentSideInfo(naming.NewComponentRef(snapName, compName), compRev)
+	comps := []*sequence.ComponentState{sequence.NewComponentState(csi, snap.StandardComponent)}
+	snapstate.Set(s.state, snapName, &snapstate.SnapState{
+		Active:   true,
+		SnapType: "app",
+		Sequence: snapstatetest.NewSequenceFromRevisionSideInfos(
+			[]*sequence.RevisionSideState{
+				sequence.NewRevisionSideState(oldSI, comps),
+				sequence.NewRevisionSideState(currentSI, nil),
+			}),
+		Current: currentSnapRev,
+	})
+
+	chg := s.state.NewChange("test change", "change desc")
+
+	// the tasks below mirror removeInactiveRevision for the old revision:
+	// clear-snap, then unlink-component + discard-component for each component,
+	// then discard-snap.
+	clearData := s.state.NewTask("clear-snap", "clear data for old revision")
+	clearData.Set("snap-setup", &snapstate.SnapSetup{SideInfo: oldSI})
+	chg.AddTask(clearData)
+
+	unlink := s.state.NewTask("unlink-component", "unlink old revision component")
+	unlink.Set("snap-setup-task", clearData.ID())
+	unlink.Set("component-setup", snapstate.NewComponentSetup(csi, snap.StandardComponent, ""))
+	unlink.WaitFor(clearData)
+	chg.AddTask(unlink)
+
+	discardComp := s.state.NewTask("discard-component", "discard old revision component")
+	discardComp.Set("snap-setup-task", clearData.ID())
+	discardComp.Set("component-setup-task", unlink.ID())
+	discardComp.WaitFor(unlink)
+	chg.AddTask(discardComp)
+
+	discardSnap := s.state.NewTask("discard-snap", "discard old revision")
+	discardSnap.Set("snap-setup-task", clearData.ID())
+	discardSnap.WaitFor(discardComp)
+	chg.AddTask(discardSnap)
+
+	// then something fails, provoking the undo of the whole change
+	terr := s.state.NewTask("error-trigger", "provoking undo")
+	terr.WaitFor(discardSnap)
+	chg.AddTask(terr)
+
+	s.state.Unlock()
+
+	for i := 0; i < 10; i++ {
+		s.se.Ensure()
+		s.se.Wait()
+	}
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	// discard-snap really ran and removed the old revision from the sequence
+	var snapst snapstate.SnapState
+	c.Assert(snapstate.Get(s.state, snapName, &snapst), IsNil)
+	c.Check(snapst.Sequence.LastIndex(oldSnapRev), Equals, -1)
+	c.Check(snapst.Current, Equals, currentSnapRev)
+
+	// the change fails because of the error-trigger, but the undo of
+	// unlink-component must succeed (as a no-op) rather than error with
+	// "snap revision is not in the sequence"
+	err := chg.Err()
+	c.Assert(err, NotNil)
+	c.Check(strings.Contains(err.Error(), "is not in the sequence"), Equals, false,
+		Commentf("unexpected error: %v", err))
+
+	// the unlink-component task must have been undone cleanly
+	c.Check(unlink.Status(), Equals, state.UndoneStatus)
+
+	// the component symlink is not re-created: the old revision is gone
+	for _, op := range s.fakeBackend.ops {
+		c.Check(op.op, Not(Equals), "link-component")
+	}
 }

--- a/overlord/snapstate/handlers_components_link_test.go
+++ b/overlord/snapstate/handlers_components_link_test.go
@@ -20,6 +20,8 @@
 package snapstate_test
 
 import (
+	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -119,6 +121,82 @@ func (s *linkCompSnapSuite) TestDoLinkComponent(c *C) {
 	s.state.Unlock()
 
 	s.testDoLinkComponent(c, snapName, snapRev, []*snap.ComponentSideInfo{})
+}
+
+// TestDoLinkComponentUpdatesSeqFile verifies that linking a component updates
+// the on-disk sequence file, so that it stays consistent with the component
+// information held in the state (the sequence file is written at snap link
+// time, before components are linked).
+func (s *linkCompSnapSuite) TestDoLinkComponentUpdatesSeqFile(c *C) {
+	const snapName = "mysnap"
+	const compName = "mycomp"
+	snapRev := snap.R(1)
+	compRev := snap.R(7)
+
+	s.state.Lock()
+	// state does not contain the component yet
+	setStateWithOneSnap(s.state, snapName, snapRev)
+
+	// pretend that link-snap already wrote the sequence file (without
+	// components, as the component is not linked yet)
+	var snapst snapstate.SnapState
+	c.Assert(snapstate.Get(s.state, snapName, &snapst), IsNil)
+	c.Assert(snapstate.WriteSeqFile(snapName, &snapst), IsNil)
+
+	si := createTestSnapInfoForComponent(c, snapName, snapRev, compName)
+	ssu := createTestSnapSetup(si, snapstate.Flags{})
+
+	t := s.state.NewTask("link-component", "task desc")
+	cref := naming.NewComponentRef(snapName, compName)
+	csi := snap.NewComponentSideInfo(cref, compRev)
+	t.Set("component-setup", snapstate.NewComponentSetup(csi, snap.StandardComponent, ""))
+	t.Set("snap-setup", ssu)
+	chg := s.state.NewChange("test change", "change desc")
+	chg.AddTask(t)
+
+	s.state.Unlock()
+
+	s.se.Ensure()
+	s.se.Wait()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	c.Check(chg.Err(), IsNil)
+	c.Assert(t.Status(), Equals, state.DoneStatus)
+
+	// the on-disk sequence file must now contain the linked component. we
+	// compare the unmarshaled content rather than the raw JSON so that the test
+	// does not depend on field ordering or other serialization details.
+	seqContent, err := os.ReadFile(snap.SequenceFile(snapName))
+	c.Assert(err, IsNil)
+
+	var got map[string]any
+	c.Assert(json.Unmarshal(seqContent, &got), IsNil)
+	c.Check(got, DeepEquals, map[string]any{
+		"sequence": []any{
+			map[string]any{
+				"name":     "mysnap",
+				"snap-id":  "some-snap-id",
+				"revision": "1",
+				"components": []any{
+					map[string]any{
+						"side-info": map[string]any{
+							"component": map[string]any{
+								"snap-name":      "mysnap",
+								"component-name": "mycomp",
+							},
+							"revision": "7",
+						},
+						"type": "standard",
+					},
+				},
+			},
+		},
+		"current":               "1",
+		"migrated-hidden":       false,
+		"migrated-exposed-home": false,
+	})
 }
 
 func (s *linkCompSnapSuite) TestDoLinkComponentOtherCompPresent(c *C) {

--- a/overlord/snapstate/handlers_discard_test.go
+++ b/overlord/snapstate/handlers_discard_test.go
@@ -20,6 +20,7 @@
 package snapstate_test
 
 import (
+	"encoding/json"
 	"os"
 
 	. "gopkg.in/check.v1"
@@ -355,6 +356,27 @@ func (s *discardSnapSuite) TestDoDiscardSnapKeepsSeqFileForNonLastRevision(c *C)
 	defer s.state.Unlock()
 	c.Check(t.Status(), Equals, state.DoneStatus)
 	c.Check(seqFilePath, testutil.FilePresent)
+
+	// the discarded revision must no longer be present in the sequence file. we
+	// compare the unmarshaled content rather than the raw JSON so that the test
+	// does not depend on field ordering or other serialization details.
+	seqContent, err := os.ReadFile(seqFilePath)
+	c.Assert(err, IsNil)
+
+	var got map[string]any
+	c.Assert(json.Unmarshal(seqContent, &got), IsNil)
+	c.Check(got, DeepEquals, map[string]any{
+		"sequence": []any{
+			map[string]any{
+				"name":     "foo",
+				"snap-id":  "",
+				"revision": "33",
+			},
+		},
+		"current":               "33",
+		"migrated-hidden":       false,
+		"migrated-exposed-home": false,
+	})
 }
 
 func (s *discardSnapSuite) TestDoDiscardSnapNoErrorIfSeqFileMissing(c *C) {

--- a/overlord/snapstate/sequence/sequence.go
+++ b/overlord/snapstate/sequence/sequence.go
@@ -25,6 +25,7 @@ package sequence
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/naming"
@@ -137,14 +138,16 @@ func (snapSeq *SnapSequence) LastIndex(revision snap.Revision) int {
 	return -1
 }
 
-var ErrSnapRevNotInSequence = errors.New("snap is not in the sequence")
+// ErrSnapRevNotInSequence is returned when an operation targets a snap
+// revision that is not present in the snap sequence.
+var ErrSnapRevNotInSequence = errors.New("snap revision is not in the sequence")
 
 // AddComponentForRevision adds a component to the last instance of snapRev in
 // the sequence.
 func (snapSeq *SnapSequence) AddComponentForRevision(snapRev snap.Revision, cs *ComponentState) error {
 	snapIdx := snapSeq.LastIndex(snapRev)
 	if snapIdx == -1 {
-		return ErrSnapRevNotInSequence
+		return fmt.Errorf("%w: %s", ErrSnapRevNotInSequence, snapRev)
 	}
 	revSt := snapSeq.Revisions[snapIdx]
 

--- a/overlord/snapstate/sequence/sequence_test.go
+++ b/overlord/snapstate/sequence/sequence_test.go
@@ -123,7 +123,9 @@ func (s *sequenceTestSuite) TestAddComponentForRevision(c *C) {
 	c.Assert(seq.AddComponentForRevision(snapRev, cs3), IsNil)
 	c.Assert(seq.Revisions[0].Components, DeepEquals, []*sequence.ComponentState{cs2, cs3})
 
-	c.Assert(seq.AddComponentForRevision(snap.R(2), cs3), Equals, sequence.ErrSnapRevNotInSequence)
+	err := seq.AddComponentForRevision(snap.R(2), cs3)
+	c.Assert(err, testutil.ErrorIs, sequence.ErrSnapRevNotInSequence)
+	c.Assert(err, ErrorMatches, "snap revision is not in the sequence: 2")
 }
 
 func (s *sequenceTestSuite) TestRemoveComponentForRevision(c *C) {


### PR DESCRIPTION
Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?