### PR TITLE
snapdtool: add InternalLibExecDir helper (p0)

### DIFF
--- a/snapdtool/tool_linux.go
+++ b/snapdtool/tool_linux.go
@@ -20,6 +20,7 @@
 package snapdtool
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -54,6 +55,8 @@ var (
 
 	syscallExec = syscall.Exec
 	osReadlink  = os.Readlink
+
+	errNoInternalLibExecDir = errors.New("cannot find internal libexec directory")
 )
 
 // DistroSupportsReExec returns true if the distribution we are running on can use re-exec.
@@ -97,6 +100,33 @@ func candidateVersionNewer(coreOrSnapdPath string) (bool, error) {
 	return true, nil
 }
 
+// InternalLibExecDir returns the libexec directory for the currently executing
+// process. The return value is either the distro libexec directory or the
+// libexec directory in the core/snapd snap if the current binary is run from
+// that location.
+func InternalLibExecDir() (string, error) {
+	exe, err := osReadlink(selfExe)
+	if err != nil {
+		return "", err
+	}
+
+	if !strings.HasPrefix(exe, dirs.DistroLibExecDir) {
+		idx := strings.LastIndex(exe, "/usr/")
+		if idx > 0 {
+			prefix := exe[:idx]
+			libExecDir := filepath.Join(prefix, dirs.CoreLibExecDir)
+			if osutil.IsDirectory(libExecDir) {
+				return libExecDir, nil
+			}
+		}
+	}
+
+	if osutil.IsDirectory(dirs.DistroLibExecDir) {
+		return dirs.DistroLibExecDir, nil
+	}
+	return "", errNoInternalLibExecDir
+}
+
 // InternalToolPath returns the path of an internal snapd tool. The tool
 // *must* be located inside the same tree as the current binary.
 //
