### PR TITLE
tests: clear any pre-existing warnings to make test deterministic

### DIFF
--- a/tests/main/snap-info/task.yaml
+++ b/tests/main/snap-info/task.yaml
@@ -11,6 +11,10 @@ details: |
 systems: [-amazon-*, -centos-*]
 
 prepare: |
+    # Clear any pre-existing warnings.
+    snap warnings >/dev/null
+    snap okay || true
+
     snap pack "$TESTSLIB"/snaps/basic
     snap install test-snapd-tools
     snap install --channel beta --devmode test-snapd-devmode


### PR DESCRIPTION
Fix [Error executing openstack:ubuntu-26.04-64:tests/main/snap-info](https://github.com/canonical/snapd/actions/runs/32716792828/job/97428824541?pr=17373#step:25:88)

```
...
+ snap info --verbose test-snapd-tools
+ NOMATCH grade:
WARNING: There is 1 new warning. See 'snap warnings'.
+ snap info --verbose basic_1.0_all.snap
+ MATCH sha3-384:
+ snap info --verbose test-snapd-tools
+ MATCH '  ignore-validation:'
WARNING: There is 1 new warning. See 'snap warnings'.
+ echo 'Ensure we show friendly error messages'
Ensure we show friendly error messages
+ snap info no-such-snap
+ true
+ MATCH 'no snap found for "no-such-snap"'
+ snap info no-such-snap no-such-other-snap
+ true
+ MATCH 'warning: no snap found for "no-such-snap"'
+ MATCH 'warning: no snap found for "no-such-other-snap"'
+ MATCH 'error: no valid snaps given'
+ snap info no-such-snap test-snapd-tools
+ MATCH 'warning: no snap found for "no-such-snap"'
+ not test -s out.stderr
```

Every `snap` command calls [maybePresentWarnings](https://github.com/canonical/snapd/blob/master/cmd/snapd/cli/main.go#L684) and thus, here `snap info` keeps complaining about warnings that were present before executing the test.