### PR TITLE
interfaces/builtin/u2f_devices.go: use fido-id udev builtin to identify devices

### DIFF
--- a/interfaces/builtin/u2f_devices.go
+++ b/interfaces/builtin/u2f_devices.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/udev"
+	"github.com/snapcore/snapd/systemd"
 )
 
 const u2fDevicesSummary = `allows access to u2f devices`
@@ -252,8 +253,16 @@ type u2fDevicesInterface struct {
 }
 
 func (iface *u2fDevicesInterface) UDevConnectedPlug(spec *udev.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	for _, d := range u2fDevices {
-		spec.TagDevice(fmt.Sprintf("# %s\nSUBSYSTEM==\"hidraw\", KERNEL==\"hidraw*\", ATTRS{idVendor}==\"%s\", ATTRS{idProduct}==\"%s\"", d.Name, d.VendorIDPattern, d.ProductIDPattern))
+
+	if err := systemd.EnsureAtLeast(244); err != nil {
+		if !systemd.IsSystemdTooOld(err) {
+			return err
+		}
+		for _, d := range u2fDevices {
+			spec.TagDevice(fmt.Sprintf("# %s\nSUBSYSTEM==\"hidraw\", KERNEL==\"hidraw*\", ATTRS{idVendor}==\"%s\", ATTRS{idProduct}==\"%s\"", d.Name, d.VendorIDPattern, d.ProductIDPattern))
+		}
+	} else {
+		spec.TagDevice(fmt.Sprintf("SUBSYSTEM==\"hidraw\", KERNEL==\"hidraw*\", ENV{ID_SECURITY_TOKEN}==\"1\""))
 	}
 	return nil
 }

--- a/interfaces/builtin/u2f_devices_test.go
+++ b/interfaces/builtin/u2f_devices_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/udev"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -88,7 +89,9 @@ func (s *u2fDevicesInterfaceSuite) TestAppArmorSpec(c *C) {
 	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, `/dev/hidraw* rwk,`)
 }
 
-func (s *u2fDevicesInterfaceSuite) TestUDevSpec(c *C) {
+func (s *u2fDevicesInterfaceSuite) TestUDevSpecOldSystemd(c *C) {
+	defer systemd.MockSystemdVersion(243, nil)()
+
 	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
 	c.Assert(err, IsNil)
 	spec := udev.NewSpecification(appSet)
@@ -97,6 +100,19 @@ func (s *u2fDevicesInterfaceSuite) TestUDevSpec(c *C) {
 	c.Assert(spec.Snippets(), testutil.Contains, `# u2f-devices
 # Yubico YubiKey
 SUBSYSTEM=="hidraw", KERNEL=="hidraw*", ATTRS{idVendor}=="1050", ATTRS{idProduct}=="0113|0114|0115|0116|0120|0121|0200|0402|0403|0406|0407|0410", TAG+="snap_consumer_app"`)
+	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
+}
+
+func (s *u2fDevicesInterfaceSuite) TestUDevSpec(c *C) {
+	defer systemd.MockSystemdVersion(244, nil)()
+
+	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
+	c.Assert(err, IsNil)
+	spec := udev.NewSpecification(appSet)
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+	c.Assert(spec.Snippets(), HasLen, 2)
+	c.Assert(spec.Snippets(), testutil.Contains, `# u2f-devices
+SUBSYSTEM=="hidraw", KERNEL=="hidraw*", ENV{ID_SECURITY_TOKEN}=="1", TAG+="snap_consumer_app"`)
 	c.Assert(spec.Snippets(), testutil.Contains, fmt.Sprintf(`TAG=="snap_consumer_app", SUBSYSTEM!="module", SUBSYSTEM!="subsystem", RUN+="%v/snap-device-helper $env{ACTION} snap_consumer_app $devpath $major:$minor"`, dirs.DistroLibExecDir))
 }
 


### PR DESCRIPTION
Because the list of usb ids might grow, that would need us to maintain that list. Instead we can rely on report_descriptor which identifies correctly u2f devices. And this is already parsed by fido-id by udev.

Suggested by https://bugs.launchpad.net/snapd/+bug/2164382