### PR TITLE
tests: clear any pre-existing warnings to make test deterministic

### DIFF
--- a/tests/main/bad-interfaces-warn/task.yaml
+++ b/tests/main/bad-interfaces-warn/task.yaml
@@ -6,6 +6,9 @@ details: |
   command list the invalid interfaces.
 
 prepare: |
+  # Clear any pre-existing warnings.
+  snap warnings >/dev/null
+  snap okay || true
   snap pack test-snap
 
 restore: |


### PR DESCRIPTION
Fix [Error executing openstack:ubuntu-26.04-64:tests/main/bad-interfaces-warn](https://github.com/canonical/snapd/actions/runs/32481498202/job/97354220096?pr=17453#step:25:245)

```
+ echo 'Installing a snap with invalid interfaces issues a warning'
Installing a snap with invalid interfaces issues a warning
+ snap install --dangerous test-snap_1_all.snap
+ MATCH 'WARNING: There is 1 new warning. See '\''snap warnings'\'''
grep error: pattern not found, got:
test-snap 1 installed
WARNING: There are 2 new warnings. See 'snap warnings'.
```