### PR TITLE
o/devicemgmtstate: fix flaky unit test

### DIFF
--- a/overlord/devicemgmtstate/devicemgmtmgr_test.go
+++ b/overlord/devicemgmtstate/devicemgmtmgr_test.go
@@ -1318,7 +1318,9 @@ func (s *deviceMgmtMgrSuite) TestDoValidateMessageBadSignature(c *C) {
 	c.Assert(err, IsNil)
 
 	// tamper the raw assertion body
-	reqMsg.RawAssertion = bytes.Replace(reqMsg.RawAssertion, []byte("get"), []byte("set"), 1)
+	c.Assert(bytes.Contains(reqMsg.RawAssertion, []byte(testRequestBody)), Equals, true)
+	tamperedBody := strings.Replace(testRequestBody, `"get"`, `"set"`, 1)
+	reqMsg.RawAssertion = bytes.Replace(reqMsg.RawAssertion, []byte(testRequestBody), []byte(tamperedBody), 1)
 
 	ms := &devicemgmtstate.DeviceMgmtState{
 		Sequences: map[string]*devicemgmtstate.SequenceState{


### PR DESCRIPTION
Saw this test fail with:

```
no matching public key "CbXMpwGvZCQpFdXTcjPEBIIhNfaXSwZvPYset4ydRCCUhxxLA333jum2zIba_dsJ"
```

Note the "set" substring in the public key. This test had the chance to replace a randomly generated "get" in the public key field with a "set". This change fixes the test by mutating the assertion body and replacing the whole thing.