### PR TITLE
interfaces/builtin/content: add support for sharing content from snap components

### DIFF
--- a/interfaces/builtin/content.go
+++ b/interfaces/builtin/content.go
@@ -101,30 +101,37 @@ const componentPrefix = "$SNAP_COMPONENT("
 // parseComponentPath decomposes a $SNAP_COMPONENT(<name>)[/<sub>] path.
 //
 // If the path is not a component path (does not start with componentPrefix),
-// isComponent is false and the other return values are zero.
+// isComponent is false and the other return values are empty.
 //
 // If it is a component path, compName holds the component name and subPath
 // holds the remainder (possibly empty, meaning the whole component is shared).
-// err is set when the path is malformed. Whole-component sharing is allowed:
-// both $SNAP_COMPONENT(foo) and $SNAP_COMPONENT(foo)/ resolve with subPath == "".
+// err is set when the path is malformed, or when the subpath (when present)
+// does not pass the same validation as ordinary paths. Whole-component
+// sharing is allowed: both $SNAP_COMPONENT(foo) and $SNAP_COMPONENT(foo)/
+// resolve with subPath == "".
 func parseComponentPath(path string) (compName, subPath string, isComponent bool, err error) {
 	if !strings.HasPrefix(path, componentPrefix) {
 		return "", "", false, nil
 	}
 	rest := path[len(componentPrefix):]
 	compName, tail, had := strings.Cut(rest, ")")
-	if !had || compName == "" {
+	if !had || compName == "" || (tail != "" && !strings.HasPrefix(tail, "/")) {
 		return "", "", true, fmt.Errorf("invalid format in path %q", path)
 	}
 	if tail == "" || tail == "/" {
 		// Whole-component sharing: $SNAP_COMPONENT(foo) or $SNAP_COMPONENT(foo)/
 		return compName, "", true, nil
 	}
-	if !strings.HasPrefix(tail, "/") {
-		// Trailing non-slash characters after ), e.g. $SNAP_COMPONENT(foo)bar
-		return "", "", true, fmt.Errorf("invalid format in path %q", path)
+
+	// $SNAP_COMPONENT(foo)/bar -> bar
+	subPath = tail[1:]
+	if subPath != "" {
+		if err := validatePath(subPath); err != nil {
+			return "", "", true, err
+		}
 	}
-	return compName, tail[1:], true, nil
+
+	return compName, subPath, true, nil
 }
 
 func checkLabelAttributes(attrs map[string]any, nameDef string) error {
@@ -188,28 +195,26 @@ func (iface *contentInterface) BeforePrepareSlot(slot *snap.SlotInfo) error {
 	// reference a component declared in the snap, and their subpath (when
 	// present) must pass the same validation as ordinary paths.
 	for _, p := range wpath {
-		if _, _, isComp, err := parseComponentPath(p); err != nil {
-			return err
-		} else if isComp {
+		// isComp is checked before err so that even a malformed component
+		// path (e.g. dirty subpath) in a write list reports the read-only
+		// restriction.
+		if _, _, isComp, err := parseComponentPath(p); isComp {
 			return fmt.Errorf("component paths can only be used with read, not write: %q", p)
+		} else if err != nil {
+			return err
 		}
 		if err := validatePath(p); err != nil {
 			return err
 		}
 	}
 	for _, p := range rpath {
-		compName, subPath, isComp, err := parseComponentPath(p)
+		compName, _, isComp, err := parseComponentPath(p)
 		if err != nil {
 			return err
 		}
 		if isComp {
 			if _, ok := slot.Snap.Components[compName]; !ok {
 				return fmt.Errorf("component %s specified in path %q is not defined in the snap", compName, p)
-			}
-			if subPath != "" {
-				if err := validatePath(subPath); err != nil {
-					return err
-				}
 			}
 			continue
 		}
@@ -294,12 +299,39 @@ func resolveSpecialVariable(path string, snapInfo *snap.Info, perspective snap.E
 	return snapInfo.ExpandSnapVariablesSetSnapMountDir(filepath.Join("$SNAP", path), dirs.CoreSnapMountDir, perspective)
 }
 
+// componentSource resolves the source path and the basename to use for
+// target derivation for an installed component. ok is false if the
+// component is declared in the snap but not installed (absent from the
+// app set).
+func componentSource(slot *interfaces.ConnectedSlot, compName, subPath string) (source, sourceName string, ok bool) {
+	ci := slot.AppSet().Component(compName)
+	if ci == nil {
+		// Component declared but not installed.
+		return "", "", false
+	}
+	// snap.ComponentMountDir is rooted at dirs.SnapMountDir, but content
+	// interface paths must use dirs.CoreSnapMountDir to be consistent with
+	// $SNAP resolution and visible inside the snap mount namespace (where
+	// /snap is the mount point, not /var/lib/snapd/snap).
+	compMountDir := snap.ComponentMountDir(compName, ci.Revision, slot.Snap().InstanceName())
+	source = filepath.Clean(filepath.Join(
+		dirs.CoreSnapMountDir, strings.TrimPrefix(compMountDir, dirs.SnapMountDir), subPath))
+	if subPath == "" {
+		// Whole-component sharing: use the component name as the
+		// basename so that, with a "source" section present, the target
+		// resolves to <target>/<compName> rather than the revision
+		// directory.
+		sourceName = compName
+	}
+	return source, sourceName, true
+}
+
 // sourceTarget resolves the source and target paths for a given read/write
 // slot path. For component paths ($SNAP_COMPONENT(...)), the source is the
 // component mount directory of the installed component; if the component is
-// declared but not installed (not present in the slot's app set), ok is false
-// and the caller should skip the path. For ordinary paths the behavior is
-// unchanged and ok is always true.
+// declared in the snap but not installed (absent from the slot's app set),
+// ok is false and the caller should skip the path. For ordinary paths the
+// behavior is unchanged and ok is always true.
 func sourceTarget(plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot, relSrc string) (source, target string, ok bool) {
 	// The 'target' attribute has already been verified in BeforePreparePlug.
 	_ = plug.Attr("target", &target)
@@ -311,30 +343,9 @@ func sourceTarget(plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot
 	var sourceName string
 
 	if compName, subPath, isComp, err := parseComponentPath(relSrc); err == nil && isComp {
-		var ci *snap.ComponentInfo
-		for _, comp := range slot.AppSet().Components() {
-			if comp.Component.ComponentName == compName {
-				ci = comp
-				break
-			}
-		}
-		if ci == nil {
-			// Component declared but not installed: skip this path.
+		source, sourceName, ok = componentSource(slot, compName, subPath)
+		if !ok {
 			return "", "", false
-		}
-		// snap.ComponentMountDir is rooted at dirs.SnapMountDir, but content
-		// interface paths must use dirs.CoreSnapMountDir to be consistent with
-		// $SNAP resolution and visible inside the snap mount namespace (where
-		// /snap is the mount point, not /var/lib/snapd/snap).
-		compMountDir := snap.ComponentMountDir(compName, ci.Revision, slot.Snap().InstanceName())
-		source = filepath.Clean(filepath.Join(
-			dirs.CoreSnapMountDir, strings.TrimPrefix(compMountDir, dirs.SnapMountDir), subPath))
-		if subPath == "" {
-			// Whole-component sharing: use the component name as the
-			// basename so that, with a "source" section present, the target
-			// resolves to <target>/<compName> rather than the revision
-			// directory.
-			sourceName = compName
 		}
 	} else {
 		// Errors from parseComponentPath are safely ignored here: the slot
@@ -357,6 +368,9 @@ func sourceTarget(plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot
 	return source, target, true
 }
 
+// mountEntry builds the bind-mount entry for a read/write slot path. ok is
+// false if the path references a component that is declared in the snap but
+// not installed; the caller should then skip the entry.
 func mountEntry(plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot, relSrc string, extraOptions ...string) (osutil.MountEntry, bool) {
 	options := make([]string, 0, len(extraOptions)+1)
 	options = append(options, "bind")

--- a/interfaces/builtin/content.go
+++ b/interfaces/builtin/content.go
@@ -91,6 +91,47 @@ func validatePath(path string) error {
 	return nil
 }
 
+// componentPrefix is the marker introducing a component-relative path in a
+// content slot attribute, e.g. $SNAP_COMPONENT(mycomp)/share. The same
+// constant is also defined in interfaces/builtin/helpers.go (for
+// validateSourceDirs) and interfaces/snap_app_set.go (for
+// ExpandSliceSnapVariablesWithOrder); keep them in sync.
+const componentPrefix = "$SNAP_COMPONENT("
+
+// parseComponentPath decomposes a $SNAP_COMPONENT(<name>)[/<sub>] path.
+//
+// If the path is not a component path (does not start with componentPrefix),
+// isComponent is false and the other return values are zero.
+//
+// If it is a component path, compName holds the component name and subPath
+// holds the remainder (possibly empty, meaning the whole component is shared).
+// err is set when the path is malformed. Whole-component sharing is allowed:
+// both $SNAP_COMPONENT(foo) and $SNAP_COMPONENT(foo)/ resolve with subPath == "".
+func parseComponentPath(path string) (compName, subPath string, isComponent bool, err error) {
+	if !strings.HasPrefix(path, componentPrefix) {
+		return "", "", false, nil
+	}
+	rest := path[len(componentPrefix):]
+	closeIdx := strings.IndexByte(rest, ')')
+	if closeIdx < 0 {
+		return "", "", true, fmt.Errorf("invalid format in path %q", path)
+	}
+	compName = rest[:closeIdx]
+	if compName == "" {
+		return "", "", true, fmt.Errorf("invalid format in path %q", path)
+	}
+	tail := rest[closeIdx+1:]
+	if tail == "" || tail == "/" {
+		// Whole-component sharing: $SNAP_COMPONENT(foo) or $SNAP_COMPONENT(foo)/
+		return compName, "", true, nil
+	}
+	if !strings.HasPrefix(tail, "/") {
+		// Trailing non-slash characters after ), e.g. $SNAP_COMPONENT(foo)bar
+		return "", "", true, fmt.Errorf("invalid format in path %q", path)
+	}
+	return compName, tail[1:], true, nil
+}
+
 func checkLabelAttributes(attrs map[string]any, nameDef string) error {
 	// The ContentCompatLabel feature is checked only at matching time,
 	// here we allow the compatibility labels to exist in any case as it
@@ -147,10 +188,36 @@ func (iface *contentInterface) BeforePrepareSlot(slot *snap.SlotInfo) error {
 		return fmt.Errorf("read or write path must be set")
 	}
 
-	// go over both paths
-	paths := rpath
-	paths = append(paths, wpath...)
-	for _, p := range paths {
+	// Component paths ($SNAP_COMPONENT(...)) are only permitted in read
+	// paths; they are rejected for write paths. Read component paths must
+	// reference a component declared in the snap, and their subpath (when
+	// present) must pass the same validation as ordinary paths.
+	for _, p := range wpath {
+		if _, _, isComp, err := parseComponentPath(p); err != nil {
+			return err
+		} else if isComp {
+			return fmt.Errorf("component paths can only be used with read, not write: %q", p)
+		}
+		if err := validatePath(p); err != nil {
+			return err
+		}
+	}
+	for _, p := range rpath {
+		compName, subPath, isComp, err := parseComponentPath(p)
+		if err != nil {
+			return err
+		}
+		if isComp {
+			if _, ok := slot.Snap.Components[compName]; !ok {
+				return fmt.Errorf("component %s specified in path %q is not defined in the snap", compName, p)
+			}
+			if subPath != "" {
+				if err := validatePath(subPath); err != nil {
+					return err
+				}
+			}
+			continue
+		}
 		if err := validatePath(p); err != nil {
 			return err
 		}
@@ -232,37 +299,79 @@ func resolveSpecialVariable(path string, snapInfo *snap.Info, perspective snap.E
 	return snapInfo.ExpandSnapVariablesSetSnapMountDir(filepath.Join("$SNAP", path), dirs.CoreSnapMountDir, perspective)
 }
 
-func sourceTarget(plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot, relSrc string) (string, string) {
-	var target string
+// sourceTarget resolves the source and target paths for a given read/write
+// slot path. For component paths ($SNAP_COMPONENT(...)), the source is the
+// component mount directory of the installed component; if the component is
+// declared but not installed (not present in the slot's app set), ok is false
+// and the caller should skip the path. For ordinary paths the behavior is
+// unchanged and ok is always true.
+func sourceTarget(plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot, relSrc string) (source, target string, ok bool) {
 	// The 'target' attribute has already been verified in BeforePreparePlug.
 	_ = plug.Attr("target", &target)
-	// Source uses PerspectiveOther to resolve $SNAP to the provider's instance
-	// name, ensuring we mount content from the exact connected instance (which
-	// could be parallel installed) rather than a default instance without the
-	// instance key.
-	source := resolveSpecialVariable(relSrc, slot.Snap(), snap.PerspectiveOther)
+
+	// sourceName, when non-empty, overrides the basename of source used to
+	// derive the target when a "source" section is present. This is used for
+	// whole-component sharing where the basename of the component mount
+	// directory is the (uninteresting) revision.
+	var sourceName string
+
+	if compName, subPath, isComp, err := parseComponentPath(relSrc); err == nil && isComp {
+		var ci *snap.ComponentInfo
+		for _, comp := range slot.AppSet().Components() {
+			if comp.Component.ComponentName == compName {
+				ci = comp
+				break
+			}
+		}
+		if ci == nil {
+			// Component declared but not installed: skip this path.
+			return "", "", false
+		}
+		// snap.ComponentMountDir is rooted at dirs.SnapMountDir, but content
+		// interface paths must use dirs.CoreSnapMountDir to be consistent with
+		// $SNAP resolution and visible inside the snap mount namespace (where
+		// /snap is the mount point, not /var/lib/snapd/snap).
+		compMountDir := snap.ComponentMountDir(compName, ci.Revision, slot.Snap().InstanceName())
+		source = filepath.Clean(filepath.Join(
+			dirs.CoreSnapMountDir, strings.TrimPrefix(compMountDir, dirs.SnapMountDir), subPath))
+		if subPath == "" {
+			// Whole-component sharing: use the component name as the
+			// basename so that, with a "source" section present, the target
+			// resolves to <target>/<compName> rather than the revision
+			// directory.
+			sourceName = compName
+		}
+	} else {
+		// Errors from parseComponentPath are safely ignored here: the slot
+		// has already been vetted in BeforePrepareSlot, which rejects any
+		// malformed path before it reaches this code. Non-component paths are
+		// resolved as ordinary $SNAP paths.
+		source = resolveSpecialVariable(relSrc, slot.Snap(), snap.PerspectiveOther)
+	}
 	// Target uses PerspectiveSelf as the consumer sees its own snap name.
 	target = resolveSpecialVariable(target, plug.Snap(), snap.PerspectiveSelf)
 
 	// Check if the "source" section is present.
 	var unused map[string]any
 	if err := slot.Attr("source", &unused); err == nil {
-		_, sourceName := filepath.Split(source)
+		if sourceName == "" {
+			_, sourceName = filepath.Split(source)
+		}
 		target = filepath.Join(target, sourceName)
 	}
-	return source, target
+	return source, target, true
 }
 
-func mountEntry(plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot, relSrc string, extraOptions ...string) osutil.MountEntry {
+func mountEntry(plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot, relSrc string, extraOptions ...string) (osutil.MountEntry, bool) {
 	options := make([]string, 0, len(extraOptions)+1)
 	options = append(options, "bind")
 	options = append(options, extraOptions...)
-	source, target := sourceTarget(plug, slot, relSrc)
+	source, target, ok := sourceTarget(plug, slot, relSrc)
 	return osutil.MountEntry{
 		Name:    source,
 		Dir:     target,
 		Options: options,
-	}
+	}, ok
 }
 
 func (iface *contentInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
@@ -282,7 +391,9 @@ func (iface *contentInterface) AppArmorConnectedPlug(spec *apparmor.Specificatio
 				// Use PerspectiveOther: resolve to provider's precise instance
 				// name
 				resolveSpecialVariable(w, slot.Snap(), snap.PerspectiveOther))
-			source, target := sourceTarget(plug, slot, w)
+			// Write paths can never reference components (rejected in
+			// BeforePrepareSlot), so ok is always true here.
+			source, target, _ := sourceTarget(plug, slot, w)
 			emit("  # Read-write content sharing %s -> %s (w#%d)\n", plug.Ref(), slot.Ref(), i)
 			emit("  mount options=(bind, rw) \"%s/\" -> \"%s{,-[0-9]*}/\",\n", source, target)
 			emit("  mount options=(rprivate) -> \"%s{,-[0-9]*}/\",\n", target)
@@ -305,11 +416,13 @@ func (iface *contentInterface) AppArmorConnectedPlug(spec *apparmor.Specificatio
 # read-only.
 `)
 		for i, r := range readPaths {
-			fmt.Fprintf(contentSnippet, "\"%s/**\" mrkix,\n",
-				// Use PerspectiveOther: resolve to provider's precise instance name
-				resolveSpecialVariable(r, slot.Snap(), snap.PerspectiveOther))
+			source, target, ok := sourceTarget(plug, slot, r)
+			if !ok {
+				// Component declared but not installed: skip this path.
+				continue
+			}
+			fmt.Fprintf(contentSnippet, "\"%s/**\" mrkix,\n", source)
 
-			source, target := sourceTarget(plug, slot, r)
 			emit("  # Read-only content sharing %s -> %s (r#%d)\n", plug.Ref(), slot.Ref(), i)
 			emit("  mount options=(bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n", source, target)
 			emit("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target)
@@ -337,7 +450,7 @@ func (iface *contentInterface) AppArmorConnectedSlot(spec *apparmor.Specificatio
 # tells the slotting app about files to share.
 `)
 		for _, w := range writePaths {
-			_, target := sourceTarget(plug, slot, w)
+			_, target, _ := sourceTarget(plug, slot, w)
 			fmt.Fprintf(contentSnippet, "\"%s/**\" mrwklix,\n",
 				target)
 		}
@@ -356,14 +469,20 @@ func (iface *contentInterface) AutoConnect(plug *snap.PlugInfo, slot *snap.SlotI
 
 func (iface *contentInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	for _, r := range iface.path(slot, "read") {
-		err := spec.AddMountEntry(mountEntry(plug, slot, r, "ro"))
-		if err != nil {
+		me, ok := mountEntry(plug, slot, r, "ro")
+		if !ok {
+			// Component declared but not installed: skip this path.
+			continue
+		}
+		if err := spec.AddMountEntry(me); err != nil {
 			return err
 		}
 	}
 	for _, w := range iface.path(slot, "write") {
-		err := spec.AddMountEntry(mountEntry(plug, slot, w))
-		if err != nil {
+		// Write paths can never reference components (rejected in
+		// BeforePrepareSlot), so ok is always true here.
+		me, _ := mountEntry(plug, slot, w)
+		if err := spec.AddMountEntry(me); err != nil {
 			return err
 		}
 	}

--- a/interfaces/builtin/content.go
+++ b/interfaces/builtin/content.go
@@ -125,10 +125,8 @@ func parseComponentPath(path string) (compName, subPath string, isComponent bool
 
 	// $SNAP_COMPONENT(foo)/bar -> bar
 	subPath = tail[1:]
-	if subPath != "" {
-		if err := validatePath(subPath); err != nil {
-			return "", "", true, err
-		}
+	if err := validatePath(subPath); err != nil {
+		return "", "", true, err
 	}
 
 	return compName, subPath, true, nil
@@ -190,34 +188,29 @@ func (iface *contentInterface) BeforePrepareSlot(slot *snap.SlotInfo) error {
 		return fmt.Errorf("read or write path must be set")
 	}
 
-	// Component paths ($SNAP_COMPONENT(...)) are only permitted in read
-	// paths; they are rejected for write paths. Read component paths must
-	// reference a component declared in the snap, and their subpath (when
-	// present) must pass the same validation as ordinary paths.
 	for _, p := range wpath {
-		// isComp is checked before err so that even a malformed component
-		// path (e.g. dirty subpath) in a write list reports the read-only
-		// restriction.
-		if _, _, isComp, err := parseComponentPath(p); isComp {
+		if _, _, isComp, _ := parseComponentPath(p); isComp {
+			// $SNAP_COMPONENT(...) are not allowed for write.
 			return fmt.Errorf("component paths can only be used with read, not write: %q", p)
-		} else if err != nil {
-			return err
 		}
+
 		if err := validatePath(p); err != nil {
 			return err
 		}
 	}
 	for _, p := range rpath {
-		compName, _, isComp, err := parseComponentPath(p)
-		if err != nil {
-			return err
-		}
-		if isComp {
+		if compName, _, isComp, err := parseComponentPath(p); isComp {
+			// Looks like a $SNAP_COMPONENT(...)
+			if err != nil {
+				// Which is invalid
+				return err
+			}
 			if _, ok := slot.Snap.Components[compName]; !ok {
 				return fmt.Errorf("component %s specified in path %q is not defined in the snap", compName, p)
 			}
 			continue
 		}
+
 		if err := validatePath(p); err != nil {
 			return err
 		}
@@ -299,23 +292,23 @@ func resolveSpecialVariable(path string, snapInfo *snap.Info, perspective snap.E
 	return snapInfo.ExpandSnapVariablesSetSnapMountDir(filepath.Join("$SNAP", path), dirs.CoreSnapMountDir, perspective)
 }
 
-// componentSource resolves the source path and the basename to use for
-// target derivation for an installed component. ok is false if the
-// component is declared in the snap but not installed (absent from the
-// app set).
-func componentSource(slot *interfaces.ConnectedSlot, compName, subPath string) (source, sourceName string, ok bool) {
-	ci := slot.AppSet().Component(compName)
-	if ci == nil {
-		// Component declared but not installed.
-		return "", "", false
-	}
-	// snap.ComponentMountDir is rooted at dirs.SnapMountDir, but content
-	// interface paths must use dirs.CoreSnapMountDir to be consistent with
-	// $SNAP resolution and visible inside the snap mount namespace (where
-	// /snap is the mount point, not /var/lib/snapd/snap).
-	compMountDir := snap.ComponentMountDir(compName, ci.Revision, slot.Snap().InstanceName())
+// resolveComponentSource resolves the source path and the basename to use for
+// target derivation for an installed component.
+func resolveComponentSource(snapInfo *snap.Info, compInfo *snap.ComponentInfo, subPath string) (
+	source, sourceName string,
+) {
+	compName := compInfo.Component.ComponentName
+	// Content-interface paths must be rooted at dirs.CoreSnapMountDir (/snap)
+	// so they are accessible inside the snap mount namespace, where /snap is
+	// always the bind-mount point regardless of the host's SnapMountDir.
+	// TODO this could use a helper in 'snap'
 	source = filepath.Clean(filepath.Join(
-		dirs.CoreSnapMountDir, strings.TrimPrefix(compMountDir, dirs.SnapMountDir), subPath))
+		dirs.CoreSnapMountDir,
+		snapInfo.InstanceName(),
+		"components", "mnt",
+		compName, compInfo.Revision.String(),
+		subPath,
+	))
 	if subPath == "" {
 		// Whole-component sharing: use the component name as the
 		// basename so that, with a "source" section present, the target
@@ -323,16 +316,17 @@ func componentSource(slot *interfaces.ConnectedSlot, compName, subPath string) (
 		// directory.
 		sourceName = compName
 	}
-	return source, sourceName, true
+	return source, sourceName
 }
 
 // sourceTarget resolves the source and target paths for a given read/write
-// slot path. For component paths ($SNAP_COMPONENT(...)), the source is the
-// component mount directory of the installed component; if the component is
-// declared in the snap but not installed (absent from the slot's app set),
-// ok is false and the caller should skip the path. For ordinary paths the
-// behavior is unchanged and ok is always true.
-func sourceTarget(plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot, relSrc string) (source, target string, ok bool) {
+// slot path and indicates whether the source of the mount is available.
+//
+// Specifically in the case of $SNAP_COMPONENT(...) entries, if the component is
+// not installed, available is false.
+func sourceTarget(plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot, relSrc string) (
+	source, target string, available bool,
+) {
 	// The 'target' attribute has already been verified in BeforePreparePlug.
 	_ = plug.Attr("target", &target)
 
@@ -342,16 +336,16 @@ func sourceTarget(plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot
 	// directory is the (uninteresting) revision.
 	var sourceName string
 
-	if compName, subPath, isComp, err := parseComponentPath(relSrc); err == nil && isComp {
-		source, sourceName, ok = componentSource(slot, compName, subPath)
-		if !ok {
+	if compName, subPath, isComp, err := parseComponentPath(relSrc); isComp && err == nil {
+		ci := slot.AppSet().Component(compName)
+		if ci == nil {
+			// Component declared but not installed.
 			return "", "", false
 		}
+
+		source, sourceName = resolveComponentSource(slot.Snap(), ci, subPath)
 	} else {
-		// Errors from parseComponentPath are safely ignored here: the slot
-		// has already been vetted in BeforePrepareSlot, which rejects any
-		// malformed path before it reaches this code. Non-component paths are
-		// resolved as ordinary $SNAP paths.
+		// Regular (non-component) $SNAP/$SNAP_DATA/$SNAP_COMMON path.
 		source = resolveSpecialVariable(relSrc, slot.Snap(), snap.PerspectiveOther)
 	}
 	// Target uses PerspectiveSelf as the consumer sees its own snap name.
@@ -368,19 +362,27 @@ func sourceTarget(plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot
 	return source, target, true
 }
 
-// mountEntry builds the bind-mount entry for a read/write slot path. ok is
-// false if the path references a component that is declared in the snap but
-// not installed; the caller should then skip the entry.
-func mountEntry(plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot, relSrc string, extraOptions ...string) (osutil.MountEntry, bool) {
+// mountEntry builds the bind-mount entry for a read/write slot path.
+//
+// available is false if the path references a component that is declared in the
+// snap but not installed; the caller should then skip the entry.
+func mountEntry(plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot, relSrc string, extraOptions ...string) (
+	entry osutil.MountEntry, available bool,
+) {
 	options := make([]string, 0, len(extraOptions)+1)
 	options = append(options, "bind")
 	options = append(options, extraOptions...)
-	source, target, ok := sourceTarget(plug, slot, relSrc)
+	source, target, sourceAvailable := sourceTarget(plug, slot, relSrc)
+	if !sourceAvailable {
+		// unavailable, e.g. could be a component which is not installed
+		return osutil.MountEntry{}, false
+	}
+
 	return osutil.MountEntry{
 		Name:    source,
 		Dir:     target,
 		Options: options,
-	}, ok
+	}, true
 }
 
 func (iface *contentInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
@@ -480,7 +482,7 @@ func (iface *contentInterface) MountConnectedPlug(spec *mount.Specification, plu
 	for _, r := range iface.path(slot, "read") {
 		me, ok := mountEntry(plug, slot, r, "ro")
 		if !ok {
-			// Component declared but not installed: skip this path.
+			// Could be a not-installed component entry
 			continue
 		}
 		if err := spec.AddMountEntry(me); err != nil {
@@ -488,9 +490,10 @@ func (iface *contentInterface) MountConnectedPlug(spec *mount.Specification, plu
 		}
 	}
 	for _, w := range iface.path(slot, "write") {
-		// Write paths can never reference components (rejected in
-		// BeforePrepareSlot), so ok is always true here.
-		me, _ := mountEntry(plug, slot, w)
+		me, ok := mountEntry(plug, slot, w)
+		if !ok {
+			return fmt.Errorf("internal error: unexpected incomplete write mount entry")
+		}
 		if err := spec.AddMountEntry(me); err != nil {
 			return err
 		}

--- a/interfaces/builtin/content.go
+++ b/interfaces/builtin/content.go
@@ -319,6 +319,14 @@ func resolveComponentSource(snapInfo *snap.Info, compInfo *snap.ComponentInfo, s
 	return source, sourceName
 }
 
+// exportUnderPlugTarget returns true when the content exposed by the slot
+// should be placed under the target location named by the plug. This is
+// indicated by presence of the 'source' attribute on the slot side.
+func exportUnderPlugTarget(slot *interfaces.ConnectedSlot) bool {
+	var unused map[string]any
+	return slot.Attr("source", &unused) == nil
+}
+
 // sourceTarget resolves the source and target paths for a given read/write
 // slot path and indicates whether the source of the mount is available.
 //
@@ -330,11 +338,10 @@ func sourceTarget(plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot
 	// The 'target' attribute has already been verified in BeforePreparePlug.
 	_ = plug.Attr("target", &target)
 
-	// sourceName, when non-empty, overrides the basename of source used to
-	// derive the target when a "source" section is present. This is used for
-	// whole-component sharing where the basename of the component mount
-	// directory is the (uninteresting) revision.
-	var sourceName string
+	// sourceNameOverride, when non-empty, overrides the default name used in the case
+	// we're exporting the source location beneath the target path prescribed in
+	// the plug attributes.
+	var sourceNameOverride string
 
 	if compName, subPath, isComp, err := parseComponentPath(relSrc); isComp && err == nil {
 		ci := slot.AppSet().Component(compName)
@@ -343,7 +350,7 @@ func sourceTarget(plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot
 			return "", "", false
 		}
 
-		source, sourceName = resolveComponentSource(slot.Snap(), ci, subPath)
+		source, sourceNameOverride = resolveComponentSource(slot.Snap(), ci, subPath)
 	} else {
 		// Regular (non-component) $SNAP/$SNAP_DATA/$SNAP_COMMON path.
 		source = resolveSpecialVariable(relSrc, slot.Snap(), snap.PerspectiveOther)
@@ -351,11 +358,19 @@ func sourceTarget(plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot
 	// Target uses PerspectiveSelf as the consumer sees its own snap name.
 	target = resolveSpecialVariable(target, plug.Snap(), snap.PerspectiveSelf)
 
-	// Check if the "source" section is present.
-	var unused map[string]any
-	if err := slot.Attr("source", &unused); err == nil {
-		if sourceName == "" {
-			_, sourceName = filepath.Split(source)
+	// Figure out the target path if the source is supposed to be exported on a
+	// path beneath the target prescribed in the plug.
+	if exportUnderPlugTarget(slot) {
+		// unless there's an override, as it is in the case of components, we
+		// use the basename by default, e.g.
+		// source:
+		//   - $SNAP/foo                 -> $TARGET/foo
+		//   - $SNAP                     -> $TARGET/<snap-name>
+		//   - $SNAP_COMPONENT(bar)/foo  -> $TARGET/foo
+		//   - $SNAP_COMPONENT(bar)      -> $TARGET/bar
+		sourceName := filepath.Base(source)
+		if sourceNameOverride != "" {
+			sourceName = sourceNameOverride
 		}
 		target = filepath.Join(target, sourceName)
 	}

--- a/interfaces/builtin/content.go
+++ b/interfaces/builtin/content.go
@@ -112,15 +112,10 @@ func parseComponentPath(path string) (compName, subPath string, isComponent bool
 		return "", "", false, nil
 	}
 	rest := path[len(componentPrefix):]
-	closeIdx := strings.IndexByte(rest, ')')
-	if closeIdx < 0 {
+	compName, tail, had := strings.Cut(rest, ")")
+	if !had || compName == "" {
 		return "", "", true, fmt.Errorf("invalid format in path %q", path)
 	}
-	compName = rest[:closeIdx]
-	if compName == "" {
-		return "", "", true, fmt.Errorf("invalid format in path %q", path)
-	}
-	tail := rest[closeIdx+1:]
 	if tail == "" || tail == "/" {
 		// Whole-component sharing: $SNAP_COMPONENT(foo) or $SNAP_COMPONENT(foo)/
 		return compName, "", true, nil

--- a/interfaces/builtin/content_test.go
+++ b/interfaces/builtin/content_test.go
@@ -1456,6 +1456,25 @@ components:
 		`component paths can only be used with read, not write: "\$SNAP_COMPONENT\(comp1\)/share"`)
 }
 
+func (s *ContentSuite) TestSanitizeSlotComponentDirtySubpathInWrite(c *C) {
+	const yaml = `name: producer
+version: 0
+slots:
+  content:
+    interface: content
+    write:
+      - $SNAP_COMPONENT(comp1)/../out
+components:
+  comp1:
+    type: standard
+`
+	// Even with a dirty subpath, a component path in write must report the
+	// read-only restriction, not a subpath validation error.
+	slot := MockSlot(c, yaml, nil, "content")
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), ErrorMatches,
+		`component paths can only be used with read, not write: "\$SNAP_COMPONENT\(comp1\)/\.\./out"`)
+}
+
 func (s *ContentSuite) TestSanitizeSlotComponentMalformed(c *C) {
 	const tmpl = `name: producer
 version: 0

--- a/interfaces/builtin/content_test.go
+++ b/interfaces/builtin/content_test.go
@@ -1339,3 +1339,322 @@ func (s *ContentSuite) TestStaticInfo(c *C) {
 	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "compatibility: $SLOT_COMPAT(compatibility)")
 	c.Assert(si.AffectsPlugOnRefresh, Equals, true)
 }
+
+const contentComponentProviderYaml = `name: producer
+version: 0
+slots:
+  content:
+    interface: content
+    read:
+      - $SNAP_COMPONENT(comp1)/share
+components:
+  comp1:
+    type: standard
+`
+
+const contentComponentPlugYaml = `name: consumer
+version: 0
+plugs:
+  content:
+    target: $SNAP/import
+apps:
+  app:
+    command: foo
+`
+
+func (s *ContentSuite) TestSanitizeSlotComponentRead(c *C) {
+	slot := MockSlot(c, contentComponentProviderYaml, nil, "content")
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), IsNil)
+}
+
+func (s *ContentSuite) TestSanitizeSlotComponentReadSourceSection(c *C) {
+	const yaml = `name: producer
+version: 0
+slots:
+  content:
+    interface: content
+    source:
+      read:
+        - $SNAP_COMPONENT(comp1)/share
+components:
+  comp1:
+    type: standard
+`
+	slot := MockSlot(c, yaml, nil, "content")
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), IsNil)
+}
+
+func (s *ContentSuite) TestSanitizeSlotComponentWhole(c *C) {
+	for _, p := range []string{
+		"$SNAP_COMPONENT(comp1)",
+		"$SNAP_COMPONENT(comp1)/",
+	} {
+		const tmpl = `name: producer
+version: 0
+slots:
+  content:
+    interface: content
+    read: [%s]
+components:
+  comp1:
+    type: standard
+`
+		slot := MockSlot(c, fmt.Sprintf(tmpl, p), nil, "content")
+		c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), IsNil)
+	}
+}
+
+func (s *ContentSuite) TestSanitizeSlotComponentUndeclared(c *C) {
+	const yaml = `name: producer
+version: 0
+slots:
+  content:
+    interface: content
+    read:
+      - $SNAP_COMPONENT(nocomp)/share
+components:
+  comp1:
+    type: standard
+`
+	slot := MockSlot(c, yaml, nil, "content")
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), ErrorMatches,
+		`component nocomp specified in path "\$SNAP_COMPONENT\(nocomp\)/share" is not defined in the snap`)
+}
+
+func (s *ContentSuite) TestSanitizeSlotComponentInWrite(c *C) {
+	const yaml = `name: producer
+version: 0
+slots:
+  content:
+    interface: content
+    write:
+      - $SNAP_COMPONENT(comp1)/share
+components:
+  comp1:
+    type: standard
+`
+	slot := MockSlot(c, yaml, nil, "content")
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), ErrorMatches,
+		`component paths can only be used with read, not write: "\$SNAP_COMPONENT\(comp1\)/share"`)
+}
+
+func (s *ContentSuite) TestSanitizeSlotComponentInSourceWrite(c *C) {
+	const yaml = `name: producer
+version: 0
+slots:
+  content:
+    interface: content
+    source:
+      write:
+        - $SNAP_COMPONENT(comp1)/share
+components:
+  comp1:
+    type: standard
+`
+	slot := MockSlot(c, yaml, nil, "content")
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), ErrorMatches,
+		`component paths can only be used with read, not write: "\$SNAP_COMPONENT\(comp1\)/share"`)
+}
+
+func (s *ContentSuite) TestSanitizeSlotComponentMalformed(c *C) {
+	const tmpl = `name: producer
+version: 0
+slots:
+  content:
+    interface: content
+    read: [%s]
+components:
+  comp1:
+    type: standard
+`
+	for _, p := range []string{
+		"$SNAP_COMPONENT(comp1",     // no closing paren
+		"$SNAP_COMPONENT()",         // empty name
+		"$SNAP_COMPONENT(comp1)foo", // trailing non-slash after )
+	} {
+		slot := MockSlot(c, fmt.Sprintf(tmpl, p), nil, "content")
+		c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), ErrorMatches,
+			`invalid format in path .*`)
+	}
+}
+
+func (s *ContentSuite) TestSanitizeSlotComponentBadSubpath(c *C) {
+	const tmpl = `name: producer
+version: 0
+slots:
+  content:
+    interface: content
+    read: [%s]
+components:
+  comp1:
+    type: standard
+`
+	// relative/unclean subpath
+	slot := MockSlot(c, fmt.Sprintf(tmpl, "$SNAP_COMPONENT(comp1)/../out"), nil, "content")
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), ErrorMatches,
+		`content interface path is not clean: "\.\./out"`)
+	// AppArmor-interpreted character in subpath
+	slot = MockSlot(c, fmt.Sprintf(tmpl, "$SNAP_COMPONENT(comp1)/sh*re"), nil, "content")
+	c.Assert(interfaces.BeforePrepareSlot(s.iface, slot), ErrorMatches,
+		`content interface path is invalid:.*`)
+}
+
+// Check that a read path pointing at an installed component produces a
+// bind-mount entry and AppArmor rules referencing the component mount dir.
+func (s *ContentSuite) TestConnectedPlugComponentRead(c *C) {
+	plug, _ := MockConnectedPlug(c, contentComponentPlugYaml, &snap.SideInfo{Revision: snap.R(7)}, "content")
+	comps := []compRawInfo{
+		{"component: producer+comp1\ntype: standard", snap.R(11)},
+	}
+	slot, _ := mockConnectedSlotWithComps(c, contentComponentProviderYaml,
+		&snap.SideInfo{Revision: snap.R(5)}, comps, "content")
+
+	compShare := filepath.Join(dirs.CoreSnapMountDir, "producer/components/mnt/comp1/11/share")
+
+	// Mount specification
+	mountSpec := &mount.Specification{}
+	c.Assert(mountSpec.AddConnectedPlug(s.iface, plug, slot), IsNil)
+	expectedMnt := []osutil.MountEntry{{
+		Name:    compShare,
+		Dir:     filepath.Join(dirs.CoreSnapMountDir, "consumer/7/import"),
+		Options: []string{"bind", "ro"},
+	}}
+	c.Assert(mountSpec.MountEntries(), DeepEquals, expectedMnt)
+
+	// AppArmor specification
+	apparmorSpec := apparmor.NewSpecification(plug.AppSet())
+	c.Assert(apparmorSpec.AddConnectedPlug(s.iface, plug, slot), IsNil)
+	c.Assert(apparmorSpec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
+	expectedSnippet := `
+# In addition to the bind mount, add any AppArmor rules so that
+# snaps may directly access the slot implementation's files
+# read-only.
+"` + compShare + `/**" mrkix,
+`
+	c.Assert(apparmorSpec.SnippetForTag("snap.consumer.app"), Equals, expectedSnippet)
+
+	// update-ns entries reference the component mount dir as source
+	updateNS := strings.Join(apparmorSpec.UpdateNS(), "")
+	c.Check(updateNS, testutil.Contains,
+		`  # Read-only content sharing consumer:content -> producer:content (r#0)`)
+	c.Check(updateNS, testutil.Contains,
+		fmt.Sprintf(`  mount options=(bind) "%s/" -> "/snap/consumer/7/import{,-[0-9]*}/",`, compShare))
+	c.Check(updateNS, testutil.Contains,
+		`  remount options=(bind, ro) "/snap/consumer/7/import{,-[0-9]*}/",`)
+}
+
+// Check that whole-component sharing resolves to the component mount dir.
+func (s *ContentSuite) TestConnectedPlugComponentWhole(c *C) {
+	const yaml = `name: producer
+version: 0
+slots:
+  content:
+    interface: content
+    read:
+      - $SNAP_COMPONENT(comp1)
+components:
+  comp1:
+    type: standard
+`
+	plug, _ := MockConnectedPlug(c, contentComponentPlugYaml, &snap.SideInfo{Revision: snap.R(7)}, "content")
+	comps := []compRawInfo{
+		{"component: producer+comp1\ntype: standard", snap.R(11)},
+	}
+	slot, _ := mockConnectedSlotWithComps(c, yaml, &snap.SideInfo{Revision: snap.R(5)}, comps, "content")
+
+	compDir := filepath.Join(dirs.CoreSnapMountDir, "producer/components/mnt/comp1/11")
+
+	mountSpec := &mount.Specification{}
+	c.Assert(mountSpec.AddConnectedPlug(s.iface, plug, slot), IsNil)
+	expectedMnt := []osutil.MountEntry{{
+		Name:    compDir,
+		Dir:     filepath.Join(dirs.CoreSnapMountDir, "consumer/7/import"),
+		Options: []string{"bind", "ro"},
+	}}
+	c.Assert(mountSpec.MountEntries(), DeepEquals, expectedMnt)
+}
+
+// Check that whole-component sharing with a "source" section uses the
+// component name (not the revision) as the target basename.
+func (s *ContentSuite) TestConnectedPlugComponentWholeSource(c *C) {
+	const yaml = `name: producer
+version: 0
+slots:
+  content:
+    interface: content
+    source:
+      read:
+        - $SNAP_COMPONENT(comp1)
+components:
+  comp1:
+    type: standard
+`
+	plug, _ := MockConnectedPlug(c, contentComponentPlugYaml, &snap.SideInfo{Revision: snap.R(7)}, "content")
+	comps := []compRawInfo{
+		{"component: producer+comp1\ntype: standard", snap.R(11)},
+	}
+	slot, _ := mockConnectedSlotWithComps(c, yaml, &snap.SideInfo{Revision: snap.R(5)}, comps, "content")
+
+	compDir := filepath.Join(dirs.CoreSnapMountDir, "producer/components/mnt/comp1/11")
+
+	mountSpec := &mount.Specification{}
+	c.Assert(mountSpec.AddConnectedPlug(s.iface, plug, slot), IsNil)
+	expectedMnt := []osutil.MountEntry{{
+		Name:    compDir,
+		Dir:     filepath.Join(dirs.CoreSnapMountDir, "consumer/7/import/comp1"),
+		Options: []string{"bind", "ro"},
+	}}
+	c.Assert(mountSpec.MountEntries(), DeepEquals, expectedMnt)
+}
+
+// Check that a component declared but not installed is silently skipped,
+// while other (non-component) read paths in the same slot are unaffected.
+func (s *ContentSuite) TestConnectedPlugComponentAbsent(c *C) {
+	const yaml = `name: producer
+version: 0
+slots:
+  content:
+    interface: content
+    read:
+      - $SNAP/share
+      - $SNAP_COMPONENT(comp1)/share
+components:
+  comp1:
+    type: standard
+`
+	plug, _ := MockConnectedPlug(c, contentComponentPlugYaml, &snap.SideInfo{Revision: snap.R(7)}, "content")
+	// No components passed to the app set: comp1 is declared but not installed.
+	slot, _ := mockConnectedSlotWithComps(c, yaml, &snap.SideInfo{Revision: snap.R(5)}, nil, "content")
+
+	// Only the $SNAP/share path produces a mount entry.
+	mountSpec := &mount.Specification{}
+	c.Assert(mountSpec.AddConnectedPlug(s.iface, plug, slot), IsNil)
+	expectedMnt := []osutil.MountEntry{{
+		Name:    filepath.Join(dirs.CoreSnapMountDir, "producer/5/share"),
+		Dir:     filepath.Join(dirs.CoreSnapMountDir, "consumer/7/import"),
+		Options: []string{"bind", "ro"},
+	}}
+	c.Assert(mountSpec.MountEntries(), DeepEquals, expectedMnt)
+
+	// AppArmor: only the $SNAP/share path produces rules; the component path
+	// contributes neither a direct-access rule nor update-ns entries.
+	apparmorSpec := apparmor.NewSpecification(plug.AppSet())
+	c.Assert(apparmorSpec.AddConnectedPlug(s.iface, plug, slot), IsNil)
+	expectedSnippet := `
+# In addition to the bind mount, add any AppArmor rules so that
+# snaps may directly access the slot implementation's files
+# read-only.
+"/snap/producer/5/share/**" mrkix,
+`
+	c.Assert(apparmorSpec.SnippetForTag("snap.consumer.app"), Equals, expectedSnippet)
+
+	updateNS := strings.Join(apparmorSpec.UpdateNS(), "")
+	c.Check(updateNS, testutil.Contains,
+		`  # Read-only content sharing consumer:content -> producer:content (r#0)`)
+	c.Check(updateNS, testutil.Contains,
+		`  mount options=(bind) "/snap/producer/5/share/" -> "/snap/consumer/7/import{,-[0-9]*}/",`)
+	c.Check(updateNS, testutil.Contains,
+		`  remount options=(bind, ro) "/snap/consumer/7/import{,-[0-9]*}/",`)
+	// No reference to the (absent) component mount dir.
+	c.Check(updateNS, Not(testutil.Contains), "components/mnt/comp1")
+}

--- a/interfaces/snap_app_set.go
+++ b/interfaces/snap_app_set.go
@@ -51,6 +51,17 @@ func (a *SnapAppSet) Components() []*snap.ComponentInfo {
 	return a.components
 }
 
+// Component looks up a component with a given name and returns its info, or nil
+// if the component was not set when creating the app set.
+func (a *SnapAppSet) Component(name string) *snap.ComponentInfo {
+	for _, comp := range a.Components() {
+		if comp.Component.ComponentName == name {
+			return comp
+		}
+	}
+	return nil
+}
+
 // InstanceName returns the instance name of the snap that this SnapAppSet is
 // based on.
 func (a *SnapAppSet) InstanceName() naming.InstanceName {

--- a/interfaces/snap_app_set_test.go
+++ b/interfaces/snap_app_set_test.go
@@ -567,11 +567,11 @@ slots:
 
 	comps := set.Components()
 	c.Check(comps, DeepEquals, []*snap.ComponentInfo{compInfo})
-	comp1Info := set.Component("comp")
+	comp1Info := set.Component("comp1")
 	c.Check(comp1Info, DeepEquals, compInfo)
 	// The comp2 component  was not in the set
 	comp2Info := set.Component("comp2")
-	c.Check(comp2Info, Equals, nil)
+	c.Check(comp2Info, IsNil)
 }
 
 func (s *snapAppSetSuite) TestNewAppSetWithWrongComponent(c *C) {

--- a/interfaces/snap_app_set_test.go
+++ b/interfaces/snap_app_set_test.go
@@ -533,6 +533,47 @@ func (s *snapAppSetSuite) TestInstanceName(c *C) {
 	c.Check(set.InstanceName(), Equals, naming.InstanceName("test-snap"))
 }
 
+func (s *snapAppSetSuite) TestComponents(c *C) {
+	const yaml = `name: name
+version: 1
+apps:
+  app:
+    slots: [app-slot]
+hooks:
+  install:
+    slots: [hook-slot]
+components:
+  comp1:
+    type: standard
+    hooks:
+      install:
+  comp2:
+    type: standard
+    hooks:
+      install:
+slots:
+  slot:
+  hook-slot:
+  app-slot:
+`
+	info := snaptest.MockInfo(c, yaml, nil)
+
+	compInfo := snaptest.MockComponent(c, "component: name+comp1\ntype: standard\nversion: 1.0", info, snap.ComponentSideInfo{
+		Revision: snap.R(1),
+	})
+
+	set, err := interfaces.NewSnapAppSet(info, []*snap.ComponentInfo{compInfo})
+	c.Assert(err, IsNil)
+
+	comps := set.Components()
+	c.Check(comps, DeepEquals, []*snap.ComponentInfo{compInfo})
+	comp1Info := set.Component("comp")
+	c.Check(comp1Info, DeepEquals, compInfo)
+	// The comp2 component  was not in the set
+	comp2Info := set.Component("comp2")
+	c.Check(comp2Info, Equals, nil)
+}
+
 func (s *snapAppSetSuite) TestNewAppSetWithWrongComponent(c *C) {
 	info := snaptest.MockInfo(c, yaml, nil)
 	_, err := interfaces.NewSnapAppSet(info, []*snap.ComponentInfo{

--- a/tests/main/interfaces-content-components/comp1/comp1-content/comp-file
+++ b/tests/main/interfaces-content-components/comp1/comp1-content/comp-file
@@ -1,0 +1,1 @@
+comp1 content v1

--- a/tests/main/interfaces-content-components/comp1/meta/component.yaml
+++ b/tests/main/interfaces-content-components/comp1/meta/component.yaml
@@ -1,0 +1,5 @@
+component: test-snapd-content-components-provider+comp1
+type: standard
+version: 1.0
+summary: Component with content
+description: Component providing content for the content interface

--- a/tests/main/interfaces-content-components/comp2/comp2-content/comp-file
+++ b/tests/main/interfaces-content-components/comp2/comp2-content/comp-file
@@ -1,0 +1,1 @@
+comp2 content v1

--- a/tests/main/interfaces-content-components/comp2/meta/component.yaml
+++ b/tests/main/interfaces-content-components/comp2/meta/component.yaml
@@ -1,0 +1,5 @@
+component: test-snapd-content-components-provider+comp2
+type: standard
+version: 1.0
+summary: Component 2 with content
+description: Second component providing content for the content interface

--- a/tests/main/interfaces-content-components/comp3/comp3-file
+++ b/tests/main/interfaces-content-components/comp3/comp3-file
@@ -1,0 +1,1 @@
+comp3 content v1

--- a/tests/main/interfaces-content-components/comp3/meta/component.yaml
+++ b/tests/main/interfaces-content-components/comp3/meta/component.yaml
@@ -1,0 +1,5 @@
+component: test-snapd-content-components-provider+comp3
+type: standard
+version: 1.0
+summary: Component 3 with content
+description: Third component providing content for the content interface, shared as a whole

--- a/tests/main/interfaces-content-components/task.yaml
+++ b/tests/main/interfaces-content-components/task.yaml
@@ -1,0 +1,144 @@
+summary: Test content interface sharing of component content via $SNAP_COMPONENT
+
+details: |
+  Verifies that the content interface can share read-only content from
+  components using the $SNAP_COMPONENT(<comp>)/<path> syntax in a slot's
+  read path, as well as sharing an entire component with
+  $SNAP_COMPONENT(<comp>).
+
+  A provider snap declares a content slot with four read paths: one
+  pointing at snap content ($SNAP/snap-content), two pointing at
+  component content ($SNAP_COMPONENT(comp1)/comp1-content and
+  $SNAP_COMPONENT(comp2)/comp2-content) and one sharing a whole component
+  ($SNAP_COMPONENT(comp3)). A consumer snap connects to the slot and
+  checks for the presence of each.
+
+  The test verifies that:
+  - With the provider installed but no components, snap content is visible
+    and component content is absent (silently skipped).
+  - After installing comp1, snap and comp1 content are visible, comp2 and
+    comp3 are absent.
+  - After installing comp2, snap, comp1 and comp2 content are visible, comp3
+    is absent.
+  - After installing comp3, all four are visible.
+  - After refreshing comp1 with new content, the new content is visible in
+    the consumer's mount namespace.
+  - After removing comp1, comp1 content is gone but snap, comp2 and comp3
+    content remain.
+  - After refreshing the provider snap and all components together (snap
+    content changed, comp1 reinstalled with new content, comp2 refreshed
+    with new content, comp3 refreshed with new content), all updated content
+    is visible.
+
+systems: [ubuntu-2*, ubuntu-core-*, fedora-*]
+
+prepare: |
+  echo "Build the components"
+  snap pack comp1
+  snap pack comp2
+  snap pack comp3
+
+execute: |
+  echo "Install the consumer and provider (without components)"
+  "$TESTSTOOLS"/snaps-state install-local test-snapd-content-components-provider
+  "$TESTSTOOLS"/snaps-state install-local test-snapd-content-components-consumer
+
+  echo "Connect the content interface"
+  snap connect test-snapd-content-components-consumer:content \
+    test-snapd-content-components-provider:content
+
+  echo "Then snap content is visible but component content is absent"
+  test-snapd-content-components-consumer.check | tee out-before
+  MATCH '^snap-content: snap content v1$' < out-before
+  MATCH '^comp1-content: <not found>$' < out-before
+  MATCH '^comp2-content: <not found>$' < out-before
+  MATCH '^comp3-content: <not found>$' < out-before
+
+  echo "When comp1 is installed"
+  snap install --dangerous test-snapd-content-components-provider+comp1_1.0.comp
+
+  echo "Then snap and comp1 content are visible, comp2 and comp3 are still absent"
+  test-snapd-content-components-consumer.check | tee out-after-comp1
+  MATCH '^snap-content: snap content v1$' < out-after-comp1
+  MATCH '^comp1-content: comp1 content v1$' < out-after-comp1
+  MATCH '^comp2-content: <not found>$' < out-after-comp1
+  MATCH '^comp3-content: <not found>$' < out-after-comp1
+
+  echo "When comp2 is installed"
+  snap install --dangerous test-snapd-content-components-provider+comp2_1.0.comp
+
+  echo "Then snap, comp1 and comp2 content are visible, comp3 is still absent"
+  test-snapd-content-components-consumer.check | tee out-after-comp2
+  MATCH '^snap-content: snap content v1$' < out-after-comp2
+  MATCH '^comp1-content: comp1 content v1$' < out-after-comp2
+  MATCH '^comp2-content: comp2 content v1$' < out-after-comp2
+  MATCH '^comp3-content: <not found>$' < out-after-comp2
+
+  echo "When comp3 is installed"
+  snap install --dangerous test-snapd-content-components-provider+comp3_1.0.comp
+
+  echo "Then snap, comp1, comp2 and comp3 content are all visible"
+  test-snapd-content-components-consumer.check | tee out-after-comp3
+  MATCH '^snap-content: snap content v1$' < out-after-comp3
+  MATCH '^comp1-content: comp1 content v1$' < out-after-comp3
+  MATCH '^comp2-content: comp2 content v1$' < out-after-comp3
+  MATCH '^comp3-content: comp3 content v1$' < out-after-comp3
+
+  echo "When comp1 is refreshed with new content"
+  echo "comp1 content v2" > comp1/comp1-content/comp-file
+  rm -f test-snapd-content-components-provider+comp1_1.0.comp
+  snap pack comp1
+  snap install --dangerous test-snapd-content-components-provider+comp1_1.0.comp
+
+  echo "Then the new comp1 content is visible in the mount namespace"
+  test-snapd-content-components-consumer.check | tee out-after-refresh
+  MATCH '^snap-content: snap content v1$' < out-after-refresh
+  MATCH '^comp1-content: comp1 content v2$' < out-after-refresh
+  MATCH '^comp2-content: comp2 content v1$' < out-after-refresh
+  MATCH '^comp3-content: comp3 content v1$' < out-after-refresh
+
+  echo "When comp1 is removed"
+  snap remove test-snapd-content-components-provider+comp1
+
+  echo "Then comp1 content is gone but snap, comp2 and comp3 content remain"
+  test-snapd-content-components-consumer.check | tee out-after-remove
+  MATCH '^snap-content: snap content v1$' < out-after-remove
+  MATCH '^comp1-content: <not found>$' < out-after-remove
+  MATCH '^comp2-content: comp2 content v1$' < out-after-remove
+  MATCH '^comp3-content: comp3 content v1$' < out-after-remove
+
+  echo "When the provider snap and all components are refreshed together"
+  echo "snap content v2" > test-snapd-content-components-provider/snap-content/snap-file
+  echo "comp1 content v3" > comp1/comp1-content/comp-file
+  echo "comp2 content v2" > comp2/comp2-content/comp-file
+  echo "comp3 content v2" > comp3/comp3-file
+  rm -f test-snapd-content-components-provider_1.0_*.snap
+  rm -f test-snapd-content-components-provider+comp1_1.0.comp
+  rm -f test-snapd-content-components-provider+comp2_1.0.comp
+  rm -f test-snapd-content-components-provider+comp3_1.0.comp
+  snap pack test-snapd-content-components-provider
+  snap pack comp1
+  snap pack comp2
+  snap pack comp3
+  snap install --dangerous \
+    test-snapd-content-components-provider_1.0_*.snap \
+    test-snapd-content-components-provider+comp1_1.0.comp \
+    test-snapd-content-components-provider+comp2_1.0.comp \
+    test-snapd-content-components-provider+comp3_1.0.comp
+
+  echo "Then all content is updated"
+  test-snapd-content-components-consumer.check | tee out-after-provider-refresh
+  MATCH '^snap-content: snap content v2$' < out-after-provider-refresh
+  MATCH '^comp1-content: comp1 content v3$' < out-after-provider-refresh
+  MATCH '^comp2-content: comp2 content v2$' < out-after-provider-refresh
+  MATCH '^comp3-content: comp3 content v2$' < out-after-provider-refresh
+
+  echo "Cleanup"
+  snap remove --purge test-snapd-content-components-provider
+  test-snapd-content-components-consumer.check | tee out-post-remove
+  MATCH '^snap-content: <not found>$' < out-post-remove
+  MATCH '^comp1-content: <not found>$' < out-post-remove
+  MATCH '^comp2-content: <not found>$' < out-post-remove
+  MATCH '^comp3-content: <not found>$' < out-post-remove
+
+  snap remove --purge test-snapd-content-components-consumer

--- a/tests/main/interfaces-content-components/test-snapd-content-components-consumer/bin/check
+++ b/tests/main/interfaces-content-components/test-snapd-content-components-consumer/bin/check
@@ -1,0 +1,29 @@
+#!/bin/sh -e
+
+echo "checking snap content"
+if [ -f "$SNAP/shared/snap-content/snap-file" ]; then
+    echo "snap-content: $(cat "$SNAP/shared/snap-content/snap-file")"
+else
+    echo "snap-content: <not found>"
+fi
+
+echo "checking comp1 content"
+if [ -f "$SNAP/shared/comp1-content/comp-file" ]; then
+    echo "comp1-content: $(cat "$SNAP/shared/comp1-content/comp-file")"
+else
+    echo "comp1-content: <not found>"
+fi
+
+echo "checking comp2 content"
+if [ -f "$SNAP/shared/comp2-content/comp-file" ]; then
+    echo "comp2-content: $(cat "$SNAP/shared/comp2-content/comp-file")"
+else
+    echo "comp2-content: <not found>"
+fi
+
+echo "checking comp3 content"
+if [ -f "$SNAP/shared/comp3/comp3-file" ]; then
+    echo "comp3-content: $(cat "$SNAP/shared/comp3/comp3-file")"
+else
+    echo "comp3-content: <not found>"
+fi

--- a/tests/main/interfaces-content-components/test-snapd-content-components-consumer/meta/snap.yaml
+++ b/tests/main/interfaces-content-components/test-snapd-content-components-consumer/meta/snap.yaml
@@ -1,0 +1,14 @@
+name: test-snapd-content-components-consumer
+version: 1.0
+base: core24
+
+apps:
+  check:
+    command: bin/check
+    plugs:
+      - content
+
+plugs:
+  content:
+    interface: content
+    target: $SNAP/shared

--- a/tests/main/interfaces-content-components/test-snapd-content-components-provider/meta/snap.yaml
+++ b/tests/main/interfaces-content-components/test-snapd-content-components-provider/meta/snap.yaml
@@ -1,0 +1,21 @@
+name: test-snapd-content-components-provider
+version: 1.0
+base: core24
+
+slots:
+  content:
+    interface: content
+    source:
+      read:
+        - $SNAP/snap-content
+        - $SNAP_COMPONENT(comp1)/comp1-content
+        - $SNAP_COMPONENT(comp2)/comp2-content
+        - $SNAP_COMPONENT(comp3)
+
+components:
+  comp1:
+    type: standard
+  comp2:
+    type: standard
+  comp3:
+    type: standard

--- a/tests/main/interfaces-content-components/test-snapd-content-components-provider/snap-content/snap-file
+++ b/tests/main/interfaces-content-components/test-snapd-content-components-provider/snap-content/snap-file
@@ -1,0 +1,1 @@
+snap content v1


### PR DESCRIPTION
interfaces/builtin/content: add support for sharing content from snap components Add support for sharing content from snap components using the following syntax:

```yaml
slots:
  my-content:
    interface: content
    read:
     # existing syntax
     - $SNAP/from-snap
     # new syntax
     - $SNAP_COMPONENT(foo)/from-comp-foo
```

Components are optional, hence their content will only appear if relevant components are installed.

Related: [SNAPDENG-37406](https://warthogs.atlassian.net/browse/SNAPDENG-37406)


[SNAPDENG-37406]: https://warthogs.atlassian.net/browse/SNAPDENG-37406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