### PR TITLE
tests: extend nested tests support for openstack-validation backend

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -1323,7 +1323,7 @@ nested_create_vm_service() {
     elif [[ "$SPREAD_BACKEND" = openstack-arm-ext* ]]; then
         PARAM_MEM="-m ${NESTED_MEM:-8192}"
         PARAM_SMP="-smp ${NESTED_CPUS:-6}"
-    elif [[ "$SPREAD_BACKEND" = openstack-ext* ]]; then
+    elif [[ "$SPREAD_BACKEND" = openstack-ext* ]] || [[ "$SPREAD_BACKEND" = "openstack-validation" ]]; then
         PARAM_MEM="-m ${NESTED_MEM:-4096}"
         PARAM_SMP="-smp ${NESTED_CPUS:-3}"
     else


### PR DESCRIPTION
The idea of this change is to allow nested executions using the openstack-validation backend which is now used for edge/beta validation