### PR TITLE
overlord/install: fix flaky TestEncryptionAvailabilityCheck timeout mock

### DIFF
--- a/overlord/install/install_test.go
+++ b/overlord/install/install_test.go
@@ -726,11 +726,14 @@ func (s *installSuite) mockHelperForEncryptionAvailabilityCheck(c *C, isSupporte
 		}
 
 		if checkFailErrors == ErrorSecbootTimeout {
-			select {
-			case <-ctx.Done():
-				return nil, nil, ctx.Err()
-			case <-time.After(20 * time.Millisecond):
-			}
+			// Wait deterministically for the context to expire (its
+			// timeout is mocked to be very short) instead of racing
+			// it against a fixed sleep. Racing an unrelated timer is
+			// flaky on slow or heavily loaded machines, where
+			// scheduling delays can let both timers become ready by
+			// the time the select is evaluated.
+			<-ctx.Done()
+			return nil, nil, ctx.Err()
 		}
 
 		switch errorsDetected {
@@ -762,11 +765,10 @@ func (s *installSuite) mockHelperForEncryptionAvailabilityCheck(c *C, isSupporte
 			}
 
 			if checkFailErrors == ErrorSecbootTimeout {
-				select {
-				case <-ctx.Done():
-					return nil, ctx.Err()
-				case <-time.After(20 * time.Millisecond):
-				}
+				// See the equivalent comment in the
+				// secboot.PreinstallCheck mock above.
+				<-ctx.Done()
+				return nil, ctx.Err()
 			}
 
 			switch errorsDetected {


### PR DESCRIPTION
The `ErrorSecbootTimeout` mocks for `secboot.PreinstallCheck` and
`secboot.PreinstallCheckAction` in `TestEncryptionAvailabilityCheck`
simulated a slow check by racing a

```go
select {
case <-ctx.Done():
    return nil, nil, ctx.Err()
case <-time.After(20 * time.Millisecond):
}
```

against a context whose timeout is mocked down to 1ms.

Under normal load `ctx.Done()` always wins by a wide margin, but on a
slow or heavily loaded machine, scheduling delays for the whole
process can exceed the 20ms gap, letting both timers become ready by
the time `select` is evaluated. Go picks pseudo-randomly among ready
cases in that situation, so the mock occasionally took the "success"
branch instead of returning `ctx.Err()`, making
`encryptionAvailabilityCheck` return a non-nil check context where the
test expected nil:

```
obtained *secboot.PreinstallCheckContext = &secboot.PreinstallCheckContext{}
expected *secboot.PreinstallCheckContext = (*secboot.PreinstallCheckContext)(nil)
```

This was observed as an intermittent failure on a Debian s390x buildd.

Fixed by waiting deterministically on `ctx.Done()` instead of racing
it against an unrelated timer: the mock only needs to simulate "the
check took too long", not actually perform concurrent work that can
be cancelled.

Verified with:
```
go test ./overlord/install/... -race -count=20 -check.f TestEncryptionAvailabilityCheck
```