### PR TITLE
tests: explicitly add staged python packages to path

### DIFF
--- a/tests/lib/snaps/store/test-snapd-location-control-provider/snapcraft.yaml
+++ b/tests/lib/snaps/store/test-snapd-location-control-provider/snapcraft.yaml
@@ -6,6 +6,9 @@ confinement: strict
 grade: stable
 base: core24
 
+environment:
+    PYTHONPATH: "$SNAP/usr/lib/python3/dist-packages:${PYTHONPATH}"
+
 apps:
     provider:
         command: wrapper


### PR DESCRIPTION
Fix [Error executing openstack:ubuntu-26.04-64:tests/main/interfaces-location-control](https://github.com/canonical/snapd/actions/runs/32747636825/job/97529045324?pr=17373#step:25:97)

```
...
retry: command sh -c tests.session -u test exec test-snapd-location-control-provider.consumer Get | MATCH "location-provider-added" failed with code 1
retry: next attempt in 1.0 second(s) (attempt 9 of 10)
Traceback (most recent call last):
File "/snap/test-snapd-location-control-provider/32/consumer", line 3, in <module>
import dbus
ModuleNotFoundError: No module named 'dbus'
grep error: pattern not found, got:

retry: command sh -c tests.session -u test exec test-snapd-location-control-provider.consumer Get | MATCH "location-provider-added" failed with code 1
retry: command sh -c tests.session -u test exec test-snapd-location-control-provider.consumer Get | MATCH "location-provider-added" keeps failing after 10 attempts
```