### PR TITLE
i/builtin: shutdown interface allows RebootWithFlags

### DIFF
--- a/interfaces/builtin/shutdown.go
+++ b/interfaces/builtin/shutdown.go
@@ -51,7 +51,7 @@ dbus (send)
     bus=system
     path=/org/freedesktop/login1
     interface=org.freedesktop.login1.Manager
-    member={ListInhibitors,Inhibit,PowerOff,Reboot,Suspend,Hibernate,SuspendThenHibernate,HybridSleep,CanPowerOff,CanReboot,CanSuspend,CanHibernate,CanSuspendThenHibernate,CanHybridSleep,ScheduleShutdown,CancelScheduledShutdown,SetWallMessage,SetRebootParameter}
+    member={ListInhibitors,Inhibit,PowerOff,Reboot,RebootWithFlags,Suspend,Hibernate,SuspendThenHibernate,HybridSleep,CanPowerOff,CanReboot,CanSuspend,CanHibernate,CanSuspendThenHibernate,CanHybridSleep,ScheduleShutdown,CancelScheduledShutdown,SetWallMessage,SetRebootParameter}
     peer=(label=unconfined),
 
 # Allow clients to introspect


### PR DESCRIPTION
The shutdown interface currently allows `org.freedesktop.login1.Manager.Reboot`, but not `RebootWithFlags`. The latter is needed when a blocking inhibitor is held by another process — for example, Ptyxis (the default terminal in Ubuntu 26.04) inhibits shutdown while an app is running.

[MM request](https://chat.canonical.com/canonical/pl/41wm9d7ay3rbikhgprot8ffkny)
Relates to [OEX86-972](https://warthogs.atlassian.net/browse/OEX86-972) and https://github.com/canonical/ubuntu-desktop-provision/pull/1533.
FYI: @medicalwei


[SNAPDENG-37456](https://warthogs.atlassian.net/browse/SNAPDENG-37456)


[OEX86-972]: https://warthogs.atlassian.net/browse/OEX86-972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SNAPDENG-37456]: https://warthogs.atlassian.net/browse/SNAPDENG-37456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