### PR TITLE
tests: add missing shebang

### DIFF
--- a/tests/lib/snaps/store/test-snapd-location-control-provider/snapcraft.yaml
+++ b/tests/lib/snaps/store/test-snapd-location-control-provider/snapcraft.yaml
@@ -25,6 +25,7 @@ parts:
     deps:
         plugin: python
         stage-packages: [python3-gi, python3-dbus, gir1.2-glib-2.0]
+        source: .
     copy:
         plugin: dump
         source: .

--- a/tests/lib/snaps/store/test-snapd-location-control-provider/wrapper
+++ b/tests/lib/snaps/store/test-snapd-location-control-provider/wrapper
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 export GI_TYPELIB_PATH=$SNAP/usr/lib/girepository-1.0:$(ls -d $SNAP/usr/lib/*/girepository-1.0)
 
-$SNAP/usr/bin/python3 $SNAP/provider.py
+"$SNAP/usr/bin/python3" $SNAP/provider.py


### PR DESCRIPTION
```
1638: Aug 31 12:35:38 aug311230-027676 test-snapd-location-control-provider.provider[10252]: cannot snap-exec: cannot exec "/snap/test-snapd-location-control-provider/33/wrapper": exec format error
```