### PR TITLE
confdb,daemon: extract validate constraints helper

### DIFF
--- a/confdb/confdb.go
+++ b/confdb/confdb.go
@@ -1862,6 +1862,27 @@ func (v *View) CheckAllConstraintsAreUsed(requests []string, constraints map[str
 	return newUnmatchedConstraintsError(v, requests, unusedConstraints)
 }
 
+// ValidateConstraints checks that every constraint value is a non-null scalar.
+func ValidateConstraints(constraints map[string]any) error {
+	for k, v := range constraints {
+		var typeStr string
+		switch v.(type) {
+		case nil:
+			typeStr = "null"
+		case []any:
+			typeStr = "array"
+		case map[string]any:
+			typeStr = "map"
+		default:
+			continue
+		}
+
+		return fmt.Errorf("constraint value must be non-null scalar but parameter %q has %s constraint", k, typeStr)
+	}
+
+	return nil
+}
+
 func getVisibilitiesToPrune(userAccess Access) []Visibility {
 	if userAccess == AdminAccess {
 		return nil

--- a/confdb/confdb_test.go
+++ b/confdb/confdb_test.go
@@ -764,6 +764,51 @@ func (s *viewSuite) TestViewCheckAllConstraintsAreUsed(c *C) {
 	}
 }
 
+func (s *viewSuite) TestValidateConstraintsOK(c *C) {
+	err := confdb.ValidateConstraints(map[string]any{
+		"iface": "wlan0",
+		"count": 1,
+		"admin": true,
+	})
+	c.Assert(err, IsNil)
+}
+
+func (s *viewSuite) TestValidateConstraintsEmpty(c *C) {
+	err := confdb.ValidateConstraints(nil)
+	c.Assert(err, IsNil)
+}
+
+func (s *viewSuite) TestValidateConstraintsInvalid(c *C) {
+	tests := []struct {
+		name        string
+		constraints map[string]any
+		expectedErr string
+	}{
+		{
+			name:        "null value",
+			constraints: map[string]any{"iface": nil},
+			expectedErr: `constraint value must be non-null scalar but parameter "iface" has null constraint`,
+		},
+		{
+			name:        "array value",
+			constraints: map[string]any{"iface": []any{"wlan0", "wlan1"}},
+			expectedErr: `constraint value must be non-null scalar but parameter "iface" has array constraint`,
+		},
+		{
+			name:        "map value",
+			constraints: map[string]any{"iface": map[string]any{"name": "wlan0"}},
+			expectedErr: `constraint value must be non-null scalar but parameter "iface" has map constraint`,
+		},
+	}
+
+	for _, t := range tests {
+		cmt := Commentf("%s test", t.name)
+		err := confdb.ValidateConstraints(t.constraints)
+		c.Assert(err, NotNil, cmt)
+		c.Check(err, ErrorMatches, t.expectedErr, cmt)
+	}
+}
+
 func (s *viewSuite) TestViewAssertionWithPlaceholder(c *C) {
 	for _, t := range []struct {
 		rule     map[string]any

--- a/daemon/api_confdb.go
+++ b/daemon/api_confdb.go
@@ -80,7 +80,7 @@ func getView(c *Command, r *http.Request, _ *auth.UserState) Response {
 			return BadRequest(`"constraints" must be a JSON object`)
 		}
 
-		err := validateConstraints(constraints)
+		err := confdb.ValidateConstraints(constraints)
 		if err != nil {
 			return BadRequest(err.Error())
 		}
@@ -115,26 +115,6 @@ func getView(c *Command, r *http.Request, _ *auth.UserState) Response {
 
 	ensureStateSoon(st)
 	return AsyncResponse(nil, chgID)
-}
-
-func validateConstraints(cstrs map[string]any) error {
-	for k, v := range cstrs {
-		var typeStr string
-		switch v.(type) {
-		case nil:
-			typeStr = "null"
-		case []any:
-			typeStr = "array"
-		case map[string]any:
-			typeStr = "map"
-		default:
-			continue
-		}
-
-		return fmt.Errorf("constraint value must be non-null scalar but parameter %q has %s constraint", k, typeStr)
-	}
-
-	return nil
 }
 
 func setView(c *Command, r *http.Request, _ *auth.UserState) Response {


### PR DESCRIPTION
In [#17039 (add confdb handler for device management)](https://github.com/canonical/snapd/pull/17039), we need a reusable helper to validate confdb constraints in the confdb subsystem handler (`o/confdbstate`). I've decided to create a separate PR for that change since it's self contained and reduces the number of packages #17039 touches.