### PR TITLE
tests: use new nested images in spread tests

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -199,16 +199,16 @@ backends:
                 image: snapd-spread/ubuntu-18.04-64
                 workers: 8
             - ubuntu-core-20-64:
-                image: snapd-spread/ubuntu-20.04-64-uefi
+                image: snapd-spread/ubuntu-20.04-64
                 workers: 8
             - ubuntu-core-22-64:
-                image: snapd-spread/ubuntu-22.04-64-uefi
+                image: snapd-spread/ubuntu-22.04-64
                 workers: 8
             - ubuntu-core-24-64:
-                image: snapd-spread/ubuntu-24.04-64-uefi
+                image: snapd-spread/ubuntu-24.04-64
                 workers: 8
             - ubuntu-core-26-64:
-                image: snapd-spread/ubuntu-26.04-64-uefi
+                image: snapd-spread/ubuntu-26.04-64
                 workers: 8
 
             - debian-12-64:

--- a/spread.yaml
+++ b/spread.yaml
@@ -272,19 +272,19 @@ backends:
         environment: *openstack-env
         systems: &openstack-nested-systems
             - ubuntu-16.04-64:
-                  image: snapd-spread/ubuntu-16.04-64
+                  image: snapd-spread/ubuntu-16.04-64-nested
                   storage: 20G
                   workers: 4
             - ubuntu-18.04-64:
-                  image: snapd-spread/ubuntu-18.04-64
+                  image: snapd-spread/ubuntu-18.04-64-nested
                   storage: 20G
                   workers: 4
             - ubuntu-20.04-64:
-                  image: snapd-spread/ubuntu-20.04-64-hwe
+                  image: snapd-spread/ubuntu-20.04-64-nested
                   storage: 20G
                   workers: 12
             - ubuntu-22.04-64:
-                  image: snapd-spread/ubuntu-22.04-64
+                  image: snapd-spread/ubuntu-22.04-64-nested
                   storage: 25G
                   workers: 12
             - ubuntu-24.04-64:
@@ -1516,8 +1516,6 @@ suites:
             REMOTE_CFG_FILE: "$PROJECT_PATH/remote.setup.cfg"
             # Define which tests to run in the nested vm in run-spread test
             NESTED_SPREAD_TESTS: '$(HOST: echo "${NESTED_SPREAD_TESTS:-}")'
-            # Indicates that by default snapd pkg is built from current
-            SNAPD_DEB_FROM_REPO: '$(HOST: echo "${SPREAD_SNAPD_DEB_FROM_REPO:-false}")'
             # Use the specified username or certificate for ssh connections to the nested vm
             NESTED_REMOTE_USER_NAME: '$(HOST: echo "${NESTED_REMOTE_USER_NAME:-user1}")'
             NESTED_REMOTE_USER_CERT: '$(HOST: echo "${NESTED_REMOTE_USER_CERT:-}")'
@@ -1601,8 +1599,6 @@ suites:
             NESTED_ENABLE_SECURE_BOOT: '$(HOST: echo "${NESTED_ENABLE_SECURE_BOOT:-false}")'
             # Configuration file used for remote tools
             REMOTE_CFG_FILE: "$PROJECT_PATH/remote.setup.cfg"
-            # Indicates that by default snapd pkg is built from current
-            SNAPD_DEB_FROM_REPO: '$(HOST: echo "${SPREAD_SNAPD_DEB_FROM_REPO:-false}")'
             # Use the specified username or certificate for ssh connections to the nested vm
             NESTED_REMOTE_USER_NAME: '$(HOST: echo "${NESTED_REMOTE_USER_NAME:-user1}")'
             NESTED_REMOTE_USER_CERT: '$(HOST: echo "${NESTED_REMOTE_USER_CERT:-}")'
@@ -1680,8 +1676,6 @@ suites:
             NESTED_EXTRA_CMDLINE: '$(HOST: echo "${NESTED_EXTRA_CMDLINE:-}")'
             # Configuration file used for remote tools
             REMOTE_CFG_FILE: "$PROJECT_PATH/remote.setup.cfg"
-            # Indicates that by default snapd pkg is built from current
-            SNAPD_DEB_FROM_REPO: '$(HOST: echo "${SPREAD_SNAPD_DEB_FROM_REPO:-false}")'
             # Use the specified username or certificate for ssh connections to the nested vm
             NESTED_REMOTE_USER_NAME: '$(HOST: echo "${NESTED_REMOTE_USER_NAME:-user1}")'
             NESTED_REMOTE_USER_CERT: '$(HOST: echo "${NESTED_REMOTE_USER_CERT:-}")'
