### PR TITLE
systemd/logind: always use display-eligible session to compute SessionClass

### DIFF
--- a/cmd/snapd/cli/cmd_routine_user_service_precondition_test.go
+++ b/cmd/snapd/cli/cmd_routine_user_service_precondition_test.go
@@ -100,26 +100,26 @@ func (s *SnapSuite) TestRoutineUserServicePreconditionGreeterInvalidErrorExitCod
 
 func (s *SnapSuite) TestRoutineUserServicePreconditionNoSession(c *C) {
 	restore := snap.MockLogindSessionClass(func(ctx context.Context) (string, error) {
-		return "", fmt.Errorf("loginctl command [show-session auto -p Class] failed with exit status 1: No session for PID")
+		return "", fmt.Errorf("cannot find session for the current user: 1000")
 	})
 	defer restore()
 
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"routine", "user-service-precondition"})
 	c.Assert(err, NotNil)
 	c.Check(snap.ExitCodeFromError(err), Equals, 1)
-	c.Check(err.Error(), Equals, "cannot determine session class: loginctl command [show-session auto -p Class] failed with exit status 1: No session for PID")
+	c.Check(err.Error(), Equals, "cannot determine session class: cannot find session for the current user: 1000")
 	c.Check(s.Stderr(), Equals, "")
 }
 
 func (s *SnapSuite) TestRoutineUserServicePreconditionNoSessionWithErrorExitCode(c *C) {
 	restore := snap.MockLogindSessionClass(func(ctx context.Context) (string, error) {
-		return "", fmt.Errorf("loginctl command [show-session auto -p Class] failed with exit status 1: No session for PID")
+		return "", fmt.Errorf("cannot find session for the current user: 1000")
 	})
 	defer restore()
 
 	_, err := snap.Parser(snap.Client()).ParseArgs([]string{"routine", "user-service-precondition", "--error-exit-code", "3"})
 	c.Assert(err, NotNil)
 	c.Check(snap.ExitCodeFromError(err), Equals, 3)
-	c.Check(err.Error(), Equals, "cannot determine session class: loginctl command [show-session auto -p Class] failed with exit status 1: No session for PID")
+	c.Check(err.Error(), Equals, "cannot determine session class: cannot find session for the current user: 1000")
 	c.Check(s.Stderr(), Equals, "")
 }

--- a/systemd/logind/logind.go
+++ b/systemd/logind/logind.go
@@ -23,10 +23,13 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/systemd"
 )
 
 // loginctlCmd calls loginctl with the given args, returning its standard
@@ -83,20 +86,97 @@ func (e *Error) Error() string {
 }
 
 // SessionClass returns the class of the current session as reported by
