### PR TITLE
tests: clear any pre-existing warnings to make test deterministic

### DIFF
--- a/tests/main/interfaces-posix-mq/task.yaml
+++ b/tests/main/interfaces-posix-mq/task.yaml
@@ -25,6 +25,10 @@ systems:
     - -opensuse-*
 
 prepare: |
+    # Clear any pre-existing warnings.
+    snap warnings >/dev/null
+    snap okay || true
+
     # Source code is at https://github.com/canonical/test-snapd-posix-mq
     snap install test-snapd-posix-mq
     snap warnings | MATCH 'No further warnings.|No warnings.'


### PR DESCRIPTION
Fix [Error preparing openstack:ubuntu-26.04-64:tests/main/interfaces-posix-mq](https://github.com/canonical/snapd/actions/runs/32481498202/job/97354220096?pr=17453#step:25:221)

```
...
+ snap install test-snapd-posix-mq
test-snapd-posix-mq 0.9 from Zygmunt Krynicki (zygoon) installed
WARNING: There is 1 new warning. See 'snap warnings'.
+ snap warnings
+ MATCH 'No further warnings.|No warnings.'
grep error: pattern not found, got:
last-occurrence:  today at 07:32 UTC
warning: |
the snapd.apparmor service is disabled; snap applications will likely not
start.
Run "systemctl enable --now snapd.apparmor" to correct this.
```