### PR TITLE
tests: do not put GOPATH in /tmp, use disk backed TMPDIR

### DIFF
--- a/cmd/snap-update-ns/utils_test.go
+++ b/cmd/snap-update-ns/utils_test.go
@@ -907,10 +907,11 @@ func (s *realSystemSuite) SetUpTest(c *C) {
 // This doesn't test the chown logic as that requires root.
 func (s *realSystemSuite) TestSecureMkdirAllWithinForReal(c *C) {
 	d := c.MkDir()
+	tmpDir := os.TempDir()
 	// Create d (which already exists) with mode 0777 (but c.MkDir() used 0700
 	// internally and since we are not creating the directory we should not be
 	// changing that.
-	c.Assert(update.MkdirAllWithin(d, "/tmp", 0777, sys.FlagID, sys.FlagID, nil), IsNil)
+	c.Assert(update.MkdirAllWithin(d, tmpDir, 0777, sys.FlagID, sys.FlagID, nil), IsNil)
 	fi, err := os.Stat(d)
 	c.Assert(err, IsNil)
 	c.Check(fi.IsDir(), Equals, true)
@@ -920,7 +921,7 @@ func (s *realSystemSuite) TestSecureMkdirAllWithinForReal(c *C) {
 	// check that it was applied. Note that default umask 022 is subtracted so
 	// effective directory has different permissions.
 	d1 := filepath.Join(d, "subdir")
-	c.Assert(update.MkdirAllWithin(d1, "/tmp", 0707, sys.FlagID, sys.FlagID, nil), IsNil)
+	c.Assert(update.MkdirAllWithin(d1, tmpDir, 0707, sys.FlagID, sys.FlagID, nil), IsNil)
 	fi, err = os.Stat(d1)
 	c.Assert(err, IsNil)
 	c.Check(fi.IsDir(), Equals, true)
@@ -929,7 +930,7 @@ func (s *realSystemSuite) TestSecureMkdirAllWithinForReal(c *C) {
 	// Create d2, which is a deeper subdirectory, with another distinct mode
 	// and check that it was applied.
 	d2 := filepath.Join(d, "subdir/subdir/subdir")
-	c.Assert(update.MkdirAllWithin(d2, "/tmp", 0750, sys.FlagID, sys.FlagID, nil), IsNil)
+	c.Assert(update.MkdirAllWithin(d2, tmpDir, 0750, sys.FlagID, sys.FlagID, nil), IsNil)
 	fi, err = os.Stat(d1)
 	c.Assert(err, IsNil)
 	c.Check(fi.IsDir(), Equals, true)

--- a/cmd/snapctl/tool/snap-exec/main_test.go
+++ b/cmd/snapctl/tool/snap-exec/main_test.go
@@ -641,6 +641,14 @@ func (s *snapExecSuite) TestSnapExecCompleteClassicReexec(c *C) {
 }
 
 func (s *snapExecSuite) TestSnapExecCompleteClassicNoReexec(c *C) {
+	// snap-exec normally receives SNAP_SAVED_TMPDIR without TMPDIR after passing
+	// through setuid snap-confine. remove the test runner's TMPDIR to simulate that.
+	tmpDir, tmpDirSet := os.LookupEnv("TMPDIR")
+	c.Assert(os.Unsetenv("TMPDIR"), IsNil)
+	if tmpDirSet {
+		defer os.Setenv("TMPDIR", tmpDir)
+	}
+
 	restore := release.MockReleaseInfo(&release.OS{ID: "centos"})
 	defer restore()
 	dirs.SetRootDir(c.MkDir())

--- a/cmd/snapd/cli/cmd_run_test.go
+++ b/cmd/snapd/cli/cmd_run_test.go
@@ -1868,7 +1868,7 @@ func (s *RunSuite) TestSnapRunXauthorityMigration(c *check.C) {
 	})
 	defer restorer()
 
-	xauthPath, err := x11.MockXauthority(2)
+	xauthPath, err := x11.MockXauthorityAt("/tmp", 2)
 	c.Assert(err, check.IsNil)
 	defer os.Remove(xauthPath)
 

--- a/osutil/unlink_test.go
+++ b/osutil/unlink_test.go
@@ -22,6 +22,7 @@ package osutil_test
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 
 	"gopkg.in/check.v1"
@@ -89,11 +90,11 @@ func (s *unlinkSuite) TestUnlinkManyFails(c *check.C) {
 		{
 			dirname:   filepath.Join(s.d, "does-not-exist"),
 			filenames: []string{"bar", "baz"},
-			expected:  `open /tmp/.*/does-not-exist: no such file or directory`,
+			expected:  `open ` + regexp.QuoteMeta(filepath.Join(s.d, "does-not-exist")) + `: no such file or directory`,
 		}, {
 			dirname:   filepath.Join(s.d, "foo"),
 			filenames: []string{"bar", "baz"},
-			expected:  `open /tmp/.*/foo: not a directory`,
+			expected:  `open ` + regexp.QuoteMeta(filepath.Join(s.d, "foo")) + `: not a directory`,
 		}, {
 			dirname:   s.d,
 			filenames: []string{"bar", "dir", "baz"},

--- a/snap/squashfs/delta_test.go
+++ b/snap/squashfs/delta_test.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"time"
 
 	. "gopkg.in/check.v1"
@@ -384,6 +385,7 @@ func (s *DeltaTestSuite) TestGenerateDeltaSnapXdelta3Success(c *C) {
 	snapdBinDir := "/usr/bin/"
 	unsquashfsPath := filepath.Join(snapdBinDir, "unsquashfs")
 	xdelta3Path := filepath.Join(snapdBinDir, "xdelta3")
+	tmpDirPattern := regexp.QuoteMeta(filepath.Clean(os.TempDir()))
 	defer squashfs.MockCommandFromSystemSnapWithContext(
 		func(ctx context.Context, cmd string, args ...string) (*exec.Cmd, error) {
 			return &exec.Cmd{Path: cmd, Args: append([]string{cmd}, args...)}, nil
@@ -402,7 +404,7 @@ func (s *DeltaTestSuite) TestGenerateDeltaSnapXdelta3Success(c *C) {
 			c.Check(len(unsquashfsArgs1), Equals, 9)
 			c.Check(unsquashfsArgs1[0:7], DeepEquals,
 				[]string{unsquashfsPath, "-da", "128", "-fr", "128", "-no-progress", "-pf"})
-			c.Check(unsquashfsArgs1[7], Matches, "/tmp/snap-delta-.*/src-pipe")
+			c.Check(unsquashfsArgs1[7], Matches, tmpDirPattern+`/snap-delta-.*/src-pipe`)
 			c.Check(unsquashfsArgs1[8], Matches, "*./source.snap")
 
 			// 2. Assert on Unsquashfs Target
@@ -410,15 +412,15 @@ func (s *DeltaTestSuite) TestGenerateDeltaSnapXdelta3Success(c *C) {
 			c.Check(len(unsquashfsArgs2), Equals, 8)
 			c.Check(unsquashfsArgs2[0:6], DeepEquals,
 				[]string{unsquashfsPath, "-da", "128", "-fr", "128", "-pf"})
-			c.Check(unsquashfsArgs2[6], Matches, "/tmp/snap-delta-.*/trgt-pipe")
+			c.Check(unsquashfsArgs2[6], Matches, tmpDirPattern+`/snap-delta-.*/trgt-pipe`)
 			c.Check(unsquashfsArgs2[7], Matches, "*./target.snap")
 
 			// 3. Assert on Xdelta3
 			xdelta3Args := cmds[2].Args
 			c.Check(len(xdelta3Args), Equals, 8)
 			c.Check(xdelta3Args[0:6], DeepEquals, []string{xdelta3Path, "-7", "-e", "-f", "-A", "-s"})
-			c.Check(xdelta3Args[6], Matches, "/tmp/snap-delta-.*/src-pipe")
-			c.Check(xdelta3Args[7], Matches, "/tmp/snap-delta-.*/trgt-pipe")
+			c.Check(xdelta3Args[6], Matches, tmpDirPattern+`/snap-delta-.*/src-pipe`)
+			c.Check(xdelta3Args[7], Matches, tmpDirPattern+`/snap-delta-.*/trgt-pipe`)
 			return nil
 		})()
 
@@ -637,6 +639,7 @@ func (s *DeltaTestSuite) TestApplyDeltaSnapXdelta3Success(c *C) {
 	unsquashfsPath := filepath.Join(snapdBinDir, "unsquashfs")
 	xdelta3Path := filepath.Join(snapdBinDir, "xdelta3")
 	mksquashfsPath := filepath.Join(snapdBinDir, "mksquashfs")
+	tmpDirPattern := regexp.QuoteMeta(filepath.Clean(os.TempDir()))
 	defer squashfs.MockCommandFromSystemSnapWithContext(
 		func(ctx context.Context, cmd string, args ...string) (*exec.Cmd, error) {
 			return &exec.Cmd{Path: cmd, Args: append([]string{cmd}, args...)}, nil
@@ -669,8 +672,8 @@ func (s *DeltaTestSuite) TestApplyDeltaSnapXdelta3Success(c *C) {
 			c.Check(cmds[2].Path, Equals, xdelta3Path)
 			c.Check(len(cmds[2].Args), Equals, 6)
 			c.Check(cmds[2].Args[0:3], DeepEquals, []string{xdelta3Path, "-d", "-f"})
-			c.Check(cmds[2].Args[4], Matches, `/tmp/snap-delta-.*/src`)
-			c.Check(cmds[2].Args[5], Matches, `/tmp/snap-delta-.*/delta`)
+			c.Check(cmds[2].Args[4], Matches, tmpDirPattern+`/snap-delta-.*/src`)
+			c.Check(cmds[2].Args[5], Matches, tmpDirPattern+`/snap-delta-.*/delta`)
 
 			// Create the target file so that growSnapToMinSize can stat it.
 			return os.WriteFile("target.snap", make([]byte, squashfs.MinimumSnapSize), 0644)

--- a/tests/unit/go/task.yaml
+++ b/tests/unit/go/task.yaml
@@ -76,7 +76,7 @@ execute: |
         if [ "$VARIANT" = "static" ] ; then
             tests.session -u test exec sh -c "cd $testdir/snapd && \
                 PATH=$PATH \
-                GOPATH=/tmp/static-unit-tests \
+                TMPDIR=/var/tmp \
                 $PROXY_PARAM \
                 ${skip:-} \
                 SKIP_TESTS_FORMAT_CHECK=1 \
@@ -86,7 +86,7 @@ execute: |
         else
             tests.session -u test exec sh -c "cd $testdir/snapd && \
                 PATH=$PATH \
-                GOPATH=/tmp/static-unit-tests \
+                TMPDIR=/var/tmp \
                 $PROXY_PARAM \
                 SKIP_COVERAGE=1 \
                 CC=$VARIANT \
@@ -115,7 +115,7 @@ execute: |
             # 14.04 only
             su -l -c "cd $testdir/snapd && \
                 PATH=$PATH \
-                GOPATH=/tmp/static-unit-tests \
+                TMPDIR=/var/tmp \
                 $PROXY_PARAM \
                 ${skip:-} \
                 SKIP_TESTS_FORMAT_CHECK=1 \
@@ -125,7 +125,7 @@ execute: |
         else
             su -l -c "cd $testdir/snapd && \
                 PATH=$PATH \
-                GOPATH=/tmp/static-unit-tests \
+                TMPDIR=/var/tmp \
                 $PROXY_PARAM \
                 SKIP_COVERAGE=1 \
                 CC=$VARIANT \

--- a/x11/xauth.go
+++ b/x11/xauth.go
@@ -118,10 +118,9 @@ func ValidateXauthority(r io.Reader) error {
 	return nil
 }
 
-// MockXauthority will create a fake xauthority file and place it
-// on a temporary path which is returned as result.
-func MockXauthority(cookies int) (string, error) {
-	f, err := os.CreateTemp("", "xauth")
+// MockXauthorityAt creates a fake xauthority file in dir and returns its path.
+func MockXauthorityAt(dir string, cookies int) (string, error) {
+	f, err := os.CreateTemp(dir, "xauth")
 	if err != nil {
 		return "", err
 	}

--- a/x11/xauth_test.go
+++ b/x11/xauth_test.go
@@ -41,7 +41,7 @@ func (s *xauthTestSuite) TestXauthFileNotAvailable(c *C) {
 }
 
 func (s *xauthTestSuite) TestXauthFileExistsButIsEmpty(c *C) {
-	xauthPath, err := x11.MockXauthority(0)
+	xauthPath, err := x11.MockXauthorityAt(c.MkDir(), 0)
 	c.Assert(err, IsNil)
 	defer os.Remove(xauthPath)
 
@@ -64,8 +64,9 @@ func (s *xauthTestSuite) TestXauthFileExistsButHasInvalidContent(c *C) {
 }
 
 func (s *xauthTestSuite) TestValidXauthFile(c *C) {
+	dir := c.MkDir()
 	for _, n := range []int{1, 2, 4} {
-		path, err := x11.MockXauthority(n)
+		path, err := x11.MockXauthorityAt(dir, n)
 		c.Assert(err, IsNil)
 		err = x11.ValidateXauthorityFile(path)
 		c.Assert(err, IsNil)


### PR DESCRIPTION
Example of the failure:
```
github.com/snapcore/snapd/tests/lib/muinstaller: write /tmp/go-build3757715198/b603/importcfg: disk quota exceeded
```

We can just use the disk, hopefully it isn't shockingly slow.