-// loginctl. It invokes "loginctl show-session auto -p Class" and parses
-// the "Class=<value>" output. An error is returned if loginctl fails,
-// for example when there is no session for the current process.
+// loginctl.
+//
+// On systemd >= 245 it invokes "loginctl show-session auto -p Class", which
+// resolves to the caller's own session if the process is inside one, and to
+// the user's display session otherwise. On older systemd it falls back to
+// resolving the user's display session via "loginctl show-user <uid> -p
+// Display" followed by "loginctl show-session <id> -p Class", which is what
+// "auto" resolves to for processes outside any session.
+//
+// Note: on systemd < 245, when invoked from inside a session, the class of
+// the user's display session is returned instead of the class of the
+// caller's own session. We could consult the XDG_SESSION_ID environment
+// variable to replicate the "caller's own session" clause of "auto", but the
+// environment may leak a stale session id of another user across "sudo"
+// invocations, so we don't do this, and when executed by an ExecCondition
+// the variable is never set in the first place.
+//
+// The primary user of this function runs as an ExecCondition of systemd user
+// services, i.e. as a child of user@UID.service which is never part of a
+// session scope, so on both paths the display session is what gets resolved.
+// Only user- and greeter-class sessions are ever display-eligible, so
+// sessions of other classes (background, and on systemd >= 256 the
+// manager-class session of the user manager itself) cannot shadow it.
+//
+// An error is returned if loginctl fails, if no session for the current user
+// could be found, or if the output is malformed. An empty class ("Class=") is
+// valid and will be returned as "" without error.
 func SessionClass(ctx context.Context) (string, error) {
+	// The special session name "auto" for "loginctl show-session" and
+	// friends was introduced in systemd 245; on older systemd, "auto" is
+	// treated as a literal session id and never resolves to anything.
+	if err := systemd.EnsureAtLeast(245); err != nil {
+		if !systemd.IsSystemdTooOld(err) {
+			// the systemd version could not be determined at all
+			return "", err
+		}
+		return sessionClassFromUserDisplay(ctx)
+	}
+	return sessionClassFromAuto(ctx)
+}
+
+// sessionClassFromAuto returns the class of the session resolved by the
+// special session name "auto" (systemd >= 245).
+func sessionClassFromAuto(ctx context.Context) (string, error) {
 	out, err := loginctlCmd(ctx, "show-session", "auto", "-p", "Class")
 	if err != nil {
 		return "", err
 	}
 
-	// strip the "Class=" prefix from the output
-	orig := strings.TrimSpace(string(out))
+	return parseProperty(string(out), "Class")
+}
+
+// sessionClassFromUserDisplay returns the class of the display session of
+// the current user, resolved with "loginctl show-user" and "loginctl
+// show-session" (works on all supported systemd versions).
+func sessionClassFromUserDisplay(ctx context.Context) (string, error) {
+	uid := os.Getuid()
+	// Note: --value is not passed to loginctl as it is only available
+	// since systemd 230, and the "Name=value" output is parsed instead.
+	out, err := loginctlCmd(ctx, "show-user", strconv.Itoa(uid), "-p", "Display")
+	if err != nil {
+		return "", err
+	}
+
+	// On old systemd, using -p implies --all, so an empty "Display=" is
+	// printed when the user has no display session, in which case no
+	// session can be determined for the user.
+	sessionID, err := parseProperty(string(out), "Display")
+	if err != nil {
+		return "", err
+	}
+	if sessionID == "" {
+		return "", fmt.Errorf("cannot find session for the current user: %d", uid)
+	}
+
+	out, err = loginctlCmd(ctx, "show-session", sessionID, "-p", "Class")
+	if err != nil {
+		return "", err
+	}
+
+	return parseProperty(string(out), "Class")
+}
+
+// parseProperty parses the "Name=value" output of loginctl's -p option. A
+// malformed output results in an error. An empty value (e.g. "Foo=") is not
+// treated as an error.
+func parseProperty(output string, name string) (string, error) {
+	orig := strings.TrimSpace(output)
 	propName, propValue, ok := strings.Cut(orig, "=")
-	if !ok || propName != "Class" || propValue == "" || strings.Contains(propValue, "=") {
-		return "", fmt.Errorf("invalid property format from loginctl for Class: %q", orig)
+	if !ok || propName != name || strings.Contains(propValue, "=") {
+		return "", fmt.Errorf("cannot parse value from loginctl output for property %q: %q", name, orig)
 	}
 
 	return strings.TrimSpace(propValue), nil

--- a/systemd/logind/logind.go
+++ b/systemd/logind/logind.go
@@ -112,7 +112,7 @@ func SessionClass(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	// Using -p implies that empty properties are shown too, so an empty
+	// Using --all implies that empty properties are shown too, so an empty
 	// "Display=" is printed when the user has no display session, in
 	// which case no session can be determined for the user.
 	sessionID, err := parseProperty(string(out), "Display")

--- a/systemd/logind/logind.go
+++ b/systemd/logind/logind.go
@@ -29,7 +29,6 @@ import (
 	"strings"
 
 	"github.com/snapcore/snapd/osutil"
-	"github.com/snapcore/snapd/systemd"
 )
 
 // loginctlCmd calls loginctl with the given args, returning its standard
@@ -85,63 +84,26 @@ func (e *Error) Error() string {
 	return fmt.Sprintf("loginctl command %v failed with exit status %d%s", e.cmd, e.exitCode, msg)
 }
 
-// SessionClass returns the class of the current session as reported by
-// loginctl.
+// SessionClass returns the class of the display session of the current
+// user as reported by loginctl.
 //
-// On systemd >= 245 it invokes "loginctl show-session auto -p Class", which
-// resolves to the caller's own session if the process is inside one, and to
-// the user's display session otherwise. On older systemd it falls back to
-// resolving the user's display session via "loginctl show-user <uid> -p
-// Display" followed by "loginctl show-session <id> -p Class", which is what
-// "auto" resolves to for processes outside any session.
+// It first invokes "loginctl show-user <uid> -p Display" to resolve the
+// display session of the current user, and then "loginctl show-session <id>
+// -p Class" to get the class of that session, parsing the "Class=<value>"
+// output.
 //
-// Note: on systemd < 245, when invoked from inside a session, the class of
-// the user's display session is returned instead of the class of the
-// caller's own session. We could consult the XDG_SESSION_ID environment
-// variable to replicate the "caller's own session" clause of "auto", but the
-// environment may leak a stale session id of another user across "sudo"
-// invocations, so we don't do this, and when executed by an ExecCondition
-// the variable is never set in the first place.
+// Note that when invoked from inside a session, the class of the display
+// session of the current user is returned, which may be a different session
+// than the one the current process is part of (if any). User sessions are
+// display-eligible if and only if they are of class "user", "greeter", or
+// "user-early" (on systemd >= 256), "user-light" or "user-early-light" (on
+// systemd >= 259). User sessions of class "background" or "manager" are never
+// display-eligible, for example.
 //
-// The primary user of this function runs as an ExecCondition of systemd user
-// services, i.e. as a child of user@UID.service which is never part of a
-// session scope, so on both paths the display session is what gets resolved.
-// Only user- and greeter-class sessions are ever display-eligible, so
-// sessions of other classes (background, and on systemd >= 256 the
-// manager-class session of the user manager itself) cannot shadow it.
-//
-// An error is returned if loginctl fails, if no session for the current user
-// could be found, or if the output is malformed. An empty class ("Class=") is
-// valid and will be returned as "" without error.
+// An error is returned if loginctl fails, if no session for the current
+// user could be found, or if the output is malformed. An empty class
+// ("Class=") is valid and will be returned as "" without error.
 func SessionClass(ctx context.Context) (string, error) {
-	// The special session name "auto" for "loginctl show-session" and
-	// friends was introduced in systemd 245; on older systemd, "auto" is
-	// treated as a literal session id and never resolves to anything.
-	if err := systemd.EnsureAtLeast(245); err != nil {
-		if !systemd.IsSystemdTooOld(err) {
-			// the systemd version could not be determined at all
-			return "", err
-		}
-		return sessionClassFromUserDisplay(ctx)
-	}
-	return sessionClassFromAuto(ctx)
-}
-
-// sessionClassFromAuto returns the class of the session resolved by the
-// special session name "auto" (systemd >= 245).
-func sessionClassFromAuto(ctx context.Context) (string, error) {
-	out, err := loginctlCmd(ctx, "show-session", "auto", "-p", "Class")
-	if err != nil {
-		return "", err
-	}
-
-	return parseProperty(string(out), "Class")
-}
-
-// sessionClassFromUserDisplay returns the class of the display session of
-// the current user, resolved with "loginctl show-user" and "loginctl
-// show-session" (works on all supported systemd versions).
-func sessionClassFromUserDisplay(ctx context.Context) (string, error) {
 	uid := os.Getuid()
 	// Note: --value is not passed to loginctl as it is only available
 	// since systemd 230, and the "Name=value" output is parsed instead.
@@ -150,9 +112,9 @@ func sessionClassFromUserDisplay(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	// On old systemd, using -p implies --all, so an empty "Display=" is
-	// printed when the user has no display session, in which case no
-	// session can be determined for the user.
+	// Using -p implies that empty properties are shown too, so an empty
+	// "Display=" is printed when the user has no display session, in
+	// which case no session can be determined for the user.
 	sessionID, err := parseProperty(string(out), "Display")
 	if err != nil {
 		return "", err

--- a/systemd/logind/logind.go
+++ b/systemd/logind/logind.go
@@ -87,9 +87,9 @@ func (e *Error) Error() string {
 // SessionClass returns the class of the display session of the current
 // user as reported by loginctl.
 //
-// It first invokes "loginctl show-user <uid> -p Display" to resolve the
+// It first invokes "loginctl show-user <uid> --all -p Display" to resolve the
 // display session of the current user, and then "loginctl show-session <id>
-// -p Class" to get the class of that session, parsing the "Class=<value>"
+// --all -p Class" to get the class of that session, parsing the "Class=<value>"
 // output.
 //
 // Note that when invoked from inside a session, the class of the display
@@ -107,7 +107,7 @@ func SessionClass(ctx context.Context) (string, error) {
 	uid := os.Getuid()
 	// Note: --value is not passed to loginctl as it is only available
 	// since systemd 230, and the "Name=value" output is parsed instead.
-	out, err := loginctlCmd(ctx, "show-user", strconv.Itoa(uid), "-p", "Display")
+	out, err := loginctlCmd(ctx, "show-user", strconv.Itoa(uid), "--all", "-p", "Display")
 	if err != nil {
 		return "", err
 	}
@@ -123,7 +123,7 @@ func SessionClass(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("cannot find session for the current user: %d", uid)
 	}
 
-	out, err = loginctlCmd(ctx, "show-session", sessionID, "-p", "Class")
+	out, err = loginctlCmd(ctx, "show-session", sessionID, "--all", "-p", "Class")
 	if err != nil {
 		return "", err
 	}

--- a/systemd/logind/logind.go
+++ b/systemd/logind/logind.go
@@ -92,17 +92,15 @@ func (e *Error) Error() string {
 // --all -p Class" to get the class of that session, parsing the "Class=<value>"
 // output.
 //
-// Note that when invoked from inside a session, the class of the display
-// session of the current user is returned, which may be a different session
-// than the one the current process is part of (if any). User sessions are
-// display-eligible if and only if they are of class "user", "greeter", or
-// "user-early" (on systemd >= 256), "user-light" or "user-early-light" (on
-// systemd >= 259). User sessions of class "background" or "manager" are never
-// display-eligible, for example.
+// Note that the class of the display session of the current user is returned,
+// which may be a different session than the one the current process is part of
+// (if any). User sessions are display-eligible if and only if they are of
+// class "user", "greeter", or "user-early" (on systemd >= 256), "user-light"
+// or "user-early-light" (on systemd >= 259). User sessions of class
+// "background" or "manager", for example, are never display-eligible.
 //
 // An error is returned if loginctl fails, if no session for the current
-// user could be found, or if the output is malformed. An empty class
-// ("Class=") is valid and will be returned as "" without error.
+// user could be found, or if the output is malformed or class empty.
 func SessionClass(ctx context.Context) (string, error) {
 	uid := os.Getuid()
 	// Note: --value is not passed to loginctl as it is only available
@@ -115,7 +113,7 @@ func SessionClass(ctx context.Context) (string, error) {
 	// Using --all implies that empty properties are shown too, so an empty
 	// "Display=" is printed when the user has no display session, in
 	// which case no session can be determined for the user.
-	sessionID, err := parseProperty(string(out), "Display")
+	sessionID, err := parseProperty(string(out), "Display", true)
 	if err != nil {
 		return "", err
 	}
@@ -128,16 +126,16 @@ func SessionClass(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	return parseProperty(string(out), "Class")
+	return parseProperty(string(out), "Class", false)
 }
 
 // parseProperty parses the "Name=value" output of loginctl's -p option. A
 // malformed output results in an error. An empty value (e.g. "Foo=") is not
 // treated as an error.
-func parseProperty(output string, name string) (string, error) {
+func parseProperty(output string, name string, allowEmpty bool) (string, error) {
 	orig := strings.TrimSpace(output)
 	propName, propValue, ok := strings.Cut(orig, "=")
-	if !ok || propName != name || strings.Contains(propValue, "=") {
+	if !ok || propName != name || strings.Contains(propValue, "=") || !allowEmpty && propValue == "" {
 		return "", fmt.Errorf("cannot parse value from loginctl output for property %q: %q", name, orig)
 	}
 

--- a/systemd/logind/logind_test.go
+++ b/systemd/logind/logind_test.go
@@ -148,7 +148,7 @@ func (s *logindSuite) TestSessionClassMalformedOutput(c *C) {
 		c.Check(err, ErrorMatches, `cannot parse value from loginctl output for property "Display": .*`)
 	}
 
-	for _, output := range []string{"", "unexpected-no-equals\n", "foo=user\n", "Class=foo=\n"} {
+	for _, output := range []string{"", "unexpected-no-equals\n", "foo=user\n", "Class=foo=\n", "Class=", "Class=\n"} {
 		restore := logind.MockLoginctl(sessionClassLoginctlMock(c, "Display=c5\n", output))
 		defer restore()
 

--- a/systemd/logind/logind_test.go
+++ b/systemd/logind/logind_test.go
@@ -21,10 +21,14 @@ package logind_test
 
 import (
 	"context"
+	"errors"
+	"os"
+	"strconv"
 	"testing"
 
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/systemd/logind"
 )
 
@@ -36,6 +40,9 @@ type logindSuite struct{}
 var _ = Suite(&logindSuite{})
 
 func (s *logindSuite) TestSessionClass(c *C) {
+	restore := systemd.MockSystemdVersion(245, nil)
+	defer restore()
+
 	// All known session classes from systemd's logind-session.h
 	for _, class := range []string{
 		"user",
@@ -75,12 +82,15 @@ func (s *logindSuite) TestSessionClass(c *C) {
 }
 
 func (s *logindSuite) TestSessionClassNoSession(c *C) {
+	restore := systemd.MockSystemdVersion(245, nil)
+	defer restore()
+
 	var loginctlErr *logind.Error
 	loginctlErr = &logind.Error{}
 	loginctlErr.SetExitCode(1)
 	loginctlErr.SetMsg([]byte("No session for PID"))
 
-	restore := logind.MockLoginctl(func(ctx context.Context, args ...string) ([]byte, error) {
+	restore = logind.MockLoginctl(func(ctx context.Context, args ...string) ([]byte, error) {
 		c.Check(args, DeepEquals, []string{"show-session", "auto", "-p", "Class"})
 		return nil, loginctlErr
 	})
@@ -92,7 +102,10 @@ func (s *logindSuite) TestSessionClassNoSession(c *C) {
 }
 
 func (s *logindSuite) TestSessionClassEmptyOutput(c *C) {
-	restore := logind.MockLoginctl(func(ctx context.Context, args ...string) ([]byte, error) {
+	restore := systemd.MockSystemdVersion(245, nil)
+	defer restore()
+
+	restore = logind.MockLoginctl(func(ctx context.Context, args ...string) ([]byte, error) {
 		c.Check(args, DeepEquals, []string{"show-session", "auto", "-p", "Class"})
 		return []byte(""), nil
 	})
@@ -100,11 +113,14 @@ func (s *logindSuite) TestSessionClassEmptyOutput(c *C) {
 
 	_, err := logind.SessionClass(context.Background())
 	c.Assert(err, NotNil)
-	c.Check(err, ErrorMatches, "invalid property format from loginctl for Class: .*")
+	c.Check(err, ErrorMatches, `cannot parse value from loginctl output for property "Class": .*`)
 }
 
 func (s *logindSuite) TestSessionClassMalformedOutput(c *C) {
-	for _, output := range []string{"", "unexpected-no-equals\n", "foo=user\n", "Class=\n", "Class=foo=\n"} {
+	restore := systemd.MockSystemdVersion(245, nil)
+	defer restore()
+
+	for _, output := range []string{"", "unexpected-no-equals\n", "foo=user\n", "Class=foo=\n"} {
 		restore := logind.MockLoginctl(func(ctx context.Context, args ...string) ([]byte, error) {
 			c.Check(args, DeepEquals, []string{"show-session", "auto", "-p", "Class"})
 			return []byte(output), nil
@@ -113,12 +129,15 @@ func (s *logindSuite) TestSessionClassMalformedOutput(c *C) {
 
 		_, err := logind.SessionClass(context.Background())
 		c.Assert(err, NotNil)
-		c.Check(err, ErrorMatches, "invalid property format from loginctl for Class: .*")
+		c.Check(err, ErrorMatches, `cannot parse value from loginctl output for property "Class": .*`)
 	}
 }
 
 func (s *logindSuite) TestSessionClassWithWhitespace(c *C) {
-	restore := logind.MockLoginctl(func(ctx context.Context, args ...string) ([]byte, error) {
+	restore := systemd.MockSystemdVersion(245, nil)
+	defer restore()
+
+	restore = logind.MockLoginctl(func(ctx context.Context, args ...string) ([]byte, error) {
 		c.Check(args, DeepEquals, []string{"show-session", "auto", "-p", "Class"})
 		return []byte("  Class=user  \n"), nil
 	})
@@ -127,6 +146,207 @@ func (s *logindSuite) TestSessionClassWithWhitespace(c *C) {
 	got, err := logind.SessionClass(context.Background())
 	c.Assert(err, IsNil)
 	c.Check(got, Equals, "user")
+}
+
+func (s *logindSuite) TestSessionClassVersionBoundary(c *C) {
+	// with systemd >= 245 the session is resolved via the special name
+	// "auto", independently of the exact version
+	for _, version := range []int{245, 252, 255, 256} {
+		restore := systemd.MockSystemdVersion(version, nil)
+		defer restore()
+
+		restore = logind.MockLoginctl(func(ctx context.Context, args ...string) ([]byte, error) {
+			c.Check(args, DeepEquals, []string{"show-session", "auto", "-p", "Class"})
+			return []byte("Class=user\n"), nil
+		})
+		defer restore()
+
+		got, err := logind.SessionClass(context.Background())
+		c.Assert(err, IsNil)
+		c.Check(got, Equals, "user")
+	}
+
+	// with systemd < 245 "auto" is not understood, the user's display
+	// session is resolved instead
+	for _, version := range []int{229, 237, 244} {
+		restore := systemd.MockSystemdVersion(version, nil)
+		defer restore()
+
+		restore = logind.MockLoginctl(func(ctx context.Context, args ...string) ([]byte, error) {
+			switch args[0] {
+			case "show-user":
+				c.Check(args, DeepEquals, []string{"show-user", strconv.Itoa(os.Getuid()), "-p", "Display"})
+				return []byte("Display=c5\n"), nil
+			case "show-session":
+				c.Check(args, DeepEquals, []string{"show-session", "c5", "-p", "Class"})
+				return []byte("Class=user\n"), nil
+			}
+			return nil, nil
+		})
+		defer restore()
+
+		got, err := logind.SessionClass(context.Background())
+		c.Assert(err, IsNil)
+		c.Check(got, Equals, "user")
+	}
+}
+
+func (s *logindSuite) TestSessionClassFromUserDisplay(c *C) {
+	restore := systemd.MockSystemdVersion(237, nil)
+	defer restore()
+
+	var output string
+
+	restore = logind.MockLoginctl(func(ctx context.Context, args ...string) ([]byte, error) {
+		switch args[0] {
+		case "show-user":
+			c.Check(args, DeepEquals, []string{"show-user", strconv.Itoa(os.Getuid()), "-p", "Display"})
+			return []byte(output), nil
+		case "show-session":
+			c.Check(args, DeepEquals, []string{"show-session", "c7", "-p", "Class"})
+			return []byte("Class=greeter\n"), nil
+		}
+		return nil, nil
+	})
+	defer restore()
+
+	// the display session class is returned, with the full call sequence
+	output = "Display=c7\n"
+	got, err := logind.SessionClass(context.Background())
+	c.Assert(err, IsNil)
+	c.Check(got, Equals, "greeter")
+
+	// no trailing newline on the display session id
+	output = "Display=c7"
+	got, err = logind.SessionClass(context.Background())
+	c.Assert(err, IsNil)
+	c.Check(got, Equals, "greeter")
+
+	// whitespace around the display session id is tolerated
+	output = "  Display=c7  \n"
+	got, err = logind.SessionClass(context.Background())
+	c.Assert(err, IsNil)
+	c.Check(got, Equals, "greeter")
+
+	// the class output of the resolved session is malformed
+	restore = logind.MockLoginctl(func(ctx context.Context, args ...string) ([]byte, error) {
+		switch args[0] {
+		case "show-user":
+			c.Check(args, DeepEquals, []string{"show-user", strconv.Itoa(os.Getuid()), "-p", "Display"})
+			return []byte("Display=c7\n"), nil
+		case "show-session":
+			c.Check(args, DeepEquals, []string{"show-session", "c7", "-p", "Class"})
+			return []byte("unexpected-no-equals\n"), nil
+		}
+		return nil, nil
+	})
+	defer restore()
+
+	_, err = logind.SessionClass(context.Background())
+	c.Assert(err, NotNil)
+	c.Check(err, ErrorMatches, `cannot parse value from loginctl output for property "Class": .*`)
+}
+
+func (s *logindSuite) TestSessionClassFromUserDisplayNoSession(c *C) {
+	restore := systemd.MockSystemdVersion(237, nil)
+	defer restore()
+
+	// on old systemd -p implies --all, so an empty Display is printed
+	// when the user has no display session
+	for _, displayOutput := range []string{"Display=\n", "Display="} {
+		restore := logind.MockLoginctl(func(ctx context.Context, args ...string) ([]byte, error) {
+			c.Check(args, DeepEquals, []string{"show-user", strconv.Itoa(os.Getuid()), "-p", "Display"})
+			return []byte(displayOutput), nil
+		})
+		defer restore()
+
+		_, err := logind.SessionClass(context.Background())
+		c.Assert(err, ErrorMatches, "cannot find session for the current user: .*")
+	}
+}
+
+func (s *logindSuite) TestSessionClassFromUserDisplayMalformedOutput(c *C) {
+	restore := systemd.MockSystemdVersion(237, nil)
+	defer restore()
+
+	for _, displayOutput := range []string{"", "unexpected-no-equals\n", "foo=c5\n", "Display=c5=x\n"} {
+		restore := logind.MockLoginctl(func(ctx context.Context, args ...string) ([]byte, error) {
+			c.Check(args, DeepEquals, []string{"show-user", strconv.Itoa(os.Getuid()), "-p", "Display"})
+			return []byte(displayOutput), nil
+		})
+		defer restore()
+
+		_, err := logind.SessionClass(context.Background())
+		c.Assert(err, NotNil)
+		c.Check(err, ErrorMatches, `cannot parse value from loginctl output for property "Display": .*`)
+	}
+}
+
+func (s *logindSuite) TestSessionClassFromUserDisplayErrors(c *C) {
+	restore := systemd.MockSystemdVersion(237, nil)
+	defer restore()
+
+	// show-user fails, e.g. when the user is not tracked by logind
+	loginctlErr := &logind.Error{}
+	loginctlErr.SetCmd([]string{"show-user", strconv.Itoa(os.Getuid()), "-p", "Display"})
+	loginctlErr.SetExitCode(1)
+	loginctlErr.SetMsg([]byte("Failed to look up user"))
+
+	calls := 0
+	restore = logind.MockLoginctl(func(ctx context.Context, args ...string) ([]byte, error) {
+		calls++
+		return nil, loginctlErr
+	})
+	defer restore()
+
+	_, err := logind.SessionClass(context.Background())
+	c.Assert(err, NotNil)
+	c.Check(err, ErrorMatches, "loginctl command .* failed with exit status 1: Failed to look up user")
+	c.Check(calls, Equals, 1)
+
+	// show-session fails, e.g. when the display session vanished between
+	// the two calls
+	loginctlErr = &logind.Error{}
+	loginctlErr.SetCmd([]string{"show-session", "c5", "-p", "Class"})
+	loginctlErr.SetExitCode(1)
+	loginctlErr.SetMsg([]byte("No session 'c5' known"))
+
+	calls = 0
+	restore = logind.MockLoginctl(func(ctx context.Context, args ...string) ([]byte, error) {
+		calls++
+		switch args[0] {
+		case "show-user":
+			c.Check(args, DeepEquals, []string{"show-user", strconv.Itoa(os.Getuid()), "-p", "Display"})
+			return []byte("Display=c5\n"), nil
+		case "show-session":
+			return nil, loginctlErr
+		}
+		return nil, nil
+	})
+	defer restore()
+
+	_, err = logind.SessionClass(context.Background())
+	c.Assert(err, NotNil)
+	c.Check(err, ErrorMatches, "loginctl command .* failed with exit status 1: No session 'c5' known")
+	c.Check(calls, Equals, 2)
+}
+
+func (s *logindSuite) TestSessionClassVersionDeterminationError(c *C) {
+	versionErr := errors.New("cannot read systemd version")
+	restore := systemd.MockSystemdVersion(0, versionErr)
+	defer restore()
+
+	calls := 0
+	restore = logind.MockLoginctl(func(ctx context.Context, args ...string) ([]byte, error) {
+		calls++
+		return nil, nil
+	})
+	defer restore()
+
+	_, err := logind.SessionClass(context.Background())
+	c.Assert(err, NotNil)
+	c.Check(err, ErrorMatches, "cannot read systemd version")
+	c.Check(calls, Equals, 0)
 }
 
 func (s *logindSuite) TestError(c *C) {

--- a/systemd/logind/logind_test.go
+++ b/systemd/logind/logind_test.go
@@ -21,14 +21,12 @@ package logind_test
 
 import (
 	"context"
-	"errors"
 	"os"
 	"strconv"
 	"testing"
 
 	. "gopkg.in/check.v1"
 
-	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/systemd/logind"
 )
 
@@ -39,10 +37,25 @@ type logindSuite struct{}
 
 var _ = Suite(&logindSuite{})
 
-func (s *logindSuite) TestSessionClass(c *C) {
-	restore := systemd.MockSystemdVersion(245, nil)
-	defer restore()
+// sessionClassLoginctlMock returns a loginctl mock for logind.SessionClass,
+// responding to the "show-user <uid> -p Display" invocation with
+// displayOutput, and to the "show-session c5 -p Class" invocation with
+// classOutput.
+func sessionClassLoginctlMock(c *C, displayOutput, classOutput string) func(ctx context.Context, args ...string) ([]byte, error) {
+	return func(ctx context.Context, args ...string) ([]byte, error) {
+		switch args[0] {
+		case "show-user":
+			c.Check(args, DeepEquals, []string{"show-user", strconv.Itoa(os.Getuid()), "-p", "Display"})
+			return []byte(displayOutput), nil
+		case "show-session":
+			c.Check(args, DeepEquals, []string{"show-session", "c5", "-p", "Class"})
+			return []byte(classOutput), nil
+		}
+		return nil, nil
+	}
+}
 
+func (s *logindSuite) TestSessionClass(c *C) {
 	// All known session classes from systemd's logind-session.h
 	for _, class := range []string{
 		"user",
@@ -58,21 +71,15 @@ func (s *logindSuite) TestSessionClass(c *C) {
 		"manager-early",
 		"none",
 	} {
-		restore := logind.MockLoginctl(func(ctx context.Context, args ...string) ([]byte, error) {
-			c.Check(args, DeepEquals, []string{"show-session", "auto", "-p", "Class"})
-			return []byte("Class=" + class + "\n"), nil
-		})
+		restore := logind.MockLoginctl(sessionClassLoginctlMock(c, "Display=c5\n", "Class="+class+"\n"))
 		defer restore()
 
 		got, err := logind.SessionClass(context.Background())
 		c.Assert(err, IsNil)
 		c.Check(got, Equals, class)
 
-		// Try without trailing \n
-		restore = logind.MockLoginctl(func(ctx context.Context, args ...string) ([]byte, error) {
-			c.Check(args, DeepEquals, []string{"show-session", "auto", "-p", "Class"})
-			return []byte("Class=" + class), nil
-		})
+		// Try without trailing \n on the show-session output
+		restore = logind.MockLoginctl(sessionClassLoginctlMock(c, "Display=c5\n", "Class="+class))
 		defer restore()
 
 		got, err = logind.SessionClass(context.Background())
@@ -82,219 +89,13 @@ func (s *logindSuite) TestSessionClass(c *C) {
 }
 
 func (s *logindSuite) TestSessionClassNoSession(c *C) {
-	restore := systemd.MockSystemdVersion(245, nil)
-	defer restore()
-
 	var loginctlErr *logind.Error
 	loginctlErr = &logind.Error{}
 	loginctlErr.SetExitCode(1)
-	loginctlErr.SetMsg([]byte("No session for PID"))
-
-	restore = logind.MockLoginctl(func(ctx context.Context, args ...string) ([]byte, error) {
-		c.Check(args, DeepEquals, []string{"show-session", "auto", "-p", "Class"})
-		return nil, loginctlErr
-	})
-	defer restore()
-
-	_, err := logind.SessionClass(context.Background())
-	c.Assert(err, NotNil)
-	c.Check(err, ErrorMatches, "loginctl command .* failed with exit status 1: No session for PID")
-}
-
-func (s *logindSuite) TestSessionClassEmptyOutput(c *C) {
-	restore := systemd.MockSystemdVersion(245, nil)
-	defer restore()
-
-	restore = logind.MockLoginctl(func(ctx context.Context, args ...string) ([]byte, error) {
-		c.Check(args, DeepEquals, []string{"show-session", "auto", "-p", "Class"})
-		return []byte(""), nil
-	})
-	defer restore()
-
-	_, err := logind.SessionClass(context.Background())
-	c.Assert(err, NotNil)
-	c.Check(err, ErrorMatches, `cannot parse value from loginctl output for property "Class": .*`)
-}
-
-func (s *logindSuite) TestSessionClassMalformedOutput(c *C) {
-	restore := systemd.MockSystemdVersion(245, nil)
-	defer restore()
-
-	for _, output := range []string{"", "unexpected-no-equals\n", "foo=user\n", "Class=foo=\n"} {
-		restore := logind.MockLoginctl(func(ctx context.Context, args ...string) ([]byte, error) {
-			c.Check(args, DeepEquals, []string{"show-session", "auto", "-p", "Class"})
-			return []byte(output), nil
-		})
-		defer restore()
-
-		_, err := logind.SessionClass(context.Background())
-		c.Assert(err, NotNil)
-		c.Check(err, ErrorMatches, `cannot parse value from loginctl output for property "Class": .*`)
-	}
-}
-
-func (s *logindSuite) TestSessionClassWithWhitespace(c *C) {
-	restore := systemd.MockSystemdVersion(245, nil)
-	defer restore()
-
-	restore = logind.MockLoginctl(func(ctx context.Context, args ...string) ([]byte, error) {
-		c.Check(args, DeepEquals, []string{"show-session", "auto", "-p", "Class"})
-		return []byte("  Class=user  \n"), nil
-	})
-	defer restore()
-
-	got, err := logind.SessionClass(context.Background())
-	c.Assert(err, IsNil)
-	c.Check(got, Equals, "user")
-}
-
-func (s *logindSuite) TestSessionClassVersionBoundary(c *C) {
-	// with systemd >= 245 the session is resolved via the special name
-	// "auto", independently of the exact version
-	for _, version := range []int{245, 252, 255, 256} {
-		restore := systemd.MockSystemdVersion(version, nil)
-		defer restore()
-
-		restore = logind.MockLoginctl(func(ctx context.Context, args ...string) ([]byte, error) {
-			c.Check(args, DeepEquals, []string{"show-session", "auto", "-p", "Class"})
-			return []byte("Class=user\n"), nil
-		})
-		defer restore()
-
-		got, err := logind.SessionClass(context.Background())
-		c.Assert(err, IsNil)
-		c.Check(got, Equals, "user")
-	}
-
-	// with systemd < 245 "auto" is not understood, the user's display
-	// session is resolved instead
-	for _, version := range []int{229, 237, 244} {
-		restore := systemd.MockSystemdVersion(version, nil)
-		defer restore()
-
-		restore = logind.MockLoginctl(func(ctx context.Context, args ...string) ([]byte, error) {
-			switch args[0] {
-			case "show-user":
-				c.Check(args, DeepEquals, []string{"show-user", strconv.Itoa(os.Getuid()), "-p", "Display"})
-				return []byte("Display=c5\n"), nil
-			case "show-session":
-				c.Check(args, DeepEquals, []string{"show-session", "c5", "-p", "Class"})
-				return []byte("Class=user\n"), nil
-			}
-			return nil, nil
-		})
-		defer restore()
-
-		got, err := logind.SessionClass(context.Background())
-		c.Assert(err, IsNil)
-		c.Check(got, Equals, "user")
-	}
-}
-
-func (s *logindSuite) TestSessionClassFromUserDisplay(c *C) {
-	restore := systemd.MockSystemdVersion(237, nil)
-	defer restore()
-
-	var output string
-
-	restore = logind.MockLoginctl(func(ctx context.Context, args ...string) ([]byte, error) {
-		switch args[0] {
-		case "show-user":
-			c.Check(args, DeepEquals, []string{"show-user", strconv.Itoa(os.Getuid()), "-p", "Display"})
-			return []byte(output), nil
-		case "show-session":
-			c.Check(args, DeepEquals, []string{"show-session", "c7", "-p", "Class"})
-			return []byte("Class=greeter\n"), nil
-		}
-		return nil, nil
-	})
-	defer restore()
-
-	// the display session class is returned, with the full call sequence
-	output = "Display=c7\n"
-	got, err := logind.SessionClass(context.Background())
-	c.Assert(err, IsNil)
-	c.Check(got, Equals, "greeter")
-
-	// no trailing newline on the display session id
-	output = "Display=c7"
-	got, err = logind.SessionClass(context.Background())
-	c.Assert(err, IsNil)
-	c.Check(got, Equals, "greeter")
-
-	// whitespace around the display session id is tolerated
-	output = "  Display=c7  \n"
-	got, err = logind.SessionClass(context.Background())
-	c.Assert(err, IsNil)
-	c.Check(got, Equals, "greeter")
-
-	// the class output of the resolved session is malformed
-	restore = logind.MockLoginctl(func(ctx context.Context, args ...string) ([]byte, error) {
-		switch args[0] {
-		case "show-user":
-			c.Check(args, DeepEquals, []string{"show-user", strconv.Itoa(os.Getuid()), "-p", "Display"})
-			return []byte("Display=c7\n"), nil
-		case "show-session":
-			c.Check(args, DeepEquals, []string{"show-session", "c7", "-p", "Class"})
-			return []byte("unexpected-no-equals\n"), nil
-		}
-		return nil, nil
-	})
-	defer restore()
-
-	_, err = logind.SessionClass(context.Background())
-	c.Assert(err, NotNil)
-	c.Check(err, ErrorMatches, `cannot parse value from loginctl output for property "Class": .*`)
-}
-
-func (s *logindSuite) TestSessionClassFromUserDisplayNoSession(c *C) {
-	restore := systemd.MockSystemdVersion(237, nil)
-	defer restore()
-
-	// on old systemd -p implies --all, so an empty Display is printed
-	// when the user has no display session
-	for _, displayOutput := range []string{"Display=\n", "Display="} {
-		restore := logind.MockLoginctl(func(ctx context.Context, args ...string) ([]byte, error) {
-			c.Check(args, DeepEquals, []string{"show-user", strconv.Itoa(os.Getuid()), "-p", "Display"})
-			return []byte(displayOutput), nil
-		})
-		defer restore()
-
-		_, err := logind.SessionClass(context.Background())
-		c.Assert(err, ErrorMatches, "cannot find session for the current user: .*")
-	}
-}
-
-func (s *logindSuite) TestSessionClassFromUserDisplayMalformedOutput(c *C) {
-	restore := systemd.MockSystemdVersion(237, nil)
-	defer restore()
-
-	for _, displayOutput := range []string{"", "unexpected-no-equals\n", "foo=c5\n", "Display=c5=x\n"} {
-		restore := logind.MockLoginctl(func(ctx context.Context, args ...string) ([]byte, error) {
-			c.Check(args, DeepEquals, []string{"show-user", strconv.Itoa(os.Getuid()), "-p", "Display"})
-			return []byte(displayOutput), nil
-		})
-		defer restore()
-
-		_, err := logind.SessionClass(context.Background())
-		c.Assert(err, NotNil)
-		c.Check(err, ErrorMatches, `cannot parse value from loginctl output for property "Display": .*`)
-	}
-}
-
-func (s *logindSuite) TestSessionClassFromUserDisplayErrors(c *C) {
-	restore := systemd.MockSystemdVersion(237, nil)
-	defer restore()
-
-	// show-user fails, e.g. when the user is not tracked by logind
-	loginctlErr := &logind.Error{}
-	loginctlErr.SetCmd([]string{"show-user", strconv.Itoa(os.Getuid()), "-p", "Display"})
-	loginctlErr.SetExitCode(1)
 	loginctlErr.SetMsg([]byte("Failed to look up user"))
 
-	calls := 0
-	restore = logind.MockLoginctl(func(ctx context.Context, args ...string) ([]byte, error) {
-		calls++
+	restore := logind.MockLoginctl(func(ctx context.Context, args ...string) ([]byte, error) {
+		c.Check(args, DeepEquals, []string{"show-user", strconv.Itoa(os.Getuid()), "-p", "Display"})
 		return nil, loginctlErr
 	})
 	defer restore()
@@ -302,16 +103,22 @@ func (s *logindSuite) TestSessionClassFromUserDisplayErrors(c *C) {
 	_, err := logind.SessionClass(context.Background())
 	c.Assert(err, NotNil)
 	c.Check(err, ErrorMatches, "loginctl command .* failed with exit status 1: Failed to look up user")
-	c.Check(calls, Equals, 1)
 
-	// show-session fails, e.g. when the display session vanished between
-	// the two calls
+	// an empty "Display=" means the user has no display session
+	for _, displayOutput := range []string{"Display=\n", "Display="} {
+		restore := logind.MockLoginctl(sessionClassLoginctlMock(c, displayOutput, "Class=user\n"))
+		defer restore()
+
+		_, err := logind.SessionClass(context.Background())
+		c.Assert(err, ErrorMatches, "cannot find session for the current user: .*")
+	}
+
+	// the display session may vanish between the two calls
 	loginctlErr = &logind.Error{}
-	loginctlErr.SetCmd([]string{"show-session", "c5", "-p", "Class"})
 	loginctlErr.SetExitCode(1)
 	loginctlErr.SetMsg([]byte("No session 'c5' known"))
 
-	calls = 0
+	calls := 0
 	restore = logind.MockLoginctl(func(ctx context.Context, args ...string) ([]byte, error) {
 		calls++
 		switch args[0] {
@@ -331,22 +138,48 @@ func (s *logindSuite) TestSessionClassFromUserDisplayErrors(c *C) {
 	c.Check(calls, Equals, 2)
 }
 
-func (s *logindSuite) TestSessionClassVersionDeterminationError(c *C) {
-	versionErr := errors.New("cannot read systemd version")
-	restore := systemd.MockSystemdVersion(0, versionErr)
+func (s *logindSuite) TestSessionClassMalformedOutput(c *C) {
+	for _, output := range []string{"", "unexpected-no-equals\n", "foo=c5\n", "Display=foo=x\n"} {
+		restore := logind.MockLoginctl(sessionClassLoginctlMock(c, output, "Class=user\n"))
+		defer restore()
+
+		_, err := logind.SessionClass(context.Background())
+		c.Assert(err, NotNil)
+		c.Check(err, ErrorMatches, `cannot parse value from loginctl output for property "Display": .*`)
+	}
+
+	for _, output := range []string{"", "unexpected-no-equals\n", "foo=user\n", "Class=foo=\n"} {
+		restore := logind.MockLoginctl(sessionClassLoginctlMock(c, "Display=c5\n", output))
+		defer restore()
+
+		_, err := logind.SessionClass(context.Background())
+		c.Assert(err, NotNil)
+		c.Check(err, ErrorMatches, `cannot parse value from loginctl output for property "Class": .*`)
+	}
+}
+
+func (s *logindSuite) TestSessionClassWithWhitespace(c *C) {
+	restore := logind.MockLoginctl(sessionClassLoginctlMock(c, "  Display=c5  \n", "Class=user\n"))
 	defer restore()
 
-	calls := 0
-	restore = logind.MockLoginctl(func(ctx context.Context, args ...string) ([]byte, error) {
-		calls++
-		return nil, nil
-	})
+	got, err := logind.SessionClass(context.Background())
+	c.Assert(err, IsNil)
+	c.Check(got, Equals, "user")
+
+	// no trailing \n on the display session id
+	restore = logind.MockLoginctl(sessionClassLoginctlMock(c, "Display=c5", "Class=user\n"))
 	defer restore()
 
-	_, err := logind.SessionClass(context.Background())
-	c.Assert(err, NotNil)
-	c.Check(err, ErrorMatches, "cannot read systemd version")
-	c.Check(calls, Equals, 0)
+	got, err = logind.SessionClass(context.Background())
+	c.Assert(err, IsNil)
+	c.Check(got, Equals, "user")
+
+	restore = logind.MockLoginctl(sessionClassLoginctlMock(c, "Display=c5\n", "  Class=user  \n"))
+	defer restore()
+
+	got, err = logind.SessionClass(context.Background())
+	c.Assert(err, IsNil)
+	c.Check(got, Equals, "user")
 }
 
 func (s *logindSuite) TestError(c *C) {

--- a/systemd/logind/logind_test.go
+++ b/systemd/logind/logind_test.go
@@ -45,10 +45,10 @@ func sessionClassLoginctlMock(c *C, displayOutput, classOutput string) func(ctx 
 	return func(ctx context.Context, args ...string) ([]byte, error) {
 		switch args[0] {
 		case "show-user":
-			c.Check(args, DeepEquals, []string{"show-user", strconv.Itoa(os.Getuid()), "-p", "Display"})
+			c.Check(args, DeepEquals, []string{"show-user", strconv.Itoa(os.Getuid()), "--all", "-p", "Display"})
 			return []byte(displayOutput), nil
 		case "show-session":
-			c.Check(args, DeepEquals, []string{"show-session", "c5", "-p", "Class"})
+			c.Check(args, DeepEquals, []string{"show-session", "c5", "--all", "-p", "Class"})
 			return []byte(classOutput), nil
 		}
 		return nil, nil
@@ -95,7 +95,7 @@ func (s *logindSuite) TestSessionClassNoSession(c *C) {
 	loginctlErr.SetMsg([]byte("Failed to look up user"))
 
 	restore := logind.MockLoginctl(func(ctx context.Context, args ...string) ([]byte, error) {
-		c.Check(args, DeepEquals, []string{"show-user", strconv.Itoa(os.Getuid()), "-p", "Display"})
+		c.Check(args, DeepEquals, []string{"show-user", strconv.Itoa(os.Getuid()), "--all", "-p", "Display"})
 		return nil, loginctlErr
 	})
 	defer restore()
@@ -123,7 +123,7 @@ func (s *logindSuite) TestSessionClassNoSession(c *C) {
 		calls++
 		switch args[0] {
 		case "show-user":
-			c.Check(args, DeepEquals, []string{"show-user", strconv.Itoa(os.Getuid()), "-p", "Display"})
+			c.Check(args, DeepEquals, []string{"show-user", strconv.Itoa(os.Getuid()), "--all", "-p", "Display"})
 			return []byte("Display=c5\n"), nil
 		case "show-session":
 			return nil, loginctlErr


### PR DESCRIPTION
Follow-up/fix of #17378

Replace the calls to `loginctl show-session auto` with instead using `loginctl show-user <uid> -p Display` to get the session ID of the display-eligible session for the current user, then use that session ID to call `loginctl show-session <id> -p Class`.

The semantics are different: with `loginctl show-session auto`, if invoked within a session, that session will always be selected, and its class returned, otherwise it would fall back to the display-eligible session elected by systemd. Thus, the output varied based on if/which session the command was invoked from.

By instead explicitly using `loginctl show-user <UID> -p Display`, the session in which the command is invoked is not relevant, instead it always looks for the best display-eligible session, and returns its class. That is, it looks for a session for the given UID which has class "user" or "greeter", with "user" taking precedence. Technically, if there are multiple sessions with the same class, it will select among them, preferring x11/wayland over tty over unspecified, but this has no effect on the output of session class anyway.

The desired use-case is for the `ExecCondition` stanzas of user daemons to call `snap routine user-service-precondition`, which in turn calls `logind.SessionClass`. The commands in `ExecCondition` are always invoked from outside any particular session, so the behavior happens to identical for this use-case in both the old and new implementations.

Spec here: https://docs.google.com/document/d/1PeWQrLDExIb5I7HqDYm1dn9WzQcqksKBn5a6V5ASvoI/edit?tab=t.0

This work is tracked internally by https://warthogs.atlassian.net/browse/SNAPDENG-37371
