### PR TITLE
o/confdbstate: assert Settle errors

### DIFF
--- a/overlord/confdbstate/confdbstate_test.go
+++ b/overlord/confdbstate/confdbstate_test.go
@@ -204,6 +204,7 @@ func (s *confdbTestSuite) SetUpTest(c *C) {
 }
 
 func (s *confdbTestSuite) TearDownTest(c *C) {
+	c.Assert(s.o.Stop(), IsNil)
 	if s.restoreDeviceCtx != nil {
 		s.restoreDeviceCtx()
 		s.restoreDeviceCtx = nil
@@ -312,7 +313,8 @@ func (s *confdbTestSuite) TestSetView(c *C) {
 	c.Assert(err, IsNil)
 
 	s.state.Unlock()
-	s.o.Settle(5 * time.Second)
+	err = s.o.Settle(5 * time.Second)
+	c.Assert(err, IsNil)
 	s.state.Lock()
 
 	chg := s.state.Change(chgID)
@@ -340,7 +342,8 @@ func (s *confdbTestSuite) TestSetViewDoesNotEraseOtherSchemaUnderSameAccount(c *
 	c.Assert(err, IsNil)
 
 	s.state.Unlock()
-	s.o.Settle(5 * time.Second)
+	err = s.o.Settle(5 * time.Second)
+	c.Assert(err, IsNil)
 	s.state.Lock()
 
 	c.Assert(s.state.Change(chgID).Status(), Equals, state.DoneStatus)
@@ -353,7 +356,8 @@ func (s *confdbTestSuite) TestSetViewDoesNotEraseOtherSchemaUnderSameAccount(c *
 	c.Assert(err, IsNil)
 
 	s.state.Unlock()
-	s.o.Settle(5 * time.Second)
+	err = s.o.Settle(5 * time.Second)
+	c.Assert(err, IsNil)
 	s.state.Lock()
 
 	c.Assert(s.state.Change(chgID).Status(), Equals, state.DoneStatus)
@@ -433,7 +437,8 @@ func (s *confdbTestSuite) TestUnsetView(c *C) {
 	c.Assert(err, IsNil)
 
 	s.state.Unlock()
-	s.o.Settle(5 * time.Second)
+	err = s.o.Settle(5 * time.Second)
+	c.Assert(err, IsNil)
 	s.state.Lock()
 
 	chg := s.state.Change(chgID)
@@ -1124,7 +1129,8 @@ func (s *confdbTestSuite) TestWriteConfdbCreatesNewChange(c *C) {
 	c.Assert(chg.ID(), Equals, chgID)
 
 	s.state.Unlock()
-	s.o.Settle(testutil.HostScaledTimeout(5 * time.Second))
+	err = s.o.Settle(testutil.HostScaledTimeout(5 * time.Second))
+	c.Assert(err, IsNil)
 	s.state.Lock()
 
 	s.checkSetConfdbChange(c, chg, hooks)
@@ -1134,10 +1140,13 @@ func (s *confdbTestSuite) TestWriteConfdbFromSnapCreatesNewChange(c *C) {
 	hooks, restore := s.mockConfdbHooks()
 	defer restore()
 
+	settleErr := make(chan error, 1)
 	restore = confdbstate.MockEnsureNow(func(*state.State) {
 		s.checkOngoingWriteConfdbTx(c, s.devAccID, "network")
 
-		go s.o.Settle(testutil.HostScaledTimeout(5 * time.Second))
+		go func() {
+			settleErr <- s.o.Settle(testutil.HostScaledTimeout(5 * time.Second))
+		}()
 	})
 	defer restore()
 
@@ -1157,6 +1166,9 @@ func (s *confdbTestSuite) TestWriteConfdbFromSnapCreatesNewChange(c *C) {
 	ctx.Lock()
 	err = confdbstate.WriteConfdbFromSnap(ctx, view, map[string]any{"ssid": "foo"}, nil)
 	c.Assert(err, IsNil)
+	ctx.Unlock()
+	c.Assert(<-settleErr, IsNil)
+	ctx.Lock()
 
 	// this is called automatically by hooks or manually for daemon/
 	ctx.Done()
@@ -1604,9 +1616,12 @@ func (s *confdbTestSuite) testReadConfdbFromSnap(c *C, ctx *hookstate.Context) *
 	hooks, restore := s.mockConfdbHooks()
 	defer restore()
 
+	settleErr := make(chan error, 1)
 	restore = confdbstate.MockEnsureNow(func(*state.State) {
 		s.checkOngoingReadConfdbTx(c, s.devAccID, "network")
-		go s.o.Settle(5 * time.Second)
+		go func() {
+			settleErr <- s.o.Settle(testutil.HostScaledTimeout(5 * time.Second))
+		}()
 	})
 	defer restore()
 
@@ -1623,6 +1638,14 @@ func (s *confdbTestSuite) testReadConfdbFromSnap(c *C, ctx *hookstate.Context) *
 	view := s.dbSchema.View("setup-wifi")
 	tx, err := confdbstate.ReadConfdbFromSnap(ctx, view, []string{"ssid"}, nil, nil)
 	c.Assert(err, IsNil)
+	ctx.Unlock()
+	select {
+	case err = <-settleErr:
+		c.Assert(err, IsNil)
+	case <-time.After(testutil.HostScaledTimeout(6 * time.Second)):
+		c.Fatal("timed out waiting for settle")
+	}
+	ctx.Lock()
 	c.Assert(s.state.Changes(), HasLen, 1)
 
 	val, err := tx.Get(parsePath(c, "wifi.ssid"), nil)
@@ -1752,7 +1775,8 @@ func (s *confdbTestSuite) TestGetTransactionTimesOut(c *C) {
 	c.Assert(tx, IsNil)
 
 	s.state.Unlock()
-	s.o.Settle(testutil.HostScaledTimeout(2 * time.Second))
+	err = s.o.Settle(testutil.HostScaledTimeout(2 * time.Second))
+	c.Assert(err, IsNil)
 	s.state.Lock()
 
 	err = confdbstate.WriteConfdbFromSnap(ctx, view, nil, nil)
@@ -2069,10 +2093,13 @@ func (s *confdbTestSuite) TestWriteAffectingEphemeralMustDefineSaveViewHook(c *C
 	s.setupConfdbScenario(c, map[string]confdbHooks{"custodian-snap": hooks}, nil)
 	s.state.Unlock()
 
+	settleErr := make(chan error, 1)
 	restore := confdbstate.MockEnsureNow(func(*state.State) {
 		s.checkOngoingWriteConfdbTx(c, s.devAccID, "network")
 
-		go s.o.Settle(testutil.HostScaledTimeout(5 * time.Second))
+		go func() {
+			settleErr <- s.o.Settle(testutil.HostScaledTimeout(5 * time.Second))
+		}()
 	})
 	defer restore()
 
@@ -2096,6 +2123,14 @@ func (s *confdbTestSuite) TestWriteAffectingEphemeralMustDefineSaveViewHook(c *C
 		"ssid": "foo",
 	}, nil)
 	c.Assert(err, IsNil)
+	ctx.Unlock()
+	select {
+	case err = <-settleErr:
+		c.Assert(err, IsNil)
+	case <-time.After(testutil.HostScaledTimeout(6 * time.Second)):
+		c.Fatal("timed out waiting for settle")
+	}
+	ctx.Lock()
 }
 
 func (s *confdbTestSuite) TestReadCoveringEphemeralMustDefineLoadViewHook(c *C) {


### PR DESCRIPTION
confdbstate_test.go was not asserting errors in quite a few Settle calls.