### PR TITLE
tests: unify ubuntu-image handling

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -75,6 +75,9 @@ jobs:
           - runs-on: ${{ github.event.repository.private && '["self-hosted", "Linux", "jammy", "ARM64", "large"]' || '["ubuntu-22.04-arm"]' }}
             variant: pristine
 
+  ubuntu-image-build-not-required:
+    uses: ./.github/workflows/ubuntu-image-build.yaml
+
   create-vendor-dir:
     runs-on: ubuntu-latest
     name: Create go vendor

--- a/.github/workflows/spread-tests.yaml
+++ b/.github/workflows/spread-tests.yaml
@@ -139,6 +139,9 @@ jobs:
           if grep -q '^Run nested$' <<<$labels; then
             echo "RUN_NESTED_LABEL=true" >> $GITHUB_ENV
           fi
+          if grep -q '^ubuntu-image update required$' <<<$labels; then
+            echo "SPREAD_UBUNTU_IMAGE_USE_LOCAL_SNAPD=true" >> $GITHUB_ENV
+          fi
 
     - name: Get previous attempt
       id: get-previous-attempt

--- a/.github/workflows/ubuntu-image-build.yaml
+++ b/.github/workflows/ubuntu-image-build.yaml
@@ -1,0 +1,32 @@
+name: Build ubuntu-image
+
+on:
+  workflow_call:
+
+jobs:
+  ubuntu-image-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout snapd
+        uses: actions/checkout@v6
+        with:
+          path: snapd
+
+      - name: Checkout ubuntu-image
+        uses: actions/checkout@v6
+        with:
+          repository: canonical/ubuntu-image
+          ref: main
+          path: ubuntu-image
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: ubuntu-image/go.mod
+          cache-dependency-path: ubuntu-image/go.sum
+
+      - name: Build ubuntu-image against local snapd
+        working-directory: ubuntu-image
+        run: |
+          go mod edit -replace="github.com/snapcore/snapd=$GITHUB_WORKSPACE/snapd"
+          go build -mod=mod -o "$RUNNER_TEMP/ubuntu-image" ./cmd/ubuntu-image

--- a/spread.yaml
+++ b/spread.yaml
@@ -45,11 +45,9 @@ environment:
     # a global setting for LXD channel to use in the tests
     LXD_SNAP_CHANNEL: "latest/candidate"
     OLD_UBUNTU_IMAGE_SNAP_CHANNEL: "2/stable"
-    UBUNTU_IMAGE_SNAP_CHANNEL: "latest/beta"
     SNAPCRAFT_SNAP_CHANNEL: "latest/stable"
-    # controls whether ubuntu-image is built using the current snapd tree as a
-    # dependency or the one listed in its go.mod
-    UBUNTU_IMAGE_ALLOW_API_BREAK: '$(HOST: echo "${SPREAD_UBUNTU_IMAGE_ALLOW_API_BREAK:-true}")'
+    # controls whether ubuntu-image is built using the current snapd tree
+    UBUNTU_IMAGE_USE_LOCAL_SNAPD: '$(HOST: echo "${SPREAD_UBUNTU_IMAGE_USE_LOCAL_SNAPD:-false}")'
     CORE_CHANNEL: '$(HOST: echo "${SPREAD_CORE_CHANNEL:-edge}")'
     BASE_CHANNEL: '$(HOST: echo "${SPREAD_BASE_CHANNEL:-edge}")'
     # Channel for kernel cannot be edge as that one is not signed with Canonical keys
@@ -1536,7 +1534,6 @@ suites:
             if os.query is-xenial; then
                 # the new ubuntu-image expects mkfs to support -d option, which was not
                 # supported yet by the version of mkfs that shipped with Ubuntu 16.04
-                # also ubuntu-image binary is not prebuilt for arm instances
                 snap install ubuntu-image --channel="$OLD_UBUNTU_IMAGE_SNAP_CHANNEL" --classic
             else
                 if os.query is-arm; then
@@ -1545,7 +1542,7 @@ suites:
 
                 #shellcheck source=tests/lib/image.sh
                 . "$TESTSLIB"/image.sh
