### PR TITLE
asserts: add developer account prerequisite for snap resource pair

### DIFF
--- a/asserts/batch_test.go
+++ b/asserts/batch_test.go
@@ -145,6 +145,32 @@ func (s *batchSuite) TestCommitToAndObserve(c *C) {
 	})
 }
 
+func (s *batchSuite) TestCommitSnapResourcePairBeforeDeveloperAccount(c *C) {
+	err := s.db.Add(s.storeSigning.StoreAccountKey(""))
+	c.Assert(err, IsNil)
+	err = s.db.Add(s.dev1Acct)
+	c.Assert(err, IsNil)
+
+	decl := s.snapDecl(c, "foo", nil)
+	developer := assertstest.NewAccount(s.storeSigning, "developer2", nil, "")
+	pair, err := s.storeSigning.Sign(asserts.SnapResourcePairType, map[string]any{
+		"snap-id":           decl.SnapID(),
+		"resource-name":     "component",
+		"resource-revision": "1",
+		"snap-revision":     "1",
+		"developer-id":      developer.AccountID(),
+		"timestamp":         time.Now().Format(time.RFC3339),
+	}, nil, "")
+	c.Assert(err, IsNil)
+
+	batch := asserts.NewBatch(nil)
+	c.Assert(batch.Add(pair), IsNil)
+	c.Assert(batch.Add(decl), IsNil)
+	c.Assert(batch.Add(developer), IsNil)
+
+	c.Assert(batch.CommitTo(s.db, nil), IsNil)
+}
+
 func (s *batchSuite) TestAddEmptyStream(c *C) {
 	b := &bytes.Buffer{}
 

--- a/asserts/snap_resource_asserts.go
+++ b/asserts/snap_resource_asserts.go
@@ -306,6 +306,7 @@ var _ consistencyChecker = (*SnapResourcePair)(nil)
 func (respair *SnapResourcePair) Prerequisites() []*Ref {
 	return []*Ref{
 		{Type: SnapDeclarationType, PrimaryKey: []string{release.Series, respair.SnapID()}},
+		{Type: AccountType, PrimaryKey: []string{respair.DeveloperID()}},
 	}
 }
 

--- a/asserts/snap_resource_asserts_test.go
+++ b/asserts/snap_resource_asserts_test.go
@@ -631,10 +631,14 @@ func (s *snapResourcePairSuite) TestPrerequisites(c *C) {
 	c.Assert(err, IsNil)
 
 	prereqs := a.Prerequisites()
-	c.Assert(prereqs, HasLen, 1)
+	c.Assert(prereqs, HasLen, 2)
 	c.Check(prereqs[0], DeepEquals, &asserts.Ref{
 		Type:       asserts.SnapDeclarationType,
 		PrimaryKey: []string{"16", "snap-id-1"},
+	})
+	c.Check(prereqs[1], DeepEquals, &asserts.Ref{
+		Type:       asserts.AccountType,
+		PrimaryKey: []string{"dev-id1"},
 	})
 }
 


### PR DESCRIPTION
## Summary

Add the developer account assertion as an explicit prerequisite of
`snap-resource-pair` assertions.

`SnapResourcePair.checkConsistency()` requires the developer account to
already exist in the assertion database, but
`SnapResourcePair.Prerequisites()` only declared the snap declaration.

As a result, `Batch.CommitTo()` could order a `snap-resource-pair` before
the matching developer `account` assertion and fail even when that
account was present later in the same assertion stream.

## Fix

Declare the developer `AccountType` reference from
`SnapResourcePair.Prerequisites()` so prerequisite sorting commits the
account before the resource pair.

## Tests

Added a regression test that constructs the problematic order explicitly:

- snap-resource-pair
- snap-declaration
- developer account

Before this change, the test fails with:

    cannot accept some assertions:
     - snap-resource-pair assertion ... does not have a matching account
       assertion for the developer ...

With this change, the batch commits successfully.

The fix was also checked against a real Ubuntu 26.04 seed assertion
bundle containing 35 assertions that reproduced the issue.

Using the parent revision, committing that bundle fails with the same
missing developer account error. With this change applied, the same
bundle commits successfully (`COMMIT OK`).

Relevant assertion tests pass, including the new regression and the
updated `SnapResourcePair.Prerequisites()` test.