### PR TITLE
systemd: read NOTIFY_SOCKET once and reuse socket connection

### DIFF
--- a/cmd/snapd/cli/cmd_run.go
+++ b/cmd/snapd/cli/cmd_run.go
@@ -69,6 +69,7 @@ var (
 	syscallExec              = syscall.Exec
 	userCurrent              = user.Current
 	osGetenv                 = os.Getenv
+	systemdNotifySocket      = systemd.NotifySocket
 	timeNow                  = time.Now
 	selinuxIsEnabled         = selinux.IsEnabled
 	selinuxVerifyPathContext = selinux.VerifyPathContext
@@ -1687,6 +1688,11 @@ func (x *cmdRun) runSnapConfine(info *snap.Info, runner runnable, beforeExec fun
 	// We have a new location for the ticket, update the environment variable.
 	if len(krb5ccnamePath) > 0 {
 		env["KRB5CCNAME"] = krb5ccnamePath
+	}
+
+	// NOTIFY_SOCKET is unset on initialization, let's add it back.
+	if systemdNotifySocket() != "" {
+		env["NOTIFY_SOCKET"] = systemdNotifySocket()
 	}
 
 	// Guarantee that XDG_RUNTIME_DIR does exist before launching the snap.

--- a/cmd/snapd/cli/cmd_run.go
+++ b/cmd/snapd/cli/cmd_run.go
@@ -69,7 +69,6 @@ var (
 	syscallExec              = syscall.Exec
 	userCurrent              = user.Current
 	osGetenv                 = os.Getenv
-	systemdNotifySocket      = systemd.NotifySocket
 	timeNow                  = time.Now
 	selinuxIsEnabled         = selinux.IsEnabled
 	selinuxVerifyPathContext = selinux.VerifyPathContext
@@ -1688,11 +1687,6 @@ func (x *cmdRun) runSnapConfine(info *snap.Info, runner runnable, beforeExec fun
 	// We have a new location for the ticket, update the environment variable.
 	if len(krb5ccnamePath) > 0 {
 		env["KRB5CCNAME"] = krb5ccnamePath
-	}
-
-	// NOTIFY_SOCKET is unset on initialization, let's add it back.
-	if systemdNotifySocket() != "" {
-		env["NOTIFY_SOCKET"] = systemdNotifySocket()
 	}
 
 	// Guarantee that XDG_RUNTIME_DIR does exist before launching the snap.

--- a/cmd/snapd/cli/cmd_run_test.go
+++ b/cmd/snapd/cli/cmd_run_test.go
@@ -254,6 +254,10 @@ func (s *RunSuite) TestSnapRunAppIntegration(c *check.C) {
 		defer os.Unsetenv("TMPDIR")
 	}
 
+	defer snaprun.MockSystemdNotifySocket(func() string {
+		return "/run/systemd/notify"
+	})()
+
 	// mock installed snap
 	snaptest.MockSnapCurrent(c, string(mockYamlForNameBase("snapname", "")), &snap.SideInfo{
 		Revision: snap.R("x2"),
@@ -283,6 +287,7 @@ func (s *RunSuite) TestSnapRunAppIntegration(c *check.C) {
 		"snapname.app", "--arg1", "arg2"})
 	c.Check(execEnv, testutil.Contains, "SNAP_REVISION=x2")
 	c.Check(execEnv, testutil.Contains, fmt.Sprintf("TMPDIR=%s", tmpdir))
+	c.Check(execEnv, testutil.Contains, "NOTIFY_SOCKET=/run/systemd/notify")
 }
 
 func checkHintFileNotLocked(c *check.C, snapName string) {
@@ -1652,6 +1657,9 @@ func (s *RunSuite) TestSnapRunSnapdHelperPath(c *check.C) {
 
 func (s *RunSuite) TestSnapRunAppIntegrationFromCore(c *check.C) {
 	defer mockSnapConfine(filepath.Join(dirs.SnapMountDir, "core", "111", dirs.CoreLibExecDir))()
+	defer snaprun.MockSystemdNotifySocket(func() string {
+		return "/run/systemd/notify"
+	})()
 
 	// mock installed snap
 	snaptest.MockSnapCurrent(c, string(mockYamlForNameBase("snapname", "")), &snap.SideInfo{
@@ -1687,6 +1695,7 @@ func (s *RunSuite) TestSnapRunAppIntegrationFromCore(c *check.C) {
 		filepath.Join(dirs.CoreLibExecDir, "snap-exec"),
 		"snapname.app", "--arg1", "arg2"})
 	c.Check(execEnv, testutil.Contains, "SNAP_REVISION=x2")
+	c.Check(execEnv, testutil.Contains, "NOTIFY_SOCKET=/run/systemd/notify")
 }
 
 func (s *RunSuite) TestSnapRunAppIntegrationFromSnapd(c *check.C) {
@@ -1726,6 +1735,7 @@ func (s *RunSuite) TestSnapRunAppIntegrationFromSnapd(c *check.C) {
 		filepath.Join(dirs.CoreLibExecDir, "snap-exec"),
 		"snapname.app", "--arg1", "arg2"})
 	c.Check(execEnv, testutil.Contains, "SNAP_REVISION=x2")
+	c.Check(execEnv, check.Not(testutil.Contains), "NOTIFY_SOCKET=/run/systemd/notify")
 }
 
 func (s *RunSuite) TestSnapRunExposeKerberosTickets(c *check.C) {

--- a/cmd/snapd/cli/cmd_run_test.go
+++ b/cmd/snapd/cli/cmd_run_test.go
@@ -254,10 +254,6 @@ func (s *RunSuite) TestSnapRunAppIntegration(c *check.C) {
 		defer os.Unsetenv("TMPDIR")
 	}
 
-	defer snaprun.MockSystemdNotifySocket(func() string {
-		return "/run/systemd/notify"
-	})()
-
 	// mock installed snap
 	snaptest.MockSnapCurrent(c, string(mockYamlForNameBase("snapname", "")), &snap.SideInfo{
 		Revision: snap.R("x2"),
@@ -287,7 +283,6 @@ func (s *RunSuite) TestSnapRunAppIntegration(c *check.C) {
 		"snapname.app", "--arg1", "arg2"})
 	c.Check(execEnv, testutil.Contains, "SNAP_REVISION=x2")
 	c.Check(execEnv, testutil.Contains, fmt.Sprintf("TMPDIR=%s", tmpdir))
-	c.Check(execEnv, testutil.Contains, "NOTIFY_SOCKET=/run/systemd/notify")
 }
 
 func checkHintFileNotLocked(c *check.C, snapName string) {
@@ -1657,9 +1652,6 @@ func (s *RunSuite) TestSnapRunSnapdHelperPath(c *check.C) {
 
 func (s *RunSuite) TestSnapRunAppIntegrationFromCore(c *check.C) {
 	defer mockSnapConfine(filepath.Join(dirs.SnapMountDir, "core", "111", dirs.CoreLibExecDir))()
-	defer snaprun.MockSystemdNotifySocket(func() string {
-		return "/run/systemd/notify"
-	})()
 
 	// mock installed snap
 	snaptest.MockSnapCurrent(c, string(mockYamlForNameBase("snapname", "")), &snap.SideInfo{
@@ -1695,7 +1687,6 @@ func (s *RunSuite) TestSnapRunAppIntegrationFromCore(c *check.C) {
 		filepath.Join(dirs.CoreLibExecDir, "snap-exec"),
 		"snapname.app", "--arg1", "arg2"})
 	c.Check(execEnv, testutil.Contains, "SNAP_REVISION=x2")
-	c.Check(execEnv, testutil.Contains, "NOTIFY_SOCKET=/run/systemd/notify")
 }
 
 func (s *RunSuite) TestSnapRunAppIntegrationFromSnapd(c *check.C) {
@@ -1735,7 +1726,6 @@ func (s *RunSuite) TestSnapRunAppIntegrationFromSnapd(c *check.C) {
 		filepath.Join(dirs.CoreLibExecDir, "snap-exec"),
 		"snapname.app", "--arg1", "arg2"})
 	c.Check(execEnv, testutil.Contains, "SNAP_REVISION=x2")
-	c.Check(execEnv, check.Not(testutil.Contains), "NOTIFY_SOCKET=/run/systemd/notify")
 }
 
 func (s *RunSuite) TestSnapRunExposeKerberosTickets(c *check.C) {

--- a/cmd/snapd/cli/cmd_userd.go
+++ b/cmd/snapd/cli/cmd_userd.go
@@ -34,12 +34,16 @@ import (
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snapdtool"
+	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/usersession/agent"
 	"github.com/snapcore/snapd/usersession/autostart"
 	"github.com/snapcore/snapd/usersession/userd"
 )
 
-var autostartSessionApps = autostart.AutostartSessionApps
+var (
+	autostartSessionApps      = autostart.AutostartSessionApps
+	systemdInitSdNotifySocket = systemd.InitSdNotifySocket
+)
 
 type cmdUserd struct {
 	Autostart bool `long:"autostart"`
@@ -90,6 +94,9 @@ func (x *cmdUserd) Execute(args []string) error {
 	if len(args) > 0 {
 		return ErrExtraArgs
 	}
+
+	// This should be called as early as possible to read and unset NOTIFY_SOCKET.
+	systemdInitSdNotifySocket()
 
 	if x.Autostart {
 		// there may be two snap dirs (~/snap and ~/.snap/data)

--- a/cmd/snapd/cli/cmd_userd_test.go
+++ b/cmd/snapd/cli/cmd_userd_test.go
@@ -73,6 +73,17 @@ func (s *userdSuite) TestUserdBadCommandline(c *C) {
 	c.Assert(err, ErrorMatches, "too many arguments for command")
 }
 
+func (s *userdSuite) TestUserdInitSdNotifySocketCalled(c *C) {
+	restore := snap.MockSystemdInitSdNotifySocket(func() {
+		panic("systemd-init-sd-notify-socket-called")
+	})
+	defer restore()
+
+	c.Assert(func() {
+		_, _ = snap.Parser(snap.Client()).ParseArgs([]string{"userd"})
+	}, PanicMatches, "systemd-init-sd-notify-socket-called")
+}
+
 type mockSignal struct{}
 
 func (m *mockSignal) String() string {

--- a/cmd/snapd/cli/export_test.go
+++ b/cmd/snapd/cli/export_test.go
@@ -211,6 +211,14 @@ func MockGetEnv(f func(name string) string) (restore func()) {
 	}
 }
 
+func MockSystemdNotifySocket(f func() string) (restore func()) {
+	systemdNotifySocketOrig := systemdNotifySocket
+	systemdNotifySocket = f
+	return func() {
+		systemdNotifySocket = systemdNotifySocketOrig
+	}
+}
+
 func MockOsReadlink(f func(string) (string, error)) (restore func()) {
 	osReadlinkOrig := osReadlink
 	osReadlink = f

--- a/cmd/snapd/cli/export_test.go
+++ b/cmd/snapd/cli/export_test.go
@@ -476,6 +476,10 @@ func MockAutostartSessionApps(f func(string) error) func() {
 	}
 }
 
+func MockSystemdInitSdNotifySocket(f func()) (restore func()) {
+	return testutil.Mock(&systemdInitSdNotifySocket, f)
+}
+
 func ParseQuotaValues(maxMemory, cpuMax, cpuSet, threadsMax, journalSizeMax, journalRateLimit string) (*client.QuotaValues, error) {
 	var quotas cmdSetQuota
 

--- a/cmd/snapd/cli/export_test.go
+++ b/cmd/snapd/cli/export_test.go
@@ -211,14 +211,6 @@ func MockGetEnv(f func(name string) string) (restore func()) {
 	}
 }
 
-func MockSystemdNotifySocket(f func() string) (restore func()) {
-	systemdNotifySocketOrig := systemdNotifySocket
-	systemdNotifySocket = f
-	return func() {
-		systemdNotifySocket = systemdNotifySocketOrig
-	}
-}
-
 func MockOsReadlink(f func(string) (string, error)) (restore func()) {
 	osReadlinkOrig := osReadlink
 	osReadlink = f

--- a/cmd/snapd/daemon/main.go
+++ b/cmd/snapd/daemon/main.go
@@ -65,6 +65,9 @@ func Main() {
 		snapdtool.ExecInSnapdOrCoreSnap()
 	}
 
+	// This should be called as early as possible to read and unset NOTIFY_SOCKET.
+	systemd.InitSdNotifySocket()
+
 	// Set up security logging via the audit subsystem.
 	teardownSecurityLogging := setupSecurityLogging()
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -60,6 +60,7 @@ import (
 var ErrRestartSocket = fmt.Errorf("daemon stop requested to wait for socket activation")
 var ErrNoFailureRecoveryNeeded = fmt.Errorf("no failure recovery needed")
 
+var systemdInitSdNotifySocket = systemd.InitSdNotifySocket
 var systemdSdNotify = systemd.SdNotify
 
 const (
@@ -396,6 +397,8 @@ func logit(handler http.Handler) http.Handler {
 // Init sets up the Daemon's internal workings.
 // Don't call more than once.
 func (d *Daemon) Init() error {
+	systemdInitSdNotifySocket()
+
 	listenerMap, err := netutil.ActivationListeners()
 	if err != nil {
 		return err

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -60,7 +60,6 @@ import (
 var ErrRestartSocket = fmt.Errorf("daemon stop requested to wait for socket activation")
 var ErrNoFailureRecoveryNeeded = fmt.Errorf("no failure recovery needed")
 
-var systemdInitSdNotifySocket = systemd.InitSdNotifySocket
 var systemdSdNotify = systemd.SdNotify
 
 const (
@@ -397,8 +396,6 @@ func logit(handler http.Handler) http.Handler {
 // Init sets up the Daemon's internal workings.
 // Don't call more than once.
 func (d *Daemon) Init() error {
-	systemdInitSdNotifySocket()
-
 	listenerMap, err := netutil.ActivationListeners()
 	if err != nil {
 		return err

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -1493,6 +1493,22 @@ func (s *daemonSuite) TestHandleUnexpectedRestart(c *check.C) {
 	c.Assert(d.Start(context.Background()), check.Equals, ErrNoFailureRecoveryNeeded)
 }
 
+func (s *daemonSuite) TestInitCallsInitSdNotifySocket(c *check.C) {
+	d, err := New()
+	c.Assert(err, check.IsNil)
+
+	systemdInitSdNotifySocket = func() {
+		// panic so rest of Init does not run, we just want to test that
+		// is systemd.InitSdNotifySocket called.
+		panic("initialized")
+	}
+	defer func() {
+		systemdInitSdNotifySocket = systemd.InitSdNotifySocket
+	}()
+
+	c.Assert(d.Init, check.PanicMatches, "initialized")
+}
+
 func clientForSnapdSocket() *http.Client {
 	return &http.Client{
 		Transport: &http.Transport{

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -1493,22 +1493,6 @@ func (s *daemonSuite) TestHandleUnexpectedRestart(c *check.C) {
 	c.Assert(d.Start(context.Background()), check.Equals, ErrNoFailureRecoveryNeeded)
 }
 
-func (s *daemonSuite) TestInitCallsInitSdNotifySocket(c *check.C) {
-	d, err := New()
-	c.Assert(err, check.IsNil)
-
-	systemdInitSdNotifySocket = func() {
-		// panic so rest of Init does not run, we just want to test that
-		// is systemd.InitSdNotifySocket called.
-		panic("initialized")
-	}
-	defer func() {
-		systemdInitSdNotifySocket = systemd.InitSdNotifySocket
-	}()
-
-	c.Assert(d.Init, check.PanicMatches, "initialized")
-}
-
 func clientForSnapdSocket() *http.Client {
 	return &http.Client{
 		Transport: &http.Transport{

--- a/interfaces/builtin/daemon_notify.go
+++ b/interfaces/builtin/daemon_notify.go
@@ -21,12 +21,12 @@ package builtin
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	apparmor_sandbox "github.com/snapcore/snapd/sandbox/apparmor"
+	"github.com/snapcore/snapd/systemd"
 )
 
 const daemonNotifySummary = `allows sending daemon status changes to service manager`
@@ -51,13 +51,11 @@ type daemoNotifyInterface struct {
 	commonInterface
 }
 
-var osGetenv = os.Getenv
-
 func (iface *daemoNotifyInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// If the system has defined it, use NOTIFY_SOCKET from the environment. Note
 	// this is safe because it is examined on snapd start and snaps cannot manipulate
 	// the environment of snapd.
-	notifySocket := osGetenv("NOTIFY_SOCKET")
+	notifySocket := systemd.NotifySocket()
 	if notifySocket == "" {
 		notifySocket = "/run/systemd/notify"
 	}

--- a/interfaces/builtin/daemon_notify.go
+++ b/interfaces/builtin/daemon_notify.go
@@ -51,11 +51,13 @@ type daemoNotifyInterface struct {
 	commonInterface
 }
 
+var systemdNotifySocket = systemd.NotifySocket
+
 func (iface *daemoNotifyInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// If the system has defined it, use NOTIFY_SOCKET from the environment. Note
 	// this is safe because it is examined on snapd start and snaps cannot manipulate
 	// the environment of snapd.
-	notifySocket := systemd.NotifySocket()
+	notifySocket := systemdNotifySocket()
 	if notifySocket == "" {
 		notifySocket = "/run/systemd/notify"
 	}

--- a/interfaces/builtin/daemon_notify_test.go
+++ b/interfaces/builtin/daemon_notify_test.go
@@ -20,12 +20,15 @@
 package builtin_test
 
 import (
+	"os"
+
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -74,11 +77,8 @@ func (s *daemoNotifySuite) TestBeforePreparePlug(c *C) {
 }
 
 func (s *daemoNotifySuite) TestAppArmorConnectedPlugNotifySocketDefault(c *C) {
-	restore := builtin.MockOsGetenv(func(what string) string {
-		c.Assert(what, Equals, "NOTIFY_SOCKET")
-		return ""
-	})
-	defer restore()
+	os.Unsetenv("NOTIFY_SOCKET")
+	systemd.ResetNotifySocket()
 
 	// connected plugs have a non-nil security snippet for apparmor
 	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
@@ -93,11 +93,9 @@ func (s *daemoNotifySuite) TestAppArmorConnectedPlugNotifySocketDefault(c *C) {
 }
 
 func (s *daemoNotifySuite) TestAppArmorConnectedPlugNotifySocketEnvAbstractSpecial(c *C) {
-	restore := builtin.MockOsGetenv(func(what string) string {
-		c.Assert(what, Equals, "NOTIFY_SOCKET")
-		return "@/org/freedesktop/systemd1/notify/13334051644891137417"
-	})
-	defer restore()
+	os.Setenv("NOTIFY_SOCKET", "@/org/freedesktop/systemd1/notify/13334051644891137417")
+	defer os.Unsetenv("NOTIFY_SOCKET")
+	systemd.ResetNotifySocket()
 
 	// connected plugs have a non-nil security snippet for apparmor
 	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
@@ -111,11 +109,9 @@ func (s *daemoNotifySuite) TestAppArmorConnectedPlugNotifySocketEnvAbstractSpeci
 }
 
 func (s *daemoNotifySuite) TestAppArmorConnectedPlugNotifySocketEnvAbstractAny(c *C) {
-	restore := builtin.MockOsGetenv(func(what string) string {
-		c.Assert(what, Equals, "NOTIFY_SOCKET")
-		return "@foo/bar"
-	})
-	defer restore()
+	os.Setenv("NOTIFY_SOCKET", "@foo/bar")
+	defer os.Unsetenv("NOTIFY_SOCKET")
+	systemd.ResetNotifySocket()
 
 	// connected plugs have a non-nil security snippet for apparmor
 	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
@@ -129,11 +125,9 @@ func (s *daemoNotifySuite) TestAppArmorConnectedPlugNotifySocketEnvAbstractAny(c
 }
 
 func (s *daemoNotifySuite) TestAppArmorConnectedPlugNotifySocketEnvFsPath(c *C) {
-	restore := builtin.MockOsGetenv(func(what string) string {
-		c.Assert(what, Equals, "NOTIFY_SOCKET")
-		return "/foo/bar"
-	})
-	defer restore()
+	os.Setenv("NOTIFY_SOCKET", "/foo/bar")
+	defer os.Unsetenv("NOTIFY_SOCKET")
+	systemd.ResetNotifySocket()
 
 	// connected plugs have a non-nil security snippet for apparmor
 	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
@@ -146,12 +140,7 @@ func (s *daemoNotifySuite) TestAppArmorConnectedPlugNotifySocketEnvFsPath(c *C) 
 }
 
 func (s *daemoNotifySuite) TestAppArmorConnectedPlugNotifySocketEnvBadFormat(c *C) {
-	var socketPath string
-	restore := builtin.MockOsGetenv(func(what string) string {
-		c.Assert(what, Equals, "NOTIFY_SOCKET")
-		return socketPath
-	})
-	defer restore()
+	defer os.Unsetenv("NOTIFY_SOCKET")
 
 	for idx, tc := range []struct {
 		format string
@@ -163,7 +152,8 @@ func (s *daemoNotifySuite) TestAppArmorConnectedPlugNotifySocketEnvBadFormat(c *
 		{`/foo/bar"[]`, `cannot use \".*\" as notify socket path: \".*\" contains a reserved apparmor char from .*`},
 	} {
 		c.Logf("trying %d: %v", idx, tc)
-		socketPath = tc.format
+		os.Setenv("NOTIFY_SOCKET", tc.format)
+		systemd.ResetNotifySocket()
 		// connected plugs have a non-nil security snippet for apparmor
 		appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
 		c.Assert(err, IsNil)

--- a/interfaces/builtin/daemon_notify_test.go
+++ b/interfaces/builtin/daemon_notify_test.go
@@ -20,8 +20,6 @@
 package builtin_test
 
 import (
-	"os"
-
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/interfaces"
@@ -77,8 +75,8 @@ func (s *daemoNotifySuite) TestBeforePreparePlug(c *C) {
 }
 
 func (s *daemoNotifySuite) TestAppArmorConnectedPlugNotifySocketDefault(c *C) {
-	os.Unsetenv("NOTIFY_SOCKET")
-	systemd.ResetNotifySocket()
+	restore := systemd.MockNotifySocket("")
+	defer restore()
 
 	// connected plugs have a non-nil security snippet for apparmor
 	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
@@ -93,9 +91,8 @@ func (s *daemoNotifySuite) TestAppArmorConnectedPlugNotifySocketDefault(c *C) {
 }
 
 func (s *daemoNotifySuite) TestAppArmorConnectedPlugNotifySocketEnvAbstractSpecial(c *C) {
-	os.Setenv("NOTIFY_SOCKET", "@/org/freedesktop/systemd1/notify/13334051644891137417")
-	defer os.Unsetenv("NOTIFY_SOCKET")
-	systemd.ResetNotifySocket()
+	restore := systemd.MockNotifySocket("@/org/freedesktop/systemd1/notify/13334051644891137417")
+	defer restore()
 
 	// connected plugs have a non-nil security snippet for apparmor
 	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
@@ -109,9 +106,8 @@ func (s *daemoNotifySuite) TestAppArmorConnectedPlugNotifySocketEnvAbstractSpeci
 }
 
 func (s *daemoNotifySuite) TestAppArmorConnectedPlugNotifySocketEnvAbstractAny(c *C) {
-	os.Setenv("NOTIFY_SOCKET", "@foo/bar")
-	defer os.Unsetenv("NOTIFY_SOCKET")
-	systemd.ResetNotifySocket()
+	restore := systemd.MockNotifySocket("@foo/bar")
+	defer restore()
 
 	// connected plugs have a non-nil security snippet for apparmor
 	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
@@ -125,9 +121,8 @@ func (s *daemoNotifySuite) TestAppArmorConnectedPlugNotifySocketEnvAbstractAny(c
 }
 
 func (s *daemoNotifySuite) TestAppArmorConnectedPlugNotifySocketEnvFsPath(c *C) {
-	os.Setenv("NOTIFY_SOCKET", "/foo/bar")
-	defer os.Unsetenv("NOTIFY_SOCKET")
-	systemd.ResetNotifySocket()
+	restore := systemd.MockNotifySocket("/foo/bar")
+	defer restore()
 
 	// connected plugs have a non-nil security snippet for apparmor
 	appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
@@ -140,8 +135,6 @@ func (s *daemoNotifySuite) TestAppArmorConnectedPlugNotifySocketEnvFsPath(c *C) 
 }
 
 func (s *daemoNotifySuite) TestAppArmorConnectedPlugNotifySocketEnvBadFormat(c *C) {
-	defer os.Unsetenv("NOTIFY_SOCKET")
-
 	for idx, tc := range []struct {
 		format string
 		error  string
@@ -152,8 +145,8 @@ func (s *daemoNotifySuite) TestAppArmorConnectedPlugNotifySocketEnvBadFormat(c *
 		{`/foo/bar"[]`, `cannot use \".*\" as notify socket path: \".*\" contains a reserved apparmor char from .*`},
 	} {
 		c.Logf("trying %d: %v", idx, tc)
-		os.Setenv("NOTIFY_SOCKET", tc.format)
-		systemd.ResetNotifySocket()
+		restore := systemd.MockNotifySocket(tc.format)
+		defer restore()
 		// connected plugs have a non-nil security snippet for apparmor
 		appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)
 		c.Assert(err, IsNil)

--- a/interfaces/builtin/daemon_notify_test.go
+++ b/interfaces/builtin/daemon_notify_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/snap"
-	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/testutil"
 )
 
@@ -75,7 +74,7 @@ func (s *daemoNotifySuite) TestBeforePreparePlug(c *C) {
 }
 
 func (s *daemoNotifySuite) TestAppArmorConnectedPlugNotifySocketDefault(c *C) {
-	restore := systemd.MockNotifySocket("")
+	restore := builtin.MockSystemdNotifySocket("")
 	defer restore()
 
 	// connected plugs have a non-nil security snippet for apparmor
@@ -91,7 +90,7 @@ func (s *daemoNotifySuite) TestAppArmorConnectedPlugNotifySocketDefault(c *C) {
 }
 
 func (s *daemoNotifySuite) TestAppArmorConnectedPlugNotifySocketEnvAbstractSpecial(c *C) {
-	restore := systemd.MockNotifySocket("@/org/freedesktop/systemd1/notify/13334051644891137417")
+	restore := builtin.MockSystemdNotifySocket("@/org/freedesktop/systemd1/notify/13334051644891137417")
 	defer restore()
 
 	// connected plugs have a non-nil security snippet for apparmor
@@ -106,7 +105,7 @@ func (s *daemoNotifySuite) TestAppArmorConnectedPlugNotifySocketEnvAbstractSpeci
 }
 
 func (s *daemoNotifySuite) TestAppArmorConnectedPlugNotifySocketEnvAbstractAny(c *C) {
-	restore := systemd.MockNotifySocket("@foo/bar")
+	restore := builtin.MockSystemdNotifySocket("@foo/bar")
 	defer restore()
 
 	// connected plugs have a non-nil security snippet for apparmor
@@ -121,7 +120,7 @@ func (s *daemoNotifySuite) TestAppArmorConnectedPlugNotifySocketEnvAbstractAny(c
 }
 
 func (s *daemoNotifySuite) TestAppArmorConnectedPlugNotifySocketEnvFsPath(c *C) {
-	restore := systemd.MockNotifySocket("/foo/bar")
+	restore := builtin.MockSystemdNotifySocket("/foo/bar")
 	defer restore()
 
 	// connected plugs have a non-nil security snippet for apparmor
@@ -145,7 +144,7 @@ func (s *daemoNotifySuite) TestAppArmorConnectedPlugNotifySocketEnvBadFormat(c *
 		{`/foo/bar"[]`, `cannot use \".*\" as notify socket path: \".*\" contains a reserved apparmor char from .*`},
 	} {
 		c.Logf("trying %d: %v", idx, tc)
-		restore := systemd.MockNotifySocket(tc.format)
+		restore := builtin.MockSystemdNotifySocket(tc.format)
 		defer restore()
 		// connected plugs have a non-nil security snippet for apparmor
 		appSet, err := interfaces.NewSnapAppSet(s.plug.Snap(), nil)

--- a/interfaces/builtin/export_test.go
+++ b/interfaces/builtin/export_test.go
@@ -120,16 +120,6 @@ func MockConnectedSlot(c *C, yaml string, si *snap.SideInfo, slotName string) (*
 	panic(fmt.Sprintf("cannot find slot %q in snap %q", slotName, info.InstanceName()))
 }
 
-func MockOsGetenv(mock func(string) string) (restore func()) {
-	old := osGetenv
-	restore = func() {
-		osGetenv = old
-	}
-	osGetenv = mock
-
-	return restore
-}
-
 func MockProcCpuinfo(filename string) (restore func()) {
 	old := procCpuinfo
 	restore = func() {

--- a/interfaces/builtin/export_test.go
+++ b/interfaces/builtin/export_test.go
@@ -155,3 +155,9 @@ func MockGpioCheckConfigfsSupport(fn func() error) (restore func()) {
 func AllowedKernelMountOptions() []string {
 	return allowedKernelMountOptions
 }
+
+func MockSystemdNotifySocket(socket string) (restore func()) {
+	return testutil.Mock(&systemdNotifySocket, func() string {
+		return socket
+	})
+}

--- a/systemd/export_linux_test.go
+++ b/systemd/export_linux_test.go
@@ -1,5 +1,5 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
-//go:build !linux
+//go:build linux
 
 /*
  * Copyright (C) 2017-2026 Canonical Ltd
@@ -20,17 +20,16 @@
 
 package systemd
 
-import (
-	"errors"
-	"os"
-)
+import "sync"
 
-var errUnsupported = errors.New("unsupported on non-Linux systems")
+func ResetSdNotify() {
+	sdNotifyOnce = sync.Once{}
+	sdNotifySocket = ""
 
-func SdNotify(notifyState string) error {
-	return errUnsupported
-}
-
-func SdNotifyWithFds(notifyState string, files ...*os.File) error {
-	return errUnsupported
+	sdNotifyMu.Lock()
+	defer sdNotifyMu.Unlock()
+	if sdNotifyConnCache != nil {
+		sdNotifyConnCache.Close()
+		sdNotifyConnCache = nil
+	}
 }

--- a/systemd/export_linux_test.go
+++ b/systemd/export_linux_test.go
@@ -20,16 +20,19 @@
 
 package systemd
 
-import "sync"
+import "net"
 
 func ResetSdNotify() {
-	sdNotifyOnce = sync.Once{}
-	sdNotifySocket = ""
-
 	sdNotifyMu.Lock()
 	defer sdNotifyMu.Unlock()
 	if sdNotifyConnCache != nil {
 		sdNotifyConnCache.Close()
 		sdNotifyConnCache = nil
 	}
+}
+
+func SdNotifyConnCache() *net.UnixConn {
+	sdNotifyMu.Lock()
+	defer sdNotifyMu.Unlock()
+	return sdNotifyConnCache
 }

--- a/systemd/export_linux_test.go
+++ b/systemd/export_linux_test.go
@@ -31,10 +31,14 @@ func ResetSdNotifyConnCache() {
 }
 
 func SdNotifyCache() *sdNotifyConnCache {
+	sdNotifyCache.Lock()
+	defer sdNotifyCache.Unlock()
 	return &sdNotifyCache
 }
 
 func (c *sdNotifyConnCache) Closed() bool {
+	sdNotifyCache.Lock()
+	defer sdNotifyCache.Unlock()
 	return c.conn == nil
 }
 

--- a/systemd/export_linux_test.go
+++ b/systemd/export_linux_test.go
@@ -20,10 +20,6 @@
 
 package systemd
 
-import (
-	"github.com/snapcore/snapd/testutil"
-)
-
 func ResetSdNotifyConnCache() {
 	sdNotifyCache.Lock()
 	defer sdNotifyCache.Unlock()
@@ -40,8 +36,4 @@ func (c *sdNotifyConnCache) Closed() bool {
 	sdNotifyCache.Lock()
 	defer sdNotifyCache.Unlock()
 	return c.conn == nil
-}
-
-func MockNotifySocket(socket string) (restore func()) {
-	return testutil.Mock(&sdNotifySocket, socket)
 }

--- a/systemd/export_linux_test.go
+++ b/systemd/export_linux_test.go
@@ -20,19 +20,24 @@
 
 package systemd
 
-import "net"
+import (
+	"github.com/snapcore/snapd/testutil"
+)
 
-func ResetSdNotify() {
-	sdNotifyMu.Lock()
-	defer sdNotifyMu.Unlock()
-	if sdNotifyConnCache != nil {
-		sdNotifyConnCache.Close()
-		sdNotifyConnCache = nil
-	}
+func ResetSdNotifyConnCache() {
+	sdNotifyCache.Lock()
+	defer sdNotifyCache.Unlock()
+	sdNotifyCache.Close()
 }
 
-func SdNotifyConnCache() *net.UnixConn {
-	sdNotifyMu.Lock()
-	defer sdNotifyMu.Unlock()
-	return sdNotifyConnCache
+func SdNotifyCache() *sdNotifyConnCache {
+	return &sdNotifyCache
+}
+
+func (c *sdNotifyConnCache) Closed() bool {
+	return c.conn == nil
+}
+
+func MockNotifySocket(socket string) (restore func()) {
+	return testutil.Mock(&sdNotifySocket, socket)
 }

--- a/systemd/export_linux_test.go
+++ b/systemd/export_linux_test.go
@@ -20,10 +20,17 @@
 
 package systemd
 
+import "sync"
+
 func ResetSdNotifyConnCache() {
 	sdNotifyCache.Lock()
 	defer sdNotifyCache.Unlock()
 	sdNotifyCache.Close()
+}
+
+func ResetSdNotifySocketCache() {
+	sdNotifySocket = ""
+	sdNotifySocketOnce = sync.Once{}
 }
 
 func SdNotifyCache() *sdNotifyConnCache {

--- a/systemd/export_test.go
+++ b/systemd/export_test.go
@@ -29,10 +29,6 @@ var (
 	Jctl = jctl
 )
 
-func MockOsGetenv(f func(string) string) func() {
-	return testutil.Mock(&osGetenv, f)
-}
-
 func MockOsutilStreamCommand(f func(string, ...string) (io.ReadCloser, error)) func() {
 	return testutil.Mock(&osutilStreamCommand, f)
 }

--- a/systemd/sdnotify.go
+++ b/systemd/sdnotify.go
@@ -21,32 +21,31 @@ package systemd
 
 import (
 	"os"
-	"sync"
 
 	"github.com/snapcore/snapd/osutil"
 )
 
-var (
-	sdNotifyOnce   sync.Once
-	sdNotifySocket string
-)
+var sdNotifySocket string
 
-// NotifySocket returns the value of the NOTIFY_SOCKET environment variable.
-// It is read and cached once on first access, and the variable is unset.
+func init() {
+	sdNotifySocket = os.Getenv("NOTIFY_SOCKET")
+	os.Unsetenv("NOTIFY_SOCKET")
+}
+
+// NotifySocket returns the cached value of the NOTIFY_SOCKET environment
+// variable, which is read and unset during package initialization.
 func NotifySocket() string {
-	sdNotifyOnce.Do(func() {
-		sdNotifySocket = os.Getenv("NOTIFY_SOCKET")
-		os.Unsetenv("NOTIFY_SOCKET")
-	})
 	return sdNotifySocket
 }
 
-// ResetNotifySocket resets the cached NOTIFY_SOCKET value so that the next call
-// to NotifySocket re-reads it from the environment. It is meant to be used in
-// tests together with os.Setenv/os.Unsetenv.
-func ResetNotifySocket() {
-	osutil.MustBeTestBinary("cannot use ResetNotifySocket outside of tests")
+// MockNotifySocket overrides the cached NOTIFY_SOCKET value. It is meant to be
+// used in tests.
+func MockNotifySocket(socket string) (restore func()) {
+	osutil.MustBeTestBinary("cannot use MockNotifySocket outside of tests")
 
-	sdNotifyOnce = sync.Once{}
-	sdNotifySocket = ""
+	old := sdNotifySocket
+	sdNotifySocket = socket
+	return func() {
+		sdNotifySocket = old
+	}
 }

--- a/systemd/sdnotify.go
+++ b/systemd/sdnotify.go
@@ -1,0 +1,52 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package systemd
+
+import (
+	"os"
+	"sync"
+
+	"github.com/snapcore/snapd/osutil"
+)
+
+var (
+	sdNotifyOnce   sync.Once
+	sdNotifySocket string
+)
+
+// NotifySocket returns the value of the NOTIFY_SOCKET environment variable.
+// It is read and cached once on first access, and the variable is unset.
+func NotifySocket() string {
+	sdNotifyOnce.Do(func() {
+		sdNotifySocket = os.Getenv("NOTIFY_SOCKET")
+		os.Unsetenv("NOTIFY_SOCKET")
+	})
+	return sdNotifySocket
+}
+
+// ResetNotifySocket resets the cached NOTIFY_SOCKET value so that the next call
+// to NotifySocket re-reads it from the environment. It is meant to be used in
+// tests together with os.Setenv/os.Unsetenv.
+func ResetNotifySocket() {
+	osutil.MustBeTestBinary("cannot use ResetNotifySocket outside of tests")
+
+	sdNotifyOnce = sync.Once{}
+	sdNotifySocket = ""
+}

--- a/systemd/sdnotify.go
+++ b/systemd/sdnotify.go
@@ -25,13 +25,18 @@ import (
 
 var sdNotifySocket string
 
-func init() {
+// InitSdNotifySocket reads and unsets the NOTIFY_SOCKET environment variable.
+// It should be called once during package initialization, before any other
+// code that might use NotifySocket().
+//
+// To get the cached value, use NotifySocket().
+func InitSdNotifySocket() {
 	sdNotifySocket = os.Getenv("NOTIFY_SOCKET")
 	os.Unsetenv("NOTIFY_SOCKET")
 }
 
 // NotifySocket returns the cached value of the NOTIFY_SOCKET environment
-// variable, which is read and unset during package initialization.
+// variable, InitSdNotifySocket() must be called first.
 func NotifySocket() string {
 	return sdNotifySocket
 }

--- a/systemd/sdnotify.go
+++ b/systemd/sdnotify.go
@@ -21,22 +21,26 @@ package systemd
 
 import (
 	"os"
+	"sync"
 )
 
 var sdNotifySocket string
+var sdNotifySocketOnce sync.Once
 
 // InitSdNotifySocket reads and unsets the NOTIFY_SOCKET environment variable.
-// It should be called once during package initialization, before any other
-// code that might use NotifySocket().
 //
 // To get the cached value, use NotifySocket().
 func InitSdNotifySocket() {
-	sdNotifySocket = os.Getenv("NOTIFY_SOCKET")
-	os.Unsetenv("NOTIFY_SOCKET")
+	sdNotifySocketOnce.Do(func() {
+		sdNotifySocket = os.Getenv("NOTIFY_SOCKET")
+		os.Unsetenv("NOTIFY_SOCKET")
+	})
 }
 
 // NotifySocket returns the cached value of the NOTIFY_SOCKET environment
-// variable, InitSdNotifySocket() must be called first.
+// variable.
 func NotifySocket() string {
+	// ensure the NOTIFY_SOCKET environment variable is read and unset before returning the cached value
+	InitSdNotifySocket()
 	return sdNotifySocket
 }

--- a/systemd/sdnotify.go
+++ b/systemd/sdnotify.go
@@ -21,8 +21,6 @@ package systemd
 
 import (
 	"os"
-
-	"github.com/snapcore/snapd/osutil"
 )
 
 var sdNotifySocket string
@@ -36,16 +34,4 @@ func init() {
 // variable, which is read and unset during package initialization.
 func NotifySocket() string {
 	return sdNotifySocket
-}
-
-// MockNotifySocket overrides the cached NOTIFY_SOCKET value. It is meant to be
-// used in tests.
-func MockNotifySocket(socket string) (restore func()) {
-	osutil.MustBeTestBinary("cannot use MockNotifySocket outside of tests")
-
-	old := sdNotifySocket
-	sdNotifySocket = socket
-	return func() {
-		sdNotifySocket = old
-	}
 }

--- a/systemd/sdnotify_linux.go
+++ b/systemd/sdnotify_linux.go
@@ -53,6 +53,9 @@ func SdNotify(notifyState string) error {
 	}
 
 	if _, err := conn.Write([]byte(notifyState)); err != nil {
+		// UNIXGRAM sockets are connectionless, so an error here likely indicates
+		// that the socket is no longer valid. We drop the cached connection to
+		// ensure the next call reconnects.
 		// drop the cached connection so the next call reconnects
 		conn.Close()
 		sdNotifyConnCache = nil
@@ -113,7 +116,9 @@ func SdNotifyWithFds(notifyState string, files ...*os.File) error {
 	}
 
 	if sendMsgErr != nil {
-		// drop the cached connection so the next call reconnects
+		// UNIXGRAM sockets are connectionless, so an error here likely indicates
+		// that the socket is no longer valid. We drop the cached connection to
+		// ensure the next call reconnects.
 		conn.Close()
 		sdNotifyConnCache = nil
 	}

--- a/systemd/sdnotify_linux.go
+++ b/systemd/sdnotify_linux.go
@@ -26,8 +26,14 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"sync"
 
 	"golang.org/x/sys/unix"
+)
+
+var (
+	sdNotifyMu        sync.Mutex
+	sdNotifyConnCache *net.UnixConn
 )
 
 // SdNotify sends the given state string notification to systemd.
@@ -38,15 +44,21 @@ func SdNotify(notifyState string) error {
 		return fmt.Errorf("invalid empty notify state")
 	}
 
+	sdNotifyMu.Lock()
+	defer sdNotifyMu.Unlock()
+
 	conn, err := sdNotifyConn()
 	if err != nil {
 		return err
 	}
-	// TODO: keep it open to avoid re-opening and make sure to have O_CLOEXEC
-	defer conn.Close()
 
-	_, err = conn.Write([]byte(notifyState))
-	return err
+	if _, err := conn.Write([]byte(notifyState)); err != nil {
+		// drop the cached connection so the next call reconnects
+		conn.Close()
+		sdNotifyConnCache = nil
+		return err
+	}
+	return nil
 }
 
 // SdNotifyWithFds sends the given state string notification and file
@@ -64,12 +76,13 @@ func SdNotifyWithFds(notifyState string, files ...*os.File) error {
 		return fmt.Errorf("at least one file is required")
 	}
 
+	sdNotifyMu.Lock()
+	defer sdNotifyMu.Unlock()
+
 	conn, err := sdNotifyConn()
 	if err != nil {
 		return err
 	}
-	// TODO: keep it open to avoid re-opening and make sure to have O_CLOEXEC
-	defer conn.Close()
 
 	rawConn, err := conn.SyscallConn()
 	if err != nil {
@@ -99,13 +112,21 @@ func SdNotifyWithFds(notifyState string, files ...*os.File) error {
 		return err
 	}
 
+	if sendMsgErr != nil {
+		// drop the cached connection so the next call reconnects
+		conn.Close()
+		sdNotifyConnCache = nil
+	}
 	return sendMsgErr
 }
 
-var osGetenv = os.Getenv
-
+// sdNotifyConn should be called with sdNotifyMu locked.
 func sdNotifyConn() (*net.UnixConn, error) {
-	notifySocket := osGetenv("NOTIFY_SOCKET")
+	if sdNotifyConnCache != nil {
+		return sdNotifyConnCache, nil
+	}
+
+	notifySocket := NotifySocket()
 	if notifySocket == "" {
 		return nil, fmt.Errorf("cannot find NOTIFY_SOCKET environment variable")
 	}
@@ -117,5 +138,11 @@ func sdNotifyConn() (*net.UnixConn, error) {
 		Name: notifySocket,
 		Net:  "unixgram",
 	}
-	return net.DialUnix("unixgram", nil, raddr)
+	// net.DialUnix opens the socket with SOCK_CLOEXEC.
+	conn, err := net.DialUnix("unixgram", nil, raddr)
+	if err != nil {
+		return nil, err
+	}
+	sdNotifyConnCache = conn
+	return conn, nil
 }

--- a/systemd/sdnotify_linux.go
+++ b/systemd/sdnotify_linux.go
@@ -32,9 +32,65 @@ import (
 )
 
 var (
-	sdNotifyMu        sync.Mutex
-	sdNotifyConnCache *net.UnixConn
+	sdNotifyCache sdNotifyConnCache
 )
+
+type sdNotifyConnCache struct {
+	conn *net.UnixConn
+	mu   sync.Mutex
+}
+
+func (c *sdNotifyConnCache) Lock() {
+	c.mu.Lock()
+}
+
+func (c *sdNotifyConnCache) Unlock() {
+	c.mu.Unlock()
+}
+
+func (c *sdNotifyConnCache) assertLocked() {
+	if c.mu.TryLock() {
+		c.mu.Unlock()
+		panic("internal error: sdNotifyConnCache lock is not held")
+	}
+}
+
+func (c *sdNotifyConnCache) Close() {
+	c.assertLocked()
+	if c.conn != nil {
+		c.conn.Close()
+		c.conn = nil
+	}
+}
+
+// Conn should be called with the lock held.
+func (c *sdNotifyConnCache) Conn() (*net.UnixConn, error) {
+	c.assertLocked()
+
+	if c.conn != nil {
+		return c.conn, nil
+	}
+
+	notifySocket := NotifySocket()
+	if notifySocket == "" {
+		return nil, fmt.Errorf("cannot find NOTIFY_SOCKET environment variable")
+	}
+	if !strings.HasPrefix(notifySocket, "@") && !strings.HasPrefix(notifySocket, "/") {
+		return nil, fmt.Errorf("cannot use NOTIFY_SOCKET %q", notifySocket)
+	}
+
+	raddr := &net.UnixAddr{
+		Name: notifySocket,
+		Net:  "unixgram",
+	}
+	// net.DialUnix opens the socket with SOCK_CLOEXEC.
+	conn, err := net.DialUnix("unixgram", nil, raddr)
+	if err != nil {
+		return nil, err
+	}
+	c.conn = conn
+	return conn, nil
+}
 
 // SdNotify sends the given state string notification to systemd.
 //
@@ -44,10 +100,10 @@ func SdNotify(notifyState string) error {
 		return fmt.Errorf("invalid empty notify state")
 	}
 
-	sdNotifyMu.Lock()
-	defer sdNotifyMu.Unlock()
+	sdNotifyCache.Lock()
+	defer sdNotifyCache.Unlock()
 
-	conn, err := sdNotifyConn()
+	conn, err := sdNotifyCache.Conn()
 	if err != nil {
 		return err
 	}
@@ -56,9 +112,7 @@ func SdNotify(notifyState string) error {
 		// UNIXGRAM sockets are connectionless, so an error here likely indicates
 		// that the socket is no longer valid. We drop the cached connection to
 		// ensure the next call reconnects.
-		// drop the cached connection so the next call reconnects
-		conn.Close()
-		sdNotifyConnCache = nil
+		sdNotifyCache.Close()
 		return err
 	}
 	return nil
@@ -79,10 +133,10 @@ func SdNotifyWithFds(notifyState string, files ...*os.File) error {
 		return fmt.Errorf("at least one file is required")
 	}
 
-	sdNotifyMu.Lock()
-	defer sdNotifyMu.Unlock()
+	sdNotifyCache.Lock()
+	defer sdNotifyCache.Unlock()
 
-	conn, err := sdNotifyConn()
+	conn, err := sdNotifyCache.Conn()
 	if err != nil {
 		return err
 	}
@@ -119,35 +173,7 @@ func SdNotifyWithFds(notifyState string, files ...*os.File) error {
 		// UNIXGRAM sockets are connectionless, so an error here likely indicates
 		// that the socket is no longer valid. We drop the cached connection to
 		// ensure the next call reconnects.
-		conn.Close()
-		sdNotifyConnCache = nil
+		sdNotifyCache.Close()
 	}
 	return sendMsgErr
-}
-
-// sdNotifyConn should be called with sdNotifyMu locked.
-func sdNotifyConn() (*net.UnixConn, error) {
-	if sdNotifyConnCache != nil {
-		return sdNotifyConnCache, nil
-	}
-
-	notifySocket := NotifySocket()
-	if notifySocket == "" {
-		return nil, fmt.Errorf("cannot find NOTIFY_SOCKET environment variable")
-	}
-	if !strings.HasPrefix(notifySocket, "@") && !strings.HasPrefix(notifySocket, "/") {
-		return nil, fmt.Errorf("cannot use NOTIFY_SOCKET %q", notifySocket)
-	}
-
-	raddr := &net.UnixAddr{
-		Name: notifySocket,
-		Net:  "unixgram",
-	}
-	// net.DialUnix opens the socket with SOCK_CLOEXEC.
-	conn, err := net.DialUnix("unixgram", nil, raddr)
-	if err != nil {
-		return nil, err
-	}
-	sdNotifyConnCache = conn
-	return conn, nil
 }

--- a/systemd/sdnotify_linux.go
+++ b/systemd/sdnotify_linux.go
@@ -40,10 +40,12 @@ type sdNotifyConnCache struct {
 	mu   sync.Mutex
 }
 
+// Lock acquires the cache lock.
 func (c *sdNotifyConnCache) Lock() {
 	c.mu.Lock()
 }
 
+// Unlock releases the cache lock.
 func (c *sdNotifyConnCache) Unlock() {
 	c.mu.Unlock()
 }
@@ -55,6 +57,7 @@ func (c *sdNotifyConnCache) assertLocked() {
 	}
 }
 
+// Close should be called with the lock held.
 func (c *sdNotifyConnCache) Close() {
 	c.assertLocked()
 	if c.conn != nil {

--- a/systemd/sdnotify_linux_test.go
+++ b/systemd/sdnotify_linux_test.go
@@ -61,6 +61,7 @@ func (sd *sdNotifyTestSuite) testSdNotifyWrongNotifySocket(c *C, withFds bool) {
 	} {
 		os.Setenv("NOTIFY_SOCKET", t.env)
 		defer os.Unsetenv("NOTIFY_SOCKET")
+		systemd.ResetSdNotify()
 
 		if withFds {
 			f, err := os.OpenFile(filepath.Join(c.MkDir(), "test"), os.O_RDWR|os.O_CREATE, 0644)
@@ -83,17 +84,14 @@ func (sd *sdNotifyTestSuite) TestSdNotifyWithFdsWrongNotifySocket(c *C) {
 }
 
 func (sd *sdNotifyTestSuite) TestSdNotifyIntegration(c *C) {
-	fakeEnv := map[string]string{}
-	restore := systemd.MockOsGetenv(func(k string) string {
-		return fakeEnv[k]
-	})
-	defer restore()
+	defer os.Unsetenv("NOTIFY_SOCKET")
 
 	for _, sockPath := range []string{
 		filepath.Join(c.MkDir(), "socket"),
 		"@socket",
 	} {
-		fakeEnv["NOTIFY_SOCKET"] = sockPath
+		os.Setenv("NOTIFY_SOCKET", sockPath)
+		systemd.ResetSdNotify()
 
 		conn, err := net.ListenUnixgram("unixgram", &net.UnixAddr{
 			Name: sockPath,
@@ -123,17 +121,14 @@ func panicOnErr(err error) {
 }
 
 func (sd *sdNotifyTestSuite) TestSdNotifyWithFdsIntegration(c *C) {
-	fakeEnv := map[string]string{}
-	restore := systemd.MockOsGetenv(func(k string) string {
-		return fakeEnv[k]
-	})
-	defer restore()
+	defer os.Unsetenv("NOTIFY_SOCKET")
 
 	for _, sockPath := range []string{
 		filepath.Join(c.MkDir(), "socket"),
 		"@socket",
 	} {
-		fakeEnv["NOTIFY_SOCKET"] = sockPath
+		os.Setenv("NOTIFY_SOCKET", sockPath)
+		systemd.ResetSdNotify()
 
 		tmpdir := c.MkDir()
 

--- a/systemd/sdnotify_linux_test.go
+++ b/systemd/sdnotify_linux_test.go
@@ -26,6 +26,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"golang.org/x/sys/unix"
@@ -59,8 +60,8 @@ func (sd *sdNotifyTestSuite) testSdNotifyWrongNotifySocket(c *C, withFds bool) {
 		{"", "cannot find NOTIFY_SOCKET environment variable"},
 		{"xxx", `cannot use NOTIFY_SOCKET "xxx"`},
 	} {
-		os.Setenv("NOTIFY_SOCKET", t.env)
-		defer os.Unsetenv("NOTIFY_SOCKET")
+		restore := systemd.MockNotifySocket(t.env)
+		defer restore()
 		systemd.ResetSdNotify()
 
 		if withFds {
@@ -84,13 +85,12 @@ func (sd *sdNotifyTestSuite) TestSdNotifyWithFdsWrongNotifySocket(c *C) {
 }
 
 func (sd *sdNotifyTestSuite) TestSdNotifyIntegration(c *C) {
-	defer os.Unsetenv("NOTIFY_SOCKET")
-
 	for _, sockPath := range []string{
 		filepath.Join(c.MkDir(), "socket"),
 		"@socket",
 	} {
-		os.Setenv("NOTIFY_SOCKET", sockPath)
+		restore := systemd.MockNotifySocket(sockPath)
+		defer restore()
 		systemd.ResetSdNotify()
 
 		conn, err := net.ListenUnixgram("unixgram", &net.UnixAddr{
@@ -114,6 +114,83 @@ func (sd *sdNotifyTestSuite) TestSdNotifyIntegration(c *C) {
 	}
 }
 
+func (sd *sdNotifyTestSuite) testSdNotifyReconnectsAfterWriteError(c *C, withFds bool) {
+	notify := systemd.SdNotify
+	if withFds {
+		f, err := os.OpenFile(filepath.Join(c.MkDir(), "fd"), os.O_RDWR|os.O_CREATE, 0644)
+		c.Assert(err, IsNil)
+		defer f.Close()
+
+		notify = func(state string) error {
+			return systemd.SdNotifyWithFds(state, f)
+		}
+	}
+
+	for _, sockPath := range []string{
+		filepath.Join(c.MkDir(), "socket"),
+		"@socket",
+	} {
+		restore := systemd.MockNotifySocket(sockPath)
+		defer restore()
+		systemd.ResetSdNotify()
+
+		addr := &net.UnixAddr{
+			Name: sockPath,
+			Net:  "unixgram",
+		}
+
+		readOne := func(conn *net.UnixConn) string {
+			var buf [128]byte
+			n, err := conn.Read(buf[:])
+			c.Assert(err, IsNil)
+			return string(buf[:n])
+		}
+
+		// initial notification connects and caches the connection
+		conn1, err := net.ListenUnixgram("unixgram", addr)
+		c.Assert(err, IsNil)
+
+		err = notify("first")
+		c.Assert(err, IsNil)
+		c.Check(readOne(conn1), Equals, "first")
+		c.Check(systemd.SdNotifyConnCache(), NotNil)
+
+		// closing the listener makes subsequent writes fail, which
+		// should drop the cached connection
+		conn1.Close()
+
+		err = notify("second")
+		c.Assert(err, ErrorMatches, ".*connection refused")
+		c.Check(systemd.SdNotifyConnCache(), IsNil)
+
+		// a new listener at the same address receives notifications
+		// again, proving the next call reconnected
+		if !strings.HasPrefix(sockPath, "@") {
+			// closing the listener leaves the socket file behind
+			c.Assert(os.Remove(sockPath), IsNil)
+		}
+		conn2, err := net.ListenUnixgram("unixgram", addr)
+		c.Assert(err, IsNil)
+
+		err = notify("third")
+		c.Assert(err, IsNil)
+		c.Check(readOne(conn2), Equals, "third")
+		c.Check(systemd.SdNotifyConnCache(), NotNil)
+
+		conn2.Close()
+	}
+}
+
+func (sd *sdNotifyTestSuite) TestSdNotifyReconnectsAfterWriteError(c *C) {
+	const withFds = false
+	sd.testSdNotifyReconnectsAfterWriteError(c, withFds)
+}
+
+func (sd *sdNotifyTestSuite) TestSdNotifyWithFdsReconnectsAfterWriteError(c *C) {
+	const withFds = true
+	sd.testSdNotifyReconnectsAfterWriteError(c, withFds)
+}
+
 func panicOnErr(err error) {
 	if err != nil {
 		panic(err)
@@ -121,13 +198,12 @@ func panicOnErr(err error) {
 }
 
 func (sd *sdNotifyTestSuite) TestSdNotifyWithFdsIntegration(c *C) {
-	defer os.Unsetenv("NOTIFY_SOCKET")
-
 	for _, sockPath := range []string{
 		filepath.Join(c.MkDir(), "socket"),
 		"@socket",
 	} {
-		os.Setenv("NOTIFY_SOCKET", sockPath)
+		restore := systemd.MockNotifySocket(sockPath)
+		defer restore()
 		systemd.ResetSdNotify()
 
 		tmpdir := c.MkDir()

--- a/systemd/sdnotify_linux_test.go
+++ b/systemd/sdnotify_linux_test.go
@@ -52,6 +52,15 @@ func (sd *sdNotifyTestSuite) TestSdNotifyWithFdsMissingFds(c *C) {
 	c.Check(systemd.SdNotifyWithFds("some-state"), ErrorMatches, "at least one file is required")
 }
 
+func (sd *sdNotifyTestSuite) TestInitSdNotifySocketCachesAndUnsetsEnv(c *C) {
+	os.Setenv("NOTIFY_SOCKET", "@test-socket")
+	systemd.InitSdNotifySocket()
+
+	c.Check(systemd.NotifySocket(), Equals, "@test-socket")
+	_, found := os.LookupEnv("NOTIFY_SOCKET")
+	c.Check(found, Equals, false)
+}
+
 func (sd *sdNotifyTestSuite) TestSdNotifyCacheConnRequiresLock(c *C) {
 	c.Assert(func() {
 		_, _ = systemd.SdNotifyCache().Conn()
@@ -72,8 +81,8 @@ func (sd *sdNotifyTestSuite) testSdNotifyWrongNotifySocket(c *C, withFds bool) {
 		{"", "cannot find NOTIFY_SOCKET environment variable"},
 		{"xxx", `cannot use NOTIFY_SOCKET "xxx"`},
 	} {
-		restore := systemd.MockNotifySocket(t.env)
-		defer restore()
+		os.Setenv("NOTIFY_SOCKET", t.env)
+		systemd.InitSdNotifySocket()
 		systemd.ResetSdNotifyConnCache()
 
 		if withFds {
@@ -101,8 +110,8 @@ func (sd *sdNotifyTestSuite) TestSdNotifyIntegration(c *C) {
 		filepath.Join(c.MkDir(), "socket"),
 		"@socket",
 	} {
-		restore := systemd.MockNotifySocket(sockPath)
-		defer restore()
+		os.Setenv("NOTIFY_SOCKET", sockPath)
+		systemd.InitSdNotifySocket()
 		systemd.ResetSdNotifyConnCache()
 
 		conn, err := net.ListenUnixgram("unixgram", &net.UnixAddr{
@@ -142,8 +151,8 @@ func (sd *sdNotifyTestSuite) testSdNotifyClearsConnCacheAfterError(c *C, withFds
 		filepath.Join(c.MkDir(), "socket"),
 		"@socket",
 	} {
-		restore := systemd.MockNotifySocket(sockPath)
-		defer restore()
+		os.Setenv("NOTIFY_SOCKET", sockPath)
+		systemd.InitSdNotifySocket()
 		systemd.ResetSdNotifyConnCache()
 
 		addr := &net.UnixAddr{
@@ -214,8 +223,8 @@ func (sd *sdNotifyTestSuite) TestSdNotifyWithFdsIntegration(c *C) {
 		filepath.Join(c.MkDir(), "socket"),
 		"@socket",
 	} {
-		restore := systemd.MockNotifySocket(sockPath)
-		defer restore()
+		os.Setenv("NOTIFY_SOCKET", sockPath)
+		systemd.InitSdNotifySocket()
 		systemd.ResetSdNotifyConnCache()
 
 		tmpdir := c.MkDir()

--- a/systemd/sdnotify_linux_test.go
+++ b/systemd/sdnotify_linux_test.go
@@ -52,6 +52,18 @@ func (sd *sdNotifyTestSuite) TestSdNotifyWithFdsMissingFds(c *C) {
 	c.Check(systemd.SdNotifyWithFds("some-state"), ErrorMatches, "at least one file is required")
 }
 
+func (sd *sdNotifyTestSuite) TestSdNotifyCacheConnRequiresLock(c *C) {
+	c.Assert(func() {
+		_, _ = systemd.SdNotifyCache().Conn()
+	}, PanicMatches, "internal error: sdNotifyConnCache lock is not held")
+}
+
+func (sd *sdNotifyTestSuite) TestSdNotifyCacheCloseRequiresLock(c *C) {
+	c.Assert(func() {
+		systemd.SdNotifyCache().Close()
+	}, PanicMatches, "internal error: sdNotifyConnCache lock is not held")
+}
+
 func (sd *sdNotifyTestSuite) testSdNotifyWrongNotifySocket(c *C, withFds bool) {
 	for _, t := range []struct {
 		env    string
@@ -62,7 +74,7 @@ func (sd *sdNotifyTestSuite) testSdNotifyWrongNotifySocket(c *C, withFds bool) {
 	} {
 		restore := systemd.MockNotifySocket(t.env)
 		defer restore()
-		systemd.ResetSdNotify()
+		systemd.ResetSdNotifyConnCache()
 
 		if withFds {
 			f, err := os.OpenFile(filepath.Join(c.MkDir(), "test"), os.O_RDWR|os.O_CREATE, 0644)
@@ -91,7 +103,7 @@ func (sd *sdNotifyTestSuite) TestSdNotifyIntegration(c *C) {
 	} {
 		restore := systemd.MockNotifySocket(sockPath)
 		defer restore()
-		systemd.ResetSdNotify()
+		systemd.ResetSdNotifyConnCache()
 
 		conn, err := net.ListenUnixgram("unixgram", &net.UnixAddr{
 			Name: sockPath,
@@ -114,7 +126,7 @@ func (sd *sdNotifyTestSuite) TestSdNotifyIntegration(c *C) {
 	}
 }
 
-func (sd *sdNotifyTestSuite) testSdNotifyReconnectsAfterWriteError(c *C, withFds bool) {
+func (sd *sdNotifyTestSuite) testSdNotifyClearsConnCacheAfterError(c *C, withFds bool) {
 	notify := systemd.SdNotify
 	if withFds {
 		f, err := os.OpenFile(filepath.Join(c.MkDir(), "fd"), os.O_RDWR|os.O_CREATE, 0644)
@@ -132,7 +144,7 @@ func (sd *sdNotifyTestSuite) testSdNotifyReconnectsAfterWriteError(c *C, withFds
 	} {
 		restore := systemd.MockNotifySocket(sockPath)
 		defer restore()
-		systemd.ResetSdNotify()
+		systemd.ResetSdNotifyConnCache()
 
 		addr := &net.UnixAddr{
 			Name: sockPath,
@@ -153,7 +165,7 @@ func (sd *sdNotifyTestSuite) testSdNotifyReconnectsAfterWriteError(c *C, withFds
 		err = notify("first")
 		c.Assert(err, IsNil)
 		c.Check(readOne(conn1), Equals, "first")
-		c.Check(systemd.SdNotifyConnCache(), NotNil)
+		c.Check(systemd.SdNotifyCache().Closed(), Equals, false)
 
 		// closing the listener makes subsequent writes fail, which
 		// should drop the cached connection
@@ -161,7 +173,7 @@ func (sd *sdNotifyTestSuite) testSdNotifyReconnectsAfterWriteError(c *C, withFds
 
 		err = notify("second")
 		c.Assert(err, ErrorMatches, ".*connection refused")
-		c.Check(systemd.SdNotifyConnCache(), IsNil)
+		c.Check(systemd.SdNotifyCache().Closed(), Equals, true)
 
 		// a new listener at the same address receives notifications
 		// again, proving the next call reconnected
@@ -175,20 +187,20 @@ func (sd *sdNotifyTestSuite) testSdNotifyReconnectsAfterWriteError(c *C, withFds
 		err = notify("third")
 		c.Assert(err, IsNil)
 		c.Check(readOne(conn2), Equals, "third")
-		c.Check(systemd.SdNotifyConnCache(), NotNil)
+		c.Check(systemd.SdNotifyCache().Closed(), Equals, false)
 
 		conn2.Close()
 	}
 }
 
-func (sd *sdNotifyTestSuite) TestSdNotifyReconnectsAfterWriteError(c *C) {
+func (sd *sdNotifyTestSuite) TestSdNotifyClearsConnCacheAfterError(c *C) {
 	const withFds = false
-	sd.testSdNotifyReconnectsAfterWriteError(c, withFds)
+	sd.testSdNotifyClearsConnCacheAfterError(c, withFds)
 }
 
-func (sd *sdNotifyTestSuite) TestSdNotifyWithFdsReconnectsAfterWriteError(c *C) {
+func (sd *sdNotifyTestSuite) TestSdNotifyWithFdsClearsConnCacheAfterError(c *C) {
 	const withFds = true
-	sd.testSdNotifyReconnectsAfterWriteError(c, withFds)
+	sd.testSdNotifyClearsConnCacheAfterError(c, withFds)
 }
 
 func panicOnErr(err error) {
@@ -204,7 +216,7 @@ func (sd *sdNotifyTestSuite) TestSdNotifyWithFdsIntegration(c *C) {
 	} {
 		restore := systemd.MockNotifySocket(sockPath)
 		defer restore()
-		systemd.ResetSdNotify()
+		systemd.ResetSdNotifyConnCache()
 
 		tmpdir := c.MkDir()
 

--- a/systemd/sdnotify_linux_test.go
+++ b/systemd/sdnotify_linux_test.go
@@ -53,11 +53,18 @@ func (sd *sdNotifyTestSuite) TestSdNotifyWithFdsMissingFds(c *C) {
 }
 
 func (sd *sdNotifyTestSuite) TestInitSdNotifySocketCachesAndUnsetsEnv(c *C) {
+	systemd.ResetSdNotifySocketCache()
 	os.Setenv("NOTIFY_SOCKET", "@test-socket")
 	systemd.InitSdNotifySocket()
 
 	c.Check(systemd.NotifySocket(), Equals, "@test-socket")
 	_, found := os.LookupEnv("NOTIFY_SOCKET")
+	c.Check(found, Equals, false)
+
+	// re-running is a no-op
+	systemd.InitSdNotifySocket()
+	c.Check(systemd.NotifySocket(), Equals, "@test-socket")
+	_, found = os.LookupEnv("NOTIFY_SOCKET")
 	c.Check(found, Equals, false)
 }
 
@@ -81,8 +88,8 @@ func (sd *sdNotifyTestSuite) testSdNotifyWrongNotifySocket(c *C, withFds bool) {
 		{"", "cannot find NOTIFY_SOCKET environment variable"},
 		{"xxx", `cannot use NOTIFY_SOCKET "xxx"`},
 	} {
+		systemd.ResetSdNotifySocketCache()
 		os.Setenv("NOTIFY_SOCKET", t.env)
-		systemd.InitSdNotifySocket()
 		systemd.ResetSdNotifyConnCache()
 
 		if withFds {
@@ -110,8 +117,8 @@ func (sd *sdNotifyTestSuite) TestSdNotifyIntegration(c *C) {
 		filepath.Join(c.MkDir(), "socket"),
 		"@socket",
 	} {
+		systemd.ResetSdNotifySocketCache()
 		os.Setenv("NOTIFY_SOCKET", sockPath)
-		systemd.InitSdNotifySocket()
 		systemd.ResetSdNotifyConnCache()
 
 		conn, err := net.ListenUnixgram("unixgram", &net.UnixAddr{
@@ -151,8 +158,8 @@ func (sd *sdNotifyTestSuite) testSdNotifyClearsConnCacheAfterError(c *C, withFds
 		filepath.Join(c.MkDir(), "socket"),
 		"@socket",
 	} {
+		systemd.ResetSdNotifySocketCache()
 		os.Setenv("NOTIFY_SOCKET", sockPath)
-		systemd.InitSdNotifySocket()
 		systemd.ResetSdNotifyConnCache()
 
 		addr := &net.UnixAddr{
@@ -223,8 +230,8 @@ func (sd *sdNotifyTestSuite) TestSdNotifyWithFdsIntegration(c *C) {
 		filepath.Join(c.MkDir(), "socket"),
 		"@socket",
 	} {
+		systemd.ResetSdNotifySocketCache()
 		os.Setenv("NOTIFY_SOCKET", sockPath)
-		systemd.InitSdNotifySocket()
 		systemd.ResetSdNotifyConnCache()
 
 		tmpdir := c.MkDir()


### PR DESCRIPTION
- NOTIFY_SOCKET environment variable should be read at the start and then unset, other packages should consult the systemd package for the value.
- Keep sdnotify socket connection open no need to open a new connection for each request, only retry connection on failure.

This change should be used by https://github.com/canonical/snapd/pull/17421 when it lands.

JIRA: SNAPDENG-37452