-                get_ubuntu_image
+                prepare_ubuntu_image
             fi
 
 
@@ -1621,7 +1618,6 @@ suites:
             if os.query is-xenial; then
                 # the new ubuntu-image expects mkfs to support -d option, which was not
                 # supported yet by the version of mkfs that shipped with Ubuntu 16.04
-                # also ubuntu-image binary is not prebuilt for arm instances
                 snap install ubuntu-image --channel="$OLD_UBUNTU_IMAGE_SNAP_CHANNEL" --classic
             else
                 if os.query is-arm; then
@@ -1630,7 +1626,7 @@ suites:
 
                 #shellcheck source=tests/lib/image.sh
                 . "$TESTSLIB"/image.sh
-                get_ubuntu_image
+                prepare_ubuntu_image
             fi
 
             # Install the snapd built
@@ -1700,7 +1696,6 @@ suites:
             if os.query is-xenial; then
                 # the new ubuntu-image expects mkfs to support -d option, which was not
                 # supported yet by the version of mkfs that shipped with Ubuntu 16.04
-                # also ubuntu-image binary is not prebuilt for arm instances
                 snap install ubuntu-image --channel="$OLD_UBUNTU_IMAGE_SNAP_CHANNEL" --classic
             else
                 if os.query is-arm; then
@@ -1709,7 +1704,7 @@ suites:
 
                 #shellcheck source=tests/lib/image.sh
                 . "$TESTSLIB"/image.sh
-                get_ubuntu_image
+                prepare_ubuntu_image
             fi
 
             # Install the snapd built
@@ -1790,14 +1785,11 @@ suites:
             if os.query is-xenial; then
                 # the new ubuntu-image expects mkfs to support -d option, which was not
                 # supported yet by the version of mkfs that shipped with Ubuntu 16.04
-                # also ubuntu-image binary is not prebuilt for arm instances
                 snap install ubuntu-image --channel="$OLD_UBUNTU_IMAGE_SNAP_CHANNEL" --classic
-            elif os.query is-arm; then
-                snap install ubuntu-image --channel="$UBUNTU_IMAGE_SNAP_CHANNEL" --classic
             else
                 #shellcheck source=tests/lib/image.sh
                 . "$TESTSLIB"/image.sh
-                get_ubuntu_image
+                prepare_ubuntu_image
             fi
 
             # Install the snapd built

--- a/tests/lib/image.sh
+++ b/tests/lib/image.sh
@@ -1,40 +1,19 @@
 #!/bin/bash
 
 build_ubuntu_image() {
-    # the helper can be invoked multiple times, so do nothing if ubuntu-image
-    # was already built and is accessible
-    if command -v ubuntu-image; then
-        return
-    fi
+    local ubuntu_image_dir
+    ubuntu_image_dir="$(mktemp -d "${TMPDIR:-/tmp}/ubuntu-image.XXXXXXXX")"
 
-    if [ "${UBUNTU_IMAGE_ALLOW_API_BREAK-true}" = "true" ]; then
-        (
-            # build a version which uses the current snapd tree as a dependency
-            # shellcheck disable=SC2030,SC2031
-            export GO111MODULE=off
-            # use go get so that ubuntu-image is built with current snapd
-            # sources
-            go get github.com/canonical/ubuntu-image/cmd/ubuntu-image
-            go install -tags 'withtestkeys' github.com/canonical/ubuntu-image/cmd/ubuntu-image
-        )
-    else
-        (
-            # build a version which uses a particular revision of snapd listed
-            # in ubuntu-image go.mod file
-            # shellcheck disable=SC2030,SC2031
-            export GO111MODULE=on
-            # shellcheck disable=SC2030,SC2031
-            unset GOPATH
-            cd /tmp || exit 1
-            git clone https://github.com/canonical/ubuntu-image
-            cd ubuntu-image || exit 1
-            go build -tags 'withtestkeys' ./cmd/ubuntu-image
-        )
-        # make it available
-        mv /tmp/ubuntu-image/ubuntu-image "$GOHOME/bin"
-    fi
+    git clone --depth=1 https://github.com/canonical/ubuntu-image "$ubuntu_image_dir"
+    (
+        # go 1.22 needs an exact toolchain name for automatic toolchain selection
+        export GOTOOLCHAIN=go1.25.0
+        cd "$ubuntu_image_dir" || exit 1
+        go mod edit -replace="github.com/snapcore/snapd=$PROJECT_PATH"
+        go build -mod=mod -tags withtestkeys -o "$GOHOME/bin/ubuntu-image" ./cmd/ubuntu-image
+    )
+    rm -rf "$ubuntu_image_dir"
 }