@@ -1770,8 +1764,6 @@ suites:
             # Indicates the amount of memory in MB to use in the nested vm
             NESTED_MEM: '$(HOST: echo "${NESTED_MEM:-4096}")'
             SPREAD_URL: https://storage.googleapis.com/snapd-spread-tests/spread/spread-amd64.tar.gz
-            # Indicates that by default snapd pkg is built from current
-            SNAPD_DEB_FROM_REPO: '$(HOST: echo "${SPREAD_SNAPD_DEB_FROM_REPO:-false}")'
             # Use the specified username or certificate for ssh connections to the nested vm
             NESTED_REMOTE_USER_NAME: '$(HOST: echo "${NESTED_REMOTE_USER_NAME:-user1}")'
             NESTED_REMOTE_USER_CERT: '$(HOST: echo "${NESTED_REMOTE_USER_CERT:-}")'

--- a/spread.yaml
+++ b/spread.yaml
@@ -1514,6 +1514,8 @@ suites:
             NESTED_IMAGE_ID: "unset"
             # Configuration file used for remote tools
             REMOTE_CFG_FILE: "$PROJECT_PATH/remote.setup.cfg"
+            # Indicates that by default snapd pkg is built from current
+            SNAPD_DEB_FROM_REPO: '$(HOST: echo "${SPREAD_SNAPD_DEB_FROM_REPO:-false}")'
             # Define which tests to run in the nested vm in run-spread test
             NESTED_SPREAD_TESTS: '$(HOST: echo "${NESTED_SPREAD_TESTS:-}")'
             # Use the specified username or certificate for ssh connections to the nested vm
@@ -1599,6 +1601,8 @@ suites:
             NESTED_ENABLE_SECURE_BOOT: '$(HOST: echo "${NESTED_ENABLE_SECURE_BOOT:-false}")'
             # Configuration file used for remote tools
             REMOTE_CFG_FILE: "$PROJECT_PATH/remote.setup.cfg"
+            # Indicates that by default snapd pkg is built from current
+            SNAPD_DEB_FROM_REPO: '$(HOST: echo "${SPREAD_SNAPD_DEB_FROM_REPO:-false}")'
             # Use the specified username or certificate for ssh connections to the nested vm
             NESTED_REMOTE_USER_NAME: '$(HOST: echo "${NESTED_REMOTE_USER_NAME:-user1}")'
             NESTED_REMOTE_USER_CERT: '$(HOST: echo "${NESTED_REMOTE_USER_CERT:-}")'
@@ -1676,6 +1680,8 @@ suites:
             NESTED_EXTRA_CMDLINE: '$(HOST: echo "${NESTED_EXTRA_CMDLINE:-}")'
             # Configuration file used for remote tools
             REMOTE_CFG_FILE: "$PROJECT_PATH/remote.setup.cfg"
+            # Indicates that by default snapd pkg is built from current
+            SNAPD_DEB_FROM_REPO: '$(HOST: echo "${SPREAD_SNAPD_DEB_FROM_REPO:-false}")'
             # Use the specified username or certificate for ssh connections to the nested vm
             NESTED_REMOTE_USER_NAME: '$(HOST: echo "${NESTED_REMOTE_USER_NAME:-user1}")'
             NESTED_REMOTE_USER_CERT: '$(HOST: echo "${NESTED_REMOTE_USER_CERT:-}")'

--- a/spread.yaml
+++ b/spread.yaml
@@ -1515,10 +1515,10 @@ suites:
             # Configuration file used for remote tools
             REMOTE_CFG_FILE: "$PROJECT_PATH/remote.setup.cfg"
             # Indicates that by default snapd pkg is built from current
-            SNAPD_DEB_FROM_REPO: '$(HOST: echo "${SPREAD_SNAPD_DEB_FROM_REPO:-false}")'
-            # Define which tests to run in the nested vm in run-spread test
             NESTED_SPREAD_TESTS: '$(HOST: echo "${NESTED_SPREAD_TESTS:-}")'
             # Use the specified username or certificate for ssh connections to the nested vm
+            SNAPD_DEB_FROM_REPO: '$(HOST: echo "${SPREAD_SNAPD_DEB_FROM_REPO:-false}")'
+            # Define which tests to run in the nested vm in run-spread test
             NESTED_REMOTE_USER_NAME: '$(HOST: echo "${NESTED_REMOTE_USER_NAME:-user1}")'
             NESTED_REMOTE_USER_CERT: '$(HOST: echo "${NESTED_REMOTE_USER_CERT:-}")'
         manual: true
