### PR TITLE
i/apparmor: fix {personal,system}-files profile if path has spaces

### DIFF
--- a/interfaces/apparmor/spec.go
+++ b/interfaces/apparmor/spec.go
@@ -870,14 +870,14 @@ func emitEnsureDir(spec *Specification, ifaceName string, ensureDirSpec *interfa
 	for iter.Next() {
 		if iter.CurrentPath() == mustExistDir {
 			emit("  # Allow the %s interface to create potentially missing directories", ifaceName)
-			emit("  owner %s rw,", appArmorDir(replacePrefixHome(mustExistDir)))
+			emit("  owner %q rw,", appArmorDir(replacePrefixHome(mustExistDir)))
 			break
 		}
 	}
 
 	// Create entries for the remaining directories after MustExistDir up to and including EnsureDir
 	for iter.Next() {
-		emit("  owner %s rw,", replacePrefixHome(iter.CurrentPathPlusSlash()))
+		emit("  owner %q rw,", replacePrefixHome(iter.CurrentPathPlusSlash()))
 	}
 }
 

--- a/interfaces/apparmor/spec_test.go
+++ b/interfaces/apparmor/spec_test.go
@@ -667,14 +667,14 @@ func (s *specSuite) TestAddEnsureDirMounts(c *C) {
 	s.spec.AddEnsureDirMounts("personal-files", ensureDirSpecs)
 	c.Check("\n"+strings.Join(s.spec.UpdateNS(), "\n"), Equals, `
   # Allow the personal-files interface to create potentially missing directories
-  owner @{HOME}/ rw,
-  owner @{HOME}/.local/ rw,
-  owner @{HOME}/.local/share/ rw,
-  owner @{HOME}/dir1/ rw,
-  owner @{HOME}/dir1/dir2/ rw,
-  owner / rw,
-  owner /dir1/ rw,
-  owner /dir1/dir2/ rw,`)
+  owner "@{HOME}/" rw,
+  owner "@{HOME}/.local/" rw,
+  owner "@{HOME}/.local/share/" rw,
+  owner "@{HOME}/dir1/" rw,
+  owner "@{HOME}/dir1/dir2/" rw,
+  owner "/" rw,
+  owner "/dir1/" rw,
+  owner "/dir1/dir2/" rw,`)
 }
 
 func (s *specSuite) TestAddEnsureDirMountsReturnsOnDirsMatch(c *C) {

--- a/interfaces/builtin/personal_files_test.go
+++ b/interfaces/builtin/personal_files_test.go
@@ -93,11 +93,31 @@ owner "@{HOME}/.local/share/dir1/dir2/target{,/,/**}" rwkl,
 
 	c.Check("\n"+strings.Join(apparmorSpec.UpdateNS(), "\n"), Equals, `
   # Allow the personal-files interface to create potentially missing directories
-  owner @{HOME}/ rw,
-  owner @{HOME}/.local/ rw,
-  owner @{HOME}/.local/share/ rw,
-  owner @{HOME}/.local/share/dir1/ rw,
-  owner @{HOME}/.local/share/dir1/dir2/ rw,`)
+  owner "@{HOME}/" rw,
+  owner "@{HOME}/.local/" rw,
+  owner "@{HOME}/.local/share/" rw,
+  owner "@{HOME}/.local/share/dir1/" rw,
+  owner "@{HOME}/.local/share/dir1/dir2/" rw,`)
+}
+
+func (s *personalFilesInterfaceSuite) TestConnectedPlugAppArmorPathWithSpaces(c *C) {
+	const mockPlugSnapInfo = `name: other
+version: 1.0
+plugs:
+ personal-files:
+  write: ["$HOME/dir with spaces/target"]
+apps:
+ app:
+  command: foo
+  plugs: [personal-files]
+`
+	plug, _ := MockConnectedPlug(c, mockPlugSnapInfo, nil, "personal-files")
+	apparmorSpec := apparmor.NewSpecification(plug.AppSet())
+	err := apparmorSpec.AddConnectedPlug(s.iface, plug, s.slot)
+	c.Assert(err, IsNil)
+
+	c.Check(apparmorSpec.SnippetForTag("snap.other.app"), testutil.Contains, `owner "@{HOME}/dir with spaces/target{,/,/**}" rwkl,`)
+	c.Check(strings.Join(apparmorSpec.UpdateNS(), "\n"), testutil.Contains, `owner "@{HOME}/dir with spaces/" rw,`)
 }
 
 func (s *personalFilesInterfaceSuite) TestConnectedPlugApparmorErrorNotString(c *C) {

--- a/interfaces/builtin/system_files_test.go
+++ b/interfaces/builtin/system_files_test.go
@@ -87,6 +87,16 @@ func (s *systemFilesInterfaceSuite) TestConnectedPlugAppArmor(c *C) {
 `)
 }
 
+func (s *systemFilesInterfaceSuite) TestAddEnsureDirMountsPathWithSpaces(c *C) {
+	apparmorSpec := apparmor.NewSpecification(s.plug.AppSet())
+	apparmorSpec.AddEnsureDirMounts("system-files", []*interfaces.EnsureDirSpec{{
+		MustExistDir: "/etc",
+		EnsureDir:    "/etc/dir with spaces",
+	}})
+
+	c.Check(strings.Join(apparmorSpec.UpdateNS(), "\n"), testutil.Contains, `owner "/etc/dir with spaces/" rw,`)
+}
+
 func (s *systemFilesInterfaceSuite) TestSanitizeSlot(c *C) {
 	c.Assert(interfaces.BeforePrepareSlot(s.iface, s.slotInfo), IsNil)
 }


### PR DESCRIPTION
A personal-files plug with a path with spaces would fail to connect because the path was not quoted in snap-update-ns profile.
```
error: cannot perform the following tasks:
- Connect spaces-demo:foo-plug to snapd:personal-files (cannot setup profiles for snap "spaces-demo": cannot load apparmor profiles: exit status 1 apparmor_parser output:
AppArmor parser error for /var/lib/snapd/apparmor/profiles/snap-update-ns.spaces-demo in profile /var/lib/snapd/apparmor/profiles/snap-update-ns.spaces-demo at line 182: syntax error, unexpected TOK_ID, expecting TOK_MODE )
```
This is how the path looked before: `owner @{HOME}/dir with spaces/ rw,`


https://warthogs.atlassian.net/browse/SNAPDENG-37374

LP: bugs.launchpad.net/snapd/+bug/2164689