-
 
 get_ubuntu_image() {
     if os.query is-arm; then
@@ -49,6 +28,14 @@ get_ubuntu_image() {
 
     test -x ubuntu-image
     mv ubuntu-image "$GOHOME/bin"
+}
+
+prepare_ubuntu_image() {
+    if [ "${UBUNTU_IMAGE_USE_LOCAL_SNAPD:-false}" = "true" ]; then
+        build_ubuntu_image
+    else
+        get_ubuntu_image
+    fi
 }
 
 # shellcheck disable=SC2120

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -1523,16 +1523,14 @@ setup_reflash_magic() {
     UNPACK_DIR="$(mktemp -d "/tmp/$core_name-unpack.XXXXXXXX")"
     unsquashfs -no-progress -f -d "$UNPACK_DIR" /var/lib/snapd/snaps/${core_name}_*.snap
 
-    if os.query is-arm; then
-        snap install ubuntu-image --channel="$UBUNTU_IMAGE_SNAP_CHANNEL" --classic
-    elif is_test_target_core 16; then
+    if is_test_target_core 16; then
         # the new ubuntu-image expects mkfs to support -d option, which was not
         # supported yet by the version of mkfs that shipped with Ubuntu 16.04
         snap install ubuntu-image --channel="$OLD_UBUNTU_IMAGE_SNAP_CHANNEL" --classic
     else
         # shellcheck source=tests/lib/image.sh
         . "$TESTSLIB/image.sh"
-        get_ubuntu_image
+        prepare_ubuntu_image
     fi
 
     # needs to be under /home because ubuntu-device-flash

--- a/tests/nested/manual/recovery-mode-failures/task.yaml
+++ b/tests/nested/manual/recovery-mode-failures/task.yaml
@@ -8,7 +8,6 @@ details: |
 systems: [ubuntu-24.04-64, ubuntu-26.04-64]
 
 environment:
-  TMPDIR: /var/tmp
   NESTED_CUSTOM_MODEL: $TESTSLIB/assertions/developer1-{VERSION}-dangerous.model
   NESTED_REPACK_FOR_FAKESTORE: true
   NESTED_FAKESTORE_BLOB_DIR: $(pwd)/fake-store-blobdir
@@ -30,18 +29,6 @@ prepare: |
 
   # shellcheck source=tests/lib/prepare.sh
   . "$TESTSLIB/prepare.sh"
-
-  # ubuntu-image embeds snapd boot assets, build the latest version against this
-  # tree instead of using the suite's prebuilt binary
-  ubuntu_image_dir="$(mktemp -d "${TMPDIR:-/tmp}/ubuntu-image.XXXXXXXX")"
-  (
-    # go 1.22 needs an exact toolchain name for automatic toolchain selection
-    export GOTOOLCHAIN=go1.25.0
-    git clone --depth=1 https://github.com/canonical/ubuntu-image "$ubuntu_image_dir"
-    cd "$ubuntu_image_dir"
-    go mod edit -replace="github.com/snapcore/snapd=$PROJECT_PATH"
-    go build -mod=mod -tags withtestkeys -o "$GOHOME/bin/ubuntu-image" ./cmd/ubuntu-image
-  )
 
   "${TESTSTOOLS}/store-state" setup-fake-store "$NESTED_FAKESTORE_BLOB_DIR"
 


### PR DESCRIPTION
This makes handling of `ubuntu-image` across tests consistent. We'll add a PR label that enables running tests that build `ubuntu-image` against snapd from the PR.

Note, whenever we use that label, we'll need to follow-up with a PR to ubuntu-image.