### PR TITLE
many: persist UC track-switch intent and validation-set keys on snap-setup (p2.1)

### DIFF
--- a/daemon/api_sideload_n_try_test.go
+++ b/daemon/api_sideload_n_try_test.go
@@ -1408,6 +1408,7 @@ func (s *sideloadSuite) TestSideloadManySnaps(c *check.C) {
 		var names []string
 		for _, sn := range goal.snaps {
 			c.Check(sn.Path, testutil.FileEquals, sn.SideInfo.RealName)
+			c.Check(sn.RevOpts.AllowUCTrackSwitch, check.Equals, false)
 
 			ts := state.NewTaskSet(st.NewTask("fake-install-snap", fmt.Sprintf("Doing a fake install of %q", sn.SideInfo.RealName)))
 			tss = append(tss, ts)
@@ -1564,6 +1565,7 @@ func (s *sideloadSuite) testSideloadManySnapsAndComponents(c *check.C, opts side
 		var names []string
 		for _, sn := range goal.snaps {
 			c.Check(sn.SideInfo.Revision.Unset(), check.Equals, true)
+			c.Check(sn.RevOpts.AllowUCTrackSwitch, check.Equals, false)
 
 			comps, ok := expectedSnapsToComps[sn.SideInfo.RealName]
 			c.Assert(ok, check.Equals, true, check.Commentf("unexpected snap name %q", sn.SideInfo.RealName))
@@ -1732,6 +1734,7 @@ func (s *sideloadSuite) TestSideloadManyAssertedSnapsAndComponents(c *check.C) {
 		var names []string
 		for _, sn := range goal.snaps {
 			c.Check(sn.SideInfo.Revision.Unset(), check.Equals, false)
+			c.Check(sn.RevOpts.AllowUCTrackSwitch, check.Equals, false)
 
 			comps, ok := snapsToComps[sn.SideInfo.RealName]
 			c.Assert(ok, check.Equals, true, check.Commentf("unexpected snap name %q", sn.SideInfo.RealName))
@@ -2174,6 +2177,7 @@ func (s *sideloadSuite) TestSideloadManySnapsAsserted(c *check.C) {
 				SnapID:   snaps[i] + "-id",
 				Revision: snap.R(41),
 			})
+			c.Check(sn.RevOpts.AllowUCTrackSwitch, check.Equals, false)
 
 			ts := state.NewTaskSet(st.NewTask("fake-install-snap", fmt.Sprintf("Doing a fake install of %q", sn.SideInfo.RealName)))
 			tss = append(tss, ts)

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -313,6 +313,9 @@ func (inst *snapInstruction) revnoOpts() *snapstate.RevisionOptions {
 		Revision:    inst.Revision,
 		CohortKey:   inst.CohortKey,
 		LeaveCohort: inst.LeaveCohort,
+		// Store install/refresh policy: allow switching to a UC track unless
+		// channel or revision is explicitly specified.
+		AllowUCTrackSwitch: inst.Channel == "" && inst.Revision.Unset(),
 	}
 }
 
@@ -943,7 +946,10 @@ func installationTaskSets(ctx context.Context, st *state.State, inst *snapInstru
 		opts.Flags.Transaction = inst.Transaction
 	}
 
-	revOpts := snapstate.RevisionOptions{}
+	// Install-many policy: always allow switching to a UC track, because
+	// the multi-snap API cannot specify channel or revision. One snap uses
+	// revnoOpts below.
+	revOpts := snapstate.RevisionOptions{AllowUCTrackSwitch: true}
 	if expectOneSnap {
 		revOpts = *inst.revnoOpts()
 	}
@@ -1072,6 +1078,11 @@ func snapUpdateMany(ctx context.Context, inst *snapInstruction, st *state.State)
 		updates = append(updates, snapstate.StoreUpdate{
 			InstanceName:         name,
 			AdditionalComponents: inst.CompsForSnaps[name],
+			RevOpts: snapstate.RevisionOptions{
+				// Refresh-many policy: always allow switching to a UC track,
+				// because the multi-snap API cannot specify channel or revision.
+				AllowUCTrackSwitch: true,
+			},
 		})
 	}
 

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -2017,8 +2017,9 @@ func (s *snapsSuite) TestPostSnapBadChannel(c *check.C) {
 
 func (s *snapsSuite) TestPostSnap(c *check.C) {
 	checkOpts := func(opts *snapstate.RevisionOptions) {
-		// no channel in -> no channel out
+		// no channel in -> no channel out, UC track policy may switch
 		c.Check(opts.Channel, check.Equals, "")
+		c.Check(opts.AllowUCTrackSwitch, check.Equals, true)
 	}
 	summary, systemRestartImmediate := s.testPostSnap(c, "", checkOpts)
 	c.Check(summary, check.Equals, `Install "foo" snap`)
@@ -2027,11 +2028,23 @@ func (s *snapsSuite) TestPostSnap(c *check.C) {
 
 func (s *snapsSuite) TestPostSnapWithChannel(c *check.C) {
 	checkOpts := func(opts *snapstate.RevisionOptions) {
-		// channel in -> channel out
+		// channel in -> channel out, UC track policy must not switch
 		c.Check(opts.Channel, check.Equals, "xyzzy")
+		c.Check(opts.AllowUCTrackSwitch, check.Equals, false)
 	}
 	summary, systemRestartImmediate := s.testPostSnap(c, `"channel": "xyzzy"`, checkOpts)
 	c.Check(summary, check.Equals, `Install "foo" snap from "xyzzy" channel`)
+	c.Check(systemRestartImmediate, check.Equals, false)
+}
+
+func (s *snapsSuite) TestPostSnapWithRevision(c *check.C) {
+	checkOpts := func(opts *snapstate.RevisionOptions) {
+		c.Check(opts.Channel, check.Equals, "")
+		c.Check(opts.Revision, check.Equals, snap.R(42))
+		c.Check(opts.AllowUCTrackSwitch, check.Equals, false)
+	}
+	summary, systemRestartImmediate := s.testPostSnap(c, `"revision": 42`, checkOpts)
+	c.Check(summary, check.Equals, `Install "foo" snap`)
 	c.Check(systemRestartImmediate, check.Equals, false)
 }
 
@@ -4245,6 +4258,7 @@ func (s *snapsSuite) TestUpdateWithAdditionalComponents(c *check.C) {
 		c.Check(goal.snaps, check.DeepEquals, []snapstate.StoreUpdate{{
 			InstanceName:         "some-snap",
 			AdditionalComponents: []string{"comp1", "comp2"},
+			RevOpts:              snapstate.RevisionOptions{AllowUCTrackSwitch: true},
 		}})
 		t := st.NewTask("fake-refresh-snap", "Doing a fake install")
 		return state.NewTaskSet(t), nil
@@ -4288,6 +4302,59 @@ func (s *snapsSuite) TestUpdateWithAdditionalComponents(c *check.C) {
 	c.Check(chg.Summary(), check.Equals, `Refresh "some-snap" snap with components "comp1", "comp2"`)
 }
 
+func (s *snapsSuite) TestUpdateAllowUCTrackSwitch(c *check.C) {
+	restore := daemon.MockAssertstateRefreshSnapAssertions(func(s *state.State, userID int, opts *assertstate.RefreshAssertionsOptions) error {
+		return nil
+	})
+	defer restore()
+
+	var expectedChannel string
+	var expectedRevision snap.Revision
+	var expectedAllow bool
+
+	restore = daemon.MockSnapstateUpdateOne(func(ctx context.Context, st *state.State, g snapstate.UpdateGoal, filter func(*snap.Info, *snapstate.SnapState) bool, opts snapstate.Options) (*state.TaskSet, error) {
+		goal := g.(*storeUpdateGoalRecorder)
+		c.Assert(goal.snaps, check.HasLen, 1)
+		c.Check(goal.snaps[0].InstanceName, check.Equals, "some-snap")
+		c.Check(goal.snaps[0].RevOpts.Channel, check.Equals, expectedChannel)
+		c.Check(goal.snaps[0].RevOpts.Revision, check.Equals, expectedRevision)
+		c.Check(goal.snaps[0].RevOpts.AllowUCTrackSwitch, check.Equals, expectedAllow)
+		t := st.NewTask("fake-refresh-snap", "Doing a fake refresh")
+		return state.NewTaskSet(t), nil
+	})
+	defer restore()
+
+	d := s.daemonWithFakeSnapManager(c)
+
+	for _, tc := range []struct {
+		body               string
+		channel            string
+		revision           snap.Revision
+		allowUCTrackSwitch bool
+	}{
+		{`{"action": "refresh"}`, "", snap.Revision{}, true},
+		{`{"action": "refresh", "channel": "latest/stable"}`, "latest/stable", snap.Revision{}, false},
+		{`{"action": "refresh", "revision": 100}`, "", snap.R(100), false},
+		{`{"action": "refresh", "channel": "latest/stable", "revision": 100}`, "latest/stable", snap.R(100), false},
+	} {
+		expectedChannel = tc.channel
+		expectedRevision = tc.revision
+		expectedAllow = tc.allowUCTrackSwitch
+
+		req, err := http.NewRequest("POST", "/v2/snaps/some-snap", strings.NewReader(tc.body))
+		c.Assert(err, check.IsNil, check.Commentf("%s", tc.body))
+
+		rsp := s.asyncReq(c, req, nil, actionIsExpected)
+
+		st := d.Overlord().State()
+		st.Lock()
+		chg := st.Change(rsp.Change)
+		c.Assert(chg, check.NotNil, check.Commentf("%s", tc.body))
+		c.Check(chg.Kind(), check.Equals, "refresh-snap", check.Commentf("%s", tc.body))
+		st.Unlock()
+	}
+}
+
 func (s *snapsSuite) TestInstallManyWithComponents(c *check.C) {
 	defer daemon.MockSnapstateInstallWithGoal(func(ctx context.Context, st *state.State, g snapstate.InstallGoal, opts snapstate.Options) ([]*snap.Info, []*state.TaskSet, error) {
 		goal, ok := g.(*storeInstallGoalRecorder)
@@ -4298,10 +4365,12 @@ func (s *snapsSuite) TestInstallManyWithComponents(c *check.C) {
 			{
 				InstanceName: "some-snap",
 				Components:   []string{"some-comp1", "some-comp2"},
+				RevOpts:      snapstate.RevisionOptions{AllowUCTrackSwitch: true},
 			},
 			{
 				InstanceName: "other-snap",
 				Components:   []string{"other-comp1"},
+				RevOpts:      snapstate.RevisionOptions{AllowUCTrackSwitch: true},
 			},
 		})
 
@@ -4351,10 +4420,12 @@ func (s *snapsSuite) TestUpdateManyWithComponents(c *check.C) {
 			{
 				InstanceName:         "some-snap",
 				AdditionalComponents: []string{"some-comp1", "some-comp2"},
+				RevOpts:              snapstate.RevisionOptions{AllowUCTrackSwitch: true},
 			},
 			{
 				InstanceName:         "other-snap",
 				AdditionalComponents: []string{"other-comp1"},
+				RevOpts:              snapstate.RevisionOptions{AllowUCTrackSwitch: true},
 			},
 		})
 

--- a/daemon/api_themes_test.go
+++ b/daemon/api_themes_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/snapcore/snapd/daemon"
 	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -374,6 +375,10 @@ func (s *themesSuite) TestThemesCmdGet(c *C) {
 func (s *themesSuite) daemonWithIfaceMgr(c *C) *daemon.Daemon {
 	d := s.apiBaseSuite.daemonWithOverlordMock()
 
+	oldDeviceCtx := snapstate.DeviceCtx
+	s.AddCleanup(func() { snapstate.DeviceCtx = oldDeviceCtx })
+	snapstate.DeviceCtx = devicestate.DeviceCtx
+
 	overlord := d.Overlord()
 	st := overlord.State()
 	runner := overlord.TaskRunner()
@@ -420,6 +425,10 @@ func (s *themesSuite) TestThemesCmdPost(c *C) {
 		goal, ok := g.(*storeInstallGoalRecorder)
 		c.Assert(ok, Equals, true, Commentf("unexpected InstallGoal type %T", g))
 		c.Assert(goal.snaps, HasLen, 3)
+		for _, sn := range goal.snaps {
+			// Theme install policy: UC tracks do not apply (theme snaps are never snapd).
+			c.Check(sn.RevOpts.AllowUCTrackSwitch, Equals, false)
+		}
 
 		t := st.NewTask("fake-theme-install", "Theme install")
 		return storeSnapInfos(goal.snaps), []*state.TaskSet{state.NewTaskSet(t)}, nil

--- a/overlord/clusterstate/clusterstate.go
+++ b/overlord/clusterstate/clusterstate.go
@@ -343,6 +343,8 @@ func snapsForSubcluster(
 						InstanceName: sn.Instance,
 						RevOpts: snapstate.RevisionOptions{
 							Channel: sn.Channel,
+							// Cluster refresh policy: allow switching to a UC track (channel is from the assertion).
+							AllowUCTrackSwitch: true,
 						},
 					})
 				}
@@ -354,6 +356,8 @@ func snapsForSubcluster(
 				SkipIfPresent: true,
 				RevOpts: snapstate.RevisionOptions{
 					Channel: sn.Channel,
+					// Cluster install policy: allow switching to a UC track (channel is from the assertion).
+					AllowUCTrackSwitch: true,
 				},
 			}
 

--- a/overlord/clusterstate/clusterstate_test.go
+++ b/overlord/clusterstate/clusterstate_test.go
@@ -664,7 +664,8 @@ func (s *managerSuite) TestApplyClusterStateInstallRemoveAndUpdate(c *check.C) {
 			InstanceName:  "to-install",
 			SkipIfPresent: true,
 			RevOpts: snapstate.RevisionOptions{
-				Channel: "latest/stable",
+				Channel:            "latest/stable",
+				AllowUCTrackSwitch: true,
 			},
 		},
 	})
@@ -674,7 +675,8 @@ func (s *managerSuite) TestApplyClusterStateInstallRemoveAndUpdate(c *check.C) {
 		{
 			InstanceName: "to-refresh",
 			RevOpts: snapstate.RevisionOptions{
-				Channel: "latest/stable",
+				Channel:            "latest/stable",
+				AllowUCTrackSwitch: true,
 			},
 		},
 	})

--- a/overlord/devicestate/devicestate.go
+++ b/overlord/devicestate/devicestate.go
@@ -863,6 +863,8 @@ func (r *remodeler) updateGoal(st *state.State, sn remodelSnapTarget, components
 		RevOpts: snapstate.RevisionOptions{
 			Channel:        sn.channel,
 			ValidationSets: r.vsets,
+			// Online remodel policy: allow switching to a UC track (channel is from the model).
+			AllowUCTrackSwitch: true,
 		},
 	}), nil
 }
@@ -2544,6 +2546,8 @@ func CreateRecoverySystem(st *state.State, label string, opts CreateRecoverySyst
 			ts, _, err := snapstateDownload(context.TODO(), st, sn.Name, requiredComponents, dirs.SnapBlobDir, snapstate.RevisionOptions{
 				Channel:        sn.DefaultChannel,
 				ValidationSets: valsets,
+				// Recovery-system download policy: allow switching to a UC track (channel is from the model).
+				AllowUCTrackSwitch: true,
 			}, snapstate.Options{
 				PrereqTracker: tracker,
 			})

--- a/overlord/devicestate/devicestate_remodel_test.go
+++ b/overlord/devicestate/devicestate_remodel_test.go
@@ -466,6 +466,8 @@ func (s *deviceMgrRemodelSuite) testRemodelTasksSwitchTrack(c *C, whatRefreshes 
 		if name == whatRefreshes {
 			c.Check(channel, Equals, "18")
 		}
+		// Online remodel policy: allow switching to a UC track (channel is from the model).
+		c.Check(sn.RevOpts.AllowUCTrackSwitch, Equals, true)
 
 		c.Check(opts.Flags.Required, Equals, name != whatRefreshes)
 		c.Check(opts.Flags.NoReRefresh, Equals, true)
@@ -629,6 +631,8 @@ func (s *deviceMgrRemodelSuite) testRemodelSwitchTasks(c *C, whatNewTrack map[st
 			sn := g.snaps[0]
 			name = sn.SideInfo.RealName
 			channel = sn.RevOpts.Channel
+			// Remodel (offline) policy: UC tracks do not apply (local snap blob).
+			c.Check(sn.RevOpts.AllowUCTrackSwitch, Equals, false)
 			if localSnaps != nil {
 				found := false
 				for i := range localSnaps {
@@ -642,6 +646,8 @@ func (s *deviceMgrRemodelSuite) testRemodelSwitchTasks(c *C, whatNewTrack map[st
 			sn := g.snaps[0]
 			name = sn.InstanceName
 			channel = sn.RevOpts.Channel
+			// Online remodel policy: allow switching to a UC track (channel is from the model).
+			c.Check(sn.RevOpts.AllowUCTrackSwitch, Equals, true)
 		default:
 			return nil, fmt.Errorf("unexpected goal type: %T", goal)
 		}
@@ -2906,6 +2912,8 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnaps(c *C) {
 		name := sn.SideInfo.RealName
 
 		c.Check(sn.SideInfo.RealName, Equals, "app-snap")
+		// Remodel (offline) policy: UC tracks do not apply (local snap blob).
+		c.Check(sn.RevOpts.AllowUCTrackSwitch, Equals, false)
 
 		validate := s.state.NewTask("validate-snap", fmt.Sprintf("Validate %s", name))
 		validate.Set("snap-setup",
@@ -3168,6 +3176,8 @@ func (s *deviceMgrRemodelSuite) TestRemodelOfflineUseInstalledSnapsChannelSwitch
 		sn := g.snaps[0]
 
 		c.Check(sn.SideInfo.RealName, Equals, "app-snap")
+		// Remodel (offline) policy: UC tracks do not apply (local snap blob).
+		c.Check(sn.RevOpts.AllowUCTrackSwitch, Equals, false)
 
 		validate := s.state.NewTask("validate-snap", fmt.Sprintf("Validate %s", sn.SideInfo.RealName))
 		validate.Set("snap-setup",
@@ -5615,6 +5625,8 @@ func (s *deviceMgrRemodelSuite) testUC20RemodelLocalNonEssential(c *C, tc *uc20R
 		c.Check(si, NotNil)
 		c.Check(si.RealName, Equals, name)
 		c.Check(si.RealName, Not(Equals), "not-used-snap")
+		// Remodel (offline) policy: UC tracks do not apply (local snap blob).
+		c.Check(g.snaps[0].RevOpts.AllowUCTrackSwitch, Equals, false)
 
 		tValidate := s.state.NewTask("validate-snap", fmt.Sprintf("Validate %s", name))
 		tValidate.Set("snap-setup",
@@ -6592,6 +6604,8 @@ func mockSnapstateUpdateOne(c *C, snaps map[string]expectedSnap) (restore func()
 		// snapstate handles picking the right revision based on the given
 		// validation sets
 		c.Assert(rev.Unset(), Equals, true)
+		// Online remodel policy: allow switching to a UC track (channel is from the model).
+		c.Check(g.snaps[0].RevOpts.AllowUCTrackSwitch, Equals, true)
 
 		expected, ok := snaps[name]
 		c.Assert(ok, Equals, true, Commentf("unexpected snap update: %q", name))
@@ -6708,6 +6722,8 @@ func mockSnapstateUpdateOneFromFile(c *C, snaps map[string]expectedSnap) (restor
 		c.Assert(ok, Equals, true, Commentf("unexpected snap update: %q", name))
 
 		c.Assert(g.snaps[0].RevOpts.Revision, Equals, expected.revision)
+		// Remodel (offline) policy: UC tracks do not apply (local snap blob).
+		c.Check(g.snaps[0].RevOpts.AllowUCTrackSwitch, Equals, false)
 
 		if expected.path != "" {
 			c.Assert(g.snaps[0].Path, Equals, expected.path)
@@ -9743,6 +9759,8 @@ func (s *deviceMgrRemodelSuite) TestOfflineRemodelPreinstalledUseOldRevision(c *
 
 		rev := g.snaps[0].RevOpts.Revision
 		c.Check(rev, Equals, snap.R(1))
+		// Remodel (installed revision) policy: UC tracks do not apply (local snap blob).
+		c.Check(g.snaps[0].RevOpts.AllowUCTrackSwitch, Equals, false)
 		opts.PrereqTracker.Add(baseInfo)
 
 		prepare := s.state.NewTask("prepare-snap", fmt.Sprintf("prepare %s", name))

--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -4589,6 +4589,8 @@ func (s *deviceMgrSystemsCreateSuite) testDeviceManagerCreateRecoverySystemValid
 		}
 
 		c.Check(revOpts.Revision.Unset(), Equals, true)
+		// Recovery-system download policy: allow switching to a UC track (channel is from the model).
+		c.Check(revOpts.AllowUCTrackSwitch, Equals, true)
 
 		tDownload := s.state.NewTask("mock-download", fmt.Sprintf("Download %s to track %s", name, revOpts.Channel))
 
@@ -5142,6 +5144,8 @@ func (s *deviceMgrSystemsCreateSuite) testDeviceManagerCreateRecoverySystemValid
 		ctx context.Context, st *state.State, name string, components []string, blobDirectory string, revOpts snapstate.RevisionOptions, opts snapstate.Options) (*state.TaskSet, error,
 	) {
 		c.Assert(revOpts.Revision, Equals, snapRevisions[name])
+		// Recovery-system component download policy: UC tracks do not apply (snapd does not have components).
+		c.Check(revOpts.AllowUCTrackSwitch, Equals, false)
 
 		si := &snap.SideInfo{
 			RealName: name,
@@ -5202,6 +5206,8 @@ func (s *deviceMgrSystemsCreateSuite) testDeviceManagerCreateRecoverySystemValid
 		ctx context.Context, st *state.State, name string, components []string, dir string, revOpts snapstate.RevisionOptions, opts snapstate.Options) (*state.TaskSet, *snap.Info, error,
 	) {
 		c.Assert(revOpts.Revision.Unset(), Equals, true)
+		// Recovery-system download policy: allow switching to a UC track (channel is from the model).
+		c.Check(revOpts.AllowUCTrackSwitch, Equals, true)
 
 		si := &snap.SideInfo{
 			RealName: name,
@@ -6865,6 +6871,8 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerCreateRecoverySystemValid
 		}
 
 		c.Check(revOpts.Revision.Unset(), Equals, true)
+		// Recovery-system download policy: allow switching to a UC track (channel is from the model).
+		c.Check(revOpts.AllowUCTrackSwitch, Equals, true)
 
 		tDownload := s.state.NewTask("fake-download", fmt.Sprintf("Download %s to track %s", name, revOpts.Channel))
 		si := &snap.SideInfo{

--- a/overlord/devicestate/firstboot_test.go
+++ b/overlord/devicestate/firstboot_test.go
@@ -505,6 +505,8 @@ func checkOrder(c *C, tsAll []*state.TaskSet, snaps ...string) {
 		snapsup, err := snapstate.TaskSnapSetup(task0)
 		c.Assert(err, IsNil, Commentf("%#v", task0))
 		c.Check(snapsup.InstanceName().String(), Equals, snaps[matched])
+		// Seeding policy: UC tracks do not apply (local seed blob).
+		c.Check(snapsup.AllowUCTrackSwitch, Equals, false)
 		matched++
 	}
 	c.Check(matched, Equals, len(snaps))

--- a/overlord/snapstate/autorefresh_gating_test.go
+++ b/overlord/snapstate/autorefresh_gating_test.go
@@ -1575,8 +1575,9 @@ func (s *autorefreshGatingSuite) TestAutoRefreshPhase1(c *C) {
 	checkGatingTask(c, tss[0].Tasks()[0], map[string]*snapstate.RefreshCandidate{
 		"snap-a": {
 			SnapSetup: snapstate.SnapSetup{
-				Type:      "app",
-				PlugsOnly: true,
+				Type:               "app",
+				PlugsOnly:          true,
+				AllowUCTrackSwitch: true,
 				Flags: snapstate.Flags{
 					IsAutoRefresh: true,
 				},
@@ -1589,8 +1590,9 @@ func (s *autorefreshGatingSuite) TestAutoRefreshPhase1(c *C) {
 		},
 		"base-snap-b": {
 			SnapSetup: snapstate.SnapSetup{
-				Type:      "base",
-				PlugsOnly: true,
+				Type:               "base",
+				PlugsOnly:          true,
+				AllowUCTrackSwitch: true,
 				Flags: snapstate.Flags{
 					IsAutoRefresh: true,
 				},
@@ -1603,8 +1605,9 @@ func (s *autorefreshGatingSuite) TestAutoRefreshPhase1(c *C) {
 		},
 		"snap-c": {
 			SnapSetup: snapstate.SnapSetup{
-				Type:      "app",
-				PlugsOnly: true,
+				Type:               "app",
+				PlugsOnly:          true,
+				AllowUCTrackSwitch: true,
 				Flags: snapstate.Flags{
 					IsAutoRefresh: true,
 				},
@@ -1617,8 +1620,9 @@ func (s *autorefreshGatingSuite) TestAutoRefreshPhase1(c *C) {
 		},
 		"snap-f": {
 			SnapSetup: snapstate.SnapSetup{
-				Type:      "app",
-				PlugsOnly: true,
+				Type:               "app",
+				PlugsOnly:          true,
+				AllowUCTrackSwitch: true,
 				Flags: snapstate.Flags{
 					IsAutoRefresh: true,
 				},
@@ -1711,9 +1715,10 @@ func (s *autorefreshGatingSuite) TestAffectedByRefreshUsesCurrentSnapInfo(c *C) 
 	checkGatingTask(c, tss[0].Tasks()[0], map[string]*snapstate.RefreshCandidate{
 		"snap-b": {
 			SnapSetup: snapstate.SnapSetup{
-				Type:      "app",
-				Base:      "new-base",
-				PlugsOnly: true,
+				Type:               "app",
+				Base:               "new-base",
+				PlugsOnly:          true,
+				AllowUCTrackSwitch: true,
 				Flags: snapstate.Flags{
 					IsAutoRefresh: true,
 				},
@@ -1726,8 +1731,9 @@ func (s *autorefreshGatingSuite) TestAffectedByRefreshUsesCurrentSnapInfo(c *C) 
 		},
 		"base-snap-b": {
 			SnapSetup: snapstate.SnapSetup{
-				Type:      "base",
-				PlugsOnly: true,
+				Type:               "base",
+				PlugsOnly:          true,
+				AllowUCTrackSwitch: true,
 				Flags: snapstate.Flags{
 					IsAutoRefresh: true,
 				},
@@ -1804,8 +1810,9 @@ func (s *autorefreshGatingSuite) TestAutoRefreshPhase1ConflictsFilteredOut(c *C)
 	checkGatingTask(c, tss[0].Tasks()[0], map[string]*snapstate.RefreshCandidate{
 		"snap-a": {
 			SnapSetup: snapstate.SnapSetup{
-				Type:      "app",
-				PlugsOnly: true,
+				Type:               "app",
+				PlugsOnly:          true,
+				AllowUCTrackSwitch: true,
 				Flags: snapstate.Flags{
 					IsAutoRefresh: true,
 				},
@@ -2713,8 +2720,9 @@ func (s *autorefreshGatingSuite) TestAutoRefreshForGatingSnap(c *C) {
 	checkGatingTask(c, conditionalRefreshTask, map[string]*snapstate.RefreshCandidate{
 		"base-snap-b": {
 			SnapSetup: snapstate.SnapSetup{
-				Type:      "base",
-				PlugsOnly: true,
+				Type:               "base",
+				PlugsOnly:          true,
+				AllowUCTrackSwitch: true,
 				Flags: snapstate.Flags{
 					IsAutoRefresh: true,
 				},
@@ -2727,9 +2735,10 @@ func (s *autorefreshGatingSuite) TestAutoRefreshForGatingSnap(c *C) {
 		},
 		"snap-b": {
 			SnapSetup: snapstate.SnapSetup{
-				Type:      "app",
-				Base:      "base-snap-b",
-				PlugsOnly: true,
+				Type:               "app",
+				Base:               "base-snap-b",
+				PlugsOnly:          true,
+				AllowUCTrackSwitch: true,
 				Flags: snapstate.Flags{
 					IsAutoRefresh: true,
 				},
@@ -2820,8 +2829,9 @@ func (s *autorefreshGatingSuite) TestAutoRefreshForGatingSnapMoreAffectedSnaps(c
 	checkGatingTask(c, conditionalRefreshTask, map[string]*snapstate.RefreshCandidate{
 		"base-snap-b": {
 			SnapSetup: snapstate.SnapSetup{
-				Type:      "base",
-				PlugsOnly: true,
+				Type:               "base",
+				PlugsOnly:          true,
+				AllowUCTrackSwitch: true,
 				Flags: snapstate.Flags{
 					IsAutoRefresh: true,
 				},
@@ -2834,9 +2844,10 @@ func (s *autorefreshGatingSuite) TestAutoRefreshForGatingSnapMoreAffectedSnaps(c
 		},
 		"snap-b": {
 			SnapSetup: snapstate.SnapSetup{
-				Type:      "app",
-				Base:      "base-snap-b",
-				PlugsOnly: true,
+				Type:               "app",
+				Base:               "base-snap-b",
+				PlugsOnly:          true,
+				AllowUCTrackSwitch: true,
 				Flags: snapstate.Flags{
 					IsAutoRefresh: true,
 				},

--- a/overlord/snapstate/component_install_test.go
+++ b/overlord/snapstate/component_install_test.go
@@ -1162,6 +1162,8 @@ func (s *snapmgrTestSuite) testInstallComponents(c *C, opts testInstallComponent
 	c.Assert(err, IsNil)
 	c.Assert(snapsup, NotNil)
 	c.Assert(snapsup.ComponentExclusiveOperation, Equals, true)
+	// Component install policy: UC tracks do not apply (snapd does not have components).
+	c.Check(snapsup.AllowUCTrackSwitch, Equals, false)
 
 	// ensure that we didn't drop persistent classic flag when installing the
 	// component

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -4605,7 +4605,14 @@ func (m *SnapManager) doCheckReRefresh(t *state.Task, tomb *tomb.Tomb) error {
 		}
 	}
 
-	updated, updateTss, err := reRefreshUpdateMany(tomb.Context(nil), st, snaps, nil, re.UserID, reRefreshFilter, re.Flags, chg.ID())
+	revOpts := make([]*RevisionOptions, len(snaps))
+	for i := range snaps {
+		revOpts[i] = &RevisionOptions{
+			// Re-refresh policy: allow switching to a UC track.
+			AllowUCTrackSwitch: true,
+		}
+	}
+	updated, updateTss, err := reRefreshUpdateMany(tomb.Context(nil), st, snaps, revOpts, re.UserID, reRefreshFilter, re.Flags, chg.ID())
 	if err != nil {
 		return err
 	}

--- a/overlord/snapstate/handlers_prereq.go
+++ b/overlord/snapstate/handlers_prereq.go
@@ -249,6 +249,8 @@ func installPrereqs(t *state.Task, snapsup *SnapSetup, dctx DeviceContext, tm ti
 				InstanceName: "snapd",
 				RevOpts: RevisionOptions{
 					Channel: defaultSnapdSnapsChannel(),
+					// Snapd prereq policy: allow switching to a UC track (channel is the default).
+					AllowUCTrackSwitch: true,
 				},
 			}, opts)
 		})

--- a/overlord/snapstate/handlers_prereq_test.go
+++ b/overlord/snapstate/handlers_prereq_test.go
@@ -370,6 +370,16 @@ func (s *prereqSuite) TestDoPrereqTalksToStoreAndQueues(c *C) {
 			snapsup, err := snapstate.TaskSnapSetup(t)
 			c.Assert(err, IsNil)
 			linkedSnaps = append(linkedSnaps, snapsup.InstanceName().String())
+			switch snapsup.InstanceName().String() {
+			case "prereq1", "prereq2":
+				// Content-provider prereq policy: UC tracks do not apply (content providers are never snapd).
+				c.Check(snapsup.AllowUCTrackSwitch, Equals, false)
+			case "some-base":
+				// Base install policy: UC tracks do not apply (bases are never snapd).
+				c.Check(snapsup.AllowUCTrackSwitch, Equals, false)
+			case "snapd":
+				c.Check(snapsup.AllowUCTrackSwitch, Equals, true)
+			}
 		}
 	}
 	c.Check(linkedSnaps, testutil.DeepUnsortedMatches, expectedLinkedSnaps)

--- a/overlord/snapstate/handlers_rerefresh_test.go
+++ b/overlord/snapstate/handlers_rerefresh_test.go
@@ -142,12 +142,17 @@ func (s *reRefreshSuite) TestDoCheckReRefreshNoReRefreshes(c *C) {
 
 func (s *reRefreshSuite) TestDoCheckReRefreshPassesReRefreshSetupData(c *C) {
 	var chgID string
-	defer snapstate.MockReRefreshUpdateMany(func(_ context.Context, _ *state.State, snaps []string, _ []*snapstate.RevisionOptions, userID int, _ snapstate.UpdateFilter, flags *snapstate.Flags, changeID string) ([]string, *snapstate.UpdateTaskSets, error) {
+	defer snapstate.MockReRefreshUpdateMany(func(_ context.Context, _ *state.State, snaps []string, revOpts []*snapstate.RevisionOptions, userID int, _ snapstate.UpdateFilter, flags *snapstate.Flags, changeID string) ([]string, *snapstate.UpdateTaskSets, error) {
 		c.Check(changeID, Equals, chgID)
 		expected := []string{"foo", "bar", "baz"}
 		sort.Strings(expected)
 		sort.Strings(snaps)
 		c.Check(snaps, DeepEquals, expected)
+		c.Assert(revOpts, HasLen, len(snaps))
+		for _, opts := range revOpts {
+			c.Assert(opts, NotNil)
+			c.Check(opts.AllowUCTrackSwitch, Equals, true)
+		}
 		c.Check(userID, Equals, 42)
 		c.Check(flags, DeepEquals, &snapstate.Flags{
 			DevMode:  true,

--- a/overlord/snapstate/refreshhints_test.go
+++ b/overlord/snapstate/refreshhints_test.go
@@ -374,9 +374,10 @@ func (s *refreshHintsTestSuite) TestRefreshHintsStoresRefreshCandidates(c *C) {
 			Revision: snap.R(1),
 			SnapID:   "some-snap-id",
 		},
-		PlugsOnly: true,
-		CohortKey: "cohort",
-		Channel:   "stable",
+		PlugsOnly:          true,
+		CohortKey:          "cohort",
+		Channel:            "stable",
+		AllowUCTrackSwitch: true,
 		Flags: snapstate.Flags{
 			IsAutoRefresh: true,
 		},
@@ -404,6 +405,7 @@ func (s *refreshHintsTestSuite) TestRefreshHintsStoresRefreshCandidates(c *C) {
 		PrereqContentAttrs: map[string][]string{"foo-snap": {"some-content"}},
 		PlugsOnly:          true,
 		Channel:            "devel",
+		AllowUCTrackSwitch: true,
 		Flags: snapstate.Flags{
 			IsAutoRefresh: true,
 		},

--- a/overlord/snapstate/snapmgr.go
+++ b/overlord/snapstate/snapmgr.go
@@ -30,6 +30,7 @@ import (
 
 	"gopkg.in/tomb.v2"
 
+	"github.com/snapcore/snapd/asserts/snapasserts"
 	"github.com/snapcore/snapd/confdb"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/i18n"
@@ -111,6 +112,14 @@ type SnapSetup struct {
 	Version string `json:"version,omitempty"`
 
 	CohortKey string `json:"cohort-key,omitempty"`
+
+	// AllowUCTrackSwitch is set when UC track policy may switch this download onto a UC track
+	// so snapd stays within the UC track's feature compatibility limit.
+	AllowUCTrackSwitch bool `json:"allow-uc-track-switch,omitempty"`
+
+	// ValidationSets is the operation's planned validation-set keys.
+	// Omitted or empty means this operation has no constraints.
+	ValidationSets []snapasserts.ValidationSetKey `json:"validation-sets,omitempty"`
 
 	// FIXME: implement rename of this as suggested in
 	//  https://github.com/snapcore/snapd/pull/4103#discussion_r169569717

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -726,9 +726,9 @@ func InstallPath(st *state.State, si *snap.SideInfo, path, instanceName, channel
 		RevOpts: RevisionOptions{
 			Channel: channel,
 
-			// setting the revision here makes this single-snap path install an
-			// explicit revision update. InstallPathMany intentionally does not
-			// do this, so same-revision local snaps can be handled differently
+			// setting the revision here makes this single-snap path install a
+			// by-revision update. InstallPathMany intentionally does not do
+			// this, so same-revision local snaps can be handled differently
 			// by the two API entrypoints
 			Revision: si.Revision,
 		},
@@ -858,6 +858,8 @@ func downloadTasks(
 		return nil, nil, errors.New("internal error: cannot specify revision and cohort")
 	}
 
+	// Injected default, not a caller-requested channel. Callers that
+	// allow a UC track switch must set AllowUCTrackSwitch on RevOpts themselves.
 	if revOpts.Channel == "" {
 		revOpts.Channel = "stable"
 	}
@@ -903,6 +905,8 @@ func downloadTasks(
 		ExpectedProvenance:          info.SnapProvenance,
 		DownloadBlobDir:             downloadDir,
 		ComponentExclusiveOperation: skipSnapDownload,
+		AllowUCTrackSwitch:          revOpts.AllowUCTrackSwitch,
+		ValidationSets:              revOpts.snapSetupValidationSets(),
 	}
 
 	if sar.RedirectChannel != "" {
@@ -1189,6 +1193,8 @@ func ResolveValidationSetsEnforcementError(ctx context.Context, st *state.State,
 			InstanceName: name,
 			RevOpts: RevisionOptions{
 				ValidationSets: vsets,
+				// Validation-set auto-resolve policy: allow switching to a UC track.
+				AllowUCTrackSwitch: true,
 			},
 			AdditionalComponents: missingComponentsFor(name),
 		})
@@ -1200,6 +1206,8 @@ func ResolveValidationSetsEnforcementError(ctx context.Context, st *state.State,
 			InstanceName: name,
 			RevOpts: RevisionOptions{
 				ValidationSets: vsets,
+				// Validation-set auto-resolve policy: allow switching to a UC track.
+				AllowUCTrackSwitch: true,
 			},
 			AdditionalComponents: missingComponentsFor(name),
 			InstallIfMissing:     true,
@@ -2167,6 +2175,10 @@ type RevisionOptions struct {
 	ValidationSets *snapasserts.ValidationSets
 	CohortKey      string
 	LeaveCohort    bool
+
+	// AllowUCTrackSwitch is set when UC track policy may switch this download onto a UC track
+	// so snapd stays within the UC track's feature compatibility limit.
+	AllowUCTrackSwitch bool
 }
 
 func firstNonEmpty(strs ...string) string {
@@ -2223,6 +2235,15 @@ func (r *RevisionOptions) initializeValidationSets(vsets cachedValidationSets, o
 		r.ValidationSets = enforced
 	}
 	return nil
+}
+
+// snapSetupValidationSets returns the planned validation-set keys for
+// SnapSetup. Empty means this operation has no constraints.
+func (r *RevisionOptions) snapSetupValidationSets() []snapasserts.ValidationSetKey {
+	if r.ValidationSets == nil {
+		return []snapasserts.ValidationSetKey{}
+	}
+	return r.ValidationSets.Keys()
 }
 
 // Update initiates a change updating a snap.
@@ -2334,6 +2355,7 @@ func AutoRefresh(ctx context.Context, st *state.State) ([]string, *UpdateTaskSet
 	}
 	if !gateAutoRefreshHook {
 		// old-style refresh (gate-auto-refresh-hook feature disabled)
+		// Auto-refresh policy: refresh-all; AllowUCTrackSwitch is set in initRefreshAllStoreUpdates.
 		return updateManyFiltered(ctx, st, nil, nil, userID, nil, &Flags{IsAutoRefresh: true}, "")
 	}
 
@@ -3848,6 +3870,8 @@ func TransitionCore(st *state.State, oldName, newName string) ([]*state.TaskSet,
 			RevOpts: RevisionOptions{
 				Channel:        oldSnapst.TrackingChannel,
 				ValidationSets: enforced,
+				// Core transition policy: allow switching to a UC track (channel is from tracking).
+				AllowUCTrackSwitch: true,
 			},
 		}, Options{})
 		if err != nil {
@@ -3863,6 +3887,9 @@ func TransitionCore(st *state.State, oldName, newName string) ([]*state.TaskSet,
 			SideInfo:     &newInfo.SideInfo,
 			Type:         newInfo.Type(),
 			Version:      newInfo.Version,
+			// Core transition policy: allow switching to a UC track (channel is from tracking).
+			AllowUCTrackSwitch: true,
+			ValidationSets:     enforced.Keys(),
 		}, nil, installContext{})
 		if err != nil {
 			return nil, err

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -869,6 +869,8 @@ func (s *snapmgrTestSuite) TestDoInstallChannelDefault(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Check(snapsup.Channel, Equals, "stable")
+	// Name-based Install is not used in production; UC track policy is fail-closed.
+	c.Check(snapsup.AllowUCTrackSwitch, Equals, false)
 }
 
 func (s *snapmgrTestSuite) TestInstallRevision(c *C) {
@@ -884,6 +886,61 @@ func (s *snapmgrTestSuite) TestInstallRevision(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Check(snapsup.Revision(), Equals, snap.R(7))
+	c.Check(snapsup.AllowUCTrackSwitch, Equals, false)
+}
+
+func (s *snapmgrTestSuite) TestInstallChannelDisallowsUCTrackSwitch(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	opts := &snapstate.RevisionOptions{Channel: "some-channel"}
+	ts, err := snapstate.Install(context.Background(), s.state, "some-snap", opts, 0, snapstate.Flags{})
+	c.Assert(err, IsNil)
+
+	var snapsup snapstate.SnapSetup
+	err = ts.Tasks()[0].Get("snap-setup", &snapsup)
+	c.Assert(err, IsNil)
+
+	c.Check(snapsup.Channel, Equals, "some-channel")
+	c.Check(snapsup.AllowUCTrackSwitch, Equals, false)
+}
+
+func (s *snapmgrTestSuite) TestInstallPathDisallowsUCTrackSwitch(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	mockSnap := makeTestSnap(c, `name: some-snap
+version: 1.0
+`)
+	ts, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "some-snap"}, mockSnap, "", "", snapstate.Flags{}, nil)
+	c.Assert(err, IsNil)
+
+	sup, err := snapstate.TaskSnapSetup(ts.Tasks()[0])
+	c.Assert(err, IsNil)
+	c.Check(sup.AllowUCTrackSwitch, Equals, false)
+}
+
+func (s *snapmgrTestSuite) TestSeedingGoalDisallowsUCTrackSwitch(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	r := snapstatetest.MockDeviceModel(DefaultModel())
+	defer r()
+
+	mockSnap := makeTestSnap(c, `name: some-snap
+version: 1.0
+`)
+	goal := snapstate.SeedingGoal(snapstate.PathSnap{
+		Path:     mockSnap,
+		SideInfo: &snap.SideInfo{RealName: "some-snap"},
+		RevOpts:  snapstate.RevisionOptions{Channel: "latest/stable"},
+	})
+	_, ts, err := snapstate.InstallOne(context.Background(), s.state, goal, snapstate.Options{Seed: true})
+	c.Assert(err, IsNil)
+
+	sup, err := snapstate.TaskSnapSetup(ts.Tasks()[0])
+	c.Assert(err, IsNil)
+	c.Check(sup.AllowUCTrackSwitch, Equals, false)
 }
 
 func (s *snapmgrTestSuite) TestInstallTooEarly(c *C) {
@@ -4373,11 +4430,30 @@ func (s *snapmgrTestSuite) TestInstallMany(c *C) {
 				sup, err := snapstate.TaskSnapSetup(t)
 				c.Assert(err, IsNil)
 				c.Check(sup.Version, Equals, sup.SnapName().String()+"Ver")
+				// Name-based InstallMany is not used in production; UC track policy is fail-closed.
+				c.Check(sup.AllowUCTrackSwitch, Equals, false)
 			}
 		}
 	}
 
 	verifyDelayedEffectsTasks(c, tts[2], []int{1, 2}, 0)
+}
+
+func (s *snapmgrTestSuite) TestInstallManyRevisionDisallowsUCTrackSwitch(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	revOpts := []*snapstate.RevisionOptions{{Revision: snap.R(7)}}
+	installed, tts, err := snapstate.InstallMany(s.state, []string{"some-snap"}, revOpts, 0, nil)
+	c.Assert(err, IsNil)
+	c.Check(installed, DeepEquals, []string{"some-snap"})
+	c.Assert(tts, HasLen, 2)
+
+	var snapsup snapstate.SnapSetup
+	err = tts[0].Tasks()[0].Get("snap-setup", &snapsup)
+	c.Assert(err, IsNil)
+	c.Check(snapsup.Revision(), Equals, snap.R(7))
+	c.Check(snapsup.AllowUCTrackSwitch, Equals, false)
 }
 
 func (s *snapmgrTestSuite) TestInstallManyNoDelayed(c *C) {
@@ -5558,8 +5634,13 @@ func (s *validationSetsSuite) TestInstallSnapWithValidationSets(c *C) {
 	c.Assert(err, IsNil)
 
 	opts := &snapstate.RevisionOptions{ValidationSets: vsets}
-	_, err = snapstate.Install(context.Background(), s.state, "some-snap", opts, 0, snapstate.Flags{})
+	ts, err := snapstate.Install(context.Background(), s.state, "some-snap", opts, 0, snapstate.Flags{})
 	c.Assert(err, IsNil)
+
+	var snapsup snapstate.SnapSetup
+	err = ts.Tasks()[0].Get("snap-setup", &snapsup)
+	c.Assert(err, IsNil)
+	c.Check(snapsup.ValidationSets, DeepEquals, vsets.Keys())
 
 	// validation sets are set on the action
 	expectedOp := fakeOp{
@@ -5896,6 +5977,7 @@ epoch: 1
 				c.Assert(err, IsNil)
 				c.Check(sup.SnapName().String(), Equals, snapNames[i])
 				c.Check(sup.Version, Equals, "1.0")
+				c.Check(sup.AllowUCTrackSwitch, Equals, false)
 			}
 		}
 	}

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -5960,6 +5960,10 @@ func (s *snapmgrTestSuite) TestTransitionCoreTasks(c *C) {
 	c.Assert(tsl, HasLen, 3)
 	// 1. install core
 	verifyInstallTasks(c, snap.TypeOS, runCoreConfigure, 0, tsl[0])
+	var snapsup snapstate.SnapSetup
+	err = tsl[0].Tasks()[0].Get("snap-setup", &snapsup)
+	c.Assert(err, IsNil)
+	c.Check(snapsup.AllowUCTrackSwitch, Equals, true)
 	// 2 transition-connections
 	verifyTransitionConnectionsTasks(c, tsl[1])
 	// 3 remove-ubuntu-core
@@ -6510,7 +6514,7 @@ func (s *snapmgrTestSuite) TestTransitionCoreValidationSetsRevision(c *C) {
 		SnapType: "os",
 	})
 
-	_, err = snapstate.TransitionCore(s.state, "ubuntu-core", "core")
+	tsl, err := snapstate.TransitionCore(s.state, "ubuntu-core", "core")
 	c.Assert(err, IsNil)
 
 	c.Assert(s.fakeBackend.ops, HasLen, 2)
@@ -6525,6 +6529,13 @@ func (s *snapmgrTestSuite) TestTransitionCoreValidationSetsRevision(c *C) {
 		},
 		revno: snap.R(15),
 	})
+
+	c.Assert(tsl, HasLen, 3)
+	var snapsup snapstate.SnapSetup
+	err = tsl[0].Tasks()[0].Get("snap-setup", &snapsup)
+	c.Assert(err, IsNil)
+	c.Check(snapsup.AllowUCTrackSwitch, Equals, true)
+	c.Check(snapsup.ValidationSets, DeepEquals, []snapasserts.ValidationSetKey{"16/foo/bar/3"})
 }
 
 // Keep this test even though transition-to-snapd-snap experimental feature was removed
@@ -9609,6 +9620,22 @@ func (s *snapmgrTestSuite) TestResolveValidationSetsEnforcementError(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(affected, DeepEquals, []string{"some-other-snap", "some-snap"})
 
+	gotAllow := make(map[string]bool)
+	for _, ts := range tss {
+		if len(ts.Tasks()) == 1 && ts.Tasks()[0].Kind() == "enforce-validation-sets" {
+			continue
+		}
+		snapsup, err := snapstate.TaskSnapSetup(ts.Tasks()[0])
+		if err != nil || snapsup.ComponentExclusiveOperation {
+			continue
+		}
+		gotAllow[snapsup.InstanceName().String()] = snapsup.AllowUCTrackSwitch
+	}
+	c.Check(gotAllow, DeepEquals, map[string]bool{
+		"some-snap":       true, // missing snap install
+		"some-other-snap": true, // wrong-revision refresh
+	})
+
 	chg := s.state.NewChange("refresh-to-enforce", "")
 	for _, ts := range tss {
 		chg.AddAll(ts)
@@ -11511,6 +11538,57 @@ func (s *snapmgrTestSuite) TestDownload(c *C) {
 	c.Check(prqt.infos, DeepEquals, []*snap.Info{info})
 }
 
+func (s *snapmgrTestSuite) TestDownloadCopiesAllowUCTrackSwitch(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	ts, _, err := snapstate.Download(context.Background(), s.state, "foo", nil, c.MkDir(), snapstate.RevisionOptions{
+		AllowUCTrackSwitch: true,
+	}, snapstate.Options{})
+	c.Assert(err, IsNil)
+	var snapsup snapstate.SnapSetup
+	c.Assert(ts.MaybeEdge(snapstate.BeginEdge).Get("snap-setup", &snapsup), IsNil)
+	c.Check(snapsup.Channel, Equals, "stable")
+	c.Check(snapsup.AllowUCTrackSwitch, Equals, true)
+	c.Check(snapsup.ValidationSets, HasLen, 0)
+
+	ts, _, err = snapstate.Download(context.Background(), s.state, "foo", nil, c.MkDir(), snapstate.RevisionOptions{
+		Channel:            "some-channel",
+		AllowUCTrackSwitch: true,
+	}, snapstate.Options{})
+	c.Assert(err, IsNil)
+	c.Assert(ts.MaybeEdge(snapstate.BeginEdge).Get("snap-setup", &snapsup), IsNil)
+	c.Check(snapsup.Channel, Equals, "some-channel")
+	c.Check(snapsup.AllowUCTrackSwitch, Equals, true)
+
+	ts, _, err = snapstate.Download(context.Background(), s.state, "foo", nil, c.MkDir(), snapstate.RevisionOptions{
+		Revision:           snap.R(2),
+		AllowUCTrackSwitch: true,
+	}, snapstate.Options{})
+	c.Assert(err, IsNil)
+	c.Assert(ts.MaybeEdge(snapstate.BeginEdge).Get("snap-setup", &snapsup), IsNil)
+	c.Check(snapsup.Revision(), Equals, snap.R(2))
+	c.Check(snapsup.AllowUCTrackSwitch, Equals, true)
+}
+
+func (s *snapmgrTestSuite) TestDownloadPreservesCallerAllowUCTrackSwitch(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	ts, _, err := snapstate.Download(context.Background(), s.state, "foo", nil, c.MkDir(), snapstate.RevisionOptions{}, snapstate.Options{})
+	c.Assert(err, IsNil)
+	var snapsup snapstate.SnapSetup
+	c.Assert(ts.MaybeEdge(snapstate.BeginEdge).Get("snap-setup", &snapsup), IsNil)
+	c.Check(snapsup.AllowUCTrackSwitch, Equals, false)
+
+	ts, _, err = snapstate.Download(context.Background(), s.state, "foo", nil, c.MkDir(), snapstate.RevisionOptions{
+		Channel: "some-channel",
+	}, snapstate.Options{})
+	c.Assert(err, IsNil)
+	c.Assert(ts.MaybeEdge(snapstate.BeginEdge).Get("snap-setup", &snapsup), IsNil)
+	c.Check(snapsup.AllowUCTrackSwitch, Equals, false)
+}
+
 func (s *snapmgrTestSuite) TestDownloadWithComponents(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -11808,6 +11886,10 @@ func (s *snapmgrTestSuite) TestDownloadWithComponentsWithValidationSets(c *C) {
 
 	const componentExclusive = false
 	verifySnapAndComponentSetupsForDownload(c, begin, ts, downloadDir, componentExclusive)
+
+	var snapsup snapstate.SnapSetup
+	c.Assert(begin.Get("snap-setup", &snapsup), IsNil)
+	c.Check(snapsup.ValidationSets, DeepEquals, vsets.Keys())
 }
 
 func (s *snapmgrTestSuite) TestDownloadComponents(c *C) {
@@ -11885,6 +11967,26 @@ func (s *snapmgrTestSuite) TestDownloadComponents(c *C) {
 
 	const componentExclusive = true
 	verifySnapAndComponentSetupsForDownload(c, begin, ts, downloadDir, componentExclusive)
+
+	ts, err = snapstate.DownloadComponents(
+		context.Background(),
+		s.state,
+		"snap-1",
+		[]string{"comp-1", "comp-2"},
+		downloadDir,
+		snapstate.RevisionOptions{
+			Channel:            "latest/stable",
+			Revision:           snap.R(11),
+			AllowUCTrackSwitch: true,
+		},
+		snapstate.Options{},
+	)
+	c.Assert(err, IsNil)
+	begin = ts.MaybeEdge(snapstate.BeginEdge)
+	c.Assert(begin, NotNil)
+	var snapsup snapstate.SnapSetup
+	c.Assert(begin.Get("snap-setup", &snapsup), IsNil)
+	c.Check(snapsup.AllowUCTrackSwitch, Equals, true)
 }
 
 func verifySnapAndComponentSetupsForDownload(c *C, begin *state.Task, ts *state.TaskSet, downloadDir string, componentExclusive bool) {
@@ -11892,6 +11994,7 @@ func verifySnapAndComponentSetupsForDownload(c *C, begin *state.Task, ts *state.
 	err := begin.Get("snap-setup", &snapsup)
 	c.Assert(err, IsNil)
 	c.Check(snapsup.DownloadBlobDir, Equals, downloadDir)
+	c.Check(snapsup.AllowUCTrackSwitch, Equals, false)
 
 	expectedDownloadDir := downloadDir
 	if expectedDownloadDir == "" {

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -1248,7 +1248,6 @@ func (s *snapmgrTestSuite) testUpdateAmendRunThrough(c *C, tryMode bool, compone
 	c.Assert(snapsup, DeepEquals, snapstate.SnapSetup{
 		Channel: "channel-for-components",
 		UserID:  s.user.ID,
-
 		DownloadInfo: &snap.DownloadInfo{
 			DownloadURL: "https://some-server.com/some/path.snap",
 			Size:        5,
@@ -1528,7 +1527,6 @@ func (s *snapmgrTestSuite) testUpdateRunThrough(c *C, refreshAppAwarenessUX bool
 		Channel:   "some-channel",
 		CohortKey: "some-cohort",
 		UserID:    s.user.ID,
-
 		DownloadInfo: &snap.DownloadInfo{
 			DownloadURL: "https://some-server.com/some/path.snap",
 			Sha3_384:    "<some-hash>",
@@ -1917,7 +1915,6 @@ func (s *snapmgrTestSuite) TestParallelInstanceUpdateRunThrough(c *C) {
 	c.Assert(snapsup, DeepEquals, snapstate.SnapSetup{
 		Channel: "some-channel",
 		UserID:  s.user.ID,
-
 		DownloadInfo: &snap.DownloadInfo{
 			DownloadURL: "https://some-server.com/some/path.snap",
 			Sha3_384:    "<some-hash>",
@@ -2268,7 +2265,6 @@ func (s *snapmgrTestSuite) TestUpdateModelKernelSwitchTrackRunThrough(c *C) {
 	c.Assert(snapsup, DeepEquals, snapstate.SnapSetup{
 		Channel: "18/edge",
 		UserID:  s.user.ID,
-
 		DownloadInfo: &snap.DownloadInfo{
 			DownloadURL: "https://some-server.com/some/path.snap",
 			Sha3_384:    "<some-hash>",
@@ -5031,6 +5027,23 @@ epoch: 1*
 	c.Check(prqt.missingProviderContentTagsCalls, Equals, 1)
 }
 
+func (s *snapmgrTestSuite) TestUpdatePathWithDeviceContextDisallowsUCTrackSwitch(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	si := &snap.SideInfo{RealName: "some-snap", Revision: snap.R(8)}
+	mockSnap := makeTestSnap(c, `name: some-snap
+version: 1.0
+epoch: 1*
+`)
+	ts, err := snapstate.UpdatePathWithDeviceContext(s.state, si, mockSnap, "some-snap", nil, s.user.ID, snapstate.Flags{}, nil, nil, "")
+	c.Assert(err, IsNil)
+
+	sup, err := snapstate.TaskSnapSetup(ts.Tasks()[0])
+	c.Assert(err, IsNil)
+	c.Check(sup.AllowUCTrackSwitch, Equals, false)
+}
+
 func (s *snapmgrTestSuite) TestUpdatePathWithDeviceContextSwitchChannel(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
@@ -5380,6 +5393,54 @@ func (s *snapmgrTestSuite) TestUpdateChannelFallback(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Check(snapsup.Channel, Equals, "latest/edge")
+	// Name-based Update is not used in production; UC track policy is fail-closed.
+	c.Check(snapsup.AllowUCTrackSwitch, Equals, false)
+}
+
+func (s *snapmgrTestSuite) TestUpdateChannelDisallowsUCTrackSwitch(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:          true,
+		TrackingChannel: "latest/edge",
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}}),
+		Current:         snap.R(7),
+		SnapType:        "app",
+	})
+
+	ts, err := snapstate.Update(s.state, "some-snap", &snapstate.RevisionOptions{Channel: "some-channel"}, s.user.ID, snapstate.Flags{})
+	c.Assert(err, IsNil)
+
+	var snapsup snapstate.SnapSetup
+	err = ts.Tasks()[0].Get("snap-setup", &snapsup)
+	c.Assert(err, IsNil)
+
+	c.Check(snapsup.Channel, Equals, "some-channel")
+	c.Check(snapsup.AllowUCTrackSwitch, Equals, false)
+}
+
+func (s *snapmgrTestSuite) TestUpdateRevisionDisallowsUCTrackSwitch(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:          true,
+		TrackingChannel: "latest/edge",
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}}),
+		Current:         snap.R(7),
+		SnapType:        "app",
+	})
+
+	ts, err := snapstate.Update(s.state, "some-snap", &snapstate.RevisionOptions{Revision: snap.R(11)}, s.user.ID, snapstate.Flags{})
+	c.Assert(err, IsNil)
+
+	var snapsup snapstate.SnapSetup
+	err = ts.Tasks()[0].Get("snap-setup", &snapsup)
+	c.Assert(err, IsNil)
+
+	c.Check(snapsup.Revision(), Equals, snap.R(11))
+	c.Check(snapsup.AllowUCTrackSwitch, Equals, false)
 }
 
 func (s *snapmgrTestSuite) TestUpdateTooEarly(c *C) {
@@ -5528,6 +5589,11 @@ func (s *snapmgrTestSuite) TestUpdateMany(c *C) {
 	ts := tts[0]
 	verifyUpdateTasks(c, snap.TypeApp, 0, 3, ts)
 
+	var snapsup snapstate.SnapSetup
+	err = ts.Tasks()[0].Get("snap-setup", &snapsup)
+	c.Assert(err, IsNil)
+	c.Check(snapsup.AllowUCTrackSwitch, Equals, true)
+
 	// check that the tasks are in non-default lane
 	for _, t := range ts.Tasks() {
 		c.Assert(t.Lanes(), DeepEquals, []int{1})
@@ -5541,6 +5607,56 @@ func (s *snapmgrTestSuite) TestUpdateMany(c *C) {
 	c.Assert(err, IsNil)
 
 	checkIsAutoRefresh(c, ts.Tasks(), false)
+}
+
+func (s *snapmgrTestSuite) TestUpdateManyRevisionDisallowsUCTrackSwitch(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:          true,
+		TrackingChannel: "latest/edge",
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(7)}}),
+		Current:         snap.R(7),
+		SnapType:        "app",
+	})
+
+	revOpts := []*snapstate.RevisionOptions{{Revision: snap.R(11)}}
+	updates, tts, err := snapstate.UpdateMany(context.Background(), s.state, []string{"some-snap"}, revOpts, 0, nil)
+	c.Assert(err, IsNil)
+	c.Check(updates, DeepEquals, []string{"some-snap"})
+	c.Assert(tts, HasLen, 3)
+
+	var snapsup snapstate.SnapSetup
+	err = tts[0].Tasks()[0].Get("snap-setup", &snapsup)
+	c.Assert(err, IsNil)
+	c.Check(snapsup.Revision(), Equals, snap.R(11))
+	c.Check(snapsup.AllowUCTrackSwitch, Equals, false)
+}
+
+func (s *snapmgrTestSuite) TestUpdateManyNamedSnapsDisallowsUCTrackSwitch(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active: true,
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "some-snap", SnapID: "some-snap-id", Revision: snap.R(1)},
+		}),
+		Current:  snap.R(1),
+		SnapType: "app",
+	})
+
+	updates, tts, err := snapstate.UpdateMany(context.Background(), s.state, []string{"some-snap"}, nil, 0, nil)
+	c.Assert(err, IsNil)
+	c.Check(updates, DeepEquals, []string{"some-snap"})
+	c.Assert(tts, HasLen, 3)
+
+	var snapsup snapstate.SnapSetup
+	err = tts[0].Tasks()[0].Get("snap-setup", &snapsup)
+	c.Assert(err, IsNil)
+	// Name-based UpdateMany is not used in production; UC track policy is fail-closed.
+	c.Check(snapsup.AllowUCTrackSwitch, Equals, false)
 }
 
 func (s *snapmgrTestSuite) TestUpdateManyIgnoreRunning(c *C) {
@@ -8658,6 +8774,7 @@ func (s *validationSetsSuite) TestUpdateToRevisionWithValidationSets(c *C) {
 
 	// new snap revision from the store
 	c.Check(snapsup.Revision(), Equals, snap.R(11))
+	c.Check(snapsup.ValidationSets, DeepEquals, vsets.Keys())
 
 	c.Assert(s.fakeBackend.ops, HasLen, 2)
 	expectedOps := fakeOps{{
@@ -15750,9 +15867,8 @@ func (s *snapmgrTestSuite) TestUpdateBackToPrevRevision(c *C) {
 	err = task.Get("snap-setup", &snapsup)
 	c.Assert(err, IsNil)
 	c.Assert(snapsup, DeepEquals, snapstate.SnapSetup{
-		Channel: channel,
-		UserID:  s.user.ID,
-
+		Channel:   channel,
+		UserID:    s.user.ID,
 		SnapPath:  filepath.Join(dirs.SnapBlobDir, fmt.Sprintf("%s_%v.snap", instanceName, prevSnapRev)),
 		SideInfo:  snapsup.SideInfo,
 		Type:      snap.TypeApp,
@@ -16429,9 +16545,8 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
 	err = task.Get("snap-setup", &snapsup)
 	c.Assert(err, IsNil)
 	c.Assert(snapsup, DeepEquals, snapstate.SnapSetup{
-		Channel: channel,
-		UserID:  s.user.ID,
-
+		Channel:   channel,
+		UserID:    s.user.ID,
 		SnapPath:  filepath.Join(dirs.SnapBlobDir, fmt.Sprintf("%s_%v.snap", snapName, prevSnapRev)),
 		SideInfo:  snapsup.SideInfo,
 		Type:      snap.TypeKernel,
@@ -16973,9 +17088,8 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevisionAddComponen
 	err = task.Get("snap-setup", &snapsup)
 	c.Assert(err, IsNil)
 	c.Assert(snapsup, DeepEquals, snapstate.SnapSetup{
-		Channel: channel,
-		UserID:  s.user.ID,
-
+		Channel:   channel,
+		UserID:    s.user.ID,
 		SnapPath:  filepath.Join(dirs.SnapBlobDir, fmt.Sprintf("%s_%v.snap", snapName, prevSnapRev)),
 		SideInfo:  snapsup.SideInfo,
 		Type:      snap.TypeKernel,
@@ -17746,9 +17860,8 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThrough(c *C, opts updateW
 	c.Assert(err, IsNil)
 
 	expectedSnapsup := snapstate.SnapSetup{
-		Channel: channel,
-		UserID:  s.user.ID,
-
+		Channel:   channel,
+		UserID:    s.user.ID,
 		SideInfo:  snapsup.SideInfo,
 		Type:      opts.snapType,
 		Version:   snapName + "Ver",
@@ -18242,9 +18355,8 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThroughShareComponents(c *
 	c.Assert(err, IsNil)
 
 	expectedSnapsup := snapstate.SnapSetup{
-		Channel: channel,
-		UserID:  s.user.ID,
-
+		Channel:   channel,
+		UserID:    s.user.ID,
 		SideInfo:  snapsup.SideInfo,
 		Type:      snap.TypeKernel,
 		Version:   "kernelVer",

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -173,9 +173,11 @@ func targetFromLocalSnapWithStoreComponents(
 		info:   info,
 		snapst: *snapst,
 		setup: SnapSetup{
-			Channel:   trackedChannel,
-			CohortKey: up.RevOpts.CohortKey,
-			SnapPath:  info.MountFile(),
+			Channel:            trackedChannel,
+			CohortKey:          up.RevOpts.CohortKey,
+			SnapPath:           info.MountFile(),
+			AllowUCTrackSwitch: up.RevOpts.AllowUCTrackSwitch,
+			ValidationSets:     up.RevOpts.snapSetupValidationSets(),
 
 			// if the caller specified a revision, then we always run
 			// through the entire update process. this enables something
@@ -227,10 +229,12 @@ func targetFromActionResult(sar store.SnapActionResult, snapst *SnapState, revOp
 		info:   sar.Info,
 		snapst: *snapst,
 		setup: SnapSetup{
-			DownloadInfo:      &sar.DownloadInfo,
-			Channel:           trackedChannel,
-			CohortKey:         revOpts.CohortKey,
-			IntegrityDataInfo: sar.IntegrityData,
+			DownloadInfo:       &sar.DownloadInfo,
+			Channel:            trackedChannel,
+			CohortKey:          revOpts.CohortKey,
+			IntegrityDataInfo:  sar.IntegrityData,
+			AllowUCTrackSwitch: revOpts.AllowUCTrackSwitch,
+			ValidationSets:     revOpts.snapSetupValidationSets(),
 		},
 		components: components,
 	}, nil
@@ -297,6 +301,9 @@ func (t *target) setups(st *state.State, opts Options) (SnapSetup, []ComponentSe
 		DownloadInfo: t.setup.DownloadInfo,
 		SnapPath:     t.setup.SnapPath,
 		AlwaysUpdate: t.setup.AlwaysUpdate,
+
+		AllowUCTrackSwitch: t.setup.AllowUCTrackSwitch,
+		ValidationSets:     t.setup.ValidationSets,
 
 		Base:               t.info.Base,
 		Prereq:             keys(providerContentAttrs),
@@ -1557,6 +1564,8 @@ func initRefreshAllStoreUpdates(st *state.State, opts Options, allSnaps map[stri
 				Channel:        snapst.TrackingChannel,
 				CohortKey:      snapst.CohortKey,
 				ValidationSets: vsets,
+				// Refresh-all policy: allow switching to a UC track (channel is from tracking).
+				AllowUCTrackSwitch: true,
 			},
 		}
 	}
@@ -1701,11 +1710,13 @@ func targetFromPathSnap(update PathSnap, snapst SnapState, opts Options) (target
 
 	return target{
 		setup: SnapSetup{
-			SnapPath:  update.Path,
-			Channel:   update.RevOpts.Channel,
-			CohortKey: update.RevOpts.CohortKey,
+			SnapPath:           update.Path,
+			Channel:            update.RevOpts.Channel,
+			CohortKey:          update.RevOpts.CohortKey,
+			AllowUCTrackSwitch: update.RevOpts.AllowUCTrackSwitch,
+			ValidationSets:     update.RevOpts.snapSetupValidationSets(),
 
-			// mirror store-backed by-revision refresh: an explicit revision should
+			// mirror store-backed by-revision refresh: a requested revision should
 			// run the full update path even if the revision is already current.
 			AlwaysUpdate: !update.RevOpts.Revision.Unset(),
 		},


### PR DESCRIPTION
Part 2.1:  Persist UC track-switch intent and validation-set keys so a later intercept can honor it without guessing.
AllowUCTrackSwitch is fail-closed: omitted/false means do not switch. Callers that may switch snapd onto a UC track set it. ValidationSets are this operation's planned keys; omitted means no constraints.

This was split from Part2 #17513: After the install download step, the candidate map informs the jump onto the mapped track. (this is not fairly outdated, not worth refreshing though).

<details>
<summary>Purpose</summary>

The download intercept (2.3) runs after the store download, far from the API/refresh/remodel caller. It must not infer intent from Channel or Revision: those fields are often filled with defaults (tracking channel, injected "stable") that are not a user pin. The caller records intent now; the intercept reads it later.

</details>

<details>
<summary>Mechanism</summary>

On RevisionOptions and SnapSetup:

- AllowUCTrackSwitch: permission to apply uctrack.Resolve to this
  download. Default false. Copied through install/refresh/download
  setup; Always explicit, never inferred.
- ValidationSets: this operation's planned validation-set keys.
  Omitted or empty means no constraints or a later intercept.

</details>

<details>
<summary>Policy</summary>

Allow (set true) when snapd may choose the snapd channel:

- REST install/refresh of one snap, if channel and revision are both unset
- REST install-many / refresh-many (specific channel/revision not allowed) 
- auto-refresh / refresh-all (channel is tracking)
- re-refresh (for epoch transitions - not currently relevant to snapd)
- snapd prereq install (channel is the default)
- validation-set auto-resolve
- core transition
- online remodel (channel from the model)
- recovery-system snapd download (channel from the model)
- cluster install/refresh (channel from the assertion)

Deny (leave false) when the revision is pinned, the blob is local, or the path is not used in production:

- explicit channel or revision on a single-snap REST call
- path, sideload, try
- seed (local blob)
- offline remodel / remodel of an installed revision (local blob)
- name-based Install / Update / InstallMany / UpdateMany

Themes, content-provider prereqs, bases, and components never download
snapd; they stay false.

This PR does not call uctrack.Resolve.

</details>

Part 1: #17509 - embedding a track map into snapd that informs transitions to UC tracks based on core version. [Done]

Spec: [UC042 - Snapd LTS tracks for Ubuntu Core](https://docs.google.com/document/d/12jkKReLH2UZGYzB0SIK1aqSnLComK9gdP3LUXc-YOJ4/edit?tab=t.0)