### PR TITLE
interfaces, cmd/snap-confine: make driver-libs interfaces usable on Ubuntu Core [WIP]

### DIFF
--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -77,6 +77,7 @@ static const size_t egl_vendor_globs_len = SC_ARRAY_SIZE(egl_vendor_globs);
 static const char *nvidia_driver_version_file(void) {
     const char *path = getenv("SNAPD_TESTING_NVIDIA_DRIVER_VERSION_FILE");
     if (path != NULL) {
+        debug("overriding nvidia driver version file: %s", path);
         return path;
     }
     return "/sys/module/nvidia/version";

--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -719,18 +719,38 @@ static void sc_mount_egl(const char *rootfs_dir) {
 }
 
 void sc_mount_snap_gpu_driver(const char *rootfs_dir, const char *base_snap_name, sc_distro distro) {
-    // TODO: distro is currently unused; a subsequent change will use it to
-    // also run on Ubuntu Core (see TODO_CORE_DRIVER_LIBS.md).
-    (void)distro;
+    const bool is_classic = (distro == SC_DISTRO_CLASSIC);
+    const bool nvidia_present = access(nvidia_driver_version_file(), F_OK) == 0;
 
-    /* If NVIDIA module isn't loaded, don't attempt to mount the drivers */
-    if (access(nvidia_driver_version_file(), F_OK) != 0) {
+    // Skip entirely only on classic without an NVIDIA kernel module loaded -
+    // preserving today's trigger condition there. On core we always
+    // proceed: the snap-provided GPU content mounted below (library
+    // directories from .library-source, and on core config files from
+    // export.sources - see sc_mount_exported_paths()) is vendor-neutral and
+    // does not depend on an NVIDIA kernel module being loaded at all.
+    if (is_classic && !nvidia_present) {
         return;
     }
 
     if (sc_nonfatal_mkpath(SC_EXTRA_LIB_DIR, 0755, 0, 0) != 0) {
         die("cannot create " SC_EXTRA_LIB_DIR);
     }
+
+    int exported_paths = 0;
+#ifdef NVIDIA_MULTIARCH
+    // Snap-provided GPU library directories from .library-source: always
+    // attempted, on both classic and core, regardless of NVIDIA presence -
+    // this is vendor-neutral and not gated by is_classic/nvidia_present.
+    exported_paths = sc_mount_exported_paths(rootfs_dir);
+#endif
+
+    if (!is_classic) {
+        // Core has no host driver to scan for, and /usr/share/{vulkan,glvnd}
+        // below belong to the base snap, not a host - nothing further to do.
+        return;
+    }
+
+    // ---- Everything below is classic-only host driver scanning ----
 
 #if defined(NVIDIA_BIARCH) || defined(NVIDIA_MULTIARCH)
     /* We include the globs for the glvnd libraries for old snaps
@@ -757,11 +777,7 @@ void sc_mount_snap_gpu_driver(const char *rootfs_dir, const char *base_snap_name
     }
 #endif
 
-    int exported_paths = 0;
 #ifdef NVIDIA_MULTIARCH
-    // For hybrid we might have exported paths from snaps, otherwise do the
-    // regular multiarch.
-    exported_paths = sc_mount_exported_paths(rootfs_dir);
     if (exported_paths > 0) {
         // Copy configuration files created by {egl,vulkan}-driver-libs. The
         // sources are symlinks to files shipped by snaps, so we cannot just

--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -718,7 +718,11 @@ static void sc_mount_egl(const char *rootfs_dir) {
                                       egl_vendor_globs, egl_vendor_globs_len);
 }
 
-void sc_mount_nvidia_driver(const char *rootfs_dir, const char *base_snap_name) {
+void sc_mount_snap_gpu_driver(const char *rootfs_dir, const char *base_snap_name, sc_distro distro) {
+    // TODO: distro is currently unused; a subsequent change will use it to
+    // also run on Ubuntu Core (see TODO_CORE_DRIVER_LIBS.md).
+    (void)distro;
+
     /* If NVIDIA module isn't loaded, don't attempt to mount the drivers */
     if (access(nvidia_driver_version_file(), F_OK) != 0) {
         return;

--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -55,6 +55,19 @@
 #define SC_SNAP_DIR "/snap"
 #define SC_LIBGPU_DIR SC_EXTRA_LIB_DIR "/system/gpu"
 
+// Layout of the export backend's tree (see interfaces/export in the snapd
+// tree): one directory per interface under SC_SNAPD_EXPORT_SYSTEM, each
+// containing per-connection "unit" directories plus a flat manifest file,
+// SC_EXPORT_MANIFEST_NAME, listing every exported file as a path relative to
+// the interface's own directory, one per line, of the form
+// "<unit>/<subdir>/<file>". Exported files are pooled into the read-only gpu
+// tmpfs under SC_LIBGPU_SYSTEM_DIR, mirroring that same per-interface,
+// per-subdir layout but without the unit path component (see
+// sc_mount_exported_config_files() below).
+#define SC_SNAPD_EXPORT_SYSTEM SC_SNAPD_EXPORT "/system"
+#define SC_EXPORT_MANIFEST_NAME "export.sources"
+#define SC_LIBGPU_SYSTEM_DIR SC_LIBGPU_DIR "/system"
+
 // Globs for files to copy when exporting configuration from snaps
 #define SC_ETC_GLVND_EGL_SOURCE_DIR "/etc/glvnd/egl_vendor.d"
 #define SC_SNAP_EGL_VENDOR_GLOB SC_ETC_GLVND_EGL_SOURCE_DIR "/*_snap_*_*_*.json"
@@ -503,6 +516,175 @@ static void sc_mount_nvidia_driver_multiarch(const char *rootfs_dir, const char 
     }
 }
 
+// The set of driver-libs interfaces that may populate an export.sources
+// manifest under SC_SNAPD_EXPORT_SYSTEM. Shared by sc_has_exported_config_files()
+// and sc_mount_exported_config_files() below so there is exactly one place
+// that needs to be kept in sync with the Go side (interfaces/builtin) as new
+// interfaces adopt the export backend - a second, independently-maintained
+// copy of this list would risk the two silently disagreeing (e.g. the
+// existence check finding a manifest that the mount loop then never visits).
+static const char *const gpu_export_ifaces[] = {
+    "cuda-driver-libs",   "egl-driver-libs",      "gbm-driver-libs",    "nvidia-video-driver-libs",
+    "opengl-driver-libs", "opengles-driver-libs", "vulkan-driver-libs",
+};
+
+// Longest tolerated export.sources manifest line, i.e. the longest
+// "<unit>/<subdir>/<file>" relative path we are willing to build a
+// destination path out of. Chosen so that even the longest interface name in
+// gpu_export_ifaces plus this bound fits comfortably under PATH_MAX once
+// combined with SC_SNAPD_EXPORT_SYSTEM and SC_LIBGPU_SYSTEM_DIR (see the
+// sc_must_snprintf calls in sc_mount_exported_config_files) - real manifest
+// lines produced by the Go side are on the order of a few hundred bytes at
+// most, so this is generous headroom, not a tight fit.
+#define SC_EXPORT_MANIFEST_LINE_MAX 3000
+
+// sc_manifest_line_relpath validates one line from an export.sources
+// manifest, of the form "<unit>/<relPath>" (see AddExportedFile in
+// interfaces/export/spec.go), and returns a pointer within line to the
+// start of relPath - i.e. line with the leading "<unit>/" path component
+// stripped off - or NULL if line does not look like a valid manifest entry.
+//
+// The manifest is written entirely by snapd, and its lines never contain
+// ".." components, escape the interface's own directory, or exceed
+// SC_EXPORT_MANIFEST_LINE_MAX, so these checks are defense in depth against
+// unexpected content, not an expected failure mode. In particular the length
+// check exists so that a malformed or unexpectedly long line is turned away
+// here - visibly, as just another rejected manifest entry - rather than
+// reaching the sc_must_snprintf calls that build src/dst paths out of it
+// further down, which would die() on truncation instead of degrading
+// gracefully.
+static const char *sc_manifest_line_relpath(const char *line) {
+    if (line[0] == '\0' || line[0] == '/') {
+        return NULL;
+    }
+    if (strlen(line) > SC_EXPORT_MANIFEST_LINE_MAX) {
+        return NULL;
+    }
+    const char *sep = strchr(line, '/');
+    if (sep == NULL || sep[1] == '\0') {
+        return NULL;
+    }
+    if (strstr(line, "..") != NULL) {
+        return NULL;
+    }
+    return sep + 1;
+}
+
+// sc_has_exported_config_files reports whether any interface in
+// gpu_export_ifaces currently has an export.sources manifest, without
+// reading or mounting anything. Used by sc_mount_exported_paths() to decide
+// whether the gpu tmpfs needs to be created even when there are no
+// .library-source files to bind-mount - the two are independent facts about
+// a connection (a slot's icd-source and library-source attributes are
+// unrelated), so config export must not be gated on library export existing.
+static bool sc_has_exported_config_files(void) {
+    char manifest_path[PATH_MAX] = {0};
+    for (size_t i = 0; i < SC_ARRAY_SIZE(gpu_export_ifaces); ++i) {
+        sc_must_snprintf(manifest_path, sizeof manifest_path, "%s/%s/%s", SC_SNAPD_EXPORT_SYSTEM, gpu_export_ifaces[i],
+                         SC_EXPORT_MANIFEST_NAME);
+        if (access(manifest_path, F_OK) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// sc_mount_exported_config_files reads the export.sources manifest (see
+// SC_EXPORT_MANIFEST_NAME) for each interface in gpu_export_ifaces and
+// bind-mounts every file it lists into the pooled tree under
+// SC_LIBGPU_SYSTEM_DIR/<iface>/, so that a snap using the corresponding
+// interface can see vendor ICD/layer configuration alongside the libraries
+// mounted by the rest of sc_mount_exported_paths(). It must run before that
+// function's closing sc_remount_ro() call, since it needs to create
+// directories and placeholder files in the not-yet-read-only tmpfs.
+//
+// A missing manifest (ENOENT) means the interface currently has no
+// connections that export configuration files, and is silently skipped -
+// the expected, common case both for interfaces that never populate a
+// manifest (e.g. gbm-driver-libs, at the time of writing) and for
+// driver-libs interfaces with no current connections.
+//
+// A listed file that has disappeared since the manifest was read (e.g. the
+// exporting snap was refreshed or disconnected concurrently with this
+// snap's launch) is tolerated the same way, via sc_do_optional_mount(): a
+// launch must not fail because of a benign race with an unrelated snap. In
+// that case the placeholder file created below is removed again rather than
+// left behind empty, so a consumer never sees a zero-length stand-in for a
+// file that was never actually there.
+static void sc_mount_exported_config_files(const char *rootfs_dir) {
+    char manifest_path[PATH_MAX] = {0};
+    char line[PATH_MAX] = {0};
+    char src[PATH_MAX] = {0};
+    char dst[PATH_MAX] = {0};
+
+    for (size_t i = 0; i < SC_ARRAY_SIZE(gpu_export_ifaces); ++i) {
+        const char *iface = gpu_export_ifaces[i];
+
+        sc_must_snprintf(manifest_path, sizeof manifest_path, "%s/%s/%s", SC_SNAPD_EXPORT_SYSTEM, iface,
+                         SC_EXPORT_MANIFEST_NAME);
+
+        FILE *file SC_CLEANUP(sc_cleanup_file) = NULL;
+        file = fopen(manifest_path, "r");
+        if (file == NULL) {
+            if (errno != ENOENT) {
+                die("cannot open %s", manifest_path);
+            }
+            continue;
+        }
+
+        debug("reading export manifest %s", manifest_path);
+        while (fgets(line, sizeof line, file) != NULL) {
+            sc_str_chomp(line);
+            const char *relpath = sc_manifest_line_relpath(line);
+            if (relpath == NULL) {
+                debug("WARNING: ignoring malformed manifest entry %s in %s", line, manifest_path);
+                continue;
+            }
+
+            sc_must_snprintf(src, sizeof src, "%s/%s/%s", SC_SNAPD_EXPORT_SYSTEM, iface, line);
+            sc_must_snprintf(dst, sizeof dst, "%s" SC_LIBGPU_SYSTEM_DIR "/%s/%s", rootfs_dir, iface, relpath);
+
+            // If the destination already exists, this entry has already
+            // been mounted - encoded filenames should not collide across
+            // units, so in practice this is a safety net, not the primary
+            // defence against repeated entries.
+            struct stat stat_buf;
+            if (stat(dst, &stat_buf) == 0) {
+                debug("%s is already mounted, skipping", dst);
+                continue;
+            }
+
+            // POSIX dirname() may modify its argument, so operate on a copy.
+            char *dst_copy SC_CLEANUP(sc_cleanup_string) = sc_strdup(dst);
+            char *dst_dir = dirname(dst_copy);
+            if (sc_nonfatal_mkpath(dst_dir, 0755, 0, 0) != 0) {
+                die("cannot create %s", dst_dir);
+            }
+
+            // A regular file, not a directory, must already exist at dst
+            // before we can bind-mount a file onto it.
+            int fd = open(dst, O_CREAT | O_WRONLY | O_NOFOLLOW, 0644);
+            if (fd < 0) {
+                die("cannot create placeholder file %s", dst);
+            }
+            close(fd);
+
+            debug("mounting %s at %s", src, dst);
+            if (!sc_do_optional_mount(src, dst, NULL, MS_BIND | MS_RDONLY, NULL)) {
+                // The source vanished between the manifest being read and
+                // this mount attempt (e.g. a concurrent refresh or
+                // disconnect of the exporting snap) - remove the now-unused
+                // placeholder rather than leaving an empty file behind for a
+                // consumer to trip over.
+                debug("%s vanished before it could be mounted, removing placeholder", src);
+                if (unlink(dst) != 0) {
+                    debug("WARNING: cannot remove placeholder %s: %s", dst, strerror(errno));
+                }
+            }
+        }
+    }
+}
+
 static int sc_mount_exported_paths(const char *rootfs_dir) {
     // We are interested only in exports from GPU related interfaces to the
     // system, so we check the interface name in the files.
@@ -527,7 +709,16 @@ static int sc_mount_exported_paths(const char *rootfs_dir) {
             die("cannot search using glob pattern %s: %d", glob_pattern, err);
         }
     }
-    if (glob_res.gl_pathc == 0) {
+    // Whether to create the gpu tmpfs at all depends on two independent
+    // facts about current connections: are there .library-source files to
+    // bind-mount (glob_res, above), or is there an export.sources manifest
+    // with configuration files to bind-mount (see
+    // sc_mount_exported_config_files() below)? A slot's icd-source and
+    // library-source attributes are unrelated, so an interface that only
+    // exports configuration (nothing currently does, but the export backend
+    // is meant to be usable that way) must not be skipped just because
+    // glob_res came back empty.
+    if (glob_res.gl_pathc == 0 && !sc_has_exported_config_files()) {
         debug("no relevant sources in snaps export folder");
         return 0;
     }
@@ -594,6 +785,11 @@ static int sc_mount_exported_paths(const char *rootfs_dir) {
             sc_do_mount(path, dest_path, NULL, MS_BIND | MS_RDONLY, NULL);
         }
     }
+
+    // Config files (ICD/layer manifests etc.) exported by snaps via the
+    // export backend - see interfaces/export - must land in the same tmpfs
+    // before it is made read-only below.
+    sc_mount_exported_config_files(rootfs_dir);
 
     // Make the tmpfs read-only
     sc_remount_ro(tmpfs_path);

--- a/cmd/snap-confine/mount-support-nvidia.c
+++ b/cmd/snap-confine/mount-support-nvidia.c
@@ -22,6 +22,7 @@
 #include <fcntl.h>
 #include <glob.h>
 #include <limits.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
@@ -601,15 +602,38 @@ static int sc_mount_exported_paths(const char *rootfs_dir) {
 }
 
 // TODO move to utils.c and add some unit tests
-static void sc_copy_file(const char *src, const char *dest) {
+//
+// Copies the content of src to dest. Returns true if the file was copied,
+// false if it was skipped because src could not be opened or stat()'d.
+//
+// A missing or unreadable source is not treated as fatal: the classic-only
+// /etc/glvnd and /etc/vulkan directories this function copies from (see
+// sc_copy_glob_files() below, its only caller) contain symlinks that the
+// symlinks backend plants and removes on connect/disconnect, so src having
+// disappeared since it was discovered by the caller's glob() is an expected,
+// recoverable condition, not a bug - a snap launch must not fail just
+// because a driver snap was refreshed or disconnected at the wrong moment.
+// Once open() succeeds, POSIX unlink semantics mean the fd keeps the inode
+// alive for the rest of this function, so fstat() and sendfile() below
+// cannot fail due to a concurrent removal of src - the only source-side
+// race is in open() itself, and fstat() is guarded the same way purely for
+// defense in depth.
+//
+// Failures on the dest side (creat(), sendfile() writing to it) remain
+// fatal: those indicate a problem with our own scratch tmpfs, which we do
+// not expect anyone else to be mutating concurrently, so masking them would
+// hide a real bug rather than tolerate an expected race.
+static bool sc_copy_file(const char *src, const char *dest) {
     int fd_in SC_CLEANUP(sc_cleanup_close) = -1;
     int fd_out SC_CLEANUP(sc_cleanup_close) = -1;
     if ((fd_in = open(src, O_RDONLY)) == -1) {
-        die("cannot open %s", src);
+        debug("cannot open %s: %s, skipping", src, strerror(errno));
+        return false;
     }
     struct stat f_stat = {0};
     if (fstat(fd_in, &f_stat) == -1) {
-        die("cannot stat %s", src);
+        debug("cannot stat %s: %s, skipping", src, strerror(errno));
+        return false;
     }
     if ((fd_out = creat(dest, f_stat.st_mode)) == -1) {
         die("cannot create %s", dest);
@@ -623,6 +647,7 @@ static void sc_copy_file(const char *src, const char *dest) {
         }
         copied += written;
     }
+    return true;
 }
 
 // Copy files matching path_glob to the target directory.
@@ -664,7 +689,9 @@ static void sc_copy_glob_files(const char *rootfs_dir, const char *mnt_dir, cons
         sc_must_snprintf(target, sizeof target, "%s%s/%s", rootfs_dir, target_dir, filename);
 
         debug("copying %s to %s", glob_res.gl_pathv[i], target);
-        sc_copy_file(glob_res.gl_pathv[i], target);
+        if (!sc_copy_file(glob_res.gl_pathv[i], target)) {
+            debug("skipped %s, source vanished or became unreadable", glob_res.gl_pathv[i]);
+        }
     }
 
     // Make the tmpfs read-only

--- a/cmd/snap-confine/mount-support-nvidia.h
+++ b/cmd/snap-confine/mount-support-nvidia.h
@@ -18,6 +18,8 @@
 #ifndef SNAP_CONFINE_MOUNT_SUPPORT_NVIDIA_H
 #define SNAP_CONFINE_MOUNT_SUPPORT_NVIDIA_H
 
+#include "../libsnap-confine-private/classic.h"
+
 /**
  * Make the Nvidia driver from the classic distribution available in the snap
  * execution environment.
@@ -42,7 +44,14 @@
  * subsequently populated with symlinks that point to a number of files in the
  * /usr/lib directory on the classic filesystem. After the pivot_root() call
  * those symlinks rely on the /var/lib/snapd/hostfs directory as a "gateway".
+ *
+ * distro is the caller's classification of the current distribution (see
+ * sc_classify_distro()). On Ubuntu Core, none of the above (which assumes a
+ * mutable classic host filesystem) applies, and distro is used instead to
+ * skip straight to mounting snap-provided GPU content: library directories
+ * and, on core, configuration files exported by the driver-libs interfaces
+ * (see sc_mount_exported_paths()).
  **/
-void sc_mount_nvidia_driver(const char *rootfs_dir, const char *base_snap_name);
+void sc_mount_snap_gpu_driver(const char *rootfs_dir, const char *base_snap_name, sc_distro distro);
 
 #endif

--- a/cmd/snap-confine/mount-support-test.c
+++ b/cmd/snap-confine/mount-support-test.c
@@ -87,8 +87,73 @@ static void test_is_subdir(void) {
     g_assert_false(is_subdir("/", ""));
 }
 
+// sc_manifest_line_relpath() and its callers are only compiled when
+// NVIDIA_MULTIARCH is defined (see the #ifdef NVIDIA_MULTIARCH block around
+// sc_mount_exported_paths() in mount-support-nvidia.c, which is
+// deliberately not hoisted out of it - the shipped snapd snap always
+// builds with --enable-nvidia-multiarch), so these tests must be
+// conditional on the same macro or they fail to link/compile under
+// --enable-nvidia-biarch and the plain (neither) configure variant.
+#ifdef NVIDIA_MULTIARCH
+static void test_manifest_line_relpath__valid(void) {
+    // The common case: one unit, one subdir, one file.
+    g_assert_cmpstr(sc_manifest_line_relpath("15_snap_provider_egl-driver-libs/egl_vendor.d/foo.json"), ==,
+                    "egl_vendor.d/foo.json");
+    // Only the leading "<unit>/" component is stripped, however many further
+    // path components relpath itself has.
+    g_assert_cmpstr(sc_manifest_line_relpath("unit/a/b/c"), ==, "a/b/c");
+    // The minimal valid shape: "<unit>/<file>".
+    g_assert_cmpstr(sc_manifest_line_relpath("unit/file"), ==, "file");
+}
+
+static void test_manifest_line_relpath__invalid(void) {
+    // Empty line.
+    g_assert_null(sc_manifest_line_relpath(""));
+    // Absolute path.
+    g_assert_null(sc_manifest_line_relpath("/unit/subdir/file"));
+    // No "/" separator at all, so there is no unit component to strip.
+    g_assert_null(sc_manifest_line_relpath("nounit"));
+    // Separator is the very last character, leaving an empty relpath.
+    g_assert_null(sc_manifest_line_relpath("unit/"));
+    // ".." anywhere in the line is rejected, whether in the unit or the
+    // relpath component.
+    g_assert_null(sc_manifest_line_relpath("unit/../etc/passwd"));
+    g_assert_null(sc_manifest_line_relpath("../unit/subdir/file"));
+    // The check is a plain substring match, not a path-component match, so
+    // it also (over-broadly, but safely - see the comment on
+    // sc_manifest_line_relpath) rejects a filename that merely contains
+    // ".." without it being a path traversal, such as two dots in a row
+    // inside an otherwise normal name.
+    g_assert_null(sc_manifest_line_relpath("unit/foo..bar.json"));
+}
+
+static void test_manifest_line_relpath__too_long(void) {
+    // One byte over SC_EXPORT_MANIFEST_LINE_MAX must be rejected, the same
+    // way any other malformed entry is - rather than being handed to the
+    // sc_must_snprintf calls in sc_mount_exported_config_files(), which
+    // would die() on truncation instead of degrading gracefully (see the
+    // comment on SC_EXPORT_MANIFEST_LINE_MAX).
+    char too_long[SC_EXPORT_MANIFEST_LINE_MAX + 2] = {0};
+    memset(too_long, 'a', sizeof too_long - 1);
+    // Give it the shape of an otherwise-valid entry: "unit/<filler>".
+    too_long[4] = '/';
+    g_assert_null(sc_manifest_line_relpath(too_long));
+
+    // The boundary itself must still be accepted.
+    char at_limit[SC_EXPORT_MANIFEST_LINE_MAX + 1] = {0};
+    memset(at_limit, 'a', sizeof at_limit - 1);
+    at_limit[4] = '/';
+    g_assert_nonnull(sc_manifest_line_relpath(at_limit));
+}
+#endif  // ifdef NVIDIA_MULTIARCH
+
 static void __attribute__((constructor)) init(void) {
     g_test_add_func("/mount/get_nextpath/typical", test_get_nextpath__typical);
     g_test_add_func("/mount/get_nextpath/weird", test_get_nextpath__weird);
     g_test_add_func("/mount/is_subdir", test_is_subdir);
+#ifdef NVIDIA_MULTIARCH
+    g_test_add_func("/mount/manifest_line_relpath/valid", test_manifest_line_relpath__valid);
+    g_test_add_func("/mount/manifest_line_relpath/invalid", test_manifest_line_relpath__invalid);
+    g_test_add_func("/mount/manifest_line_relpath/too_long", test_manifest_line_relpath__too_long);
+#endif  // ifdef NVIDIA_MULTIARCH
 }

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -719,9 +719,10 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config) {
     // uniform way after pivot_root but this is good enough and requires less
     // code changes the nvidia code assumes it has access to the existing
     // pre-pivot filesystem.
-    if (config->distro == SC_DISTRO_CLASSIC) {
-        sc_mount_nvidia_driver(scratch_dir, config->base_snap_name);
-    }
+    /* TODO: enable on core */
+    /* if (config->distro == SC_DISTRO_CLASSIC) { */
+    sc_mount_nvidia_driver(scratch_dir, config->base_snap_name);
+    /* } */
     // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
     //                    pivot_root
     // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/cmd/snap-confine/mount-support.c
+++ b/cmd/snap-confine/mount-support.c
@@ -715,14 +715,11 @@ static void sc_bootstrap_mount_namespace(const struct sc_mount_config *config) {
     sc_must_snprintf(dst, sizeof dst, "%s/%s", scratch_dir, SC_HOSTFS_DIR);
     sc_do_mount(dst, dst, NULL, MS_BIND, NULL);
     sc_do_mount("none", dst, NULL, MS_PRIVATE, NULL);
-    // On classic mount the nvidia driver. Ideally this would be done in an
-    // uniform way after pivot_root but this is good enough and requires less
-    // code changes the nvidia code assumes it has access to the existing
-    // pre-pivot filesystem.
-    /* TODO: enable on core */
-    /* if (config->distro == SC_DISTRO_CLASSIC) { */
-    sc_mount_nvidia_driver(scratch_dir, config->base_snap_name);
-    /* } */
+    // Mount GPU driver content (see sc_mount_snap_gpu_driver()). Ideally this
+    // would be done in an uniform way after pivot_root but this is good
+    // enough and requires less code changes: the nvidia code assumes it has
+    // access to the existing pre-pivot filesystem.
+    sc_mount_snap_gpu_driver(scratch_dir, config->base_snap_name, config->distro);
     // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
     //                    pivot_root
     // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/cmd/snap-confine/snap-confine.apparmor.in
+++ b/cmd/snap-confine/snap-confine.apparmor.in
@@ -417,6 +417,11 @@ profile @LIBEXECDIR@/snap-confine flags=(attach_disconnected) {
     ## nvidia libraries exported by a snap
     # read source paths
     /var/lib/snapd/export/{,*} r,
+    # read the export.sources manifests and exported files for the
+    # driver-libs interfaces (see interfaces/export) - a subtree of the
+    # above, but needs to be readable at full depth, unlike the flat
+    # *.library-source files above
+    /var/lib/snapd/export/system/{,**} r,
     # for the tmpfs
     /var/lib/snapd/lib/system/ w,
     /var/lib/snapd/lib/system/gpu/ w,
@@ -425,6 +430,9 @@ profile @LIBEXECDIR@/snap-confine flags=(attach_disconnected) {
     # mounts for the source paths
     /tmp/snap-private-tmp/snap.rootfs_*/var/lib/snapd/lib/system/gpu/{,**} w,
     mount options=(ro bind) /{,var/lib/snapd/}snap/** -> /tmp/snap-private-tmp/snap.rootfs_*/var/lib/snapd/lib/system/gpu/**,
+    # bind-mount exported driver-libs config files (ICD/layer JSON) into the
+    # pooled per-interface tree
+    mount options=(ro bind) /var/lib/snapd/export/system/** -> /tmp/snap-private-tmp/snap.rootfs_*/var/lib/snapd/lib/system/gpu/system/**,
 
     # for chroot on steroids, we use pivot_root as a better chroot that makes
     # apparmor rules behave the same on classic and outside of classic.

--- a/cmd/snap-mgmt/snap-mgmt.sh.in
+++ b/cmd/snap-mgmt/snap-mgmt.sh.in
@@ -216,6 +216,16 @@ purge() {
     echo "Removing features exported from snapd to helper tools"
     rm -rf /var/lib/snapd/features
 
+    # TODO: this does not remove /var/lib/snapd/export (written by the
+    # export and configfiles backends, see interfaces/export and
+    # interfaces/builtin/helpers.go's systemLibrarySourcePath), nor the
+    # symlink directories tracked by interfaces.SymlinksUser
+    # (/etc/glvnd/egl_vendor.d, /etc/vulkan/{icd,implicit_layer,explicit_layer}.d,
+    # /usr/lib/<arch>-linux-gnu/gbm - see egl/vulkan/gbm_driver_libs.go's
+    # TrackedDirectories), even though interfaces.SymlinksUser's doc comment
+    # explicitly calls for tracked directories to be added here. Pre-existing
+    # gap, found while adding driver-libs support for Ubuntu Core.
+
     echo "Final directory cleanup"
     for snap_mount_dir in /snap /var/lib/snapd/snap; do
         if [ -L "$snap_mount_dir" ]; then

--- a/interfaces/backends/backends.go
+++ b/interfaces/backends/backends.go
@@ -24,6 +24,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/configfiles"
 	"github.com/snapcore/snapd/interfaces/dbus"
+	"github.com/snapcore/snapd/interfaces/export"
 	"github.com/snapcore/snapd/interfaces/kmod"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
 	"github.com/snapcore/snapd/interfaces/mount"
@@ -57,6 +58,7 @@ func All() []interfaces.SecurityBackend {
 		&ldconfig.Backend{},
 		&configfiles.Backend{},
 		&symlinks.Backend{},
+		&export.Backend{},
 	}
 
 	// TODO use something like:

--- a/interfaces/builtin/egl_driver_libs.go
+++ b/interfaces/builtin/egl_driver_libs.go
@@ -27,6 +27,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/compatibility"
 	"github.com/snapcore/snapd/interfaces/configfiles"
+	"github.com/snapcore/snapd/interfaces/export"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
 	"github.com/snapcore/snapd/interfaces/symlinks"
 	"github.com/snapcore/snapd/release"
@@ -104,10 +105,15 @@ func (iface *eglDriverLibsInterface) LdconfigConnectedPlug(spec *ldconfig.Specif
 
 var _ = symlinks.ConnectedPlugCallback(&eglDriverLibsInterface{})
 var _ = interfaces.ConfigfilesUser(&eglDriverLibsInterface{})
+var _ = export.ConnectedPlugCallback(&eglDriverLibsInterface{})
 
 const (
 	eglDriverLibs = "egl-driver-libs"
 	eglVendorPath = "/etc/glvnd/egl_vendor.d"
+	// eglVendorSubDir is the last path component of eglVendorPath, reused
+	// as the export backend's subdirectory name for the same content on
+	// Core - see ExportConnectedPlug.
+	eglVendorSubDir = "egl_vendor.d"
 )
 
 func (iface *eglDriverLibsInterface) TrackedDirectories() []string {
@@ -145,6 +151,21 @@ func (iface *eglDriverLibsInterface) SymlinksConnectedPlug(spec *symlinks.Specif
 	const withPriority = true
 	return symlinksForSourceDir(spec, slot,
 		sourceDirAttr{attrName: "icd-source", isOptional: false}, eglVendorPath,
+		checkEglIcdFile, withPriority)
+}
+
+func (iface *eglDriverLibsInterface) ExportConnectedPlug(spec *export.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	// Inverted polarity vs. LdconfigConnectedPlug/SymlinksConnectedPlug
+	// above: those are classic-only, this is their Core counterpart -
+	// files are exported via /var/lib/snapd/export only on core, on
+	// classic the ICD files are already discoverable via the symlinks
+	// backend.
+	if release.OnClassic {
+		return nil
+	}
+	const withPriority = true
+	return exportedFilesForSourceDir(spec, eglDriverLibs, slot,
+		sourceDirAttr{attrName: "icd-source", isOptional: false}, eglVendorSubDir,
 		checkEglIcdFile, withPriority)
 }
 

--- a/interfaces/builtin/egl_driver_libs_test.go
+++ b/interfaces/builtin/egl_driver_libs_test.go
@@ -654,6 +654,31 @@ func (s *EglDriverLibsInterfaceSuite) TestSymlinksSpecSkipsOnlyFileWithMissingLi
 	})
 }
 
+// TestExportSpecMissingLibraryIsNotFatal mirrors
+// TestSymlinksSpecNoLibrary/TestSymlinksSpecSkipsOnlyFileWithMissingLibrary
+// for the export backend, verifying the same "skip the offending file, do
+// not fail the connection" behavior applies there too (both go through the
+// same sourceDirFilesCheck/checkEglIcdFile).
+func (s *EglDriverLibsInterfaceSuite) TestExportSpecMissingLibraryIsNotFatal(c *C) {
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	// Write ICD file
+	icdDir := filepath.Join(dirs.SnapMountDir, "egl-provider/5/egl.d")
+	c.Assert(os.MkdirAll(icdDir, 0755), IsNil)
+	os.WriteFile(filepath.Join(icdDir, "nvidia.json"), []byte(`{
+    "file_format_version" : "1.0.0",
+    "ICD" : {
+        "library_path" : "libEGL_nvidia.so.0"
+    }
+}
+`), 0655)
+
+	spec := &export.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Check(spec.Files(), HasLen, 0)
+}
+
 func (s *EglDriverLibsInterfaceSuite) TestSymlinksSpecBadJson(c *C) {
 	// Write ICD file
 	icdDir := filepath.Join(dirs.SnapMountDir, "egl-provider/5/egl.d")

--- a/interfaces/builtin/egl_driver_libs_test.go
+++ b/interfaces/builtin/egl_driver_libs_test.go
@@ -608,10 +608,50 @@ func (s *EglDriverLibsInterfaceSuite) TestSymlinksSpecNoLibrary(c *C) {
 }
 `), 0655)
 
-	// Now check symlinks to be created
+	// The library referenced by the ICD file is not present anywhere
+	// under library-source: this ICD file is skipped, not an error - see
+	// errLibraryNotFound.
 	spec := &symlinks.Specification{}
-	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), ErrorMatches,
-		`invalid icd-source: nvidia.json: "libEGL_nvidia.so.0" not found in the library-source directories`)
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Check(spec.Symlinks(), HasLen, 0)
+}
+
+func (s *EglDriverLibsInterfaceSuite) TestSymlinksSpecSkipsOnlyFileWithMissingLibrary(c *C) {
+	// Two ICD files in the same directory: one whose library is present,
+	// one whose library is not. Only the latter is skipped - a single
+	// missing library must not take out sibling, otherwise valid ICD
+	// files (see errLibraryNotFound).
+	icdDir := filepath.Join(dirs.SnapMountDir, "egl-provider/5/egl.d")
+	c.Assert(os.MkdirAll(icdDir, 0755), IsNil)
+
+	missingPath := filepath.Join(icdDir, "nvidia.json")
+	os.WriteFile(missingPath, []byte(`{
+    "file_format_version" : "1.0.0",
+    "ICD" : {
+        "library_path" : "libEGL_nvidia.so.0"
+    }
+}
+`), 0655)
+
+	foundPath := filepath.Join(icdDir, "mesa.json")
+	os.WriteFile(foundPath, []byte(`{
+    "file_format_version" : "1.0.0",
+    "ICD" : {
+        "library_path" : "libEGL_mesa.so.0"
+    }
+}
+`), 0655)
+	libDir := filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib2")
+	c.Assert(os.MkdirAll(libDir, 0755), IsNil)
+	os.WriteFile(filepath.Join(libDir, "libEGL_mesa.so.0"), []byte{}, 0655)
+
+	spec := &symlinks.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Check(spec.Symlinks(), DeepEquals, map[string]symlinks.SymlinkToTarget{
+		"/etc/glvnd/egl_vendor.d": {
+			"10_snap_egl-provider_egl-slot_egl.d-mesa.json": foundPath,
+		},
+	})
 }
 
 func (s *EglDriverLibsInterfaceSuite) TestSymlinksSpecBadJson(c *C) {

--- a/interfaces/builtin/egl_driver_libs_test.go
+++ b/interfaces/builtin/egl_driver_libs_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/configfiles"
+	"github.com/snapcore/snapd/interfaces/export"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
 	"github.com/snapcore/snapd/interfaces/symlinks"
 	"github.com/snapcore/snapd/osutil"
@@ -428,6 +429,130 @@ func (s *EglDriverLibsInterfaceSuite) TestSymlinksSpecOnCore(c *C) {
 	spec := &symlinks.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Check(spec.Symlinks(), HasLen, 0)
+}
+
+// writeSnapIcdFixtures writes the snap-level ICD files, the libraries they
+// reference, and a couple of entries that must be ignored. It returns the
+// exported files a core export is expected to produce for them, keyed by
+// path relative to the unit.
+//
+// Both the ICD files and the libraries they name have to be written: a
+// library that cannot be found in library-source makes the export skip that
+// ICD file (see TestExportSpecMissingLibraryIsNotFatal), so writing only the
+// ICD files would yield an empty spec no matter what the interface does -
+// which would silently defeat the point of TestExportSpecOnClassic.
+func (s *EglDriverLibsInterfaceSuite) writeSnapIcdFixtures(c *C) map[string]osutil.FileState {
+	expected := map[string]osutil.FileState{}
+	for _, icdData := range []struct {
+		gpu    string
+		subDir string
+		dirIdx int
+	}{{"mesa", "egl.d", 10}, {"nvidia", "egl.d", 10}, {"radeon", "egl_alt.d", 11}} {
+		icdDir := filepath.Join(dirs.SnapMountDir, "egl-provider/5", icdData.subDir)
+		c.Assert(os.MkdirAll(icdDir, 0755), IsNil)
+		icdPath := filepath.Join(icdDir, icdData.gpu+".json")
+		os.WriteFile(icdPath, []byte(fmt.Sprintf(`{
+    "file_format_version" : "1.0.0",
+    "ICD" : {
+        "library_path" : "libEGL_%s.so.0"
+    }
+}
+`, icdData.gpu)), 0655)
+		libDir := filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib2")
+		c.Assert(os.MkdirAll(libDir, 0755), IsNil)
+		libPath := filepath.Join(libDir, "libEGL_"+icdData.gpu+".so.0")
+		os.WriteFile(libPath, []byte{}, 0655)
+
+		// Ignored file
+		otherPath := filepath.Join(icdDir, "foo.bar")
+		os.WriteFile(otherPath, []byte{}, 0655)
+
+		// Ignored symlink
+		os.Symlink("not_exists", filepath.Join(icdDir, "foo.json"))
+
+		fileName := fmt.Sprintf("%d_snap_egl-provider_egl-slot_%s-%s.json",
+			icdData.dirIdx, icdData.subDir, icdData.gpu)
+		expected[filepath.Join("egl_vendor.d", fileName)] = osutil.FileReference{Path: icdPath}
+	}
+	return expected
+}
+
+func (s *EglDriverLibsInterfaceSuite) TestExportSpec(c *C) {
+	// export is only active on core
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	expected := s.writeSnapIcdFixtures(c)
+
+	spec := &export.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Check(spec.Files(), DeepEquals, map[string]map[string]map[string]osutil.FileState{
+		"egl-driver-libs": {
+			"egl-provider_egl-slot_5": expected,
+		},
+	})
+}
+
+func (s *EglDriverLibsInterfaceSuite) TestExportToComps(c *C) {
+	// export is only active on core
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	// Write ICD files
+	comp1Files := map[string]osutil.FileState{}
+	comp2Files := map[string]osutil.FileState{}
+	for _, icdData := range []struct {
+		gpu      string
+		compSuff string
+		rev      snap.Revision
+		dirIdx   int
+		files    map[string]osutil.FileState
+	}{{"nvidia", "1", snap.R(11), 13, comp1Files}, {"mesa", "1", snap.R(11), 13, comp1Files},
+		{"nvidia", "2", snap.R(22), 14, comp2Files}, {"mesa", "2", snap.R(22), 14, comp2Files}} {
+		compMnt := snap.ComponentMountDir("comp"+icdData.compSuff, icdData.rev, "egl-provider")
+		icdDir := filepath.Join(compMnt, "egl.d")
+		c.Assert(os.MkdirAll(icdDir, 0755), IsNil)
+		icdPath := filepath.Join(icdDir, icdData.gpu+".json")
+		os.WriteFile(icdPath, []byte(fmt.Sprintf(`{
+    "file_format_version" : "1.0.0",
+    "ICD" : {
+        "library_path" : "libEGL_%s.so.0"
+    }
+}
+`, icdData.gpu)), 0655)
+		libDir := filepath.Join(compMnt, "lib"+icdData.compSuff)
+		c.Assert(os.MkdirAll(libDir, 0755), IsNil)
+		libPath := filepath.Join(libDir, "libEGL_"+icdData.gpu+".so.0")
+		os.WriteFile(libPath, []byte{}, 0655)
+
+		fileName := fmt.Sprintf("%d_snap_egl-provider+comp%s_egl-slot_egl.d-%s.json",
+			icdData.dirIdx, icdData.compSuff, icdData.gpu)
+		icdData.files[filepath.Join("egl_vendor.d", fileName)] = osutil.FileReference{Path: icdPath}
+	}
+
+	spec := &export.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Check(spec.Files(), DeepEquals, map[string]map[string]map[string]osutil.FileState{
+		"egl-driver-libs": {
+			"egl-provider_egl-slot_5+comp1_11": comp1Files,
+			"egl-provider_egl-slot_5+comp2_22": comp2Files,
+		},
+	})
+}
+
+func (s *EglDriverLibsInterfaceSuite) TestExportSpecOnClassic(c *C) {
+	// export is skipped on classic; the equivalent content is already
+	// discoverable there via the symlinks backend.
+	restore := release.MockOnClassic(true)
+	defer restore()
+
+	// Write the same fixtures the core test uses, so that an empty spec
+	// can only be the OnClassic check and not simply an absence of input.
+	s.writeSnapIcdFixtures(c)
+
+	spec := &export.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Check(spec.Files(), HasLen, 0)
 }
 
 func (s *EglDriverLibsInterfaceSuite) TestConfigfilesSpec(c *C) {

--- a/interfaces/builtin/export_test.go
+++ b/interfaces/builtin/export_test.go
@@ -37,7 +37,12 @@ var (
 	ImplicitSystemPermanentSlot = implicitSystemPermanentSlot
 	ImplicitSystemConnectedSlot = implicitSystemConnectedSlot
 	StringListAttribute         = stringListAttribute
+	ErrLibraryNotFound          = errLibraryNotFound
 )
+
+func FilePathInLibDirs(slot *interfaces.ConnectedSlot, fileName string) (string, error) {
+	return filePathInLibDirs(slot, fileName)
+}
 
 type GbmDriverLibsInterface gbmDriverLibsInterface
 

--- a/interfaces/builtin/export_test.go
+++ b/interfaces/builtin/export_test.go
@@ -60,6 +60,18 @@ func MprisGetName(iface interfaces.Interface, attribs map[string]any) (string, e
 	return iface.(*mprisInterface).getName(attribs)
 }
 
+func NewPathWithDirIdx(path string, idx int) pathWithDirIdx {
+	return pathWithDirIdx{path: path, idx: idx}
+}
+
+func SourceDirEncodedName(p pathWithDirIdx, slot *interfaces.ConnectedSlot, priority int64, withPriority bool) (name, component string, componentRev snap.Revision, err error) {
+	return sourceDirEncodedName(p, slot, priority, withPriority)
+}
+
+func ExportUnitAndFileName(p pathWithDirIdx, slot *interfaces.ConnectedSlot, priority int64, withPriority bool) (unit, fileName string, err error) {
+	return exportUnitAndFileName(p, slot, priority, withPriority)
+}
+
 // MockInterfaces replaces the set of known interfaces and returns a restore function.
 func MockInterfaces(ifaces map[string]interfaces.Interface) (restore func()) {
 	old := allInterfaces

--- a/interfaces/builtin/gbm_driver_libs.go
+++ b/interfaces/builtin/gbm_driver_libs.go
@@ -123,6 +123,22 @@ var _ = interfaces.SymlinksUser(&gbmDriverLibsInterface{})
 var _ = symlinks.ConnectedPlugCallback(&gbmDriverLibsInterface{})
 var _ = interfaces.ConfigfilesUser(&gbmDriverLibsInterface{})
 
+// TODO(core): gbm-driver-libs does not implement export.ConnectedPlugCallback,
+// unlike egl-driver-libs and vulkan-driver-libs. Those two interfaces list
+// their content via a "vendor JSON" convention (icd-source), which is what
+// a consumer scans to discover drivers, so the export backend just needs to
+// reproduce that listing under /var/lib/snapd/export. GBM has no such
+// listing: SymlinksConnectedPlug below places a single symlink, named after
+// the client-driver attribute, at a fixed path
+// (/usr/lib/<arch>-linux-gnu/gbm/<client-driver>) that a consumer is
+// expected to already know about or probe directly - there is nothing
+// equivalent to enumerate into an export unit, and no agreed-on path for a
+// consumer to look under on Core instead. This is a real, currently
+// undetermined gap: a gbm-driver-libs connection on Core makes the driver's
+// library-source available in the connecting snap's mount namespace (via
+// the existing per-snap bind mounts from Phase 1), but does not make it
+// discoverable there, so GBM driver discovery does not work on Core yet.
+
 func gbmVendorPath() string {
 	// TODO consider alternative architectures?
 	return fmt.Sprintf("/usr/lib/%s-linux-gnu/gbm", osutil.MachineName())

--- a/interfaces/builtin/gbm_driver_libs.go
+++ b/interfaces/builtin/gbm_driver_libs.go
@@ -20,6 +20,7 @@
 package builtin
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -32,6 +33,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/configfiles"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
 	"github.com/snapcore/snapd/interfaces/symlinks"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
@@ -158,13 +160,18 @@ func (iface *gbmDriverLibsInterface) SymlinksConnectedPlug(spec *symlinks.Specif
 	if err := slot.Attr("client-driver", &clientDriver); err != nil {
 		return fmt.Errorf("invalid client-driver: %w", err)
 	}
-	// Look for the driver library
-	// TODO: if all library-source paths refer to components that are not
-	// installed, this should be a no-op. currently filePathInLibDirs returns an
-	// error for a missing client-driver when all backing component paths were
-	// filtered out.
+	// Look for the driver library. If it cannot be found - e.g. because
+	// every component that would have provided library-source content is
+	// not currently installed - there is simply nothing to link to yet;
+	// skip silently (logging why) instead of failing the whole
+	// connection, matching how a missing library referenced by an
+	// egl/vulkan ICD or layer file is handled (see errLibraryNotFound).
 	path, err := filePathInLibDirs(slot, clientDriver)
 	if err != nil {
+		if errors.Is(err, errLibraryNotFound) {
+			logger.Noticef("%s: %v, skipping", gbmDriverLibs, err)
+			return nil
+		}
 		return err
 	}
 

--- a/interfaces/builtin/gbm_driver_libs_test.go
+++ b/interfaces/builtin/gbm_driver_libs_test.go
@@ -307,9 +307,13 @@ func (s *GbmDriverLibsInterfaceSuite) TestSymlinksSpecNoClient(c *C) {
 	restore := release.MockOnClassic(true)
 	defer restore()
 
+	// The client-driver library is not present anywhere under
+	// library-source (e.g. because the component that would have
+	// provided it is not installed): this is a no-op, not an error - see
+	// errLibraryNotFound.
 	spec := &symlinks.Specification{}
-	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), ErrorMatches,
-		`"nvidia-drm_gbm\.so" not found in the library-source directories`)
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Check(spec.Symlinks(), HasLen, 0)
 }
 
 func (s *GbmDriverLibsInterfaceSuite) TestSymlinksSpecNoClientDriver(c *C) {

--- a/interfaces/builtin/helpers.go
+++ b/interfaces/builtin/helpers.go
@@ -333,3 +333,47 @@ func exportUnitAndFileName(pathDirIdx pathWithDirIdx, slot *interfaces.Connected
 	unit = export.UnitName(slot.Snap().InstanceName(), slot.Name(), slot.Snap().Revision, component, componentRev)
 	return unit, fileName, nil
 }
+
+// exportedFilesForSourceDir declares, in spec, the files found in the
+// directories specified by the sda attribute of slot, for consumption by
+// the export backend on Core - the counterpart of symlinksForSourceDir for
+// classic. Each file is placed at "<unit>/<targetSubDir>/<encoded-name>"
+// (see AddExportedFile), where <encoded-name> is byte-identical to the
+// symlink name symlinksForSourceDir would create in targetSubDir for the
+// same connection (see sourceDirEncodedName). The checker function ensures
+// that the files we are going to export have the right content.
+// withPriority tells the function if there is a priority attribute that
+// needs to be considered when creating the encoded file name.
+func exportedFilesForSourceDir(
+	spec *export.Specification, ifaceName string, slot *interfaces.ConnectedSlot,
+	sda sourceDirAttr,
+	targetSubDir string,
+	checker func(slot *interfaces.ConnectedSlot, content []byte) error,
+	withPriority bool,
+) error {
+	var priority int64
+	if withPriority {
+		if err := slot.Attr("priority", &priority); err != nil {
+			return fmt.Errorf("invalid priority: %w", err)
+		}
+	}
+
+	sourcePaths, err := sourceDirsCheck(slot, sda, checker)
+	if err != nil {
+		return fmt.Errorf("invalid %s: %w", sda.attrName, err)
+	}
+
+	for _, pathDirIdx := range sourcePaths {
+		unit, fileName, err := exportUnitAndFileName(pathDirIdx, slot, priority, withPriority)
+		if err != nil {
+			return err
+		}
+		relPath := filepath.Join(targetSubDir, fileName)
+		if err := spec.AddExportedFile(ifaceName, unit, relPath,
+			osutil.FileReference{Path: pathDirIdx.path}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/interfaces/builtin/helpers.go
+++ b/interfaces/builtin/helpers.go
@@ -33,6 +33,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/export"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
 	"github.com/snapcore/snapd/interfaces/symlinks"
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/systemd"
@@ -129,8 +130,21 @@ func addConfigfilesForSystemLibrarySourcePaths(iface string, spec *configfiles.S
 		&osutil.MemoryFileState{Content: []byte(content), Mode: 0644})
 }
 
+// errLibraryNotFound is wrapped by the error filePathInLibDirs returns when
+// the referenced library cannot be found in any of the library-source
+// directories. It exists so that callers going through a checker function
+// (see sourceDirFilesCheck) can tell this specific, environment-dependent
+// condition - e.g. a component that would have provided the library is not
+// currently installed, or an ICD/layer file is stale - apart from other,
+// unconditionally fatal errors such as malformed JSON. The former is logged
+// and the offending file is skipped rather than failing the whole
+// connection; see LP: 1866424 for why hard-failing an interface callback on
+// a missing, possibly-transient resource is undesirable in general.
+var errLibraryNotFound = errors.New("library not found")
+
 // filePathInLibDirs returns the path of the first occurrence of fileName in the
-// list of library directories of the slot.
+// list of library directories of the slot. If fileName cannot be found in any
+// of them, the returned error wraps errLibraryNotFound.
 func filePathInLibDirs(slot *interfaces.ConnectedSlot, fileName string) (string, error) {
 	libDirs := []string{}
 	if err := slot.Attr("library-source", &libDirs); err != nil {
@@ -144,7 +158,7 @@ func filePathInLibDirs(slot *interfaces.ConnectedSlot, fileName string) (string,
 			return path, nil
 		}
 	}
-	return "", fmt.Errorf("%q not found in the library-source directories", fileName)
+	return "", fmt.Errorf("%w: %q not found in the library-source directories", errLibraryNotFound, fileName)
 }
 
 type pathWithDirIdx struct {
@@ -184,6 +198,8 @@ func sourceDirFilesCheck(slot *interfaces.ConnectedSlot, sourceDir string, check
 	if err != nil {
 		// We do not care if the directory does not exist
 		if errors.Is(err, fs.ErrNotExist) {
+			logger.Debugf("%s: %s: source directory does not exist, skipping",
+				slot.Interface(), sourceDir)
 			return nil, nil
 		} else {
 			return nil, err
@@ -202,16 +218,24 @@ func sourceDirFilesCheck(slot *interfaces.ConnectedSlot, sourceDir string, check
 			continue
 		}
 
-		content, err := os.ReadFile(filepath.Join(sourceDir, entry.Name()))
+		path := filepath.Join(sourceDir, entry.Name())
+		content, err := os.ReadFile(path)
 		if err != nil {
 			return nil, err
 		}
 		if err := checker(slot, content); err != nil {
+			if errors.Is(err, errLibraryNotFound) {
+				// Environment-dependent condition (see
+				// errLibraryNotFound): skip just this file
+				// instead of failing the whole connection.
+				logger.Noticef("%s: %s: %v, skipping", slot.Interface(), path, err)
+				continue
+			}
 			return nil, fmt.Errorf("%s: %w", entry.Name(), err)
 		}
 
 		// Good enough
-		checked = append(checked, filepath.Join(sourceDir, entry.Name()))
+		checked = append(checked, path)
 	}
 
 	return checked, nil

--- a/interfaces/builtin/helpers.go
+++ b/interfaces/builtin/helpers.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/configfiles"
+	"github.com/snapcore/snapd/interfaces/export"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
 	"github.com/snapcore/snapd/interfaces/symlinks"
 	"github.com/snapcore/snapd/osutil"
@@ -216,6 +217,69 @@ func sourceDirFilesCheck(slot *interfaces.ConnectedSlot, sourceDir string, check
 	return checked, nil
 }
 
+// sourceDirEncodedName computes the encoded name for a single file found by
+// sourceDirsCheck, of the form
+//
+//	<priority>_snap_<instance>[+<component>]_<slotName>_<escapedRelPath>
+//
+// (the priority prefix is omitted when withPriority is false). This same
+// encoding is used verbatim both for the symlink name created by classic's
+// symlinks backend (symlinksForSourceDir) and for the file name delivered by
+// the export backend on Core, so that identical content ends up named
+// identically regardless of which backend delivers it.
+//
+// It also identifies which container - the snap itself, or exactly one of
+// its components - contributed the file: component is "" when the file
+// belongs to the snap itself, and set to the component name (with
+// componentRev set to its revision) otherwise. This information is used by
+// the export backend to group files into per-container units (see
+// export.UnitName).
+func sourceDirEncodedName(pathDirIdx pathWithDirIdx, slot *interfaces.ConnectedSlot, priority int64, withPriority bool) (name string, component string, componentRev snap.Revision, err error) {
+	instance := slot.Snap().InstanceName()
+
+	// First strip out mount dir
+	relPath, err := filepath.Rel(dirs.SnapMountDir, pathDirIdx.path)
+	if err != nil {
+		return "", "", snap.Revision{}, err
+	}
+
+	// If path is in the snap, we ignore below the snap name and revision
+	// when building the name; if in a component, we ignore
+	// <instance>/components/mnt/<comp_name>/<comp_rev>/ (5 path segments).
+	splitNum := 3
+	inComponent := strings.HasPrefix(pathDirIdx.path, snap.ComponentsBaseDir(instance))
+	if inComponent {
+		splitNum = 6
+	}
+	// Named pathSegments (not "dirs") to avoid shadowing the "dirs" package
+	// imported above, which the original version of this code did.
+	pathSegments := strings.SplitN(relPath, "/", splitNum)
+	if len(pathSegments) < splitNum {
+		return "", "", snap.Revision{}, fmt.Errorf("internal error: wrong file path: %s", relPath)
+	}
+
+	compSuffix := ""
+	if inComponent {
+		component = pathSegments[3]
+		compSuffix = "+" + component
+		componentRev, err = snap.ParseRevision(pathSegments[4])
+		if err != nil {
+			return "", "", snap.Revision{}, fmt.Errorf("internal error: wrong file path: %s", relPath)
+		}
+	}
+
+	// Get last path segment and make it an easier to handle name
+	escapedRelPath := systemd.EscapeUnitNamePath(pathSegments[splitNum-1])
+	prefix := ""
+	if withPriority {
+		// The priority depends on the list order of the directories
+		// in the *-source attribute.
+		prefix = fmt.Sprintf("%d_", priority+int64(pathDirIdx.idx))
+	}
+	name = fmt.Sprintf("%ssnap_%s%s_%s_%s", prefix, instance, compSuffix, slot.Name(), escapedRelPath)
+	return name, component, componentRev, nil
+}
+
 // symlinksForSourceDir adds symlinks to be created in targetDir to spec, for the
 // files in the directories found in the sda attribute of slot. The checker function
 // function ensures that the files we are going to point to have the right content.
@@ -242,44 +306,30 @@ func symlinksForSourceDir(
 
 	// Create symlinks to snap content (which is fine as this is for super-privileged slots)
 	for _, pathDirIdx := range sourcePaths {
-		// First strip out mount dir
-		relPath, err := filepath.Rel(dirs.SnapMountDir, pathDirIdx.path)
+		name, _, _, err := sourceDirEncodedName(pathDirIdx, slot, priority, withPriority)
 		if err != nil {
 			return err
 		}
-
-		// If path is in the snap, we ignore below the snap name and revision
-		// when building the symlink name, if in component, we ignore
-		// <snap_name>/components/mnt/<comp_name>/<comp_rev>/ (5 dirs)
-		instance := slot.Snap().InstanceName()
-		splitNum := 3
-		compSuffix := ""
-		if strings.HasPrefix(pathDirIdx.path, snap.ComponentsBaseDir(instance)) {
-			splitNum = 6
-			compSuffix = "+"
-		}
-		dirs := strings.SplitN(relPath, "/", splitNum)
-		if len(dirs) < splitNum {
-			return fmt.Errorf("internal error: wrong file path: %s", relPath)
-		}
-		if compSuffix != "" {
-			compSuffix += dirs[3]
-		}
-
-		// Get last component from dirs and make path an easier to handle name
-		escapedRelPath := systemd.EscapeUnitNamePath(dirs[splitNum-1])
-		prefix := ""
-		if withPriority {
-			// The priority depends on the list order of the directories
-			// in the *-source attribute.
-			prefix = fmt.Sprintf("%d_", priority+int64(pathDirIdx.idx))
-		}
-		linkPath := filepath.Join(targetDir, fmt.Sprintf("%ssnap_%s%s_%s_%s",
-			prefix, instance, compSuffix, slot.Name(), escapedRelPath))
+		linkPath := filepath.Join(targetDir, name)
 		if err := spec.AddSymlink(pathDirIdx.path, linkPath); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+// exportUnitAndFileName computes the export unit name (see export.UnitName)
+// and the encoded file name (see sourceDirEncodedName) for a single file
+// found by sourceDirsCheck, for use by the export backend. The file name is
+// identical to what symlinksForSourceDir would produce for the same
+// connection, so that classic and Core never disagree about the identity of
+// a given piece of content.
+func exportUnitAndFileName(pathDirIdx pathWithDirIdx, slot *interfaces.ConnectedSlot, priority int64, withPriority bool) (unit string, fileName string, err error) {
+	fileName, component, componentRev, err := sourceDirEncodedName(pathDirIdx, slot, priority, withPriority)
+	if err != nil {
+		return "", "", err
+	}
+	unit = export.UnitName(slot.Snap().InstanceName(), slot.Name(), slot.Snap().Revision, component, componentRev)
+	return unit, fileName, nil
 }

--- a/interfaces/builtin/helpers_test.go
+++ b/interfaces/builtin/helpers_test.go
@@ -1,0 +1,212 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/testutil"
+)
+
+// helpersSuite exercises the naming primitives shared by classic's symlinks
+// backend (symlinksForSourceDir) and the export backend
+// (exportUnitAndFileName): both must agree on the identity of a given piece
+// of content, so these are tested together against the same fixture.
+type helpersSuite struct {
+	testutil.BaseTest
+
+	testRoot string
+	slot     *interfaces.ConnectedSlot
+}
+
+var _ = Suite(&helpersSuite{})
+
+const helpersProviderYaml = `name: helpers-provider
+version: 0
+slots:
+  drv-slot:
+    interface: egl-driver-libs
+    priority: 15
+    compatibility: egl-1-5-ubuntu-2404
+    icd-source:
+      - $SNAP/egl.d/
+    library-source:
+      - $SNAP/lib1
+      - $SNAP_COMPONENT(comp1)/lib1
+      - $SNAP_COMPONENT(comp2)/lib2
+components:
+  comp1:
+    type: standard
+  comp2:
+    type: standard
+`
+
+func (s *helpersSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+
+	s.testRoot = c.MkDir()
+	dirs.SetRootDir(s.testRoot)
+	s.AddCleanup(func() { dirs.SetRootDir("/") })
+
+	comps := []compRawInfo{
+		{"component: helpers-provider+comp1\ntype: standard", snap.R(11)},
+		{"component: helpers-provider+comp2\ntype: standard", snap.R(22)},
+	}
+	s.slot, _ = mockConnectedSlotWithComps(c, helpersProviderYaml,
+		&snap.SideInfo{Revision: snap.R(5)}, comps, "drv-slot")
+}
+
+// snapPath returns a path as if it belongs to the snap's own file tree
+// (under $SNAP), for the snap revision used by s.slot.
+func (s *helpersSuite) snapPath(rel string) string {
+	return filepath.Join(dirs.SnapMountDir, "helpers-provider/5", rel)
+}
+
+// compPath returns a path as if it belongs to the given component's file
+// tree, at the given component revision.
+func (s *helpersSuite) compPath(comp string, rev snap.Revision, rel string) string {
+	return filepath.Join(snap.ComponentMountDir(comp, rev, "helpers-provider"), rel)
+}
+
+func (s *helpersSuite) TestSourceDirEncodedNameSnapOnly(c *C) {
+	p := builtin.NewPathWithDirIdx(s.snapPath("egl.d/vendor.json"), 10)
+
+	name, component, componentRev, err := builtin.SourceDirEncodedName(p, s.slot, 15, true)
+	c.Assert(err, IsNil)
+	c.Check(name, Equals, "25_snap_helpers-provider_drv-slot_egl.d-vendor.json")
+	c.Check(component, Equals, "")
+	c.Check(componentRev, Equals, snap.Revision{})
+}
+
+func (s *helpersSuite) TestSourceDirEncodedNameNoPriority(c *C) {
+	p := builtin.NewPathWithDirIdx(s.snapPath("egl.d/vendor.json"), 10)
+
+	name, _, _, err := builtin.SourceDirEncodedName(p, s.slot, 15, false)
+	c.Assert(err, IsNil)
+	c.Check(name, Equals, "snap_helpers-provider_drv-slot_egl.d-vendor.json")
+}
+
+func (s *helpersSuite) TestSourceDirEncodedNameComponent(c *C) {
+	p := builtin.NewPathWithDirIdx(s.compPath("comp1", snap.R(11), "egl.d/vendor.json"), 13)
+
+	name, component, componentRev, err := builtin.SourceDirEncodedName(p, s.slot, 15, true)
+	c.Assert(err, IsNil)
+	c.Check(name, Equals, "28_snap_helpers-provider+comp1_drv-slot_egl.d-vendor.json")
+	c.Check(component, Equals, "comp1")
+	c.Check(componentRev, Equals, snap.R(11))
+}
+
+func (s *helpersSuite) TestSourceDirEncodedNameTwoComponentsDiffer(c *C) {
+	p1 := builtin.NewPathWithDirIdx(s.compPath("comp1", snap.R(11), "egl.d/vendor.json"), 13)
+	p2 := builtin.NewPathWithDirIdx(s.compPath("comp2", snap.R(22), "egl.d/vendor.json"), 14)
+
+	name1, comp1, rev1, err := builtin.SourceDirEncodedName(p1, s.slot, 15, true)
+	c.Assert(err, IsNil)
+	name2, comp2, rev2, err := builtin.SourceDirEncodedName(p2, s.slot, 15, true)
+	c.Assert(err, IsNil)
+
+	c.Check(name1, Not(Equals), name2)
+	c.Check(comp1, Not(Equals), comp2)
+	c.Check(rev1, Not(Equals), rev2)
+	c.Check(name1, Equals, "28_snap_helpers-provider+comp1_drv-slot_egl.d-vendor.json")
+	c.Check(name2, Equals, "29_snap_helpers-provider+comp2_drv-slot_egl.d-vendor.json")
+}
+
+func (s *helpersSuite) TestSourceDirEncodedNameBadPath(c *C) {
+	// A path with too few segments below dirs.SnapMountDir to contain a
+	// snap instance name, revision, and file name.
+	p := builtin.NewPathWithDirIdx(filepath.Join(dirs.SnapMountDir, "too-short"), 10)
+
+	_, _, _, err := builtin.SourceDirEncodedName(p, s.slot, 15, true)
+	c.Assert(err, ErrorMatches, "internal error: wrong file path: .*")
+}
+
+// TestExportFileNameMatchesSymlinkName is the key consistency check for the
+// whole design: the export backend and classic's symlinks backend must
+// derive the exact same file name for the exact same connection and file,
+// so that identical content is named identically wherever it is delivered.
+func (s *helpersSuite) TestExportFileNameMatchesSymlinkName(c *C) {
+	paths := []struct {
+		path   string
+		dirIdx int
+	}{
+		{s.snapPath("egl.d/vendor.json"), 10},
+		{s.compPath("comp1", snap.R(11), "egl.d/vendor.json"), 13},
+		{s.compPath("comp2", snap.R(22), "egl.d/vendor.json"), 14},
+	}
+
+	for _, tc := range paths {
+		p := builtin.NewPathWithDirIdx(tc.path, tc.dirIdx)
+
+		symlinkName, _, _, err := builtin.SourceDirEncodedName(p, s.slot, 15, true)
+		c.Assert(err, IsNil)
+
+		_, exportFileName, err := builtin.ExportUnitAndFileName(p, s.slot, 15, true)
+		c.Assert(err, IsNil)
+
+		c.Check(exportFileName, Equals, symlinkName)
+	}
+}
+
+func (s *helpersSuite) TestExportUnitAndFileNameSnapOnly(c *C) {
+	p := builtin.NewPathWithDirIdx(s.snapPath("egl.d/vendor.json"), 10)
+
+	unit, fileName, err := builtin.ExportUnitAndFileName(p, s.slot, 15, true)
+	c.Assert(err, IsNil)
+	c.Check(unit, Equals, "helpers-provider_drv-slot_5")
+	c.Check(fileName, Equals, "25_snap_helpers-provider_drv-slot_egl.d-vendor.json")
+}
+
+func (s *helpersSuite) TestExportUnitAndFileNameComponent(c *C) {
+	p := builtin.NewPathWithDirIdx(s.compPath("comp1", snap.R(11), "egl.d/vendor.json"), 13)
+
+	unit, fileName, err := builtin.ExportUnitAndFileName(p, s.slot, 15, true)
+	c.Assert(err, IsNil)
+	c.Check(unit, Equals, "helpers-provider_drv-slot_5+comp1_11")
+	c.Check(fileName, Equals, "28_snap_helpers-provider+comp1_drv-slot_egl.d-vendor.json")
+}
+
+// TestExportUnitAndFileNameMultipleComponentsAreSeparateUnits verifies that
+// content from different components of the same snap/slot/connection ends
+// up in distinct units, never aggregated into one - this is the whole point
+// of per-container units (see export.UnitName), preserving set atomicity
+// per container.
+func (s *helpersSuite) TestExportUnitAndFileNameMultipleComponentsAreSeparateUnits(c *C) {
+	p0 := builtin.NewPathWithDirIdx(s.snapPath("egl.d/vendor.json"), 10)
+	p1 := builtin.NewPathWithDirIdx(s.compPath("comp1", snap.R(11), "egl.d/vendor.json"), 13)
+	p2 := builtin.NewPathWithDirIdx(s.compPath("comp2", snap.R(22), "egl.d/vendor.json"), 14)
+
+	unit0, _, err := builtin.ExportUnitAndFileName(p0, s.slot, 15, true)
+	c.Assert(err, IsNil)
+	unit1, _, err := builtin.ExportUnitAndFileName(p1, s.slot, 15, true)
+	c.Assert(err, IsNil)
+	unit2, _, err := builtin.ExportUnitAndFileName(p2, s.slot, 15, true)
+	c.Assert(err, IsNil)
+
+	c.Check(unit0, Not(Equals), unit1)
+	c.Check(unit0, Not(Equals), unit2)
+	c.Check(unit1, Not(Equals), unit2)
+}

--- a/interfaces/builtin/helpers_test.go
+++ b/interfaces/builtin/helpers_test.go
@@ -20,6 +20,8 @@
 package builtin_test
 
 import (
+	"errors"
+	"os"
 	"path/filepath"
 
 	. "gopkg.in/check.v1"
@@ -209,4 +211,25 @@ func (s *helpersSuite) TestExportUnitAndFileNameMultipleComponentsAreSeparateUni
 	c.Check(unit0, Not(Equals), unit1)
 	c.Check(unit0, Not(Equals), unit2)
 	c.Check(unit1, Not(Equals), unit2)
+}
+
+func (s *helpersSuite) TestFilePathInLibDirsFound(c *C) {
+	libDir := filepath.Join(dirs.SnapMountDir, "helpers-provider/5/lib1")
+	c.Assert(os.MkdirAll(libDir, 0755), IsNil)
+	libPath := filepath.Join(libDir, "libfoo.so")
+	c.Assert(os.WriteFile(libPath, []byte{}, 0644), IsNil)
+
+	path, err := builtin.FilePathInLibDirs(s.slot, "libfoo.so")
+	c.Assert(err, IsNil)
+	c.Check(path, Equals, libPath)
+}
+
+// TestFilePathInLibDirsNotFound verifies that a missing library is reported
+// via an error wrapping errLibraryNotFound - this is the contract callers
+// (sourceDirFilesCheck, gbm's SymlinksConnectedPlug) rely on to tell "this
+// specific file/symlink should be skipped" apart from other, fatal errors.
+func (s *helpersSuite) TestFilePathInLibDirsNotFound(c *C) {
+	_, err := builtin.FilePathInLibDirs(s.slot, "libfoo.so")
+	c.Assert(err, ErrorMatches, `library not found: "libfoo.so" not found in the library-source directories`)
+	c.Check(errors.Is(err, builtin.ErrLibraryNotFound), Equals, true)
 }

--- a/interfaces/builtin/vulkan_driver_libs.go
+++ b/interfaces/builtin/vulkan_driver_libs.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/compatibility"
 	"github.com/snapcore/snapd/interfaces/configfiles"
+	"github.com/snapcore/snapd/interfaces/export"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
 	"github.com/snapcore/snapd/interfaces/symlinks"
 	"github.com/snapcore/snapd/release"
@@ -107,12 +108,19 @@ func (iface *vulkanDriverLibsInterface) LdconfigConnectedPlug(spec *ldconfig.Spe
 
 var _ = symlinks.ConnectedPlugCallback(&vulkanDriverLibsInterface{})
 var _ = interfaces.ConfigfilesUser(&vulkanDriverLibsInterface{})
+var _ = export.ConnectedPlugCallback(&vulkanDriverLibsInterface{})
 
 const (
 	vulkanDriverLibs        = "vulkan-driver-libs"
 	vulkanIcdPath           = "/etc/vulkan/icd.d"
 	vulkanExplicitLayerPath = "/etc/vulkan/explicit_layer.d"
 	vulkanImplicitLayerPath = "/etc/vulkan/implicit_layer.d"
+	// The following are the export backend's subdirectory names for the
+	// same content on Core (see ExportConnectedPlug), matching the last
+	// path component of the classic paths above.
+	vulkanIcdSubDir           = "icd.d"
+	vulkanExplicitLayerSubDir = "explicit_layer.d"
+	vulkanImplicitLayerSubDir = "implicit_layer.d"
 )
 
 // Implementation of the SymlinksUser interface
@@ -263,6 +271,36 @@ func (iface *vulkanDriverLibsInterface) SymlinksConnectedPlug(spec *symlinks.Spe
 		const withPriority = false
 		if err := symlinksForSourceDir(spec, slot,
 			sourceAttr.sda, sourceAttr.targetDir, sourceAttr.checker, withPriority); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (iface *vulkanDriverLibsInterface) ExportConnectedPlug(spec *export.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	// Inverted polarity vs. LdconfigConnectedPlug/SymlinksConnectedPlug
+	// above: those are classic-only, this is their Core counterpart -
+	// files are exported via /var/lib/snapd/export only on core, on
+	// classic the ICD/layer files are already discoverable via the
+	// symlinks backend.
+	if release.OnClassic {
+		return nil
+	}
+	for _, sourceAttr := range []struct {
+		sda          sourceDirAttr
+		targetSubDir string
+		checker      func(slot *interfaces.ConnectedSlot, content []byte) error
+	}{
+		{sourceDirAttr{attrName: "icd-source", isOptional: false},
+			vulkanIcdSubDir, checkVulkanIcdFile},
+		{sourceDirAttr{attrName: "implicit-layer-source", isOptional: true},
+			vulkanImplicitLayerSubDir, checkVulkanLayersFile},
+		{sourceDirAttr{attrName: "explicit-layer-source", isOptional: true},
+			vulkanExplicitLayerSubDir, checkVulkanLayersFile},
+	} {
+		const withPriority = false
+		if err := exportedFilesForSourceDir(spec, vulkanDriverLibs, slot,
+			sourceAttr.sda, sourceAttr.targetSubDir, sourceAttr.checker, withPriority); err != nil {
 			return err
 		}
 	}

--- a/interfaces/builtin/vulkan_driver_libs_test.go
+++ b/interfaces/builtin/vulkan_driver_libs_test.go
@@ -234,6 +234,10 @@ func (s *VulkanDriverLibsInterfaceSuite) TestSanitizePlug(c *C) {
 }
 
 func (s *VulkanDriverLibsInterfaceSuite) TestLdconfigSpec(c *C) {
+	// ldconfig is only active on classic
+	restore := release.MockOnClassic(true)
+	defer restore()
+
 	spec := &ldconfig.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Check(spec.LibDirs(), DeepEquals, map[ldconfig.SnapSlot][]string{

--- a/interfaces/builtin/vulkan_driver_libs_test.go
+++ b/interfaces/builtin/vulkan_driver_libs_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/configfiles"
+	"github.com/snapcore/snapd/interfaces/export"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
 	"github.com/snapcore/snapd/interfaces/symlinks"
 	"github.com/snapcore/snapd/osutil"
@@ -726,6 +727,192 @@ func (s *VulkanDriverLibsInterfaceSuite) TestSymlinksSpecOnCore(c *C) {
 	spec := &symlinks.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 	c.Check(spec.Symlinks(), HasLen, 0)
+}
+
+// writeSnapIcdAndLayerFixtures writes the snap-level ICD and layer files
+// plus the libraries they reference, returning the exported files a core
+// export is expected to produce for them, keyed by path relative to the
+// unit.
+//
+// The libraries matter as much as the ICD/layer files: one that cannot be
+// found in library-source makes the export skip the file naming it, so
+// writing only the JSON would yield an empty spec regardless of what the
+// interface does - which would silently defeat TestExportSpecOnClassic.
+func (s *VulkanDriverLibsInterfaceSuite) writeSnapIcdAndLayerFixtures(c *C) map[string]osutil.FileState {
+	expected := map[string]osutil.FileState{}
+	for _, icdData := range []struct {
+		gpu    string
+		subDir string
+	}{{"mesa", "vulkan/icd.d"}, {"nvidia", "vulkan/icd.d"}, {"radeon", "vulkan_alt.d"}} {
+		icdDir := filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5", icdData.subDir)
+		c.Assert(os.MkdirAll(icdDir, 0755), IsNil)
+		icdPath := filepath.Join(icdDir, icdData.gpu+".json")
+		os.WriteFile(icdPath, []byte(fmt.Sprintf(`{
+    "file_format_version" : "1.0.0",
+    "ICD" : {
+        "library_path" : "libvulkan_%s.so.0",
+        "api_version" : "1.4.303"
+    }
+}
+`, icdData.gpu)), 0655)
+		libDir := filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5/lib2")
+		c.Assert(os.MkdirAll(libDir, 0755), IsNil)
+		libPath := filepath.Join(libDir, "libvulkan_"+icdData.gpu+".so.0")
+		os.WriteFile(libPath, []byte{}, 0655)
+
+		fileName := "snap_vulkan-provider_vulkan-slot_" + strings.ReplaceAll(icdData.subDir, "/", "-") + "-" + icdData.gpu + ".json"
+		expected[filepath.Join("icd.d", fileName)] = osutil.FileReference{Path: icdPath}
+	}
+
+	// Write layers
+	implicitDir := filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5/vulkan/implicit_layer.d")
+	c.Assert(os.MkdirAll(implicitDir, 0755), IsNil)
+	implicitPath := filepath.Join(implicitDir, "gpu_layer.json")
+	os.WriteFile(implicitPath, []byte(`{
+    "file_format_version" : "1.0.1",
+    "layers" : [
+       {
+         "name": "layer1",
+         "library_path" : "libvulkan_nvidia.so.0",
+         "api_version" : "1.4.303"
+       },
+       {
+         "name": "layer2",
+         "library_path" : "libvulkan_nvidia.so.0",
+         "api_version" : "1.4.303"
+       }
+     ]
+}
+`), 0644)
+	expected[filepath.Join("implicit_layer.d", "snap_vulkan-provider_vulkan-slot_vulkan-implicit_layer.d-gpu_layer.json")] =
+		osutil.FileReference{Path: implicitPath}
+
+	explicitDir := filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5/vulkan/explicit_layer.d")
+	c.Assert(os.MkdirAll(explicitDir, 0755), IsNil)
+	explicitPath := filepath.Join(explicitDir, "gpu_layer.json")
+	os.WriteFile(explicitPath, []byte(`{
+    "file_format_version" : "1.0.1",
+    "layer": {
+       "name": "layer1",
+       "library_path" : "libvulkan_nvidia.so.0",
+       "api_version" : "1.4.303"
+     }
+}
+`), 0644)
+	expected[filepath.Join("explicit_layer.d", "snap_vulkan-provider_vulkan-slot_vulkan-explicit_layer.d-gpu_layer.json")] =
+		osutil.FileReference{Path: explicitPath}
+
+	return expected
+}
+
+func (s *VulkanDriverLibsInterfaceSuite) TestExportSpec(c *C) {
+	// export is only active on core
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	expected := s.writeSnapIcdAndLayerFixtures(c)
+
+	spec := &export.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Check(spec.Files(), DeepEquals, map[string]map[string]map[string]osutil.FileState{
+		"vulkan-driver-libs": {
+			"vulkan-provider_vulkan-slot_5": expected,
+		},
+	})
+}
+
+func (s *VulkanDriverLibsInterfaceSuite) TestExportToComps(c *C) {
+	// export is only active on core
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	gpu := "nvidia"
+	compRev := snap.R(11)
+	compMnt := snap.ComponentMountDir("comp1", compRev, "vulkan-provider")
+
+	// Write ICD file
+	icdDir := filepath.Join(compMnt, "icd.d")
+	c.Assert(os.MkdirAll(icdDir, 0755), IsNil)
+	icdPath := filepath.Join(icdDir, gpu+".json")
+	os.WriteFile(icdPath, []byte(fmt.Sprintf(`{
+    "file_format_version" : "1.0.0",
+    "ICD" : {
+        "library_path" : "libvulkan_%s.so.0",
+        "api_version" : "1.4.303"
+    }
+}
+`, gpu)), 0655)
+
+	// Write provider library
+	libDir := filepath.Join(compMnt, "lib1")
+	c.Assert(os.MkdirAll(libDir, 0755), IsNil)
+	libPath := filepath.Join(libDir, "libvulkan_"+gpu+".so.0")
+	os.WriteFile(libPath, []byte{}, 0655)
+
+	expected := map[string]osutil.FileState{
+		filepath.Join("icd.d", "snap_vulkan-provider+comp1_vulkan-slot_icd.d-"+gpu+".json"): osutil.FileReference{Path: icdPath},
+	}
+
+	// Write layers
+	implicitDir := filepath.Join(compMnt, "implicit_layer.d")
+	c.Assert(os.MkdirAll(implicitDir, 0755), IsNil)
+	implicitPath := filepath.Join(implicitDir, "gpu_layer.json")
+	os.WriteFile(implicitPath, []byte(`{
+    "file_format_version" : "1.0.1",
+    "layers" : [
+       {
+         "name": "layer1",
+         "library_path" : "libvulkan_nvidia.so.0",
+         "api_version" : "1.4.303"
+       },
+       {
+         "name": "layer2",
+         "library_path" : "libvulkan_nvidia.so.0",
+         "api_version" : "1.4.303"
+       }
+     ]
+}
+`), 0644)
+	expected[filepath.Join("implicit_layer.d", "snap_vulkan-provider+comp1_vulkan-slot_implicit_layer.d-gpu_layer.json")] =
+		osutil.FileReference{Path: implicitPath}
+
+	explicitDir := filepath.Join(compMnt, "explicit_layer.d")
+	c.Assert(os.MkdirAll(explicitDir, 0755), IsNil)
+	explicitPath := filepath.Join(explicitDir, "gpu_layer.json")
+	os.WriteFile(explicitPath, []byte(`{
+    "file_format_version" : "1.0.1",
+    "layer": {
+       "name": "layer1",
+       "library_path" : "libvulkan_nvidia.so.0",
+       "api_version" : "1.4.303"
+     }
+}
+`), 0644)
+	expected[filepath.Join("explicit_layer.d", "snap_vulkan-provider+comp1_vulkan-slot_explicit_layer.d-gpu_layer.json")] =
+		osutil.FileReference{Path: explicitPath}
+
+	spec := &export.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Check(spec.Files(), DeepEquals, map[string]map[string]map[string]osutil.FileState{
+		"vulkan-driver-libs": {
+			"vulkan-provider_vulkan-slot_5+comp1_11": expected,
+		},
+	})
+}
+
+func (s *VulkanDriverLibsInterfaceSuite) TestExportSpecOnClassic(c *C) {
+	// export is skipped on classic; the equivalent content is already
+	// discoverable there via the symlinks backend.
+	restore := release.MockOnClassic(true)
+	defer restore()
+
+	// Write the same fixtures the core test uses, so that an empty spec
+	// can only be the OnClassic check and not simply an absence of input.
+	s.writeSnapIcdAndLayerFixtures(c)
+
+	spec := &export.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Check(spec.Files(), HasLen, 0)
 }
 
 func (s *VulkanDriverLibsInterfaceSuite) TestStaticInfo(c *C) {

--- a/interfaces/builtin/vulkan_driver_libs_test.go
+++ b/interfaces/builtin/vulkan_driver_libs_test.go
@@ -446,9 +446,12 @@ func (s *VulkanDriverLibsInterfaceSuite) TestSymlinksSpecNoLibrary(c *C) {
 }
 `), 0655)
 
+	// The library referenced by the ICD file is not present anywhere
+	// under library-source: this ICD file is skipped, not an error - see
+	// errLibraryNotFound.
 	spec := &symlinks.Specification{}
-	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), ErrorMatches,
-		`invalid icd-source: nvidia.json: "libGLX_nvidia.so.0" not found in the library-source directories`)
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Check(spec.Symlinks(), HasLen, 0)
 }
 
 func (s *VulkanDriverLibsInterfaceSuite) TestSymlinksSpecOptional(c *C) {

--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -412,6 +412,8 @@ const (
 	SecurityConfigfiles SecuritySystem = "configfiles"
 	// SecuritySymlinks identifies the symlinks security system.
 	SecuritySymlinks SecuritySystem = "symlinks"
+	// SecurityExport identifies the export security system.
+	SecurityExport SecuritySystem = "export"
 )
 
 var isValidBusName = regexp.MustCompile(`^[a-zA-Z_-][a-zA-Z0-9_-]*(\.[a-zA-Z_-][a-zA-Z0-9_-]*)+$`).MatchString

--- a/interfaces/export/backend.go
+++ b/interfaces/export/backend.go
@@ -1,0 +1,113 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Package export is a backend that copies files declared by interfaces out of
+// a snap (or its components) into a staging tree under
+// /var/lib/snapd/export/system/<interface-name>/, for later consumption by
+// snap-confine. Unlike the configfiles and symlinks backends, which modify
+// the classic rootfs, this backend targets a snapd-owned location that is
+// meaningful on both classic and Ubuntu Core systems.
+package export
+
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/timings"
+)
+
+// Backend is responsible for maintaining the snap export directory.
+type Backend struct{}
+
+var _ = interfaces.SecurityBackend(&Backend{})
+
+// Initialize does nothing for this backend.
+func (b *Backend) Initialize(opts *interfaces.SecurityBackendOptions) error {
+	return nil
+}
+
+// Name returns the name of the backend.
+func (b *Backend) Name() interfaces.SecuritySystem {
+	return interfaces.SecurityExport
+}
+
+func (b *Backend) Prepare(_ *interfaces.SnapAppSet) error {
+	// No preparation required.
+	return nil
+}
+
+// Setup will make the export backend generate the files exported by
+// connected interfaces.
+//
+// If the method fails it should be re-tried (with a sensible strategy) by the caller.
+func (b *Backend) Setup(appSet *interfaces.SnapAppSet, opts interfaces.ConfinementOptions, sctx interfaces.SetupContext, repo *interfaces.Repository, tm timings.Measurer) error {
+	snapName := appSet.InstanceName()
+	// Get the snippets that apply to this snap
+	spec, err := repo.SnapSpecification(b.Name(), appSet, opts)
+	if err != nil {
+		return fmt.Errorf("cannot obtain export specification for snap %q: %s",
+			snapName, err)
+	}
+
+	return b.ensureExports(spec.(*Specification))
+}
+
+// Remove removes exported files specific to a given snap.
+// This method should be called after removing a snap.
+//
+// If the method fails it should be re-tried (with a sensible strategy) by the caller.
+func (b *Backend) Remove(snapName string) error {
+	// If called for the system (snapd) snap, that is possible only in a
+	// classic scenario when all other snaps in the system must have been
+	// removed already to allow the removal of the snapd snap. In that
+	// case, the exported files will have already been removed by a Setup
+	// call, so we do not need to do anything here.
+
+	// TODO but this needs to be revisited for when we start supporting
+	// export plugs in snaps.
+	return nil
+}
+
+// NewSpecification returns a new specification associated with this backend.
+func (b *Backend) NewSpecification(*interfaces.SnapAppSet,
+	interfaces.ConfinementOptions) interfaces.Specification {
+	return &Specification{}
+}
+
+// SandboxFeatures returns the list of features supported by snapd for export.
+func (b *Backend) SandboxFeatures() []string {
+	return []string{"mediated-export"}
+}
+
+// ensureExports reconciles the on-disk export tree with what is declared in
+// spec.
+//
+// TODO(export): this currently does nothing. The reconciliation logic
+// (materialising per-connection unit directories, atomically flipping the
+// export.sources manifest, garbage-collecting stale units) is added in a
+// follow-up change.
+func (b *Backend) ensureExports(spec *Specification) error {
+	// Setup exports only if the snap has plugs that require it. For the
+	// moment this is only the system snap.
+	if len(spec.plugs) == 0 {
+		return nil
+	}
+
+	return nil
+}

--- a/interfaces/export/backend.go
+++ b/interfaces/export/backend.go
@@ -57,6 +57,18 @@ func (b *Backend) Prepare(_ *interfaces.SnapAppSet) error {
 //
 // If the method fails it should be re-tried (with a sensible strategy) by the caller.
 func (b *Backend) Setup(appSet *interfaces.SnapAppSet, opts interfaces.ConfinementOptions, sctx interfaces.SetupContext, repo *interfaces.Repository, tm timings.Measurer) error {
+	// Collect the set of interfaces that use the export backend at all,
+	// regardless of whether they currently have any connections. This is
+	// what lets a fully disconnected interface's export tree be garbage
+	// collected down to nothing, mirroring how the symlinks backend
+	// collects symlinkDirs from interfaces.SymlinksUser.
+	exportIfaces := map[string]bool{}
+	for _, iface := range repo.AllInterfaces() {
+		if _, ok := iface.(ConnectedPlugCallback); ok {
+			exportIfaces[iface.Name()] = true
+		}
+	}
+
 	snapName := appSet.InstanceName()
 	// Get the snippets that apply to this snap
 	spec, err := repo.SnapSpecification(b.Name(), appSet, opts)
@@ -65,7 +77,7 @@ func (b *Backend) Setup(appSet *interfaces.SnapAppSet, opts interfaces.Confineme
 			snapName, err)
 	}
 
-	return b.ensureExports(spec.(*Specification))
+	return b.ensureExports(spec.(*Specification), exportIfaces)
 }
 
 // Remove removes exported files specific to a given snap.
@@ -93,21 +105,4 @@ func (b *Backend) NewSpecification(*interfaces.SnapAppSet,
 // SandboxFeatures returns the list of features supported by snapd for export.
 func (b *Backend) SandboxFeatures() []string {
 	return []string{"mediated-export"}
-}
-
-// ensureExports reconciles the on-disk export tree with what is declared in
-// spec.
-//
-// TODO(export): this currently does nothing. The reconciliation logic
-// (materialising per-connection unit directories, atomically flipping the
-// export.sources manifest, garbage-collecting stale units) is added in a
-// follow-up change.
-func (b *Backend) ensureExports(spec *Specification) error {
-	// Setup exports only if the snap has plugs that require it. For the
-	// moment this is only the system snap.
-	if len(spec.plugs) == 0 {
-		return nil
-	}
-
-	return nil
 }

--- a/interfaces/export/backend.go
+++ b/interfaces/export/backend.go
@@ -21,8 +21,11 @@
 // a snap (or its components) into a staging tree under
 // /var/lib/snapd/export/system/<interface-name>/, for later consumption by
 // snap-confine. Unlike the configfiles and symlinks backends, which modify
-// the classic rootfs, this backend targets a snapd-owned location that is
-// meaningful on both classic and Ubuntu Core systems.
+// the classic rootfs, this backend targets a snapd-owned location instead -
+// the mechanism itself is not tied to classic or Core, but every interface
+// currently using it (see ConnectedPlugCallback implementations in
+// interfaces/builtin) only does so on Core, since on classic the same
+// content is already made discoverable via the symlinks backend.
 package export
 
 import (

--- a/interfaces/export/backend_test.go
+++ b/interfaces/export/backend_test.go
@@ -1,0 +1,174 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package export_test
+
+import (
+	"fmt"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/export"
+	"github.com/snapcore/snapd/interfaces/ifacetest"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+)
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+type backendSuite struct {
+	ifacetest.BackendSuite
+}
+
+var _ = Suite(&backendSuite{})
+
+func (s *backendSuite) SetUpTest(c *C) {
+	s.Backend = &export.Backend{}
+	s.BackendSuite.SetUpTest(c)
+	c.Assert(s.Repo.AddBackend(s.Backend), IsNil)
+}
+
+func (s *backendSuite) TestName(c *C) {
+	c.Check(s.Backend.Name(), Equals, interfaces.SecurityExport)
+}
+
+func (s *backendSuite) TestSandboxFeatures(c *C) {
+	c.Assert(s.Backend.SandboxFeatures(), DeepEquals, []string{"mediated-export"})
+}
+
+func (s *backendSuite) mockSlot(c *C, yaml string, slotName string) (*interfaces.SnapAppSet, *snap.SlotInfo) {
+	info := snaptest.MockInfo(c, yaml, nil)
+
+	set, err := interfaces.NewSnapAppSet(info, nil)
+	c.Assert(err, IsNil)
+	err = s.Repo.AddAppSet(set)
+	c.Assert(err, IsNil)
+
+	if slotInfo, ok := info.Slots[slotName]; ok {
+		return set, slotInfo
+	}
+	panic(fmt.Sprintf("cannot find slot %q in snap %q", slotName, info.InstanceName()))
+}
+
+func (s *backendSuite) mockPlug(c *C, yaml string, plugName string) (*interfaces.SnapAppSet, *snap.PlugInfo) {
+	info := snaptest.MockInfo(c, yaml, nil)
+
+	set, err := interfaces.NewSnapAppSet(info, nil)
+	c.Assert(err, IsNil)
+	err = s.Repo.AddAppSet(set)
+	c.Assert(err, IsNil)
+
+	if plugInfo, ok := info.Plugs[plugName]; ok {
+		return set, plugInfo
+	}
+	panic(fmt.Sprintf("cannot find plug %q in snap %q", plugName, info.InstanceName()))
+}
+
+const exportProvider = `name: provider
+version: 0
+type: app
+slots:
+  some-driver-libs:
+`
+
+const exportConsumer = `name: snapd
+version: 0
+type: snapd
+plugs:
+  some-driver-libs:
+apps:
+  app:
+    plugs: [some-driver-libs]
+`
+
+// TestSetupNoConnectionsIsNoop verifies that Setup() succeeds and does
+// nothing when the system snap has no connections using the export backend.
+func (s *backendSuite) TestSetupNoConnectionsIsNoop(c *C) {
+	s.Iface.InterfaceName = "some-driver-libs"
+	c.Assert(s.Repo.AddInterface(s.Iface), IsNil)
+
+	appSet, _ := s.mockPlug(c, exportConsumer, "some-driver-libs")
+	c.Assert(s.Backend.Setup(appSet, interfaces.ConfinementOptions{},
+		interfaces.SetupContext{Reason: interfaces.SnapSetupReasonOther}, s.Repo, nil), IsNil)
+}
+
+// TestConnectedPlugCallbackInvoked verifies that Setup() causes the
+// interface's ExportConnectedPlug callback to be invoked for each connected
+// slot, and that it stops being invoked once disconnected.
+func (s *backendSuite) TestConnectedPlugCallbackInvoked(c *C) {
+	var calledForSlots []string
+	s.Iface.InterfaceName = "some-driver-libs"
+	s.Iface.ExportConnectedPlugCallback = func(spec *export.Specification,
+		plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+		calledForSlots = append(calledForSlots, slot.Snap().InstanceName())
+		return nil
+	}
+	c.Assert(s.Repo.AddInterface(s.Iface), IsNil)
+
+	appSet, plugInfo := s.mockPlug(c, exportConsumer, "some-driver-libs")
+	_, slotInfo := s.mockSlot(c, exportProvider, "some-driver-libs")
+
+	// Not connected yet: Setup builds a spec with no connections, so the
+	// callback must not fire.
+	c.Assert(s.Backend.Setup(appSet, interfaces.ConfinementOptions{},
+		interfaces.SetupContext{Reason: interfaces.SnapSetupReasonOther}, s.Repo, nil), IsNil)
+	c.Check(calledForSlots, HasLen, 0)
+
+	connRef := interfaces.NewConnRef(plugInfo, slotInfo)
+	_, err := s.Repo.Connect(connRef, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+
+	c.Assert(s.Backend.Setup(appSet, interfaces.ConfinementOptions{},
+		interfaces.SetupContext{Reason: interfaces.SnapSetupReasonOther}, s.Repo, nil), IsNil)
+	c.Check(calledForSlots, DeepEquals, []string{"provider"})
+
+	calledForSlots = nil
+	c.Assert(s.Repo.Disconnect(plugInfo.Snap.InstanceName(), plugInfo.Name,
+		slotInfo.Snap.InstanceName(), slotInfo.Name), IsNil)
+	c.Assert(s.Backend.Setup(appSet, interfaces.ConfinementOptions{},
+		interfaces.SetupContext{Reason: interfaces.SnapSetupReasonOther}, s.Repo, nil), IsNil)
+	c.Check(calledForSlots, HasLen, 0)
+}
+
+// TestConnectedPlugCallbackError verifies that an error returned by the
+// interface's ExportConnectedPlug callback propagates out of Setup().
+func (s *backendSuite) TestConnectedPlugCallbackError(c *C) {
+	boom := fmt.Errorf("boom")
+	s.Iface.InterfaceName = "some-driver-libs"
+	s.Iface.ExportConnectedPlugCallback = func(spec *export.Specification,
+		plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+		return boom
+	}
+	c.Assert(s.Repo.AddInterface(s.Iface), IsNil)
+
+	appSet, plugInfo := s.mockPlug(c, exportConsumer, "some-driver-libs")
+	_, slotInfo := s.mockSlot(c, exportProvider, "some-driver-libs")
+
+	connRef := interfaces.NewConnRef(plugInfo, slotInfo)
+	_, err := s.Repo.Connect(connRef, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+
+	err = s.Backend.Setup(appSet, interfaces.ConfinementOptions{},
+		interfaces.SetupContext{Reason: interfaces.SnapSetupReasonOther}, s.Repo, nil)
+	c.Assert(err, ErrorMatches, `cannot obtain export specification for snap "snapd": boom`)
+}

--- a/interfaces/export/exported_files_test.go
+++ b/interfaces/export/exported_files_test.go
@@ -121,6 +121,24 @@ func (s *exportedFilesSuite) TestAddExportedFileInvalidRelPath(c *C) {
 	}
 }
 
+// TestAddExportedFileRelPathCannotEscapeUnit covers a gap filepath.Clean does
+// not close on its own: filepath.Clean("../x") == "../x" (there is nothing
+// for the leading ".." to cancel against), so relPath == filepath.Clean(relPath)
+// is true for these inputs and they are not absolute either - without an
+// explicit check they would pass AddExportedFile's validation and let a
+// caller place a file outside the interface's own export root.
+func (s *exportedFilesSuite) TestAddExportedFileRelPathCannotEscapeUnit(c *C) {
+	state := &osutil.MemoryFileState{}
+	for _, relPath := range []string{
+		"..",
+		"../x",
+		"../../etc/passwd",
+	} {
+		err := s.spec.AddExportedFile("egl-driver-libs", "unit", relPath, state)
+		c.Check(err, ErrorMatches, `export internal error: path escapes its unit: .*`, Commentf("relPath: %q", relPath))
+	}
+}
+
 func (s *exportedFilesSuite) TestAddExportedFileRelPathMustHaveSubdirectory(c *C) {
 	state := &osutil.MemoryFileState{}
 	err := s.spec.AddExportedFile("egl-driver-libs", "unit", "onlyfile.json", state)

--- a/interfaces/export/exported_files_test.go
+++ b/interfaces/export/exported_files_test.go
@@ -1,0 +1,132 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package export_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces/export"
+	"github.com/snapcore/snapd/osutil"
+)
+
+type exportedFilesSuite struct {
+	spec *export.Specification
+}
+
+var _ = Suite(&exportedFilesSuite{})
+
+func (s *exportedFilesSuite) SetUpTest(c *C) {
+	s.spec = &export.Specification{}
+}
+
+func (s *exportedFilesSuite) TestAddExportedFileIsRecorded(c *C) {
+	state := &osutil.MemoryFileState{Content: []byte("hello"), Mode: 0644}
+	err := s.spec.AddExportedFile("egl-driver-libs", "foo_egl-slot_5",
+		"egl_vendor.d/15_snap_foo_egl-slot_egl.d-vendor.json", state)
+	c.Assert(err, IsNil)
+
+	c.Check(s.spec.Files(), DeepEquals, map[string]map[string]map[string]osutil.FileState{
+		"egl-driver-libs": {
+			"foo_egl-slot_5": {
+				"egl_vendor.d/15_snap_foo_egl-slot_egl.d-vendor.json": state,
+			},
+		},
+	})
+}
+
+func (s *exportedFilesSuite) TestAddExportedFileMultipleInterfacesUnitsFiles(c *C) {
+	state1 := &osutil.MemoryFileState{Content: []byte("1")}
+	state2 := &osutil.MemoryFileState{Content: []byte("2")}
+	state3 := &osutil.MemoryFileState{Content: []byte("3")}
+
+	c.Assert(s.spec.AddExportedFile("egl-driver-libs", "foo_egl-slot_5",
+		"egl_vendor.d/a.json", state1), IsNil)
+	c.Assert(s.spec.AddExportedFile("egl-driver-libs", "foo_egl-slot_5+comp1_11",
+		"egl_vendor.d/b.json", state2), IsNil)
+	c.Assert(s.spec.AddExportedFile("vulkan-driver-libs", "foo_vulkan-slot_5",
+		"icd.d/c.json", state3), IsNil)
+
+	files := s.spec.Files()
+	c.Check(files, HasLen, 2)
+	c.Check(files["egl-driver-libs"], HasLen, 2)
+	c.Check(files["egl-driver-libs"]["foo_egl-slot_5"]["egl_vendor.d/a.json"], Equals, osutil.FileState(state1))
+	c.Check(files["egl-driver-libs"]["foo_egl-slot_5+comp1_11"]["egl_vendor.d/b.json"], Equals, osutil.FileState(state2))
+	c.Check(files["vulkan-driver-libs"]["foo_vulkan-slot_5"]["icd.d/c.json"], Equals, osutil.FileState(state3))
+}
+
+func (s *exportedFilesSuite) TestAddExportedFileDuplicateIsError(c *C) {
+	state := &osutil.MemoryFileState{Content: []byte("hello")}
+	c.Assert(s.spec.AddExportedFile("egl-driver-libs", "foo_egl-slot_5",
+		"egl_vendor.d/a.json", state), IsNil)
+
+	err := s.spec.AddExportedFile("egl-driver-libs", "foo_egl-slot_5",
+		"egl_vendor.d/a.json", state)
+	c.Assert(err, ErrorMatches, `export internal error: already declared file: "foo_egl-slot_5/egl_vendor.d/a.json"`)
+}
+
+func (s *exportedFilesSuite) TestAddExportedFileSameRelPathDifferentUnitIsFine(c *C) {
+	// The same relative path in two different units is not a collision -
+	// they belong to different containers (e.g. two components both
+	// shipping a file with the same base name).
+	state1 := &osutil.MemoryFileState{Content: []byte("1")}
+	state2 := &osutil.MemoryFileState{Content: []byte("2")}
+	c.Assert(s.spec.AddExportedFile("egl-driver-libs", "foo_egl-slot_5",
+		"egl_vendor.d/a.json", state1), IsNil)
+	c.Assert(s.spec.AddExportedFile("egl-driver-libs", "foo_egl-slot_5+comp1_11",
+		"egl_vendor.d/a.json", state2), IsNil)
+}
+
+func (s *exportedFilesSuite) TestAddExportedFileInvalidInterfaceName(c *C) {
+	state := &osutil.MemoryFileState{}
+	for _, ifaceName := range []string{"", "with/slash"} {
+		err := s.spec.AddExportedFile(ifaceName, "unit", "sub/file.json", state)
+		c.Check(err, ErrorMatches, `export internal error: invalid interface name: .*`)
+	}
+}
+
+func (s *exportedFilesSuite) TestAddExportedFileInvalidUnitName(c *C) {
+	state := &osutil.MemoryFileState{}
+	for _, unit := range []string{"", "with/slash"} {
+		err := s.spec.AddExportedFile("egl-driver-libs", unit, "sub/file.json", state)
+		c.Check(err, ErrorMatches, `export internal error: invalid unit name: .*`)
+	}
+}
+
+func (s *exportedFilesSuite) TestAddExportedFileInvalidRelPath(c *C) {
+	state := &osutil.MemoryFileState{}
+	for _, relPath := range []string{
+		"/abs/path.json",   // absolute
+		"sub/../path.json", // unclean
+		"sub/",             // unclean (trailing slash)
+	} {
+		err := s.spec.AddExportedFile("egl-driver-libs", "unit", relPath, state)
+		c.Check(err, ErrorMatches, `export internal error: unclean or absolute path: .*`, Commentf("relPath: %q", relPath))
+	}
+}
+
+func (s *exportedFilesSuite) TestAddExportedFileRelPathMustHaveSubdirectory(c *C) {
+	state := &osutil.MemoryFileState{}
+	err := s.spec.AddExportedFile("egl-driver-libs", "unit", "onlyfile.json", state)
+	c.Assert(err, ErrorMatches, `export internal error: path must be inside a subdirectory: "onlyfile.json"`)
+}
+
+func (s *exportedFilesSuite) TestFilesNilWhenEmpty(c *C) {
+	c.Check(s.spec.Files(), IsNil)
+}

--- a/interfaces/export/naming.go
+++ b/interfaces/export/naming.go
@@ -1,0 +1,60 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package export
+
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/snap"
+)
+
+// UnitName returns the name of the on-disk unit directory that groups
+// together the files exported for a single connection, contributed by a
+// single container: either the snap itself (component == "") or exactly
+// one of its components.
+//
+// The snap revision is always part of the name, even when component is
+// set, because the snap revision determines which subdirectory of the
+// component is scanned by the interface, and the priority/index assigned
+// to its files - so changing the snap revision can change the resulting
+// content even if the component itself is unchanged (see
+// interfaces.SnapAppSet.ExpandSliceSnapVariablesWithOrder).
+//
+// Exactly one container is referenced per unit - never an aggregate of all
+// of a snap's components - so that the name stays bounded regardless of how
+// many components a snap has. Component names are capped at 40 characters
+// (snap/naming.ValidateSnap, used by snap/naming.ComponentRef.Validate),
+// but there is no limit on the number of components a snap may have;
+// aggregating all of them into one name would make the result unbounded
+// (a driver snap with one component per GPU family could plausibly have
+// five to ten).
+//
+// The result is deterministic given its inputs, which gives two useful
+// properties: reverting a snap or a component reuses the unit already on
+// disk (if not yet garbage-collected) with no writes needed, and two
+// concurrent writers computing the unit for the same content produce
+// identical, idempotent output rather than colliding.
+func UnitName(instanceName, slotName string, snapRev snap.Revision, component string, componentRev snap.Revision) string {
+	base := fmt.Sprintf("%s_%s_%s", instanceName, slotName, snapRev)
+	if component == "" {
+		return base
+	}
+	return fmt.Sprintf("%s+%s_%s", base, component, componentRev)
+}

--- a/interfaces/export/naming_test.go
+++ b/interfaces/export/naming_test.go
@@ -1,0 +1,105 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package export_test
+
+import (
+	"strings"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces/export"
+	"github.com/snapcore/snapd/snap"
+)
+
+type namingSuite struct{}
+
+var _ = Suite(&namingSuite{})
+
+func (s *namingSuite) TestUnitNameSnapOnly(c *C) {
+	name := export.UnitName("foo", "egl-slot", snap.R(34), "", snap.Revision{})
+	c.Check(name, Equals, "foo_egl-slot_34")
+}
+
+func (s *namingSuite) TestUnitNameComponent(c *C) {
+	name := export.UnitName("foo", "egl-slot", snap.R(34), "comp1", snap.R(12))
+	c.Check(name, Equals, "foo_egl-slot_34+comp1_12")
+}
+
+func (s *namingSuite) TestUnitNameMultipleComponentsAreDistinctUnits(c *C) {
+	// Each component gets its own unit - the design explicitly rejected
+	// aggregating all of a snap's components into a single unit name (see
+	// UnitName doc comment), so two different components must never
+	// collapse onto the same unit name.
+	n1 := export.UnitName("foo", "egl-slot", snap.R(34), "comp1", snap.R(12))
+	n2 := export.UnitName("foo", "egl-slot", snap.R(34), "comp2", snap.R(22))
+	n0 := export.UnitName("foo", "egl-slot", snap.R(34), "", snap.Revision{})
+
+	c.Check(n1, Not(Equals), n2)
+	c.Check(n0, Not(Equals), n1)
+	c.Check(n0, Not(Equals), n2)
+}
+
+func (s *namingSuite) TestUnitNameDeterministic(c *C) {
+	n1 := export.UnitName("foo", "egl-slot", snap.R(34), "comp1", snap.R(12))
+	n2 := export.UnitName("foo", "egl-slot", snap.R(34), "comp1", snap.R(12))
+	c.Check(n1, Equals, n2)
+}
+
+func (s *namingSuite) TestUnitNameSnapRevisionAlwaysSignificant(c *C) {
+	// Same component and component revision, different snap revision:
+	// must produce a different unit, because the snap revision decides
+	// which subdirectory of the component is scanned and what priority
+	// its files get (see interfaces.SnapAppSet.ExpandSliceSnapVariablesWithOrder).
+	n1 := export.UnitName("foo", "egl-slot", snap.R(33), "comp1", snap.R(12))
+	n2 := export.UnitName("foo", "egl-slot", snap.R(34), "comp1", snap.R(12))
+	c.Check(n1, Not(Equals), n2)
+}
+
+func (s *namingSuite) TestUnitNameDifferentSlotsDoNotCollide(c *C) {
+	// A snap exposing two slots of the same interface must not collide,
+	// even with otherwise identical inputs.
+	n1 := export.UnitName("foo", "egl-slot-a", snap.R(34), "", snap.Revision{})
+	n2 := export.UnitName("foo", "egl-slot-b", snap.R(34), "", snap.Revision{})
+	c.Check(n1, Not(Equals), n2)
+}
+
+func (s *namingSuite) TestUnitNameParallelInstancesDoNotCollide(c *C) {
+	n1 := export.UnitName("foo", "egl-slot", snap.R(34), "", snap.Revision{})
+	n2 := export.UnitName("foo_instance", "egl-slot", snap.R(34), "", snap.Revision{})
+	c.Check(n1, Not(Equals), n2)
+}
+
+func (s *namingSuite) TestUnitNameLengthBound(c *C) {
+	// Worst-case realistic name: a 40 character snap name (the maximum
+	// allowed by snap/naming.ValidateSnap) with a 10 character instance
+	// key, a 40 character slot name, and a 40 character component name,
+	// each paired with a plausible revision. This must stay comfortably
+	// under NAME_MAX (255 bytes on Linux), since the unit name becomes a
+	// directory entry on disk.
+	longSnapName := strings.Repeat("a", 40)
+	longInstanceKey := strings.Repeat("b", 10)
+	instance := longSnapName + "_" + longInstanceKey
+	longSlot := strings.Repeat("c", 40)
+	longComp := strings.Repeat("d", 40)
+	rev := snap.R(9999999)
+
+	name := export.UnitName(instance, longSlot, rev, longComp, rev)
+	c.Check(len(name) <= 255, Equals, true, Commentf("unit name %q is %d bytes long", name, len(name)))
+}

--- a/interfaces/export/paths.go
+++ b/interfaces/export/paths.go
@@ -1,0 +1,68 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package export
+
+import (
+	"path/filepath"
+
+	"github.com/snapcore/snapd/dirs"
+)
+
+// InterfaceRoot returns the directory holding every export unit and the
+// export.sources manifest for the given interface:
+//
+//	/var/lib/snapd/export/system/<ifaceName>/
+//
+// The "system/" component is safe from collisions with per-snap export
+// trees added by a future non-system-snap plug user, because "system" is a
+// reserved snap name (see overlord/snapstate.checkInstallPreconditions).
+//
+// This directory is owned by the export backend, except for the sibling
+// /var/lib/snapd/export/system_<snap>_<slot>_<iface>.library-source files
+// written directly under /var/lib/snapd/export/ by the configfiles backend
+// (see systemLibrarySourcePath in interfaces/builtin/helpers.go): garbage
+// collection must only ever touch subtrees of InterfaceRoot, never
+// /var/lib/snapd/export/ itself.
+func InterfaceRoot(ifaceName string) string {
+	return filepath.Join(dirs.SnapExportDirUnder(dirs.GlobalRootDir), "system", ifaceName)
+}
+
+// UnitDir returns the directory holding the files exported by a single unit
+// (see UnitName) of the given interface.
+func UnitDir(ifaceName, unit string) string {
+	return filepath.Join(InterfaceRoot(ifaceName), unit)
+}
+
+// UnitTmpDir returns the temporary directory a unit is materialised into
+// before being atomically renamed into place at UnitDir. It is a sibling of
+// UnitDir (same parent directory) so that the rename is a same-filesystem,
+// same-directory rename.
+func UnitTmpDir(ifaceName, unit string) string {
+	return UnitDir(ifaceName, unit) + ".tmp"
+}
+
+// ManifestPath returns the path to the export.sources manifest for the
+// given interface. The manifest lists, one per line, the paths (relative to
+// InterfaceRoot) of every file that is currently part of the interface's
+// exported state; any unit directory under InterfaceRoot not referenced by
+// it is garbage.
+func ManifestPath(ifaceName string) string {
+	return filepath.Join(InterfaceRoot(ifaceName), "export.sources")
+}

--- a/interfaces/export/paths_test.go
+++ b/interfaces/export/paths_test.go
@@ -1,0 +1,81 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package export_test
+
+import (
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces/export"
+)
+
+type pathsSuite struct {
+	testRoot string
+}
+
+var _ = Suite(&pathsSuite{})
+
+func (s *pathsSuite) SetUpTest(c *C) {
+	s.testRoot = c.MkDir()
+	dirs.SetRootDir(s.testRoot)
+}
+
+func (s *pathsSuite) TearDownTest(c *C) {
+	dirs.SetRootDir("/")
+}
+
+func (s *pathsSuite) TestInterfaceRoot(c *C) {
+	root := export.InterfaceRoot("egl-driver-libs")
+	c.Check(root, Equals, filepath.Join(s.testRoot, "var/lib/snapd/export/system/egl-driver-libs"))
+}
+
+func (s *pathsSuite) TestInterfaceRootFollowsRootDir(c *C) {
+	before := export.InterfaceRoot("egl-driver-libs")
+	otherRoot := c.MkDir()
+	dirs.SetRootDir(otherRoot)
+	after := export.InterfaceRoot("egl-driver-libs")
+	c.Check(before, Not(Equals), after)
+	c.Check(after, Equals, filepath.Join(otherRoot, "var/lib/snapd/export/system/egl-driver-libs"))
+}
+
+func (s *pathsSuite) TestUnitDir(c *C) {
+	dir := export.UnitDir("egl-driver-libs", "foo_egl-slot_5")
+	c.Check(dir, Equals, filepath.Join(export.InterfaceRoot("egl-driver-libs"), "foo_egl-slot_5"))
+}
+
+func (s *pathsSuite) TestUnitTmpDirIsSiblingOfUnitDir(c *C) {
+	unit := export.UnitDir("egl-driver-libs", "foo_egl-slot_5")
+	tmp := export.UnitTmpDir("egl-driver-libs", "foo_egl-slot_5")
+
+	c.Check(tmp, Equals, unit+".tmp")
+	c.Check(filepath.Dir(tmp), Equals, filepath.Dir(unit))
+}
+
+func (s *pathsSuite) TestManifestPath(c *C) {
+	manifest := export.ManifestPath("egl-driver-libs")
+	c.Check(manifest, Equals, filepath.Join(export.InterfaceRoot("egl-driver-libs"), "export.sources"))
+}
+
+func (s *pathsSuite) TestPathsForDifferentInterfacesDoNotCollide(c *C) {
+	c.Check(export.InterfaceRoot("egl-driver-libs"), Not(Equals), export.InterfaceRoot("vulkan-driver-libs"))
+	c.Check(export.ManifestPath("egl-driver-libs"), Not(Equals), export.ManifestPath("vulkan-driver-libs"))
+}

--- a/interfaces/export/reconcile.go
+++ b/interfaces/export/reconcile.go
@@ -1,0 +1,266 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package export
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"syscall"
+
+	"github.com/snapcore/snapd/osutil"
+)
+
+// ensureExports reconciles the on-disk export tree with what is declared in
+// spec, for every interface in exportIfaces (every interface using the
+// export backend, whether or not it currently has any connections - see
+// Setup).
+//
+// Like the symlinks and configfiles backends, this is deliberately dumb: it
+// trusts that spec reflects the complete, current desired state (built by
+// walking every connection of the system snap's plugs, so a single call
+// yields the full state, not a delta - see
+// Repository.SnapSpecification), and it does not defend against snap
+// content being unavailable when it runs; that precondition is established
+// by the caller (see interfaces/ifacestate), not by this backend.
+func (b *Backend) ensureExports(spec *Specification, exportIfaces map[string]bool) error {
+	// Setup exports only if the snap has plugs that require it. For the
+	// moment this is only the system snap.
+	if len(spec.plugs) == 0 {
+		return nil
+	}
+
+	files := spec.Files()
+	for ifaceName := range exportIfaces {
+		if err := ensureExportsForInterface(ifaceName, files[ifaceName]); err != nil {
+			return fmt.Errorf("cannot ensure export state for interface %q: %w", ifaceName, err)
+		}
+	}
+	return nil
+}
+
+// ensureExportsForInterface reconciles the on-disk tree at InterfaceRoot(ifaceName)
+// with desired, which maps unit name (see UnitName) to the files that unit
+// must contain (path relative to the unit, see AddExportedFile). A nil or
+// empty desired means the interface currently has nothing to export (no
+// connections, or none of them declared any files), and the entire tree for
+// it is removed.
+//
+// The steps (see the design's "Write sequence"):
+//  1. materialise every unit not already present into a temporary directory,
+//     then atomically rename it into place - a directory rename is atomic,
+//     writing N files into a directory is not, so this avoids ever exposing
+//     a half-populated unit to a reader;
+//  2. atomically flip the export.sources manifest to list every file in the
+//     desired state;
+//  3. remove anything under the interface root that is not a desired unit
+//     and not the manifest - this is unconditionally correct garbage
+//     collection: it covers disconnect, snap removal, refresh, revert,
+//     component refresh, and leftover "<unit>.tmp" directories from a
+//     previous, interrupted run, all with the same rule, without needing to
+//     know why something became unreferenced.
+//
+// Collection in step 3 is deliberately immediate, in the same pass that
+// flipped the manifest, rather than being deferred to a later Setup() or
+// held back by a grace period. The consequence is that a reader which has
+// already read the manifest may find a file it lists gone, or a unit being
+// removed while it walks it. Readers are therefore *required* to be
+// resilient: skip files that cannot be found or cannot be read, rather than
+// treating either as fatal. This is a contract, not an implementation
+// detail - snap-confine's consumer of this tree honours it via
+// sc_do_optional_mount(), which silently no-ops on a missing source instead
+// of failing the snap launch.
+func ensureExportsForInterface(ifaceName string, desired map[string]map[string]osutil.FileState) error {
+	root := InterfaceRoot(ifaceName)
+
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			return err
+		}
+		entries = nil
+	}
+
+	if len(desired) > 0 {
+		if err := os.MkdirAll(root, 0755); err != nil {
+			return fmt.Errorf("cannot create %q: %w", root, err)
+		}
+	}
+
+	for unit, unitFiles := range desired {
+		// Unit names are derived from immutable snap/component
+		// revisions (see UnitName), so if the unit directory already
+		// exists it already has the right content - reverting to a
+		// unit that was not yet garbage collected reuses it verbatim,
+		// with no writes.
+		if osutil.IsDirectory(UnitDir(ifaceName, unit)) {
+			continue
+		}
+		if err := materialiseUnit(ifaceName, unit, unitFiles); err != nil {
+			return err
+		}
+	}
+
+	if err := writeManifest(ifaceName, desired); err != nil {
+		return err
+	}
+
+	manifestName := filepath.Base(ManifestPath(ifaceName))
+	for _, entry := range entries {
+		name := entry.Name()
+		if name == manifestName {
+			continue
+		}
+		if _, ok := desired[name]; ok {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(root, name)); err != nil {
+			return err
+		}
+	}
+
+	if len(desired) == 0 {
+		// Nothing references this interface's tree any more; remove
+		// it too, so a fully disconnected interface leaves no trace.
+		// The directory is expected to be empty at this point (the
+		// loop above just removed every entry, and the manifest was
+		// removed by writeManifest); tolerate it not being empty or
+		// not existing, since either just means there is nothing
+		// further to do here.
+		if err := os.Remove(root); err != nil &&
+			!errors.Is(err, fs.ErrNotExist) && !errors.Is(err, syscall.ENOTEMPTY) {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// materialiseUnit writes files into a temporary directory for unit, then
+// atomically renames it into place at UnitDir(ifaceName, unit).
+//
+// TODO: UnitTmpDir is a deterministic path derived from the unit name, so
+// two Setup() calls racing on the same unit share it. Concurrent Setup() of
+// the system snap is possible: setupSecurityByBackend drops the state lock
+// for the whole backend loop (see overlord/ifacestate/helpers.go), and
+// while connect/disconnect are serialised by CheckChangeConflictMany over
+// {plugSnap, slotSnap}, two independent snap refreshes both reach
+// setupAffectedSnaps for the system snap. The two racing calls can then
+// interleave as: one RemoveAll's the other's in-progress temporary
+// directory, or both reach AtomicRename and the loser fails with ENOTEMPTY
+// (it is rename(2), which will not replace a non-empty directory).
+//
+// The result is a spurious, transient Setup() failure that heals on retry,
+// not corrupt state: a unit name is derived from immutable revisions (see
+// UnitName), so racing writers of the same unit are writing identical
+// content. A related interleaving in ensureExportsForInterface can leave
+// the manifest referencing a unit a concurrent stale-spec writer collected,
+// which likewise resolves on the next Setup().
+//
+// Fix by giving each call a unique temporary directory (os.MkdirTemp-style)
+// or by tolerating ENOTEMPTY/EEXIST from the rename after re-verifying that
+// the target holds the expected content.
+func materialiseUnit(ifaceName, unit string, files map[string]osutil.FileState) error {
+	tmpDir := UnitTmpDir(ifaceName, unit)
+	// Remove any stale, incomplete attempt left behind by a previous,
+	// interrupted run before starting a fresh one.
+	if err := os.RemoveAll(tmpDir); err != nil {
+		return fmt.Errorf("cannot remove stale %q: %w", tmpDir, err)
+	}
+	if err := os.MkdirAll(tmpDir, 0755); err != nil {
+		return fmt.Errorf("cannot create %q: %w", tmpDir, err)
+	}
+
+	for relPath, state := range files {
+		if err := writeUnitFile(tmpDir, relPath, state); err != nil {
+			return fmt.Errorf("cannot write %q: %w", filepath.Join(unit, relPath), err)
+		}
+	}
+
+	unitDir := UnitDir(ifaceName, unit)
+	if err := osutil.AtomicRename(tmpDir, unitDir); err != nil {
+		return fmt.Errorf("cannot rename %q to %q: %w", tmpDir, unitDir, err)
+	}
+	return nil
+}
+
+// writeUnitFile writes state's content to relPath under dir, creating any
+// necessary subdirectories (relPath always has at least one - see
+// AddExportedFile).
+func writeUnitFile(dir, relPath string, state osutil.FileState) error {
+	reader, _, mode, err := state.State()
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+
+	fullPath := filepath.Join(dir, relPath)
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+		return err
+	}
+
+	f, err := os.OpenFile(fullPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode.Perm())
+	if err != nil {
+		return err
+	}
+	_, copyErr := io.Copy(f, reader)
+	closeErr := f.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	return closeErr
+}
+
+// writeManifest atomically flips the export.sources manifest for ifaceName
+// to list every file described by desired, one path relative to
+// InterfaceRoot per line, sorted for a stable diff. If desired is empty, any
+// existing manifest is removed instead of being replaced with an empty
+// file, so a fully disconnected interface leaves no trace.
+func writeManifest(ifaceName string, desired map[string]map[string]osutil.FileState) error {
+	manifestPath := ManifestPath(ifaceName)
+
+	if len(desired) == 0 {
+		err := os.Remove(manifestPath)
+		if err != nil && !errors.Is(err, fs.ErrNotExist) {
+			return err
+		}
+		return nil
+	}
+
+	var lines []string
+	for unit, files := range desired {
+		for relPath := range files {
+			lines = append(lines, filepath.Join(unit, relPath))
+		}
+	}
+	sort.Strings(lines)
+	content := strings.Join(lines, "\n") + "\n"
+
+	err := osutil.EnsureFileState(manifestPath, &osutil.MemoryFileState{Content: []byte(content), Mode: 0644})
+	if err != nil && !errors.Is(err, osutil.ErrSameState) {
+		return err
+	}
+	return nil
+}

--- a/interfaces/export/reconcile_test.go
+++ b/interfaces/export/reconcile_test.go
@@ -1,0 +1,341 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package export_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/export"
+	"github.com/snapcore/snapd/interfaces/ifacetest"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+)
+
+// reconcileSuite exercises the on-disk reconciliation performed by
+// Backend.Setup() end-to-end: the export tree it leaves behind, garbage
+// collection, and its scoping to InterfaceRoot (never touching sibling
+// state belonging to other backends).
+//
+// This does not embed backendSuite (unlike other suites in this package)
+// because backendSuite defines its own Test* methods, which would otherwise
+// be promoted and re-run, redundantly, as part of this suite too.
+type reconcileSuite struct {
+	ifacetest.BackendSuite
+}
+
+var _ = Suite(&reconcileSuite{})
+
+func (s *reconcileSuite) SetUpTest(c *C) {
+	s.Backend = &export.Backend{}
+	s.BackendSuite.SetUpTest(c)
+	c.Assert(s.Repo.AddBackend(s.Backend), IsNil)
+}
+
+func (s *reconcileSuite) mockSlot(c *C, yaml string, slotName string) (*interfaces.SnapAppSet, *snap.SlotInfo) {
+	info := snaptest.MockInfo(c, yaml, nil)
+
+	set, err := interfaces.NewSnapAppSet(info, nil)
+	c.Assert(err, IsNil)
+	err = s.Repo.AddAppSet(set)
+	c.Assert(err, IsNil)
+
+	if slotInfo, ok := info.Slots[slotName]; ok {
+		return set, slotInfo
+	}
+	panic(fmt.Sprintf("cannot find slot %q in snap %q", slotName, info.InstanceName()))
+}
+
+func (s *reconcileSuite) mockPlug(c *C, yaml string, plugName string) (*interfaces.SnapAppSet, *snap.PlugInfo) {
+	info := snaptest.MockInfo(c, yaml, nil)
+
+	set, err := interfaces.NewSnapAppSet(info, nil)
+	c.Assert(err, IsNil)
+	err = s.Repo.AddAppSet(set)
+	c.Assert(err, IsNil)
+
+	if plugInfo, ok := info.Plugs[plugName]; ok {
+		return set, plugInfo
+	}
+	panic(fmt.Sprintf("cannot find plug %q in snap %q", plugName, info.InstanceName()))
+}
+
+func (s *reconcileSuite) setup(c *C, appSet *interfaces.SnapAppSet) {
+	c.Assert(s.Backend.Setup(appSet, interfaces.ConfinementOptions{},
+		interfaces.SetupContext{Reason: interfaces.SnapSetupReasonOther}, s.Repo, nil), IsNil)
+}
+
+func (s *reconcileSuite) TestFreshCreate(c *C) {
+	s.Iface.InterfaceName = "some-driver-libs"
+	s.Iface.ExportConnectedPlugCallback = func(spec *export.Specification,
+		plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+		return spec.AddExportedFile("some-driver-libs", "provider_some-driver-libs_0",
+			"egl_vendor.d/a.json", &osutil.MemoryFileState{Content: []byte("hello"), Mode: 0644})
+	}
+	c.Assert(s.Repo.AddInterface(s.Iface), IsNil)
+
+	appSet, plugInfo := s.mockPlug(c, exportConsumer, "some-driver-libs")
+	_, slotInfo := s.mockSlot(c, exportProvider, "some-driver-libs")
+	connRef := interfaces.NewConnRef(plugInfo, slotInfo)
+	_, err := s.Repo.Connect(connRef, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+
+	s.setup(c, appSet)
+
+	unitDir := export.UnitDir("some-driver-libs", "provider_some-driver-libs_0")
+	content, err := os.ReadFile(filepath.Join(unitDir, "egl_vendor.d/a.json"))
+	c.Assert(err, IsNil)
+	c.Check(string(content), Equals, "hello")
+
+	manifest, err := os.ReadFile(export.ManifestPath("some-driver-libs"))
+	c.Assert(err, IsNil)
+	c.Check(string(manifest), Equals, "provider_some-driver-libs_0/egl_vendor.d/a.json\n")
+
+	// No leftover temporary directory.
+	c.Check(osutil.FileExists(export.UnitTmpDir("some-driver-libs", "provider_some-driver-libs_0")), Equals, false)
+}
+
+func (s *reconcileSuite) TestIdempotentReRun(c *C) {
+	s.Iface.InterfaceName = "some-driver-libs"
+	s.Iface.ExportConnectedPlugCallback = func(spec *export.Specification,
+		plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+		return spec.AddExportedFile("some-driver-libs", "provider_some-driver-libs_0",
+			"egl_vendor.d/a.json", &osutil.MemoryFileState{Content: []byte("hello"), Mode: 0644})
+	}
+	c.Assert(s.Repo.AddInterface(s.Iface), IsNil)
+
+	appSet, plugInfo := s.mockPlug(c, exportConsumer, "some-driver-libs")
+	_, slotInfo := s.mockSlot(c, exportProvider, "some-driver-libs")
+	connRef := interfaces.NewConnRef(plugInfo, slotInfo)
+	_, err := s.Repo.Connect(connRef, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+
+	s.setup(c, appSet)
+
+	unitDir := export.UnitDir("some-driver-libs", "provider_some-driver-libs_0")
+	before, err := os.Stat(unitDir)
+	c.Assert(err, IsNil)
+
+	s.setup(c, appSet)
+
+	after, err := os.Stat(unitDir)
+	c.Assert(err, IsNil)
+	// The unit directory was not touched at all on the second run (same
+	// modification time), since its name already fully determines its
+	// content (see UnitName).
+	c.Check(after.ModTime().Equal(before.ModTime()), Equals, true)
+
+	content, err := os.ReadFile(filepath.Join(unitDir, "egl_vendor.d/a.json"))
+	c.Assert(err, IsNil)
+	c.Check(string(content), Equals, "hello")
+}
+
+func (s *reconcileSuite) TestUnitReplacedOnRevisionBump(c *C) {
+	unit := "provider_some-driver-libs_0"
+	s.Iface.InterfaceName = "some-driver-libs"
+	s.Iface.ExportConnectedPlugCallback = func(spec *export.Specification,
+		plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+		return spec.AddExportedFile("some-driver-libs", unit,
+			"egl_vendor.d/a.json", &osutil.MemoryFileState{Content: []byte("hello"), Mode: 0644})
+	}
+	c.Assert(s.Repo.AddInterface(s.Iface), IsNil)
+
+	appSet, plugInfo := s.mockPlug(c, exportConsumer, "some-driver-libs")
+	_, slotInfo := s.mockSlot(c, exportProvider, "some-driver-libs")
+	connRef := interfaces.NewConnRef(plugInfo, slotInfo)
+	_, err := s.Repo.Connect(connRef, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+
+	s.setup(c, appSet)
+
+	// A new revision produces a new unit name (see UnitName); simulate it
+	// here directly since the naming derivation itself is tested
+	// elsewhere (interfaces/builtin/helpers_test.go).
+	newUnit := "provider_some-driver-libs_1"
+	s.Iface.ExportConnectedPlugCallback = func(spec *export.Specification,
+		plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+		return spec.AddExportedFile("some-driver-libs", newUnit,
+			"egl_vendor.d/a.json", &osutil.MemoryFileState{Content: []byte("goodbye"), Mode: 0644})
+	}
+
+	s.setup(c, appSet)
+
+	// The old unit is gone...
+	c.Check(osutil.FileExists(export.UnitDir("some-driver-libs", unit)), Equals, false)
+	// ...and the new one has the new content.
+	content, err := os.ReadFile(filepath.Join(export.UnitDir("some-driver-libs", newUnit), "egl_vendor.d/a.json"))
+	c.Assert(err, IsNil)
+	c.Check(string(content), Equals, "goodbye")
+
+	manifest, err := os.ReadFile(export.ManifestPath("some-driver-libs"))
+	c.Assert(err, IsNil)
+	c.Check(string(manifest), Equals, newUnit+"/egl_vendor.d/a.json\n")
+}
+
+func (s *reconcileSuite) TestGCOnDisconnect(c *C) {
+	s.Iface.InterfaceName = "some-driver-libs"
+	s.Iface.ExportConnectedPlugCallback = func(spec *export.Specification,
+		plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+		return spec.AddExportedFile("some-driver-libs", "provider_some-driver-libs_0",
+			"egl_vendor.d/a.json", &osutil.MemoryFileState{Content: []byte("hello"), Mode: 0644})
+	}
+	c.Assert(s.Repo.AddInterface(s.Iface), IsNil)
+
+	appSet, plugInfo := s.mockPlug(c, exportConsumer, "some-driver-libs")
+	_, slotInfo := s.mockSlot(c, exportProvider, "some-driver-libs")
+	connRef := interfaces.NewConnRef(plugInfo, slotInfo)
+	_, err := s.Repo.Connect(connRef, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+
+	s.setup(c, appSet)
+	c.Check(osutil.FileExists(export.InterfaceRoot("some-driver-libs")), Equals, true)
+
+	c.Assert(s.Repo.Disconnect(plugInfo.Snap.InstanceName(), plugInfo.Name,
+		slotInfo.Snap.InstanceName(), slotInfo.Name), IsNil)
+	s.setup(c, appSet)
+
+	// Disconnecting the only connection leaves nothing declared for this
+	// interface; the whole tree - unit, manifest, and the interface
+	// directory itself - is garbage collected, exactly like the symlinks
+	// backend removing every managed symlink from a directory whose spec
+	// came back empty.
+	c.Check(osutil.FileExists(export.InterfaceRoot("some-driver-libs")), Equals, false)
+}
+
+func (s *reconcileSuite) TestGCScopedToInterfaceNeverTouchesSiblingState(c *C) {
+	s.Iface.InterfaceName = "some-driver-libs"
+	s.Iface.ExportConnectedPlugCallback = func(spec *export.Specification,
+		plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+		return spec.AddExportedFile("some-driver-libs", "provider_some-driver-libs_0",
+			"egl_vendor.d/a.json", &osutil.MemoryFileState{Content: []byte("hello"), Mode: 0644})
+	}
+	c.Assert(s.Repo.AddInterface(s.Iface), IsNil)
+
+	// A file written directly under /var/lib/snapd/export/ by the
+	// configfiles backend (see systemLibrarySourcePath in
+	// interfaces/builtin/helpers.go), sitting next to (not inside) this
+	// interface's own tree.
+	exportRoot := filepath.Dir(filepath.Dir(export.InterfaceRoot("some-driver-libs")))
+	siblingFile := filepath.Join(exportRoot, "system_provider_some-driver-libs_some-driver-libs.library-source")
+	c.Assert(os.MkdirAll(exportRoot, 0755), IsNil)
+	c.Assert(os.WriteFile(siblingFile, []byte("/snap/provider/1/lib1\n"), 0644), IsNil)
+
+	appSet, plugInfo := s.mockPlug(c, exportConsumer, "some-driver-libs")
+	_, slotInfo := s.mockSlot(c, exportProvider, "some-driver-libs")
+	connRef := interfaces.NewConnRef(plugInfo, slotInfo)
+	_, err := s.Repo.Connect(connRef, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+
+	s.setup(c, appSet)
+
+	// Disconnect, triggering full GC of this interface's tree.
+	c.Assert(s.Repo.Disconnect(plugInfo.Snap.InstanceName(), plugInfo.Name,
+		slotInfo.Snap.InstanceName(), slotInfo.Name), IsNil)
+	s.setup(c, appSet)
+
+	c.Check(osutil.FileExists(export.InterfaceRoot("some-driver-libs")), Equals, false)
+	// The sibling file, one level up, must survive untouched.
+	content, err := os.ReadFile(siblingFile)
+	c.Assert(err, IsNil)
+	c.Check(string(content), Equals, "/snap/provider/1/lib1\n")
+}
+
+func (s *reconcileSuite) TestLeftoverTmpDirIsReaped(c *C) {
+	unit := "provider_some-driver-libs_0"
+	s.Iface.InterfaceName = "some-driver-libs"
+	s.Iface.ExportConnectedPlugCallback = func(spec *export.Specification,
+		plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+		return spec.AddExportedFile("some-driver-libs", unit,
+			"egl_vendor.d/a.json", &osutil.MemoryFileState{Content: []byte("hello"), Mode: 0644})
+	}
+	c.Assert(s.Repo.AddInterface(s.Iface), IsNil)
+
+	appSet, plugInfo := s.mockPlug(c, exportConsumer, "some-driver-libs")
+	_, slotInfo := s.mockSlot(c, exportProvider, "some-driver-libs")
+	connRef := interfaces.NewConnRef(plugInfo, slotInfo)
+	_, err := s.Repo.Connect(connRef, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+
+	// Simulate a crash mid-materialisation: a stale "<unit>.tmp" left
+	// behind by an interrupted previous run, before the real unit
+	// directory ever existed.
+	tmpDir := export.UnitTmpDir("some-driver-libs", unit)
+	c.Assert(os.MkdirAll(tmpDir, 0755), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(tmpDir, "garbage"), []byte("stale"), 0644), IsNil)
+
+	s.setup(c, appSet)
+
+	// The stale directory was replaced by a freshly materialised one
+	// containing only the currently declared file.
+	entries, err := os.ReadDir(export.UnitDir("some-driver-libs", unit))
+	c.Assert(err, IsNil)
+	c.Assert(entries, HasLen, 1)
+	c.Check(entries[0].Name(), Equals, "egl_vendor.d")
+
+	content, err := os.ReadFile(filepath.Join(export.UnitDir("some-driver-libs", unit), "egl_vendor.d/a.json"))
+	c.Assert(err, IsNil)
+	c.Check(string(content), Equals, "hello")
+}
+
+func (s *reconcileSuite) TestMultipleUnitsPooledUnderSameInterface(c *C) {
+	s.Iface.InterfaceName = "some-driver-libs"
+	s.Iface.ExportConnectedPlugCallback = func(spec *export.Specification,
+		plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+		if err := spec.AddExportedFile("some-driver-libs", "provider_some-driver-libs_0",
+			"egl_vendor.d/from-snap.json", &osutil.MemoryFileState{Content: []byte("snap"), Mode: 0644}); err != nil {
+			return err
+		}
+		return spec.AddExportedFile("some-driver-libs", "provider_some-driver-libs_0+comp1_1",
+			"egl_vendor.d/from-comp1.json", &osutil.MemoryFileState{Content: []byte("comp1"), Mode: 0644})
+	}
+	c.Assert(s.Repo.AddInterface(s.Iface), IsNil)
+
+	appSet, plugInfo := s.mockPlug(c, exportConsumer, "some-driver-libs")
+	_, slotInfo := s.mockSlot(c, exportProvider, "some-driver-libs")
+	connRef := interfaces.NewConnRef(plugInfo, slotInfo)
+	_, err := s.Repo.Connect(connRef, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+
+	s.setup(c, appSet)
+
+	root := export.InterfaceRoot("some-driver-libs")
+	entries, err := os.ReadDir(root)
+	c.Assert(err, IsNil)
+	var names []string
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	sort.Strings(names)
+	c.Check(names, DeepEquals, []string{
+		"export.sources", "provider_some-driver-libs_0", "provider_some-driver-libs_0+comp1_1",
+	})
+
+	manifest, err := os.ReadFile(export.ManifestPath("some-driver-libs"))
+	c.Assert(err, IsNil)
+	c.Check(string(manifest), Equals,
+		"provider_some-driver-libs_0+comp1_1/egl_vendor.d/from-comp1.json\n"+
+			"provider_some-driver-libs_0/egl_vendor.d/from-snap.json\n")
+}

--- a/interfaces/export/spec.go
+++ b/interfaces/export/spec.go
@@ -83,6 +83,13 @@ func (spec *Specification) AddExportedFile(ifaceName, unit, relPath string, stat
 	if relPath != filepath.Clean(relPath) || filepath.IsAbs(relPath) {
 		return fmt.Errorf("export internal error: unclean or absolute path: %q", relPath)
 	}
+	// filepath.Clean does not, and cannot, remove a leading ".." that has
+	// nothing to cancel against (filepath.Clean("../x") == "../x"), so the
+	// check above alone does not stop relPath from escaping the unit
+	// directory it is supposed to be confined to - reject that explicitly.
+	if relPath == ".." || strings.HasPrefix(relPath, "../") {
+		return fmt.Errorf("export internal error: path escapes its unit: %q", relPath)
+	}
 	if filepath.Dir(relPath) == "." {
 		return fmt.Errorf("export internal error: path must be inside a subdirectory: %q", relPath)
 	}

--- a/interfaces/export/spec.go
+++ b/interfaces/export/spec.go
@@ -21,8 +21,12 @@ package export
 
 import (
 	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -36,6 +40,10 @@ import (
 type Specification struct {
 	// plugs is the list of plugs using the export backend for the snap.
 	plugs []string
+	// files holds the exported tree content declared so far, keyed by
+	// interface name, then by unit name (see UnitName), then by the
+	// file's path relative to the unit (see AddExportedFile).
+	files map[string]map[string]map[string]osutil.FileState
 }
 
 // Plugs returns the plugs that use the export backend.
@@ -43,9 +51,61 @@ func (spec *Specification) Plugs() []string {
 	return spec.plugs
 }
 
-// Methods called by interfaces are added in a follow-up change, once the
-// on-disk layout (export.sources manifest, per-connection unit directories)
-// is implemented.
+// Files returns the export tree content declared so far via
+// AddExportedFile, keyed by interface name, then by unit name (see
+// UnitName), then by the file's path relative to the unit.
+func (spec *Specification) Files() map[string]map[string]map[string]osutil.FileState {
+	return spec.files
+}
+
+// AddExportedFile records that state must be exported at path
+// "<unit>/<relPath>" within the tree for ifaceName (see InterfaceRoot).
+//
+// unit groups the file together with every other file contributed by the
+// same connection and, for content coming from a component, the same
+// component (see UnitName and exportUnitAndFileName in
+// interfaces/builtin/helpers.go). relPath is the file's path within the
+// unit, and must have at least one directory component (matching the
+// layout used by every current caller, e.g. "egl_vendor.d/<encoded-name>"),
+// since it is used verbatim, stripped of the unit prefix, to place the file
+// in the pooled directory delivered into a consuming snap's mount
+// namespace.
+//
+// It is an error to declare the same (ifaceName, unit, relPath) tuple
+// twice.
+func (spec *Specification) AddExportedFile(ifaceName, unit, relPath string, state osutil.FileState) error {
+	if ifaceName == "" || strings.ContainsRune(ifaceName, '/') {
+		return fmt.Errorf("export internal error: invalid interface name: %q", ifaceName)
+	}
+	if unit == "" || strings.ContainsRune(unit, '/') {
+		return fmt.Errorf("export internal error: invalid unit name: %q", unit)
+	}
+	if relPath != filepath.Clean(relPath) || filepath.IsAbs(relPath) {
+		return fmt.Errorf("export internal error: unclean or absolute path: %q", relPath)
+	}
+	if filepath.Dir(relPath) == "." {
+		return fmt.Errorf("export internal error: path must be inside a subdirectory: %q", relPath)
+	}
+
+	if spec.files == nil {
+		spec.files = make(map[string]map[string]map[string]osutil.FileState)
+	}
+	units, ok := spec.files[ifaceName]
+	if !ok {
+		units = make(map[string]map[string]osutil.FileState)
+		spec.files[ifaceName] = units
+	}
+	files, ok := units[unit]
+	if !ok {
+		files = make(map[string]osutil.FileState)
+		units[unit] = files
+	}
+	if _, ok := files[relPath]; ok {
+		return fmt.Errorf("export internal error: already declared file: %q", filepath.Join(unit, relPath))
+	}
+	files[relPath] = state
+	return nil
+}
 
 // Implementation of methods required by interfaces.Specification
 

--- a/interfaces/export/spec.go
+++ b/interfaces/export/spec.go
@@ -1,0 +1,129 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package export
+
+import (
+	"errors"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/snap"
+)
+
+// Specification assists in collecting the set of files that interfaces want
+// to export from a snap (or its components) to the system, for consumption
+// by snap-confine.
+//
+// Unlike the Backend itself (which is stateless and non-persistent) this type
+// holds internal state that is used by the export backend during the
+// interface setup process.
+type Specification struct {
+	// plugs is the list of plugs using the export backend for the snap.
+	plugs []string
+}
+
+// Plugs returns the plugs that use the export backend.
+func (spec *Specification) Plugs() []string {
+	return spec.plugs
+}
+
+// Methods called by interfaces are added in a follow-up change, once the
+// on-disk layout (export.sources manifest, per-connection unit directories)
+// is implemented.
+
+// Implementation of methods required by interfaces.Specification
+
+// ConnectedPlugCallback must be implemented as a minimum by users of this backend.
+type ConnectedPlugCallback interface {
+	ExportConnectedPlug(spec *Specification, plug *interfaces.ConnectedPlug,
+		slot *interfaces.ConnectedSlot) error
+}
+
+func getConnectedPlugCallback(iface interfaces.Interface, instanceName string) (
+	ConnectedPlugCallback, error) {
+	if iface, ok := iface.(ConnectedPlugCallback); ok {
+		if !interfaces.IsTheSystemSnap(instanceName) {
+			return nil, errors.New("internal error: export plugs can be defined only by the system snap")
+		}
+		return iface, nil
+	}
+	return nil, nil
+}
+
+// AddConnectedPlug records export-specific side-effects of having a connected plug.
+func (spec *Specification) AddConnectedPlug(iface interfaces.Interface, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	connectedPlugCallback, err := getConnectedPlugCallback(iface, plug.Snap().InstanceName())
+	if err != nil {
+		return err
+	}
+	if connectedPlugCallback != nil {
+		return connectedPlugCallback.ExportConnectedPlug(spec, plug, slot)
+	}
+	return nil
+}
+
+// AddConnectedSlot records export-specific side-effects of having a connected slot.
+func (spec *Specification) AddConnectedSlot(iface interfaces.Interface, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	type definer interface {
+		ExportConnectedSlot(spec *Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
+	}
+	if iface, ok := iface.(definer); ok {
+		if !interfaces.IsTheSystemSnap(plug.Snap().InstanceName()) {
+			return errors.New("internal error: export plugs can be defined only by the system snap")
+		}
+		return iface.ExportConnectedSlot(spec, plug, slot)
+	}
+	return nil
+}
+
+// AddPermanentPlug records export-specific side-effects of having a plug.
+func (spec *Specification) AddPermanentPlug(iface interfaces.Interface, plug *snap.PlugInfo) error {
+	// Note that ConnectedPlugCallback must be implemented, so we
+	// check for it instead of using ExportPermanentPlug.
+	connectedPlugCallback, err := getConnectedPlugCallback(iface, plug.Snap.InstanceName())
+	if err != nil {
+		return err
+	}
+	if connectedPlugCallback != nil {
+		// Keep track of interfaces using this backend on the consumer side
+		spec.plugs = append(spec.plugs, plug.Name)
+	}
+
+	type definer interface {
+		ExportPermanentPlug(spec *Specification, plug *snap.PlugInfo) error
+	}
+	if iface, ok := iface.(definer); ok {
+		if !interfaces.IsTheSystemSnap(plug.Snap.InstanceName()) {
+			return errors.New("internal error: export plugs can be defined only by the system snap")
+		}
+		return iface.ExportPermanentPlug(spec, plug)
+	}
+	return nil
+}
+
+// AddPermanentSlot records export-specific side-effects of having a slot.
+func (spec *Specification) AddPermanentSlot(iface interfaces.Interface, slot *snap.SlotInfo) error {
+	type definer interface {
+		ExportPermanentSlot(spec *Specification, slot *snap.SlotInfo) error
+	}
+	if iface, ok := iface.(definer); ok {
+		return iface.ExportPermanentSlot(spec, slot)
+	}
+	return nil
+}

--- a/interfaces/export/spec_test.go
+++ b/interfaces/export/spec_test.go
@@ -1,0 +1,156 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package export_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/export"
+	"github.com/snapcore/snapd/interfaces/ifacetest"
+	"github.com/snapcore/snapd/snap"
+)
+
+type specSuite struct {
+	spec     *export.Specification
+	iface1   *ifacetest.TestInterface
+	plugInfo *snap.PlugInfo
+	plug     *interfaces.ConnectedPlug
+	slotInfo *snap.SlotInfo
+	slot     *interfaces.ConnectedSlot
+
+	connectedPlugCalled bool
+	connectedSlotCalled bool
+	permanentPlugCalled bool
+	permanentSlotCalled bool
+}
+
+var _ = Suite(&specSuite{
+	iface1: &ifacetest.TestInterface{
+		InterfaceName: "test",
+	},
+})
+
+func (s *specSuite) SetUpTest(c *C) {
+	s.spec = &export.Specification{}
+	s.connectedPlugCalled = false
+	s.connectedSlotCalled = false
+	s.permanentPlugCalled = false
+	s.permanentSlotCalled = false
+
+	s.iface1.ExportConnectedPlugCallback = func(spec *export.Specification,
+		plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+		s.connectedPlugCalled = true
+		return nil
+	}
+	s.iface1.ExportConnectedSlotCallback = func(spec *export.Specification,
+		plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+		s.connectedSlotCalled = true
+		return nil
+	}
+	s.iface1.ExportPermanentPlugCallback = func(spec *export.Specification,
+		plug *snap.PlugInfo) error {
+		s.permanentPlugCalled = true
+		return nil
+	}
+	s.iface1.ExportPermanentSlotCallback = func(spec *export.Specification,
+		slot *snap.SlotInfo) error {
+		s.permanentSlotCalled = true
+		return nil
+	}
+
+	const plugYaml = `name: snapd
+version: 1
+apps:
+  app:
+    plugs: [name]
+`
+	s.plug, s.plugInfo = ifacetest.MockConnectedPlug(c, plugYaml, nil, "name")
+
+	const slotYaml = `name: snap
+version: 1
+slots:
+  name:
+    interface: test
+`
+	s.slot, s.slotInfo = ifacetest.MockConnectedSlot(c, slotYaml, nil, "name")
+}
+
+// The export.Specification can be used through the interfaces.Specification interface
+func (s *specSuite) TestSpecificationIface(c *C) {
+	var r interfaces.Specification = s.spec
+
+	c.Assert(r.AddConnectedPlug(s.iface1, s.plug, s.slot), IsNil)
+	c.Check(s.connectedPlugCalled, Equals, true)
+
+	c.Assert(r.AddConnectedSlot(s.iface1, s.plug, s.slot), IsNil)
+	c.Check(s.connectedSlotCalled, Equals, true)
+
+	c.Check(s.spec.Plugs(), HasLen, 0)
+	c.Assert(r.AddPermanentPlug(s.iface1, s.plugInfo), IsNil)
+	c.Check(s.permanentPlugCalled, Equals, true)
+	c.Check(s.spec.Plugs(), DeepEquals, []string{"name"})
+
+	c.Assert(r.AddPermanentSlot(s.iface1, s.slotInfo), IsNil)
+	c.Check(s.permanentSlotCalled, Equals, true)
+}
+
+func (s *specSuite) TestPlugNotFromSystem(c *C) {
+	const plugYaml = `name: notsystem
+version: 1
+apps:
+  app:
+    plugs: [name]
+`
+	s.plug, s.plugInfo = ifacetest.MockConnectedPlug(c, plugYaml, nil, "name")
+
+	var r interfaces.Specification = s.spec
+	c.Assert(r.AddConnectedPlug(s.iface1, s.plug, s.slot), ErrorMatches,
+		"internal error: export plugs can be defined only by the system snap")
+	c.Assert(r.AddConnectedSlot(s.iface1, s.plug, s.slot), ErrorMatches,
+		"internal error: export plugs can be defined only by the system snap")
+	c.Assert(r.AddPermanentPlug(s.iface1, s.plugInfo), ErrorMatches,
+		"internal error: export plugs can be defined only by the system snap")
+
+	// The connected-plug/slot and permanent-plug callbacks are never
+	// reached, since the system-snap check happens before dispatch.
+	c.Check(s.connectedPlugCalled, Equals, false)
+	c.Check(s.connectedSlotCalled, Equals, false)
+	c.Check(s.permanentPlugCalled, Equals, false)
+
+	// AddPermanentSlot has no system-snap restriction (it mirrors the
+	// slot-side behaviour of configfiles/symlinks).
+	c.Assert(r.AddPermanentSlot(s.iface1, s.slotInfo), IsNil)
+	c.Check(s.permanentSlotCalled, Equals, true)
+}
+
+func (s *specSuite) TestNoCallbacksIsNoop(c *C) {
+	// A TestInterface with no callbacks set still satisfies the
+	// ConnectedPlugCallback marker (the method is unconditionally defined
+	// on the type), so it is tracked in Plugs(), but invoking it must be a
+	// safe no-op since all the callback fields are nil.
+	plain := &ifacetest.TestInterface{InterfaceName: "plain"}
+	var r interfaces.Specification = s.spec
+	c.Assert(r.AddConnectedPlug(plain, s.plug, s.slot), IsNil)
+	c.Assert(r.AddConnectedSlot(plain, s.plug, s.slot), IsNil)
+	c.Assert(r.AddPermanentPlug(plain, s.plugInfo), IsNil)
+	c.Assert(r.AddPermanentSlot(plain, s.slotInfo), IsNil)
+	c.Check(s.spec.Plugs(), DeepEquals, []string{"name"})
+}

--- a/interfaces/ifacetest/testiface.go
+++ b/interfaces/ifacetest/testiface.go
@@ -24,6 +24,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/configfiles"
 	"github.com/snapcore/snapd/interfaces/dbus"
+	"github.com/snapcore/snapd/interfaces/export"
 	"github.com/snapcore/snapd/interfaces/hotplug"
 	"github.com/snapcore/snapd/interfaces/kmod"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
@@ -135,6 +136,13 @@ type TestInterface struct {
 	SymlinksConnectedSlotCallback func(spec *symlinks.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
 	SymlinksPermanentPlugCallback func(spec *symlinks.Specification, plug *snap.PlugInfo) error
 	SymlinksPermanentSlotCallback func(spec *symlinks.Specification, slot *snap.SlotInfo) error
+
+	// Support for interacting with the export backend.
+
+	ExportConnectedPlugCallback func(spec *export.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
+	ExportConnectedSlotCallback func(spec *export.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
+	ExportPermanentPlugCallback func(spec *export.Specification, plug *snap.PlugInfo) error
+	ExportPermanentSlotCallback func(spec *export.Specification, slot *snap.SlotInfo) error
 }
 
 // TestHotplugInterface is an interface for various kinds of tests
@@ -588,6 +596,34 @@ func (t *TestInterface) SymlinksPermanentPlug(spec *symlinks.Specification, plug
 func (t *TestInterface) SymlinksPermanentSlot(spec *symlinks.Specification, slot *snap.SlotInfo) error {
 	if t.SymlinksPermanentSlotCallback != nil {
 		return t.SymlinksPermanentSlotCallback(spec, slot)
+	}
+	return nil
+}
+
+func (t *TestInterface) ExportConnectedPlug(spec *export.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	if t.ExportConnectedPlugCallback != nil {
+		return t.ExportConnectedPlugCallback(spec, plug, slot)
+	}
+	return nil
+}
+
+func (t *TestInterface) ExportConnectedSlot(spec *export.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	if t.ExportConnectedSlotCallback != nil {
+		return t.ExportConnectedSlotCallback(spec, plug, slot)
+	}
+	return nil
+}
+
+func (t *TestInterface) ExportPermanentPlug(spec *export.Specification, plug *snap.PlugInfo) error {
+	if t.ExportPermanentPlugCallback != nil {
+		return t.ExportPermanentPlugCallback(spec, plug)
+	}
+	return nil
+}
+
+func (t *TestInterface) ExportPermanentSlot(spec *export.Specification, slot *snap.SlotInfo) error {
+	if t.ExportPermanentSlotCallback != nil {
+		return t.ExportPermanentSlotCallback(spec, slot)
 	}
 	return nil
 }

--- a/interfaces/symlinks/backend.go
+++ b/interfaces/symlinks/backend.go
@@ -174,6 +174,18 @@ func (b *Backend) ensureSymlinks(spec *Specification, symlinkDirs map[string]boo
 			for ln, target := range lnsToTarget {
 				lnPath := filepath.Join(dir, ln)
 				logger.Debugf("ensuring symlink %q -> %q", lnPath, target)
+				// TODO: the returned error is discarded here, so a
+				// failure to create/update a symlink (e.g. a
+				// permission problem, or the target vanishing
+				// between the spec being built and this point) is
+				// silently ignored instead of being reported or
+				// even logged - unlike the removal path just above
+				// (removeUnwantedInDir), which at least logs via
+				// logger.Noticef when os.Remove fails. Found while
+				// reviewing error handling for the export backend's
+				// equivalent write path (interfaces/export); not
+				// fixed here as it is pre-existing, unrelated
+				// behavior of this backend.
 				osutil.EnsureFileState(lnPath, &osutil.SymlinkFileState{Target: target})
 			}
 		}

--- a/tests/core/interfaces-driver-libs/task.yaml
+++ b/tests/core/interfaces-driver-libs/task.yaml
@@ -46,7 +46,10 @@ execute: |
   not test -f /etc/ld.so.conf.d/snap.system.conf
   not ls /etc/glvnd/egl_vendor.d/*snap* 2>/dev/null
 
-  # TODO: verify export/data/ ICD files once the support is added
+  # TODO: assert on the exported ICD content under
+  # /var/lib/snapd/export/system/egl-driver-libs/ (the manifest and the
+  # files it lists) once this test also covers what the export backend
+  # writes, not just .library-source.
 
   # Disconnect both interfaces and verify .library-source files are cleaned up
   snap disconnect system:egl-driver-libs "$PROVIDER_SNAP":egl-driver-libs

--- a/tests/core/interfaces-driver-libs/task.yaml
+++ b/tests/core/interfaces-driver-libs/task.yaml
@@ -15,6 +15,13 @@ environment:
   COMP2: comp2
 
 prepare: |
+  # Note: comp{1,2}/libs/lib{square,multiply}.so are empty stub files. The
+  # egl-driver-libs slot validates that the library_path named by each ICD
+  # file exists somewhere in library-source (filePathInLibDirs only checks
+  # for existence), and a library that cannot be found makes the export
+  # backend skip that ICD file. Without the stubs nothing would be exported
+  # and the export path would not be exercised at all. Nothing here loads
+  # them, so their content does not matter.
   snap pack "$PROVIDER_SNAP"
   snap pack "$COMP1"
   snap pack "$COMP2"


### PR DESCRIPTION
A WIP branch with all the changes for making the driver-libs interfaces usable on Ubuntu Core. The changes are described in a plan for the agent: https://gist.github.com/bboozzoo/1c6aad41da1d60fcd04784f152b8a6a7

Related: [SNAPDENG-37372](https://warthogs.atlassian.net/browse/SNAPDENG-37372) [SNAPDENG-37235](https://warthogs.atlassian.net/browse/SNAPDENG-37235) [SNAPDENG-37234](https://warthogs.atlassian.net/browse/SNAPDENG-37234)

[SNAPDENG-37372]: https://warthogs.atlassian.net/browse/SNAPDENG-37372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SNAPDENG-37235]: https://warthogs.atlassian.net/browse/SNAPDENG-37235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SNAPDENG-37234]: https://warthogs.atlassian.net/browse/SNAPDENG-37234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