### PR TITLE
o/devicestate: correct hardware ID hash field

### DIFF
--- a/overlord/devicestate/devicestate_serial_test.go
+++ b/overlord/devicestate/devicestate_serial_test.go
@@ -1219,9 +1219,9 @@ func (s *deviceMgrSerialSuite) TestFullDeviceRegistrationHappyPrepareSerialHook(
 	defer s.state.Unlock()
 
 	body := map[string]string{
-		"hardware-id-key":        "key",
-		"hardware-id-key-sha384": "hash",
-		"request-id-signature":   "signature",
+		"hardware-id-key":          "key",
+		"hardware-id-key-sha3-384": "hash",
+		"request-id-signature":     "signature",
 	}
 
 	encodedBody, err := json.Marshal(body)
@@ -1293,9 +1293,9 @@ func (s *deviceMgrSerialSuite) TestFullDeviceRegistrationHappyPrepareSerialHook(
 	c.Assert(err, IsNil)
 
 	c.Check(details, DeepEquals, map[string]any{
-		"hardware-id-key":        "key",
-		"hardware-id-key-sha384": "hash",
-		"request-id-signature":   "signature",
+		"hardware-id-key":          "key",
+		"hardware-id-key-sha3-384": "hash",
+		"request-id-signature":     "signature",
 	})
 
 	privKey, err := devicestate.KeypairManager(s.mgr).Get(serial.DeviceKey().ID())
@@ -1326,9 +1326,9 @@ func (s *deviceMgrSerialSuite) TestFullDeviceRegistrationFailingPrepareSerialHoo
 	defer s.state.Unlock()
 
 	body := map[string]string{
-		"hardware-id-key":        "key",
-		"hardware-id-key-sha384": "hash",
-		"request-id-signature":   "signature",
+		"hardware-id-key":          "key",
+		"hardware-id-key-sha3-384": "hash",
+		"request-id-signature":     "signature",
 	}
 
 	encodedBody, err := json.Marshal(body)
@@ -1425,9 +1425,9 @@ func (s *deviceMgrSerialSuite) TestFullDeviceRegistrationHappyPrepareDevicePrepa
 	}
 
 	body := map[string]string{
-		"hardware-id-key":        "key",
-		"hardware-id-key-sha384": "hash",
-		"request-id-signature":   "signature",
+		"hardware-id-key":          "key",
+		"hardware-id-key-sha3-384": "hash",
+		"request-id-signature":     "signature",
 	}
 
 	encodedBody, err := json.Marshal(body)
@@ -1499,9 +1499,9 @@ func (s *deviceMgrSerialSuite) TestFullDeviceRegistrationHappyPrepareDevicePrepa
 	c.Assert(err, IsNil)
 
 	c.Check(details, DeepEquals, map[string]any{
-		"hardware-id-key":        "key",
-		"hardware-id-key-sha384": "hash",
-		"request-id-signature":   "signature",
+		"hardware-id-key":          "key",
+		"hardware-id-key-sha3-384": "hash",
+		"request-id-signature":     "signature",
 	})
 
 	privKey, err := devicestate.KeypairManager(s.mgr).Get(serial.DeviceKey().ID())
@@ -1518,12 +1518,12 @@ func (s *deviceMgrSerialSuite) TestPrepareDeviceSerialHookNoOverwite(c *C) {
 
 func (s *deviceMgrSerialSuite) TestPrepareDeviceSerialHookMissingHWKeyHash(c *C) {
 	body := `{"hardware-id-key":"a",  "request-id-signature":"c"}`
-	expectedErr := `'prepare-serial-request' hook did not set mandatory field "hardware-id-key-sha384" in registration body`
+	expectedErr := `'prepare-serial-request' hook did not set mandatory field "hardware-id-key-sha3-384" in registration body`
 	s.testBadPrepareDeviceSerialHook(c, body, expectedErr)
 }
 
 func (s *deviceMgrSerialSuite) TestPrepareDeviceSerialHookMissingReqIDSignature(c *C) {
-	body := `{"hardware-id-key":"a", "hardware-id-key-sha384":"b"}`
+	body := `{"hardware-id-key":"a", "hardware-id-key-sha3-384":"b"}`
 	expectedErr := `'prepare-serial-request' hook did not set mandatory field "request-id-signature" in registration body`
 	s.testBadPrepareDeviceSerialHook(c, body, expectedErr)
 }

--- a/overlord/devicestate/devicestate_serial_test.go
+++ b/overlord/devicestate/devicestate_serial_test.go
@@ -1219,7 +1219,6 @@ func (s *deviceMgrSerialSuite) TestFullDeviceRegistrationHappyPrepareSerialHook(
 	defer s.state.Unlock()
 
 	body := map[string]string{
-		"hardware-id-key":          "key",
 		"hardware-id-key-sha3-384": "hash",
 		"request-id-signature":     "signature",
 	}
@@ -1293,7 +1292,6 @@ func (s *deviceMgrSerialSuite) TestFullDeviceRegistrationHappyPrepareSerialHook(
 	c.Assert(err, IsNil)
 
 	c.Check(details, DeepEquals, map[string]any{
-		"hardware-id-key":          "key",
 		"hardware-id-key-sha3-384": "hash",
 		"request-id-signature":     "signature",
 	})
@@ -1326,7 +1324,6 @@ func (s *deviceMgrSerialSuite) TestFullDeviceRegistrationFailingPrepareSerialHoo
 	defer s.state.Unlock()
 
 	body := map[string]string{
-		"hardware-id-key":          "key",
 		"hardware-id-key-sha3-384": "hash",
 		"request-id-signature":     "signature",
 	}
@@ -1425,7 +1422,6 @@ func (s *deviceMgrSerialSuite) TestFullDeviceRegistrationHappyPrepareDevicePrepa
 	}
 
 	body := map[string]string{
-		"hardware-id-key":          "key",
 		"hardware-id-key-sha3-384": "hash",
 		"request-id-signature":     "signature",
 	}
@@ -1499,7 +1495,6 @@ func (s *deviceMgrSerialSuite) TestFullDeviceRegistrationHappyPrepareDevicePrepa
 	c.Assert(err, IsNil)
 
 	c.Check(details, DeepEquals, map[string]any{
-		"hardware-id-key":          "key",
 		"hardware-id-key-sha3-384": "hash",
 		"request-id-signature":     "signature",
 	})
@@ -1517,13 +1512,13 @@ func (s *deviceMgrSerialSuite) TestPrepareDeviceSerialHookNoOverwite(c *C) {
 }
 
 func (s *deviceMgrSerialSuite) TestPrepareDeviceSerialHookMissingHWKeyHash(c *C) {
-	body := `{"hardware-id-key":"a",  "request-id-signature":"c"}`
+	body := `{"request-id-signature":"c"}`
 	expectedErr := `'prepare-serial-request' hook did not set mandatory field "hardware-id-key-sha3-384" in registration body`
 	s.testBadPrepareDeviceSerialHook(c, body, expectedErr)
 }
 
 func (s *deviceMgrSerialSuite) TestPrepareDeviceSerialHookMissingReqIDSignature(c *C) {
-	body := `{"hardware-id-key":"a", "hardware-id-key-sha3-384":"b"}`
+	body := `{"hardware-id-key-sha3-384":"b"}`
 	expectedErr := `'prepare-serial-request' hook did not set mandatory field "request-id-signature" in registration body`
 	s.testBadPrepareDeviceSerialHook(c, body, expectedErr)
 }

--- a/overlord/devicestate/handlers_serial.go
+++ b/overlord/devicestate/handlers_serial.go
@@ -1002,7 +1002,7 @@ func (m *DeviceManager) maybeRunPrepareSerialRequestHook(st *state.State, reques
 
 	// check for the minimal mandatory fields. We're not rejecting unknown fields
 	// for forwards compatibility
-	mandatory := []string{"hardware-id-key-sha384", "request-id-signature"}
+	mandatory := []string{"hardware-id-key-sha3-384", "request-id-signature"}
 	for _, field := range mandatory {
 		if _, ok := body[field]; !ok {
 			return nil, fmt.Errorf("'prepare-serial-request' hook did not set mandatory field %q in registration body", field)

--- a/tests/core/custom-device-reg-serial-request/prepare-serial-request
+++ b/tests/core/custom-device-reg-serial-request/prepare-serial-request
@@ -7,4 +7,4 @@ HASH="some-random-hash-value"
 REQUEST_ID=$(snapctl get registration.request-id)
 
 # Set the registration body
-snapctl set registration.body="{\"hardware-id-key\": \"$KEY\", \"hardware-id-key-sha384\": \"$HASH\", \"request-id-signature\": \"$REQUEST_ID\"}"
+snapctl set registration.body="{\"hardware-id-key\": \"$KEY\", \"hardware-id-key-sha3-384\": \"$HASH\", \"request-id-signature\": \"$REQUEST_ID\"}"


### PR DESCRIPTION
Update the prepare-serial-request registration body validation and its related tests to use the correct `hardware-id-key-sha3-384` field name. 

This keeps the mandatory-field check aligned with the hardware identity assertion field, the expectations of the model service, and updates the unit and integration test fixtures accordingly.