### PR TITLE
github: when the Skip spread label is present, use github-hosted runners for spread job

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -550,6 +550,17 @@ jobs:
                 echo "nested-systems=" >> $GITHUB_OUTPUT
               fi
             fi
+
+            if grep -q '^Skip spread$' <<<$labels; then
+              github_hosted_runs_on="['ubuntu-latest']"
+              fundamental_systems="$(jq -c --arg runs_on "$github_hosted_runs_on" '.include |= map(."runs-on" = $runs_on)' .github/workflows/data-fundamental-systems.json)"
+              non_fundamental_systems="$(jq -c --arg runs_on "$github_hosted_runs_on" '.include |= map(."runs-on" = $runs_on)' .github/workflows/data-non-fundamental-systems.json)"
+              nested_systems="$(jq -c --arg runs_on "$github_hosted_runs_on" '.include |= map(."runs-on" = $runs_on)' .github/workflows/data-nested-systems.json)"
+
+              echo "fundamental-systems=$fundamental_systems" >> $GITHUB_OUTPUT
+              echo "non-fundamental-systems=$non_fundamental_systems" >> $GITHUB_OUTPUT
+              echo "nested-systems=$nested_systems" >> $GITHUB_OUTPUT
+            fi
           fi
 
   spread-fundamental:


### PR DESCRIPTION
The purpose of this PR is to take the pressure off of the self-hosted runners.