@@ -1770,6 +1770,8 @@ suites:
             # Indicates the amount of memory in MB to use in the nested vm
             NESTED_MEM: '$(HOST: echo "${NESTED_MEM:-4096}")'
             SPREAD_URL: https://storage.googleapis.com/snapd-spread-tests/spread/spread-amd64.tar.gz
+            # Indicates that by default snapd pkg is built from current
+            SNAPD_DEB_FROM_REPO: '$(HOST: echo "${SPREAD_SNAPD_DEB_FROM_REPO:-false}")'
             # Use the specified username or certificate for ssh connections to the nested vm
             NESTED_REMOTE_USER_NAME: '$(HOST: echo "${NESTED_REMOTE_USER_NAME:-user1}")'
             NESTED_REMOTE_USER_CERT: '$(HOST: echo "${NESTED_REMOTE_USER_CERT:-}")'

--- a/spread.yaml
+++ b/spread.yaml
@@ -1514,11 +1514,11 @@ suites:
             NESTED_IMAGE_ID: "unset"
             # Configuration file used for remote tools
             REMOTE_CFG_FILE: "$PROJECT_PATH/remote.setup.cfg"
-            # Indicates that by default snapd pkg is built from current
-            NESTED_SPREAD_TESTS: '$(HOST: echo "${NESTED_SPREAD_TESTS:-}")'
-            # Use the specified username or certificate for ssh connections to the nested vm
-            SNAPD_DEB_FROM_REPO: '$(HOST: echo "${SPREAD_SNAPD_DEB_FROM_REPO:-false}")'
             # Define which tests to run in the nested vm in run-spread test
+            NESTED_SPREAD_TESTS: '$(HOST: echo "${NESTED_SPREAD_TESTS:-}")'
+            # Indicates that by default snapd pkg is built from current
+            SNAPD_DEB_FROM_REPO: '$(HOST: echo "${SPREAD_SNAPD_DEB_FROM_REPO:-false}")'
+            # Use the specified username or certificate for ssh connections to the nested vm
             NESTED_REMOTE_USER_NAME: '$(HOST: echo "${NESTED_REMOTE_USER_NAME:-user1}")'
             NESTED_REMOTE_USER_CERT: '$(HOST: echo "${NESTED_REMOTE_USER_CERT:-}")'
         manual: true

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -564,6 +564,14 @@ pkg_dependencies_ubuntu_nested(){
             qemu-efi-aarch64
         "
     fi
+    if os.query is-ubuntu-ge 20.04 && ! os.query is-ubuntu-ge 24.04; then
+        add-apt-repository ppa:snappy-dev/image -y  > /dev/null 2>&1
+        echo "
+            software-properties-common
+            ubuntu-core-initramfs
+            linux-firmware
+        "
+    fi
     if os.query is-ubuntu-ge 24.04; then
         echo "
             dpkg-dev

--- a/tests/lib/pkgdb.sh
+++ b/tests/lib/pkgdb.sh
@@ -564,22 +564,28 @@ pkg_dependencies_ubuntu_nested(){
             qemu-efi-aarch64
         "
     fi
-    if os.query is-ubuntu-ge 20.04 && ! os.query is-ubuntu-ge 24.04; then
-        add-apt-repository ppa:snappy-dev/image -y  > /dev/null 2>&1
+
+    if os.query is-ubuntu-ge 20.04; then
         echo "
-            software-properties-common
-            ubuntu-core-initramfs
-            linux-firmware
+            golang
         "
-    fi
-    if os.query is-ubuntu-ge 24.04; then
-        echo "
-            dpkg-dev
-            debhelper
-            devscripts
-            distro-info
-            linux-firmware
-        "
+        if os.query is-ubuntu-ge 24.04; then
+            echo "
+                dpkg-dev
+                debhelper
+                devscripts
+                distro-info
+                linux-firmware
+            "
+        else
+            add-apt-repository ppa:snappy-dev/image -y  > /dev/null 2>&1
+            echo "
+                software-properties-common
+                ubuntu-core-initramfs
+                linux-firmware
+            "
+        fi
+
     fi
 }
 


### PR DESCRIPTION
After adding dedicated nested images, update spread.yaml to use them

Also are added dependencies which are used to build the initramfs deb package required for the kernel snap with initramfs when using Ubuntu 24.04 or later.
In Ubuntu 20.04 or 22.04 the PPA is added which is required to install ubuntu-core-initramfs (needed to build the kernel snap with initramfs).