### PR TITLE
store: retry snap-action on 408, with a bigger retry budget

### DIFF
--- a/httputil/retry.go
+++ b/httputil/retry.go
@@ -64,6 +64,9 @@ func maybeLogRetrySummary(startTime time.Time, url string, attempt *retry.Attemp
 	}
 }
 
+// RetryResponsePolicy decides whether a response is worth another attempt.
+type RetryResponsePolicy func(attempt *retry.Attempt, resp *http.Response) bool
+
 func ShouldRetryHttpResponse(attempt *retry.Attempt, resp *http.Response) bool {
 	if !attempt.More() {
 		return false
@@ -262,6 +265,12 @@ func isTimeout(err error) bool {
 
 // RetryRequest calls doRequest and read the response body in a retry loop using the given retryStrategy.
 func RetryRequest(endpoint string, doRequest func() (*http.Response, error), readResponseBody func(resp *http.Response) error, retryStrategy retry.Strategy) (resp *http.Response, err error) {
+	return RetryRequestWithPolicy(endpoint, doRequest, readResponseBody, retryStrategy, ShouldRetryHttpResponse)
+}
+
+// RetryRequestWithPolicy is like RetryRequest but decides which responses to
+// retry with the given policy instead of ShouldRetryHttpResponse.
+func RetryRequestWithPolicy(endpoint string, doRequest func() (*http.Response, error), readResponseBody func(resp *http.Response) error, retryStrategy retry.Strategy, shouldRetryResponse RetryResponsePolicy) (resp *http.Response, err error) {
 	var attempt *retry.Attempt
 	startTime := time.Now()
 	for attempt = retry.Start(retryStrategy, nil); attempt.Next(); {
@@ -279,7 +288,7 @@ func RetryRequest(endpoint string, doRequest func() (*http.Response, error), rea
 			break
 		}
 
-		if ShouldRetryHttpResponse(attempt, resp) {
+		if shouldRetryResponse(attempt, resp) {
 			resp.Body.Close()
 			continue
 		} else {

--- a/store/export_test.go
+++ b/store/export_test.go
@@ -270,6 +270,15 @@ func MockRequestTimeout(d time.Duration) (restore func()) {
 	}
 }
 
+// MockRefreshRetryStrategy mocks the retry strategy used by snap-action.
+func MockRefreshRetryStrategy(t *testutil.BaseTest, strategy retry.Strategy) {
+	originalRefreshRetryStrategy := refreshRetryStrategy
+	refreshRetryStrategy = strategy
+	t.AddCleanup(func() {
+		refreshRetryStrategy = originalRefreshRetryStrategy
+	})
+}
+
 type (
 	ErrorListEntryJSON   = errorListEntry
 	SnapActionResultJSON = snapActionResult

--- a/store/store.go
+++ b/store/store.go
@@ -86,6 +86,15 @@ var connCheckStrategy = retry.LimitCount(3, retry.LimitTime(38*time.Second,
 	},
 ))
 
+// snap-action is resolved inside task handlers, where giving up fails the
+// whole change, so it retries for longer than the interactive endpoints.
+var refreshRetryStrategy = retry.LimitCount(7, retry.LimitTime(90*time.Second,
+	retry.Exponential{
+		Initial: 500 * time.Millisecond,
+		Factor:  2.5,
+	},
+))
+
 // For testing purposes
 var squashfsSupportedDeltaFormats = squashfs.SupportedDeltaFormats
 
@@ -714,11 +723,31 @@ func decodeJSONBody(resp *http.Response, success any, failure any) error {
 
 // retryRequestDecodeJSON calls retryRequest and decodes the response into either success or failure.
 func (s *Store) retryRequestDecodeJSON(ctx context.Context, reqOptions *requestOptions, user *auth.UserState, success any, failure any) (resp *http.Response, err error) {
-	return httputil.RetryRequest(reqOptions.URL.String(), func() (*http.Response, error) {
+	return s.retryRequestDecodeJSONWith(ctx, reqOptions, user, success, failure, defaultRetryStrategy, httputil.ShouldRetryHttpResponse)
+}
+
+// refreshRequestDecodeJSON is retryRequestDecodeJSON for snap-action; see
+// refreshRetryStrategy and shouldRetryRefreshResponse.
+func (s *Store) refreshRequestDecodeJSON(ctx context.Context, reqOptions *requestOptions, user *auth.UserState, success any, failure any) (resp *http.Response, err error) {
+	return s.retryRequestDecodeJSONWith(ctx, reqOptions, user, success, failure, refreshRetryStrategy, shouldRetryRefreshResponse)
+}
+
+// shouldRetryRefreshResponse also retries 408, which the store returns when it
+// gives up on a slow request body or retires a keep-alive connection. Both are
+// transient and snap-action is a read-only query, so repeating it is safe.
+func shouldRetryRefreshResponse(attempt *retry.Attempt, resp *http.Response) bool {
+	if resp.StatusCode == 408 {
+		return attempt.More()
+	}
+	return httputil.ShouldRetryHttpResponse(attempt, resp)
+}
+
+func (s *Store) retryRequestDecodeJSONWith(ctx context.Context, reqOptions *requestOptions, user *auth.UserState, success any, failure any, strategy retry.Strategy, shouldRetryResponse httputil.RetryResponsePolicy) (resp *http.Response, err error) {
+	return httputil.RetryRequestWithPolicy(reqOptions.URL.String(), func() (*http.Response, error) {
 		return s.doRequest(ctx, s.client, reqOptions, user)
 	}, func(resp *http.Response) error {
 		return decodeJSONBody(resp, success, failure)
-	}, defaultRetryStrategy)
+	}, strategy, shouldRetryResponse)
 }
 
 // doRequest does an authenticated request to the store handling a potential macaroon refresh required if needed

--- a/store/store_action.go
+++ b/store/store_action.go
@@ -613,7 +613,7 @@ func (s *Store) snapAction(ctx context.Context, currentSnaps []*CurrentSnap, act
 	}
 
 	var results snapActionResultList
-	resp, err := s.retryRequestDecodeJSON(ctx, reqOptions, user, &results, nil)
+	resp, err := s.refreshRequestDecodeJSON(ctx, reqOptions, user, &results, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/store/store_action_test.go
+++ b/store/store_action_test.go
@@ -914,6 +914,88 @@ func (s *storeActionSuite) TestSnapActionRetryOnEOF(c *C) {
 	c.Assert(results[0].InstanceName(), Equals, "hello-world")
 }
 
+func (s *storeActionSuite) TestSnapActionRetryOn408(c *C) {
+	n := 0
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(c, r, "POST", snapActionPath)
+		n++
+		if n < 3 {
+			w.WriteHeader(408)
+			return
+		}
+		io.WriteString(w, `{
+  "results": [{
+     "result": "install",
+     "instance-key": "install-1",
+     "snap-id": "core24-id",
+     "name": "core24",
+     "snap": {
+       "snap-id": "core24-id",
+       "name": "core24",
+       "revision": 1,
+       "version": "24",
+       "publisher": {
+          "id": "canonical",
+          "username": "canonical",
+          "display-name": "Canonical"
+       }
+     }
+  }]
+}`)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	mockServerURL, _ := url.Parse(mockServer.URL)
+	cfg := store.Config{
+		StoreBaseURL: mockServerURL,
+	}
+	dauthCtx := &testDauthContext{c: c, device: s.device}
+	sto := store.New(&cfg, dauthCtx)
+
+	results, _, err := sto.SnapAction(s.ctx, nil, []*store.SnapAction{
+		{
+			Action:       "install",
+			InstanceName: "core24",
+		},
+	}, nil, nil, nil)
+	c.Assert(err, IsNil)
+	c.Check(n, Equals, 3)
+	c.Assert(results, HasLen, 1)
+	c.Check(results[0].InstanceName(), Equals, "core24")
+}
+
+func (s *storeActionSuite) TestSnapAction408Exhausted(c *C) {
+	n := 0
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(c, r, "POST", snapActionPath)
+		n++
+		w.WriteHeader(408)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	mockServerURL, _ := url.Parse(mockServer.URL)
+	cfg := store.Config{
+		StoreBaseURL: mockServerURL,
+	}
+	dauthCtx := &testDauthContext{c: c, device: s.device}
+	sto := store.New(&cfg, dauthCtx)
+
+	results, _, err := sto.SnapAction(s.ctx, nil, []*store.SnapAction{
+		{
+			Action:       "install",
+			InstanceName: "core24",
+		},
+	}, nil, nil, nil)
+	c.Assert(err, ErrorMatches, `cannot query the store for updates: got unexpected HTTP status code 408 via POST to "http://127\.0\.0\.1:.*/v2/snaps/refresh"`)
+	c.Check(err, FitsTypeOf, &store.UnexpectedHTTPStatusError{})
+	c.Check(results, HasLen, 0)
+	c.Check(n > 1, Equals, true)
+}
+
 func (s *storeActionSuite) TestSnapActionIgnoreValidation(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assertRequest(c, r, "POST", snapActionPath)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -419,6 +419,12 @@ func (s *baseStoreSuite) SetUpTest(c *C) {
 			Factor:  1,
 		},
 	)))
+	store.MockRefreshRetryStrategy(&s.BaseTest, retry.LimitCount(5, retry.LimitTime(1*time.Second,
+		retry.Exponential{
+			Initial: 1 * time.Millisecond,
+			Factor:  1,
+		},
+	)))
 }
 
 type storeTestSuite struct {
@@ -1533,6 +1539,31 @@ func (s *storeTestSuite) TestInfo500(c *C) {
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, `cannot get details for snap "hello-world": got unexpected HTTP status code 500 via GET to "http://.*?/info/hello-world.*"`)
 	c.Assert(n, Equals, 5)
+}
+
+// retrying 408 is specific to snap-action, info should still fail fast
+func (s *storeTestSuite) TestInfo408NotRetried(c *C) {
+	var n = 0
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assertRequest(c, r, "GET", infoPathPattern)
+		n++
+		w.WriteHeader(408)
+	}))
+
+	c.Assert(mockServer, NotNil)
+	defer mockServer.Close()
+
+	mockServerURL, _ := url.Parse(mockServer.URL)
+	cfg := store.Config{
+		StoreBaseURL: mockServerURL,
+		DetailFields: []string{},
+	}
+	dauthCtx := &testDauthContext{c: c, device: s.device}
+	sto := store.New(&cfg, dauthCtx)
+
+	_, err := sto.SnapInfo(s.ctx, store.SnapSpec{Name: "hello-world"}, nil)
+	c.Assert(err, ErrorMatches, `cannot get details for snap "hello-world": got unexpected HTTP status code 408 via GET to "http://.*?/info/hello-world.*"`)
+	c.Check(n, Equals, 1)
 }
 
 func (s *storeTestSuite) TestInfo500Once(c *C) {


### PR DESCRIPTION
I found there is a big discrepancy between how snap downloads are retried and how the snap store calls to `/refresh` is retried.

On a device in the field with very little bandwidth:

    admin@meterkast:~$ sudo snap install core24
    error: cannot install "core24": cannot query the store for updates: got unexpected HTTP status code
           408 via POST to "https://api.snapcraft.io/v2/snaps/refresh"

The store answers 408 when it gives up on a request body that is still trickling in, or when it retires a keep-alive connection snapd was about to reuse. httputil.ShouldRetryHttpResponse only retries >= 500, so this failed on the first attempt, and snap-action is resolved inside task handlers.

For snap-action only, retry 408 and raise the budget from ~38s/3 attempts to 90s/7. find/info/search keep the old policy, they block a live "snap" CLI request and should still fail fast.

The 10s per-request timeout is unchanged, so a refresh that needs longer than that still fails; raising it is a separate discussion.

LP: #1639981
LP: #1891618