@@ -106,33 +136,20 @@ func candidateVersionNewer(coreOrSnapdPath string) (bool, error) {
 func InternalToolPath(tool string) (string, error) {
 	distroTool := filepath.Join(dirs.DistroLibExecDir, tool)
 
-	// find the internal path relative to the running snapd, this
-	// ensure we don't rely on the state of the system (like
-	// having a valid "current" symlink).
-	exe, err := osReadlink("/proc/self/exe")
+	libExecDir, err := InternalLibExecDir()
 	if err != nil {
+		if errors.Is(err, errNoInternalLibExecDir) {
+			return distroTool, nil
+		}
 		return "", err
 	}
-
-	if !strings.HasPrefix(exe, dirs.DistroLibExecDir) {
-		// either running from mounted location or /usr/bin/snap*
-
-		// find the local prefix to the snap:
-		// /snap/snapd/123/usr/bin/snap       -> /snap/snapd/123
-		// /snap/core/234/usr/lib/snapd/snapd -> /snap/core/234
-		idx := strings.LastIndex(exe, "/usr/")
-		if idx > 0 {
-			// only assume mounted location when path contains
-			// /usr/, but does not start with one
-			prefix := exe[:idx]
-			maybeTool := filepath.Join(prefix, "/usr/lib/snapd", tool)
-			if osutil.IsExecutable(maybeTool) {
-				return maybeTool, nil
-			}
-		}
+	if libExecDir == dirs.DistroLibExecDir {
+		return distroTool, nil
 	}
-
-	// fallback to distro tool
+	snapTool := filepath.Join(libExecDir, tool)
+	if osutil.IsExecutable(snapTool) {
+		return snapTool, nil
+	}
 	return distroTool, nil
 }
 

--- a/snapdtool/tool_other.go
+++ b/snapdtool/tool_other.go
@@ -22,6 +22,10 @@ package snapdtool
 
 import (
 	"errors"
+	"fmt"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
 )
 
 var errUnsupported = errors.New("unsupported on non-Linux systems")
@@ -31,6 +35,17 @@ var errUnsupported = errors.New("unsupported on non-Linux systems")
 // On this OS this is a stub.
 func ExecInSnapdOrCoreSnap() {
 	return
+}
+
+// InternalLibExecDir returns the libexec directory for the currently executing
+// process.
+//
+// On this OS this falls back to the distro libexec directory.
+func InternalLibExecDir() (string, error) {
+	if osutil.IsDirectory(dirs.DistroLibExecDir) {
+		return dirs.DistroLibExecDir, nil
+	}
+	return "", fmt.Errorf("cannot find internal libexec directory")
 }
 
 // InternalToolPath returns the path of an internal snapd tool. The tool

--- a/snapdtool/tool_test.go
+++ b/snapdtool/tool_test.go
@@ -222,6 +222,42 @@ func (s *toolSuite) TestSystemSnapSupportsReExec(c *C) {
 	c.Check(err, IsNil)
 }
 
+func (s *toolSuite) TestInternalLibExecDirNoReexec(c *C) {
+	c.Assert(os.MkdirAll(dirs.DistroLibExecDir, 0755), IsNil)
+	restore := snapdtool.MockOsReadlink(func(string) (string, error) {
+		return filepath.Join(dirs.DistroLibExecDir, "snapd"), nil
+	})
+	defer restore()
+
+	dir, err := snapdtool.InternalLibExecDir()
+	c.Check(err, IsNil)
+	c.Check(dir, Equals, dirs.DistroLibExecDir)
+}
+
+func (s *toolSuite) TestInternalLibExecDirReadlinkError(c *C) {
+	restore := snapdtool.MockOsReadlink(func(string) (string, error) {
+		return "", fmt.Errorf("boom")
+	})
+	defer restore()
+
+	dir, err := snapdtool.InternalLibExecDir()
+	c.Check(err, ErrorMatches, "boom")
+	c.Check(dir, Equals, "")
+}
+
+func (s *toolSuite) TestInternalLibExecDirWithReexec(c *C) {
+	libExecDir := filepath.Join(s.snapdPath, "usr/lib/snapd")
+	c.Assert(os.MkdirAll(libExecDir, 0755), IsNil)
+	restore := snapdtool.MockOsReadlink(func(string) (string, error) {
+		return filepath.Join(s.snapdPath, "/usr/lib/snapd/snapd"), nil
+	})
+	defer restore()
+
+	dir, err := snapdtool.InternalLibExecDir()
+	c.Assert(err, IsNil)
+	c.Check(dir, Equals, libExecDir)
+}
+
 func (s *toolSuite) TestInternalToolPathNoReexec(c *C) {
 	restore := snapdtool.MockOsReadlink(func(string) (string, error) {
 		return filepath.Join(dirs.DistroLibExecDir, "snapd"), nil
@@ -231,6 +267,17 @@ func (s *toolSuite) TestInternalToolPathNoReexec(c *C) {
 	path, err := snapdtool.InternalToolPath("potato")
 	c.Check(err, IsNil)
 	c.Check(path, Equals, filepath.Join(dirs.DistroLibExecDir, "potato"))
+}
+
+func (s *toolSuite) TestInternalToolPathReadlinkError(c *C) {
+	restore := snapdtool.MockOsReadlink(func(string) (string, error) {
+		return "", fmt.Errorf("boom")
+	})
+	defer restore()
+
+	path, err := snapdtool.InternalToolPath("potato")
+	c.Check(err, ErrorMatches, "boom")
+	c.Check(path, Equals, "")
 }
 
 func (s *toolSuite) TestInternalToolPathWithReexec(c *C) {


### PR DESCRIPTION
Extract `InternalLibExecDir()` from `InternalToolPath` so callers can locate the running snapd's libexec dir (distro package or re-execed snap) without requiring a tool binary.

[Split from #17509.](https://github.com/canonical/snapd/pull/17509)

JIRA: https://warthogs.atlassian.net/browse/SNAPDENG-35855