### PR TITLE
tests/lib/prepare: configurable snapd memory limit, workaround for CentOS

### DIFF
--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -363,6 +363,11 @@ prepare_memory_limit_override() {
             # similar issues have been observed on Amazon Linux 2
             set_limit=0
             ;;
+        centos-*)
+            # try to workaround xfs doing weird things with the page cache
+            # which is counted towards the cgroup memory limits
+            memlimit="600M"
+            ;;
         *)
             if [ "$SNAPD_NO_MEMORY_LIMIT" = 1 ]; then
                 set_limit=0

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -351,6 +351,9 @@ prepare_memory_limit_override() {
     local set_limit=1
 
     memlimit="200M"
+    # soft limit which applies to v2 and controls when the kernel will apply
+    # throttling, normally unset
+    memsoftlimit=""
     case "$SPREAD_SYSTEM" in
         ubuntu-core-16-*|ubuntu-core-18-*|ubuntu-16.04-*|ubuntu-18.04-*)
             # the tests on UC16, UC18 and correspondingly 16.04 and 18.04 have
@@ -367,6 +370,10 @@ prepare_memory_limit_override() {
             # try to workaround xfs doing weird things with the page cache
             # which is counted towards the cgroup memory limits
             memlimit="600M"
+            # we also need to apply soft limit to throttle snapd or its child
+            # processes within the same cgroup, such that a lot of cached,
+            # unflushed I/O will not exhaust the hard limit
+            memsoftlimit="300M"
             ;;
         *)
             if [ "$SNAPD_NO_MEMORY_LIMIT" = 1 ]; then
@@ -404,6 +411,7 @@ prepare_memory_limit_override() {
             cat <<EOF > /etc/systemd/system/snapd.service.d/memory-max.conf
 [Service]
 MemoryMax=${memlimit}
+MemoryHigh=${memsoftlimit}
 EOF
         else
             cat <<EOF > /etc/systemd/system/snapd.service.d/memory-max.conf

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -10,6 +10,9 @@ set -eux
 . "$TESTSLIB/state.sh"
 #shellcheck source=tests/lib/core-initrd.sh
 . "$TESTSLIB"/core-initrd.sh
+#shellcheck source=tests/lib/systems.sh
+. "$TESTSLIB"/systems.sh
+
 
 disable_kernel_rate_limiting() {
     # kernel rate limiting hinders debugging security policy so turn it off
@@ -347,6 +350,7 @@ prepare_memory_limit_override() {
     # or the system is known to be problematic
     local set_limit=1
 
+    memlimit="200M"
     case "$SPREAD_SYSTEM" in
         ubuntu-core-16-*|ubuntu-core-18-*|ubuntu-16.04-*|ubuntu-18.04-*)
             # the tests on UC16, UC18 and correspondingly 16.04 and 18.04 have
@@ -389,13 +393,19 @@ prepare_memory_limit_override() {
         # oom-killer which will be caught in restore_project_each in
         # prepare-restore.sh.
         #
-        # This ought to set MemoryMax, but on systems with older systemd we need to
-        # use MemoryLimit, which is deprecated and replaced by MemoryMax now, but
-        # systemd is backwards compatible so the limit is still set.
-        cat <<EOF > /etc/systemd/system/snapd.service.d/memory-max.conf
+        # MeoryMax was added in systemd 231 ~2016, so it's safe to assume all
+        # cgroup v2 systems should be using it.
+        if is_cgroupv2; then
+            cat <<EOF > /etc/systemd/system/snapd.service.d/memory-max.conf
 [Service]
-MemoryLimit=200M
+MemoryMax=${memlimit}
 EOF
+        else
+            cat <<EOF > /etc/systemd/system/snapd.service.d/memory-max.conf
+[Service]
+MemoryLimit=${memlimit}
+EOF
+        fi
     fi
     # the service setting may have changed in the service so we need
     # to ensure snapd is reloaded


### PR DESCRIPTION
Make the memory limit configurable. Use either MemoryMax or MemoryLimit, depending on whether the host uses cgroup v2 or v1. Bump memory limits to 600MB and set a soft limit on CentOS hoping to work around the weirdness in XFS page cache handling. It is suspected that `tests/main/interface-allow-auto-connection` generates a lot of writes which fill up the page cache as xfs is unable to keep up flushing everything to disk.