### PR TITLE
overlord, tests/main/disk-reservation-size: fix default behavior when disk-reservation.size is unset

### DIFF
--- a/overlord/snapstate/autorefresh_gating_test.go
+++ b/overlord/snapstate/autorefresh_gating_test.go
@@ -2302,6 +2302,7 @@ func (s *snapmgrTestSuite) testAutoRefreshPhase2DiskSpaceCheck(c *C, fail bool) 
 
 	tr := config.NewTransaction(s.state)
 	tr.Set("core", "experimental.check-disk-space-refresh", true)
+	tr.Set("core", "disk-reservation.size", snapstate.DefaultDiskSpaceReservation)
 	tr.Commit()
 
 	snapstate.ReplaceStore(s.state, &autoRefreshGatingStore{

--- a/overlord/snapstate/autorefresh_gating_test.go
+++ b/overlord/snapstate/autorefresh_gating_test.go
@@ -2274,7 +2274,7 @@ func (s *snapmgrTestSuite) testAutoRefreshPhase2DiskSpaceCheck(c *C, fail bool) 
 	defer st.Unlock()
 
 	restore := snapstate.MockOsutilCheckFreeSpace(func(path string, sz uint64) error {
-		c.Check(sz, Equals, uint64(123)+snapstate.DefaultDiskSpaceReservation)
+		c.Check(sz, Equals, uint64(123)+snapstate.FallbackDiskSpaceReservation)
 		if fail {
 			return &osutil.NotEnoughDiskSpaceError{}
 		}
@@ -2302,7 +2302,7 @@ func (s *snapmgrTestSuite) testAutoRefreshPhase2DiskSpaceCheck(c *C, fail bool) 
 
 	tr := config.NewTransaction(s.state)
 	tr.Set("core", "experimental.check-disk-space-refresh", true)
-	tr.Set("core", "disk-reservation.size", snapstate.DefaultDiskSpaceReservation)
+	tr.Set("core", "disk-reservation.size", snapstate.FallbackDiskSpaceReservation)
 	tr.Commit()
 
 	snapstate.ReplaceStore(s.state, &autoRefreshGatingStore{

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -54,6 +54,7 @@ type (
 var ComponentSetupTask = componentSetupTask
 var RemoveComponentTasks = removeComponentTasks
 var DiskSpaceReservation = diskSpaceReservation
+var CalculateRequiredSpace = calculateRequiredSpace
 
 var DiskSpaceUnsetError = diskSpaceUnsetError
 

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -59,14 +59,14 @@ var CalculateRequiredSpace = calculateRequiredSpace
 var DiskSpaceUnsetError = diskSpaceUnsetError
 
 const (
-	None                        = none
-	Full                        = full
-	Hidden                      = hidden
-	Home                        = home
-	RevertHidden                = revertHidden
-	DisableHome                 = disableHome
-	RevertFull                  = revertFull
-	DefaultDiskSpaceReservation = defaultDiskSpaceReservation
+	None                         = none
+	Full                         = full
+	Hidden                       = hidden
+	Home                         = home
+	RevertHidden                 = revertHidden
+	DisableHome                  = disableHome
+	RevertFull                   = revertFull
+	FallbackDiskSpaceReservation = fallbackDiskSpaceReservation
 )
 
 func SetSnapManagerBackend(s *SnapManager, b ManagerBackend) {

--- a/overlord/snapstate/export_test.go
+++ b/overlord/snapstate/export_test.go
@@ -55,6 +55,8 @@ var ComponentSetupTask = componentSetupTask
 var RemoveComponentTasks = removeComponentTasks
 var DiskSpaceReservation = diskSpaceReservation
 
+var DiskSpaceUnsetError = diskSpaceUnsetError
+
 const (
 	None                        = none
 	Full                        = full

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -184,13 +184,7 @@ func ShouldSendNotificationsToTheUser(st *state.State) (bool, error) {
 	return true, nil
 }
 
-func diskSpaceReservation(size uint64, tr *config.Transaction) (uint64, error) {
-	addReservation := func(reservation uint64) (uint64, error) {
-		if size > math.MaxUint64-reservation {
-			return 0, fmt.Errorf("cannot calculate required disk space: size overflow")
-		}
-		return size + reservation, nil
-	}
+func diskSpaceReservation(tr *config.Transaction) (uint64, error) {
 
 	// the value may be a string (e.g. "5M") or a plain number of bytes
 	// (e.g. 0), as snap set stores valid JSON values in their parsed form
@@ -200,15 +194,15 @@ func diskSpaceReservation(size uint64, tr *config.Transaction) (uint64, error) {
 		return 0, diskSpaceUnsetError
 	}
 	if err != nil {
-		return addReservation(defaultDiskSpaceReservation)
+		return defaultDiskSpaceReservation, nil
 	}
 
 	parsedReservation, err := quantity.ParseSize(fmt.Sprintf("%v", reservation))
 	if err != nil {
-		return addReservation(defaultDiskSpaceReservation)
+		return defaultDiskSpaceReservation, nil
 	}
 
-	return addReservation(uint64(parsedReservation))
+	return uint64(parsedReservation), nil
 }
 
 // ConfigureSnap returns a set of tasks to configure snapName as done during installation/refresh.
@@ -2564,7 +2558,15 @@ func checkDiskSpaceDownload(st *state.State, infos []minimalInstallInfo, rootDir
 		totalSize += uint64(info.DownloadSize())
 	}
 
-	return checkForAvailableSpace(totalSize, config.NewTransaction(st), infos, "download", rootDir)
+	reservation, err := diskSpaceReservation(config.NewTransaction(st))
+	if err != nil {
+		if errors.Is(err, diskSpaceUnsetError) {
+			return nil
+		}
+		return err
+	}
+
+	return checkForAvailableSpace(totalSize, reservation, diskSpaceCheckNames(infos), "download", rootDir, "")
 }
 
 // checkDiskSpace checks if there is enough space for the requested snaps and their prerequisites
@@ -2590,35 +2592,47 @@ func checkDiskSpace(st *state.State, changeKind string, infos []minimalInstallIn
 		return nil
 	}
 
+	reservation, err := diskSpaceReservation(tr)
+	if err != nil {
+		if errors.Is(err, diskSpaceUnsetError) {
+			return nil
+		}
+		return err
+	}
+
 	totalSize, err := installSize(st, infos, userID, prqt)
 	if err != nil {
 		return err
 	}
 
-	return checkForAvailableSpace(totalSize, tr, infos, changeKind, dirs.SnapdStateDir(dirs.GlobalRootDir))
+	return checkForAvailableSpace(totalSize, reservation, diskSpaceCheckNames(infos), changeKind, dirs.SnapdStateDir(dirs.GlobalRootDir), "")
 }
 
-func checkForAvailableSpace(totalSize uint64, transaction *config.Transaction, infos []minimalInstallInfo, changeKind string, rootDir string) error {
-	requiredSpace, err := diskSpaceReservation(totalSize, transaction)
-	if err != nil {
-		// if the option is unset, we don't want to fail the operation, so we just return nil
-		if errors.Is(err, diskSpaceUnsetError) {
-			return nil
-		}
+func diskSpaceCheckNames(infos []minimalInstallInfo) []string {
+	names := make([]string, len(infos))
+	for i, info := range infos {
+		names[i] = info.InstanceName()
+	}
+	return names
+}
 
+func checkForAvailableSpace(totalSize, reservation uint64, snaps []string, changeKind, rootDir, messagePrefix string) error {
+	requiredSpace, err := calculateRequiredSpace(totalSize, reservation)
+	if err != nil {
 		return err
 	}
 
 	if err := osutilCheckFreeSpace(rootDir, requiredSpace); err != nil {
-		snaps := make([]string, len(infos))
-		for i, up := range infos {
-			snaps[i] = up.InstanceName()
-		}
 		if _, ok := err.(*osutil.NotEnoughDiskSpaceError); ok {
+			message := ""
+			if messagePrefix != "" {
+				message = fmt.Sprintf("%s: %v", messagePrefix, err)
+			}
 			return &InsufficientSpaceError{
 				Path:       rootDir,
 				Snaps:      snaps,
 				ChangeKind: changeKind,
+				Message:    message,
 			}
 		}
 		return err
@@ -3206,25 +3220,18 @@ func Remove(st *state.State, name string, revision snap.Revision, flags *RemoveF
 	// removeTasks() checks check-disk-space-remove feature flag, so snapshotSize
 	// will only be greater than 0 if the feature is enabled.
 	if snapshotSize > 0 {
-		requiredSpace, err := diskSpaceReservation(snapshotSize, config.NewTransaction(st))
-		if err != nil {
-			// if the option is unset, we don't want to fail the operation, so we just return nil
-			if errors.Is(err, diskSpaceUnsetError) {
-				return ts, nil
+		reservation, reservationErr := diskSpaceReservation(config.NewTransaction(st))
+		if reservationErr != nil {
+			if errors.Is(reservationErr, diskSpaceUnsetError) {
+				return ts, err
 			}
-			return nil, err
+			return nil, reservationErr
 		}
 
 		path := dirs.SnapdStateDir(dirs.GlobalRootDir)
-		if err := osutilCheckFreeSpace(path, requiredSpace); err != nil {
-			if _, ok := err.(*osutil.NotEnoughDiskSpaceError); ok {
-				return nil, &InsufficientSpaceError{
-					Path:       path,
-					Snaps:      []string{name},
-					ChangeKind: "remove",
-					Message:    fmt.Sprintf("cannot create automatic snapshot when removing last revision of the snap: %v", err)}
-			}
-			return nil, err
+		messagePrefix := "cannot create automatic snapshot when removing last revision of the snap"
+		if checkErr := checkForAvailableSpace(snapshotSize, reservation, []string{name}, "remove", path, messagePrefix); checkErr != nil {
+			return nil, checkErr
 		}
 	}
 	return ts, err
@@ -3649,7 +3656,7 @@ func RemoveMany(st *state.State, names []string, flags *RemoveFlags) ([]string, 
 	// removeTasks() checks check-disk-space-remove feature flag, so totalSnapshotsSize
 	// will only be greater than 0 if the feature is enabled.
 	if totalSnapshotsSize > 0 {
-		requiredSpace, err := diskSpaceReservation(totalSnapshotsSize, config.NewTransaction(st))
+		reservation, err := diskSpaceReservation(config.NewTransaction(st))
 		if err != nil {
 			// if the disk space reservation is not set, we can proceed with the removal without doing the checks
 			if errors.Is(err, diskSpaceUnsetError) {
@@ -3658,14 +3665,7 @@ func RemoveMany(st *state.State, names []string, flags *RemoveFlags) ([]string, 
 			return nil, nil, err
 		}
 
-		if err := osutilCheckFreeSpace(path, requiredSpace); err != nil {
-			if _, ok := err.(*osutil.NotEnoughDiskSpaceError); ok {
-				return nil, nil, &InsufficientSpaceError{
-					Path:       path,
-					Snaps:      names,
-					ChangeKind: "remove",
-				}
-			}
+		if err := checkForAvailableSpace(totalSnapshotsSize, reservation, names, "remove", path, ""); err != nil {
 			return nil, nil, err
 		}
 	}
@@ -4563,4 +4563,13 @@ func setupDelayedSecurityBackendEffects(st *state.State, tss []*state.TaskSet, m
 	}
 
 	return append(tss, pde)
+}
+
+func calculateRequiredSpace(totalSize, reservation uint64) (uint64, error) {
+	if totalSize > math.MaxUint64-reservation {
+		return 0, fmt.Errorf("cannot calculate required disk space: size overflow")
+	}
+
+	requiredSpace := totalSize + reservation
+	return requiredSpace, nil
 }

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -3217,6 +3217,9 @@ func Remove(st *state.State, name string, revision snap.Revision, flags *RemoveF
 
 	removals := map[string]bool{snapst.InstanceName().String(): true}
 	ts, snapshotSize, err := removeTasks(st, &snapst, removals, revision, flags)
+	if err != nil {
+		return nil, err
+	}
 	// removeTasks() checks check-disk-space-remove feature flag, so snapshotSize
 	// will only be greater than 0 if the feature is enabled.
 	if snapshotSize > 0 {

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -94,7 +94,7 @@ var ErrNothingToDo = errors.New("nothing to do")
 
 var osutilCheckFreeSpace = osutil.CheckFreeSpace
 
-const defaultDiskSpaceReservation = 5 * 1024 * 1024
+const fallbackDiskSpaceReservation = 5 * 1024 * 1024
 
 var diskSpaceUnsetError = errors.New("disk space reservation is not set in the state")
 
@@ -194,12 +194,12 @@ func diskSpaceReservation(tr *config.Transaction) (uint64, error) {
 		return 0, diskSpaceUnsetError
 	}
 	if err != nil {
-		return defaultDiskSpaceReservation, nil
+		return fallbackDiskSpaceReservation, nil
 	}
 
 	parsedReservation, err := quantity.ParseSize(fmt.Sprintf("%v", reservation))
 	if err != nil {
-		return defaultDiskSpaceReservation, nil
+		return fallbackDiskSpaceReservation, nil
 	}
 
 	return uint64(parsedReservation), nil
@@ -2617,10 +2617,11 @@ func diskSpaceCheckNames(infos []minimalInstallInfo) []string {
 }
 
 func checkForAvailableSpace(totalSize, reservation uint64, snaps []string, changeKind, rootDir, messagePrefix string) error {
-	requiredSpace, err := calculateRequiredSpace(totalSize, reservation)
-	if err != nil {
-		return err
+	if totalSize > math.MaxUint64-reservation {
+		return fmt.Errorf("cannot calculate required disk space: size overflow")
 	}
+
+	requiredSpace := totalSize + reservation
 
 	if err := osutilCheckFreeSpace(rootDir, requiredSpace); err != nil {
 		if _, ok := err.(*osutil.NotEnoughDiskSpaceError); ok {
@@ -4566,13 +4567,4 @@ func setupDelayedSecurityBackendEffects(st *state.State, tss []*state.TaskSet, m
 	}
 
 	return append(tss, pde)
-}
-
-func calculateRequiredSpace(totalSize, reservation uint64) (uint64, error) {
-	if totalSize > math.MaxUint64-reservation {
-		return 0, fmt.Errorf("cannot calculate required disk space: size overflow")
-	}
-
-	requiredSpace := totalSize + reservation
-	return requiredSpace, nil
 }

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -3226,7 +3226,7 @@ func Remove(st *state.State, name string, revision snap.Revision, flags *RemoveF
 		reservation, err := diskSpaceReservation(config.NewTransaction(st))
 		if err != nil {
 			if errors.Is(err, diskSpaceUnsetError) {
-				return ts, err
+				return ts, nil
 			}
 			return nil, err
 		}

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -96,6 +96,8 @@ var osutilCheckFreeSpace = osutil.CheckFreeSpace
 
 const defaultDiskSpaceReservation = 5 * 1024 * 1024
 
+var diskSpaceUnsetError = errors.New("disk space reservation is not set in the state")
+
 // TestingLeaveOutKernelUpdateGadgetAssets can be used to simulate an upgrade
 // from a broken snapd that does not generate a "update-gadget-assets" task.
 // See LP:#1940553
@@ -195,7 +197,7 @@ func diskSpaceReservation(size uint64, tr *config.Transaction) (uint64, error) {
 	var reservation any
 	err := tr.Get("core", "disk-reservation.size", &reservation)
 	if config.IsNoOption(err) {
-		return addReservation(defaultDiskSpaceReservation)
+		return 0, diskSpaceUnsetError
 	}
 	if err != nil {
 		return addReservation(defaultDiskSpaceReservation)
@@ -2599,6 +2601,11 @@ func checkDiskSpace(st *state.State, changeKind string, infos []minimalInstallIn
 func checkForAvailableSpace(totalSize uint64, transaction *config.Transaction, infos []minimalInstallInfo, changeKind string, rootDir string) error {
 	requiredSpace, err := diskSpaceReservation(totalSize, transaction)
 	if err != nil {
+		// if the option is unset, we don't want to fail the operation, so we just return nil
+		if errors.Is(err, diskSpaceUnsetError) {
+			return nil
+		}
+
 		return err
 	}
 
@@ -3201,6 +3208,10 @@ func Remove(st *state.State, name string, revision snap.Revision, flags *RemoveF
 	if snapshotSize > 0 {
 		requiredSpace, err := diskSpaceReservation(snapshotSize, config.NewTransaction(st))
 		if err != nil {
+			// if the option is unset, we don't want to fail the operation, so we just return nil
+			if errors.Is(err, diskSpaceUnsetError) {
+				return ts, nil
+			}
 			return nil, err
 		}
 
@@ -3640,6 +3651,10 @@ func RemoveMany(st *state.State, names []string, flags *RemoveFlags) ([]string, 
 	if totalSnapshotsSize > 0 {
 		requiredSpace, err := diskSpaceReservation(totalSnapshotsSize, config.NewTransaction(st))
 		if err != nil {
+			// if the disk space reservation is not set, we can proceed with the removal without doing the checks
+			if errors.Is(err, diskSpaceUnsetError) {
+				return removed, tasksets, nil
+			}
 			return nil, nil, err
 		}
 

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -3220,18 +3220,18 @@ func Remove(st *state.State, name string, revision snap.Revision, flags *RemoveF
 	// removeTasks() checks check-disk-space-remove feature flag, so snapshotSize
 	// will only be greater than 0 if the feature is enabled.
 	if snapshotSize > 0 {
-		reservation, reservationErr := diskSpaceReservation(config.NewTransaction(st))
-		if reservationErr != nil {
-			if errors.Is(reservationErr, diskSpaceUnsetError) {
+		reservation, err := diskSpaceReservation(config.NewTransaction(st))
+		if err != nil {
+			if errors.Is(err, diskSpaceUnsetError) {
 				return ts, err
 			}
-			return nil, reservationErr
+			return nil, err
 		}
 
 		path := dirs.SnapdStateDir(dirs.GlobalRootDir)
 		messagePrefix := "cannot create automatic snapshot when removing last revision of the snap"
-		if checkErr := checkForAvailableSpace(snapshotSize, reservation, []string{name}, "remove", path, messagePrefix); checkErr != nil {
-			return nil, checkErr
+		if err := checkForAvailableSpace(snapshotSize, reservation, []string{name}, "remove", path, messagePrefix); err != nil {
+			return nil, err
 		}
 	}
 	return ts, err

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -3962,6 +3962,27 @@ func (s *snapmgrTestSuite) TestInstallDiskSpaceError(c *C) {
 	c.Check(diskSpaceErr.Snaps, DeepEquals, []string{"some-snap"})
 }
 
+func (s *snapmgrTestSuite) TestInstallDiskSpaceCheckSkippedIfReservationUnset(c *C) {
+	var checkFreeSpaceCalls int
+	restore := snapstate.MockOsutilCheckFreeSpace(func(string, uint64) error {
+		checkFreeSpaceCalls++
+		return &osutil.NotEnoughDiskSpaceError{}
+	})
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	tr := config.NewTransaction(s.state)
+	c.Assert(tr.Set("core", "experimental.check-disk-space-install", true), IsNil)
+	tr.Commit()
+
+	opts := &snapstate.RevisionOptions{Channel: "some-channel"}
+	_, err := snapstate.Install(context.Background(), s.state, "some-snap", opts, s.user.ID, snapstate.Flags{})
+	c.Assert(err, IsNil)
+	c.Check(checkFreeSpaceCalls, Equals, 0)
+}
+
 func (s *snapmgrTestSuite) TestInstallConfigureDiskSpaceReservation(c *C) {
 	const freeDiskSpace = uint64(1500)
 	var requiredSizes []uint64

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -4033,6 +4033,7 @@ func (s *snapmgrTestSuite) TestInstallSizeError(c *C) {
 
 	tr := config.NewTransaction(s.state)
 	tr.Set("core", "experimental.check-disk-space-install", true)
+	tr.Set("core", "disk-reservation.size", snapstate.DefaultDiskSpaceReservation)
 	tr.Commit()
 
 	opts := &snapstate.RevisionOptions{Channel: "some-channel"}

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -3951,6 +3951,7 @@ func (s *snapmgrTestSuite) TestInstallDiskSpaceError(c *C) {
 
 	tr := config.NewTransaction(s.state)
 	tr.Set("core", "experimental.check-disk-space-install", true)
+	tr.Set("core", "disk-reservation.size", snapstate.DefaultDiskSpaceReservation)
 	tr.Commit()
 
 	opts := &snapstate.RevisionOptions{Channel: "some-channel"}
@@ -4578,6 +4579,7 @@ func (s *snapmgrTestSuite) TestInstallManyDiskSpaceError(c *C) {
 
 	tr := config.NewTransaction(s.state)
 	tr.Set("core", "experimental.check-disk-space-install", true)
+	tr.Set("core", "disk-reservation.size", snapstate.DefaultDiskSpaceReservation)
 	tr.Commit()
 
 	_, _, err := snapstate.InstallMany(s.state, []string{"one", "two"}, nil, 0, nil)
@@ -6151,6 +6153,7 @@ epoch: 1
 	}
 	tr := config.NewTransaction(s.state)
 	c.Assert(tr.Set("core", "experimental.check-disk-space-install", true), IsNil)
+	c.Assert(tr.Set("core", "disk-reservation.size", snapstate.DefaultDiskSpaceReservation), IsNil)
 	tr.Commit()
 
 	_, err := snapstate.InstallPathMany(context.Background(), s.state, sideInfos, paths, 0, nil)

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -3951,7 +3951,7 @@ func (s *snapmgrTestSuite) TestInstallDiskSpaceError(c *C) {
 
 	tr := config.NewTransaction(s.state)
 	tr.Set("core", "experimental.check-disk-space-install", true)
-	tr.Set("core", "disk-reservation.size", snapstate.DefaultDiskSpaceReservation)
+	tr.Set("core", "disk-reservation.size", snapstate.FallbackDiskSpaceReservation)
 	tr.Commit()
 
 	opts := &snapstate.RevisionOptions{Channel: "some-channel"}
@@ -4033,7 +4033,7 @@ func (s *snapmgrTestSuite) TestInstallSizeError(c *C) {
 
 	tr := config.NewTransaction(s.state)
 	tr.Set("core", "experimental.check-disk-space-install", true)
-	tr.Set("core", "disk-reservation.size", snapstate.DefaultDiskSpaceReservation)
+	tr.Set("core", "disk-reservation.size", snapstate.FallbackDiskSpaceReservation)
 	tr.Commit()
 
 	opts := &snapstate.RevisionOptions{Channel: "some-channel"}
@@ -4601,7 +4601,7 @@ func (s *snapmgrTestSuite) TestInstallManyDiskSpaceError(c *C) {
 
 	tr := config.NewTransaction(s.state)
 	tr.Set("core", "experimental.check-disk-space-install", true)
-	tr.Set("core", "disk-reservation.size", snapstate.DefaultDiskSpaceReservation)
+	tr.Set("core", "disk-reservation.size", snapstate.FallbackDiskSpaceReservation)
 	tr.Commit()
 
 	_, _, err := snapstate.InstallMany(s.state, []string{"one", "two"}, nil, 0, nil)
@@ -6175,7 +6175,7 @@ epoch: 1
 	}
 	tr := config.NewTransaction(s.state)
 	c.Assert(tr.Set("core", "experimental.check-disk-space-install", true), IsNil)
-	c.Assert(tr.Set("core", "disk-reservation.size", snapstate.DefaultDiskSpaceReservation), IsNil)
+	c.Assert(tr.Set("core", "disk-reservation.size", snapstate.FallbackDiskSpaceReservation), IsNil)
 	tr.Commit()
 
 	_, err := snapstate.InstallPathMany(context.Background(), s.state, sideInfos, paths, 0, nil)

--- a/overlord/snapstate/snapstate_remove_test.go
+++ b/overlord/snapstate/snapstate_remove_test.go
@@ -194,6 +194,7 @@ func (s *snapmgrTestSuite) testRemoveDiskSpaceCheck(c *C, featureFlag, automatic
 
 	tr := config.NewTransaction(s.state)
 	tr.Set("core", "experimental.check-disk-space-remove", featureFlag)
+	tr.Set("core", "disk-reservation.size", snapstate.DefaultDiskSpaceReservation)
 	tr.Commit()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
@@ -1615,6 +1616,7 @@ func (s *snapmgrTestSuite) testRemoveManyDiskSpaceCheck(c *C, featureFlag, autom
 
 	tr := config.NewTransaction(s.state)
 	tr.Set("core", "experimental.check-disk-space-remove", featureFlag)
+	tr.Set("core", "disk-reservation.size", snapstate.DefaultDiskSpaceReservation)
 	tr.Commit()
 
 	snapstate.Set(s.state, "one", &snapstate.SnapState{

--- a/overlord/snapstate/snapstate_remove_test.go
+++ b/overlord/snapstate/snapstate_remove_test.go
@@ -194,7 +194,7 @@ func (s *snapmgrTestSuite) testRemoveDiskSpaceCheck(c *C, featureFlag, automatic
 
 	tr := config.NewTransaction(s.state)
 	tr.Set("core", "experimental.check-disk-space-remove", featureFlag)
-	tr.Set("core", "disk-reservation.size", snapstate.DefaultDiskSpaceReservation)
+	tr.Set("core", "disk-reservation.size", snapstate.FallbackDiskSpaceReservation)
 	tr.Commit()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
@@ -1631,7 +1631,7 @@ func (s *snapmgrTestSuite) testRemoveManyDiskSpaceCheck(c *C, featureFlag, autom
 	restore := snapstate.MockOsutilCheckFreeSpace(func(path string, required uint64) error {
 		checkFreeSpaceCall++
 		// required size is the sum of snapshot sizes of test snaps
-		c.Check(required, Equals, uint64(30)+snapstate.DefaultDiskSpaceReservation)
+		c.Check(required, Equals, uint64(30)+snapstate.FallbackDiskSpaceReservation)
 		if freeSpaceCheckFail {
 			return &osutil.NotEnoughDiskSpaceError{}
 		}
@@ -1653,7 +1653,7 @@ func (s *snapmgrTestSuite) testRemoveManyDiskSpaceCheck(c *C, featureFlag, autom
 
 	tr := config.NewTransaction(s.state)
 	tr.Set("core", "experimental.check-disk-space-remove", featureFlag)
-	tr.Set("core", "disk-reservation.size", snapstate.DefaultDiskSpaceReservation)
+	tr.Set("core", "disk-reservation.size", snapstate.FallbackDiskSpaceReservation)
 	tr.Commit()
 
 	snapstate.Set(s.state, "one", &snapstate.SnapState{

--- a/overlord/snapstate/snapstate_remove_test.go
+++ b/overlord/snapstate/snapstate_remove_test.go
@@ -238,6 +238,43 @@ func (s *snapmgrTestSuite) TestRemoveDiskSpaceForSnapshotError(c *C) {
 	c.Check(diskSpaceErr.ChangeKind, Equals, "remove")
 }
 
+func (s *snapmgrTestSuite) TestRemoveDiskSpaceCheckSkippedIfReservationUnset(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	var snapshotSizeCalls int
+	snapstate.EstimateSnapshotSize = func(st *state.State, instanceName string, users []string) (uint64, error) {
+		snapshotSizeCalls++
+		return 1, nil
+	}
+
+	var checkFreeSpaceCalls int
+	restore := snapstate.MockOsutilCheckFreeSpace(func(string, uint64) error {
+		checkFreeSpaceCalls++
+		return nil
+	})
+	defer restore()
+
+	tr := config.NewTransaction(s.state)
+	c.Assert(tr.Set("core", "experimental.check-disk-space-remove", true), IsNil)
+	tr.Commit()
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:   true,
+		SnapType: "app",
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "some-snap", Revision: snap.R(11)},
+		}),
+		Current: snap.R(11),
+	})
+
+	ts, err := snapstate.Remove(s.state, "some-snap", snap.R(0), nil)
+	c.Assert(err, IsNil)
+	c.Assert(ts, NotNil)
+	c.Check(snapshotSizeCalls, Equals, 1)
+	c.Check(checkFreeSpaceCalls, Equals, 0)
+}
+
 func (s *snapmgrTestSuite) TestRemoveRunThrough(c *C) {
 	aux := backend.AuxStoreInfo{}    // doesn't matter for this test
 	linkCtx := backend.LinkContext{} // doesn't matter for this test
@@ -1734,6 +1771,44 @@ func (s *snapmgrTestSuite) TestRemoveManyDiskSpaceCheckPasses(c *C) {
 	freeSpaceCheckFail := false
 	err := s.testRemoveManyDiskSpaceCheck(c, featureFlag, automaticSnapshot, freeSpaceCheckFail)
 	c.Check(err, IsNil)
+}
+
+func (s *snapmgrTestSuite) TestRemoveManyDiskSpaceCheckSkippedIfReservationUnset(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	var snapshotSizeCalls int
+	snapstate.EstimateSnapshotSize = func(st *state.State, instanceName string, users []string) (uint64, error) {
+		snapshotSizeCalls++
+		return 1, nil
+	}
+
+	var checkFreeSpaceCalls int
+	restore := snapstate.MockOsutilCheckFreeSpace(func(string, uint64) error {
+		checkFreeSpaceCalls++
+		return nil
+	})
+	defer restore()
+
+	tr := config.NewTransaction(s.state)
+	c.Assert(tr.Set("core", "experimental.check-disk-space-remove", true), IsNil)
+	tr.Commit()
+
+	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
+		Active:   true,
+		SnapType: "app",
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "some-snap", Revision: snap.R(11)},
+		}),
+		Current: snap.R(11),
+	})
+
+	removed, tasksets, err := snapstate.RemoveMany(s.state, []string{"some-snap"}, nil)
+	c.Assert(err, IsNil)
+	c.Check(removed, DeepEquals, []string{"some-snap"})
+	c.Assert(tasksets, HasLen, 1)
+	c.Check(snapshotSizeCalls, Equals, 1)
+	c.Check(checkFreeSpaceCalls, Equals, 0)
 }
 
 func (s *snapmgrTestSuite) TestRemoveManyDiskSpaceReservationZeroChecksSnapshotSize(c *C) {

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -522,7 +522,7 @@ func (s *snapmgrTestSuite) TestDiskSpaceReservation(c *C) {
 	}{
 		{description: "unset", err: snapstate.DiskSpaceUnsetError},
 		{description: "nil", configured: true, value: nil, err: snapstate.DiskSpaceUnsetError},
-		{description: "invalid", configured: true, value: "invalid", expected: snapstate.DefaultDiskSpaceReservation},
+		{description: "invalid", configured: true, value: "invalid", expected: snapstate.FallbackDiskSpaceReservation},
 		{description: "numeric bytes", configured: true, value: 2048, expected: 2048},
 		{description: "string bytes", configured: true, value: "4096", expected: 4096},
 		{description: "quantity", configured: true, value: "1G", expected: 1024 * 1024 * 1024},
@@ -12042,7 +12042,7 @@ func (s *snapmgrTestSuite) TestDownloadOutOfSpace(c *C) {
 	defer s.state.Unlock()
 
 	tr := config.NewTransaction(s.state)
-	c.Assert(tr.Set("core", "disk-reservation.size", snapstate.DefaultDiskSpaceReservation), IsNil)
+	c.Assert(tr.Set("core", "disk-reservation.size", snapstate.FallbackDiskSpaceReservation), IsNil)
 	tr.Commit()
 
 	downloadDir := c.MkDir()

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -523,15 +523,14 @@ func (s *snapmgrTestSuite) TestDiskSpaceReservationCalc(c *C) {
 		expected    uint64
 		err         string
 	}{
-		{description: "unset", size: operationSize, expected: operationSize + snapstate.DefaultDiskSpaceReservation},
-		{description: "nil", configured: true, value: nil, size: operationSize, expected: operationSize + snapstate.DefaultDiskSpaceReservation},
+		{description: "unset", size: operationSize, err: snapstate.DiskSpaceUnsetError.Error()},
+		{description: "nil", configured: true, value: nil, size: operationSize, err: snapstate.DiskSpaceUnsetError.Error()},
 		{description: "invalid", configured: true, value: "invalid", size: operationSize, expected: operationSize + snapstate.DefaultDiskSpaceReservation},
 		{description: "numeric bytes", configured: true, value: 2048, size: operationSize, expected: operationSize + 2048},
 		{description: "string bytes", configured: true, value: "4096", size: operationSize, expected: operationSize + 4096},
 		{description: "quantity", configured: true, value: "1G", size: operationSize, expected: operationSize + 1024*1024*1024},
 		{description: "zero", configured: true, value: 0, size: operationSize, expected: operationSize},
 		{description: "configured overflow", configured: true, value: "1", size: ^uint64(0), err: "cannot calculate required disk space: size overflow"},
-		{description: "default overflow", size: ^uint64(0), err: "cannot calculate required disk space: size overflow"},
 	} {
 		tr := config.NewTransaction(s.state)
 		if tc.configured {
@@ -12022,6 +12021,10 @@ func (s *snapmgrTestSuite) TestDownloadOutOfSpace(c *C) {
 
 	s.state.Lock()
 	defer s.state.Unlock()
+
+	tr := config.NewTransaction(s.state)
+	c.Assert(tr.Set("core", "disk-reservation.size", snapstate.DefaultDiskSpaceReservation), IsNil)
+	tr.Commit()
 
 	downloadDir := c.MkDir()
 	_, _, err := snapstate.Download(context.Background(), s.state, "foo", nil, downloadDir, snapstate.RevisionOptions{

--- a/overlord/snapstate/snapstate_test.go
+++ b/overlord/snapstate/snapstate_test.go
@@ -509,9 +509,7 @@ func (s *snapmgrBaseTest) TearDownTest(c *C) {
 	snapstate.CanAutoRefresh = nil
 }
 
-func (s *snapmgrTestSuite) TestDiskSpaceReservationCalc(c *C) {
-	const operationSize = uint64(1024)
-
+func (s *snapmgrTestSuite) TestDiskSpaceReservation(c *C) {
 	s.state.Lock()
 	defer s.state.Unlock()
 
@@ -519,32 +517,53 @@ func (s *snapmgrTestSuite) TestDiskSpaceReservationCalc(c *C) {
 		description string
 		configured  bool
 		value       any
-		size        uint64
 		expected    uint64
-		err         string
+		err         error
 	}{
-		{description: "unset", size: operationSize, err: snapstate.DiskSpaceUnsetError.Error()},
-		{description: "nil", configured: true, value: nil, size: operationSize, err: snapstate.DiskSpaceUnsetError.Error()},
-		{description: "invalid", configured: true, value: "invalid", size: operationSize, expected: operationSize + snapstate.DefaultDiskSpaceReservation},
-		{description: "numeric bytes", configured: true, value: 2048, size: operationSize, expected: operationSize + 2048},
-		{description: "string bytes", configured: true, value: "4096", size: operationSize, expected: operationSize + 4096},
-		{description: "quantity", configured: true, value: "1G", size: operationSize, expected: operationSize + 1024*1024*1024},
-		{description: "zero", configured: true, value: 0, size: operationSize, expected: operationSize},
-		{description: "configured overflow", configured: true, value: "1", size: ^uint64(0), err: "cannot calculate required disk space: size overflow"},
+		{description: "unset", err: snapstate.DiskSpaceUnsetError},
+		{description: "nil", configured: true, value: nil, err: snapstate.DiskSpaceUnsetError},
+		{description: "invalid", configured: true, value: "invalid", expected: snapstate.DefaultDiskSpaceReservation},
+		{description: "numeric bytes", configured: true, value: 2048, expected: 2048},
+		{description: "string bytes", configured: true, value: "4096", expected: 4096},
+		{description: "quantity", configured: true, value: "1G", expected: 1024 * 1024 * 1024},
+		{description: "zero", configured: true, value: 0, expected: 0},
 	} {
 		tr := config.NewTransaction(s.state)
 		if tc.configured {
 			c.Assert(tr.Set("core", "disk-reservation.size", tc.value), IsNil)
 		}
 
-		reservation, err := snapstate.DiskSpaceReservation(tc.size, tr)
+		reservation, err := snapstate.DiskSpaceReservation(tr)
+		if tc.err != nil {
+			c.Check(err, testutil.ErrorIs, tc.err, Commentf(tc.description))
+			continue
+		}
+
+		c.Check(err, IsNil, Commentf(tc.description))
+		c.Check(reservation, Equals, tc.expected, Commentf(tc.description))
+	}
+}
+
+func (s *snapmgrTestSuite) TestCalculateRequiredSpace(c *C) {
+	for _, tc := range []struct {
+		description string
+		totalSize   uint64
+		reservation uint64
+		expected    uint64
+		err         string
+	}{
+		{description: "reservation", totalSize: 1024, reservation: 2048, expected: 3072},
+		{description: "zero reservation", totalSize: 1024, expected: 1024},
+		{description: "overflow", totalSize: ^uint64(0), reservation: 1, err: "cannot calculate required disk space: size overflow"},
+	} {
+		requiredSpace, err := snapstate.CalculateRequiredSpace(tc.totalSize, tc.reservation)
 		if tc.err != "" {
 			c.Check(err, ErrorMatches, tc.err, Commentf(tc.description))
 			continue
 		}
 
 		c.Check(err, IsNil, Commentf(tc.description))
-		c.Check(reservation, Equals, tc.expected, Commentf(tc.description))
+		c.Check(requiredSpace, Equals, tc.expected, Commentf(tc.description))
 	}
 }
 

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -6592,7 +6592,7 @@ func (s *snapmgrTestSuite) testUpdateManyDiskSpaceCheck(c *C, featureFlag, failD
 	restore := snapstate.MockOsutilCheckFreeSpace(func(path string, sz uint64) error {
 		diskCheckCalled = true
 		c.Check(path, Equals, filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd"))
-		c.Check(sz, Equals, uint64(123)+snapstate.DefaultDiskSpaceReservation)
+		c.Check(sz, Equals, uint64(123)+snapstate.FallbackDiskSpaceReservation)
 		if failDiskCheck {
 			return &osutil.NotEnoughDiskSpaceError{}
 		}
@@ -6617,7 +6617,7 @@ func (s *snapmgrTestSuite) testUpdateManyDiskSpaceCheck(c *C, featureFlag, failD
 
 	tr := config.NewTransaction(s.state)
 	tr.Set("core", "experimental.check-disk-space-refresh", featureFlag)
-	tr.Set("core", "disk-reservation.size", snapstate.DefaultDiskSpaceReservation)
+	tr.Set("core", "disk-reservation.size", snapstate.FallbackDiskSpaceReservation)
 	tr.Commit()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
@@ -7260,7 +7260,7 @@ func (s *snapmgrTestSuite) TestEmptyUpdateWithChannelChangeAndAutoAlias(c *C) {
 
 func (s *snapmgrTestSuite) testUpdateDiskSpaceCheck(c *C, featureFlag, failInstallSize, failDiskCheck bool) error {
 	restore := snapstate.MockOsutilCheckFreeSpace(func(path string, sz uint64) error {
-		c.Check(sz, Equals, uint64(123)+snapstate.DefaultDiskSpaceReservation)
+		c.Check(sz, Equals, uint64(123)+snapstate.FallbackDiskSpaceReservation)
 		if failDiskCheck {
 			return &osutil.NotEnoughDiskSpaceError{}
 		}
@@ -7286,7 +7286,7 @@ func (s *snapmgrTestSuite) testUpdateDiskSpaceCheck(c *C, featureFlag, failInsta
 
 	tr := config.NewTransaction(s.state)
 	tr.Set("core", "experimental.check-disk-space-refresh", featureFlag)
-	tr.Set("core", "disk-reservation.size", snapstate.DefaultDiskSpaceReservation)
+	tr.Set("core", "disk-reservation.size", snapstate.FallbackDiskSpaceReservation)
 	tr.Commit()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -6617,6 +6617,7 @@ func (s *snapmgrTestSuite) testUpdateManyDiskSpaceCheck(c *C, featureFlag, failD
 
 	tr := config.NewTransaction(s.state)
 	tr.Set("core", "experimental.check-disk-space-refresh", featureFlag)
+	tr.Set("core", "disk-reservation.size", snapstate.DefaultDiskSpaceReservation)
 	tr.Commit()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
@@ -7285,6 +7286,7 @@ func (s *snapmgrTestSuite) testUpdateDiskSpaceCheck(c *C, featureFlag, failInsta
 
 	tr := config.NewTransaction(s.state)
 	tr.Set("core", "experimental.check-disk-space-refresh", featureFlag)
+	tr.Set("core", "disk-reservation.size", snapstate.DefaultDiskSpaceReservation)
 	tr.Commit()
 
 	snapstate.Set(s.state, "some-snap", &snapstate.SnapState{
@@ -7308,7 +7310,7 @@ func (s *snapmgrTestSuite) testUpdateDiskSpaceCheck(c *C, featureFlag, failInsta
 	return err
 }
 
-func (s *snapmgrTestSuite) TestUpdateDiskSpaceDefaultReservationError(c *C) {
+func (s *snapmgrTestSuite) TestUpdateDiskSpaceReservationError(c *C) {
 	featureFlag := true
 	failInstallSize := false
 	failDiskCheck := true
@@ -7319,12 +7321,10 @@ func (s *snapmgrTestSuite) TestUpdateDiskSpaceDefaultReservationError(c *C) {
 	c.Check(diskSpaceErr.Snaps, DeepEquals, []string{"some-snap"})
 }
 
-func (s *snapmgrTestSuite) TestUpdateDiskSpaceDefaultReservationHappy(c *C) {
+func (s *snapmgrTestSuite) TestUpdateDiskSpaceReservationHappy(c *C) {
 	featureFlag := true
 	failInstallSize := false
 	failDiskCheck := false
-	// No disk-reservation.size is set, so the default 5MB reservation is used.
-	// The helper asserts required size == 123 + DefaultDiskSpaceReservation.
 	err := s.testUpdateDiskSpaceCheck(c, featureFlag, failInstallSize, failDiskCheck)
 	c.Check(err, IsNil)
 }

--- a/tests/main/disk-reservation-size/task.yaml
+++ b/tests/main/disk-reservation-size/task.yaml
@@ -2,7 +2,7 @@ summary: Check that disk-reservation.size option controls disk space checks.
 
 details: |
   Verify the tri-state behavior of the disk-reservation.size option:
-    - Unset (nil): uses the default 5MB reservation
+    - Unset (nil): disk space checks are skipped
     - 0: checks run with no extra reservation (only snap size required)
     - >0: checks run with the configured reservation added to snap size
   The checks are gated behind the experimental check-disk-space feature
@@ -82,17 +82,9 @@ execute: |
   "$TESTSTOOLS"/snaps-state install-local test-snapd-tools
   snap remove --purge test-snapd-tools
 
-  echo "=== Test 3: Unset reservation uses default 5MB ==="
+  echo "=== Test 3: Unset reservation does not do the check ==="
   snap unset system disk-reservation.size
-  # Still ~3MB free, so the default 5MB reservation makes the install fail
-  if "$TESTSTOOLS"/snaps-state install-local test-snapd-tools 2>install-error.txt; then
-    echo "expected install to fail with default reservation and tight space"
-    exit 1
-  fi
-  MATCH "due to low disk space" < install-error.txt
-  # With ~8MB free the snap plus the 5MB default reservation fits
-  NEWSIZE=$(($(get_disk_usage) + 8))
-  resize "${NEWSIZE}M"
+  # Still ~3MB free, so the install should succeed
   "$TESTSTOOLS"/snaps-state install-local test-snapd-tools
   snap remove --purge test-snapd-tools
 


### PR DESCRIPTION
In the disk-reservation.size PR, the default behavior when the option is unset is to give the user a reservation size of 5MB. However, we want the checks to be ignored if the reservation is unset. This PR aligns the code with the desired behavior.