### PR TITLE
systemd/fdstore: handle CLOEXEC error in fdstore

### DIFF
--- a/systemd/fdstore/export_test.go
+++ b/systemd/fdstore/export_test.go
@@ -30,12 +30,8 @@ func MockOsGetpid(f func() int) (restore func()) {
 	return testutil.Mock(&osGetpid, f)
 }
 
-func MockUnixCloseOnExec(f func(fd int)) (restore func()) {
-	return testutil.Mock(&unixCloseOnExec, f)
-}
-
-func MockUnixDup(f func(oldfd int) (fd int, err error)) (restore func()) {
-	return testutil.Mock(&unixDup, f)
+func MockFcntl(f func(fd uintptr, cmd, arg int) (int, error)) (restore func()) {
+	return testutil.Mock(&fcntl, f)
 }
 
 func MockSdNotify(f func(notifyState string) error) (restore func()) {

--- a/systemd/fdstore/fdstore.go
+++ b/systemd/fdstore/fdstore.go
@@ -97,8 +97,7 @@ func New() Store {
 var (
 	osGetpid        = os.Getpid
 	osFileClose     = (*os.File).Close
-	unixCloseOnExec = unix.CloseOnExec
-	unixDup         = unix.Dup
+	fcntl           = unix.FcntlInt
 	sdNotify        = systemd.SdNotify
 	sdNotifyWithFds = systemd.SdNotifyWithFds
 	netFileListener = net.FileListener
@@ -164,13 +163,16 @@ func (s *store) initFdstore() {
 		return
 	}
 
+	failedCloseOnExec := make(map[FdName]bool)
 	for i := 0; i < nfds; i++ {
 		fd := sd_LISTEN_FDS_START + i
 		name := FdName(names[i])
 		fdstore[name] = append(fdstore[name], os.NewFile(uintptr(fd), string(name)))
 
-		// TODO: Use raw fcntl and check for errors.
-		unixCloseOnExec(fd)
+		if _, err := fcntl(uintptr(fd), unix.F_SETFD, unix.FD_CLOEXEC); err != nil {
+			logger.Noticef("cannot set close-on-exec on fd %d (%q): %v", fd, name, err)
+			failedCloseOnExec[name] = true
+		}
 	}
 
 	// Prune unexpected file descriptors
@@ -183,6 +185,9 @@ func (s *store) initFdstore() {
 		// We only allow activation sockets to be associated with multiple fds.
 		if !name.isSocket() && len(fds) != 1 {
 			logger.Noticef("unexpected fdstore entry %[1]q found: %[1]q has more than one fd", name)
+			shouldRemove = true
+		}
+		if failedCloseOnExec[name] {
 			shouldRemove = true
 		}
 		if shouldRemove {
@@ -250,12 +255,11 @@ func (s *store) remove(name FdName) error {
 }
 
 func duplicateFile(name FdName, f *os.File) (*os.File, error) {
-	duplicatedFd, err := unixDup(int(f.Fd()))
+	// F_DUPFD_CLOEXEC duplicates the fd with close-on-exec set atomically.
+	duplicatedFd, err := fcntl(f.Fd(), unix.F_DUPFD_CLOEXEC, 0)
 	if err != nil {
 		return nil, err
 	}
-	// TODO: Use raw fcntl and check for errors.
-	unixCloseOnExec(duplicatedFd)
 
 	// Wrapping fd with os.File is a safety measure so that the finalizer
 	// would close the duplicated fd implicitly if it goes out of scope.

--- a/systemd/fdstore/fdstore.go
+++ b/systemd/fdstore/fdstore.go
@@ -169,8 +169,20 @@ func (s *store) initFdstore() {
 		name := FdName(names[i])
 		fdstore[name] = append(fdstore[name], os.NewFile(uintptr(fd), string(name)))
 
-		if _, err := fcntl(uintptr(fd), unix.F_SETFD, unix.FD_CLOEXEC); err != nil {
+		flags, err := fcntl(uintptr(fd), unix.F_GETFD, 0)
+		if err != nil {
+			logger.Noticef("cannot get fd flags on fd %d (%q): %v", fd, name, err)
+			// A single fd whose flags cannot be read makes the whole named
+			// entry unsafe, so pruning later removes all fds associated with
+			// this name.
+			failedCloseOnExec[name] = true
+			continue
+		}
+
+		if _, err := fcntl(uintptr(fd), unix.F_SETFD, flags|unix.FD_CLOEXEC); err != nil {
 			logger.Noticef("cannot set close-on-exec on fd %d (%q): %v", fd, name, err)
+			// A single fd without CLOEXEC makes the whole named entry unsafe,
+			// so pruning later removes all fds associated with this name.
 			failedCloseOnExec[name] = true
 		}
 	}

--- a/systemd/fdstore/fdstore.go
+++ b/systemd/fdstore/fdstore.go
@@ -194,8 +194,12 @@ func (s *store) initFdstore() {
 			logger.Noticef("removing unexpected fdstore entry %q", name)
 			if err := s.remove(name); err != nil {
 				logger.Noticef("internal error: cannot remove fdstore entry %q: %v", name, err)
-				continue
 			}
+			// Always close and forget the local entry, even when notifying
+			// systemd failed, otherwise the descriptor stays reachable through
+			// Get/ActivationListeners with FD_CLOEXEC possibly unset and can
+			// leak into an executed child.
+			s.removeLocal(name)
 		}
 	}
 }
@@ -247,11 +251,19 @@ func (s *store) remove(name FdName) error {
 		return err
 	}
 
+	s.removeLocal(name)
+	return nil
+}
+
+// removeLocal closes the file descriptors associated with name and forgets
+// the entry from the local fdstore map, without notifying systemd.
+//
+// Caller must hold the fdstore lock.
+func (s *store) removeLocal(name FdName) {
 	for _, f := range fdstore[name] {
 		osFileClose(f)
 	}
 	delete(fdstore, name)
-	return nil
 }
 
 func duplicateFile(name FdName, f *os.File) (*os.File, error) {

--- a/systemd/fdstore/fdstore.go
+++ b/systemd/fdstore/fdstore.go
@@ -113,6 +113,17 @@ var mu sync.RWMutex
 // passed from systemd.
 const sd_LISTEN_FDS_START = 3
 
+func setCloseOnExec(fd uintptr, name FdName) error {
+	flags, err := fcntl(fd, unix.F_GETFD, 0)
+	if err != nil {
+		return fmt.Errorf("cannot get fd flags on fd %d (%q): %w", fd, name, err)
+	}
+	if _, err = fcntl(fd, unix.F_SETFD, flags|unix.FD_CLOEXEC); err != nil {
+		return fmt.Errorf("cannot set close-on-exec on fd %d (%q): %w", fd, name, err)
+	}
+	return nil
+}
+
 func (s *store) initFdstore() {
 	mu.Lock()
 	defer mu.Unlock()
@@ -169,18 +180,8 @@ func (s *store) initFdstore() {
 		name := FdName(names[i])
 		fdstore[name] = append(fdstore[name], os.NewFile(uintptr(fd), string(name)))
 
-		flags, err := fcntl(uintptr(fd), unix.F_GETFD, 0)
-		if err != nil {
-			logger.Noticef("cannot get fd flags on fd %d (%q): %v", fd, name, err)
-			// A single fd whose flags cannot be read makes the whole named
-			// entry unsafe, so pruning later removes all fds associated with
-			// this name.
-			failedCloseOnExec[name] = true
-			continue
-		}
-
-		if _, err := fcntl(uintptr(fd), unix.F_SETFD, flags|unix.FD_CLOEXEC); err != nil {
-			logger.Noticef("cannot set close-on-exec on fd %d (%q): %v", fd, name, err)
+		if err := setCloseOnExec(uintptr(fd), name); err != nil {
+			logger.Noticef("%v", err)
 			// A single fd without CLOEXEC makes the whole named entry unsafe,
 			// so pruning later removes all fds associated with this name.
 			failedCloseOnExec[name] = true

--- a/systemd/fdstore/fdstore_test.go
+++ b/systemd/fdstore/fdstore_test.go
@@ -60,6 +60,8 @@ type fdstoreTestSuite struct {
 
 var _ = Suite(&fdstoreTestSuite{})
 
+const FD_TEST_FLAG = 0x02
+
 func (s *fdstoreTestSuite) SetUpTest(c *C) {
 	s.sdNotifyCalls = nil
 	s.errOn = nil
@@ -103,6 +105,15 @@ func (s *fdstoreTestSuite) SetUpTest(c *C) {
 	s.AddCleanup(fdstore.MockFcntl(func(fd uintptr, cmd, arg int) (int, error) {
 		s.fcntlCalls = append(s.fcntlCalls, fcntlCall{fd: fd, cmd: cmd, arg: arg})
 		switch cmd {
+		case unix.F_GETFD:
+			if arg != 0 {
+				return -1, fmt.Errorf("unexpected arg for F_GETFD: %d", arg)
+			}
+			call := fmt.Sprintf("fcntl-getfd-flags: %d", fd)
+			if strutil.ListContains(s.errOn, call) {
+				return -1, errors.New("boom!")
+			}
+			return FD_TEST_FLAG, nil
 		case unix.F_DUPFD_CLOEXEC:
 			if arg != 0 {
 				return -1, fmt.Errorf("unexpected arg for F_DUPFD_CLOEXEC: %d", arg)
@@ -117,7 +128,7 @@ func (s *fdstoreTestSuite) SetUpTest(c *C) {
 			s.closeOnExecFds = append(s.closeOnExecFds, s.lastDupFd)
 			return s.lastDupFd, nil
 		case unix.F_SETFD:
-			if arg != unix.FD_CLOEXEC {
+			if arg != (unix.FD_CLOEXEC | FD_TEST_FLAG) {
 				return -1, fmt.Errorf("unexpected arg for F_SETFD: %d", arg)
 			}
 			call := fmt.Sprintf("fcntl-setfd-cloexec: %d", fd)
@@ -521,7 +532,8 @@ func (s *fdstoreTestSuite) TestFcntlFlags(c *C) {
 	// fd 3 gets close-on-exec set during init, then is duplicated
 	// with close-on-exec set atomically on Get.
 	c.Check(s.fcntlCalls, DeepEquals, []fcntlCall{
-		{fd: 3, cmd: unix.F_SETFD, arg: unix.FD_CLOEXEC},
+		{fd: 3, cmd: unix.F_GETFD, arg: 0},
+		{fd: 3, cmd: unix.F_SETFD, arg: unix.FD_CLOEXEC | FD_TEST_FLAG},
 		{fd: 3, cmd: unix.F_DUPFD_CLOEXEC, arg: 0},
 	})
 }
@@ -547,6 +559,39 @@ func (s *fdstoreTestSuite) TestInitCloseOnExecError(c *C) {
 	c.Assert(err, ErrorMatches, `cannot get file descriptor named "memfd-secret-state": file descriptor not found`)
 
 	c.Check(logbuf.String(), testutil.Contains, `cannot set close-on-exec on fd 3 ("memfd-secret-state"): boom!`)
+	c.Check(logbuf.String(), testutil.Contains, `removing unexpected fdstore entry "memfd-secret-state"`)
+
+	// the socket (fd 4) is unaffected
+	listeners, err := store.ActivationListeners()
+	c.Assert(err, IsNil)
+	c.Check(listeners, HasLen, 1)
+
+	c.Check(s.sdNotifyCalls, DeepEquals, []string{
+		"sd-notify: FDSTOREREMOVE=1\nFDNAME=memfd-secret-state",
+	})
+}
+
+func (s *fdstoreTestSuite) TestInitGetFdFlagsError(c *C) {
+	logbuf, restore := logger.MockLogger()
+	defer restore()
+
+	os.Setenv("LISTEN_FDS", "2")
+	os.Setenv("LISTEN_FDNAMES", "memfd-secret-state:snapd.socket")
+
+	// reading flags on fd 3 (memfd-secret-state) fails
+	s.errOn = []string{"fcntl-getfd-flags: 3"}
+
+	restore = fdstore.MockNetFileListener(func(f *os.File) (ln net.Listener, err error) {
+		return &fakeListener{f}, nil
+	})
+	defer restore()
+
+	store := fdstore.New()
+	// the entry whose flags couldn't be read is pruned
+	_, err := store.Get(fdstore.FdNameMemfdSecretState)
+	c.Assert(err, ErrorMatches, `cannot get file descriptor named "memfd-secret-state": file descriptor not found`)
+
+	c.Check(logbuf.String(), testutil.Contains, `cannot get fd flags on fd 3 ("memfd-secret-state"): boom!`)
 	c.Check(logbuf.String(), testutil.Contains, `removing unexpected fdstore entry "memfd-secret-state"`)
 
 	// the socket (fd 4) is unaffected

--- a/systemd/fdstore/fdstore_test.go
+++ b/systemd/fdstore/fdstore_test.go
@@ -27,8 +27,10 @@ import (
 	"sort"
 	"testing"
 
+	"golang.org/x/sys/unix"
 	. "gopkg.in/check.v1"
 
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/strutil"
 	"github.com/snapcore/snapd/systemd"
 	"github.com/snapcore/snapd/systemd/fdstore"
@@ -37,6 +39,12 @@ import (
 
 // Hook up check.v1 into the "go test" runner
 func Test(t *testing.T) { TestingT(t) }
+
+type fcntlCall struct {
+	fd  uintptr
+	cmd int
+	arg int
+}
 
 type fdstoreTestSuite struct {
 	testutil.BaseTest
@@ -47,6 +55,7 @@ type fdstoreTestSuite struct {
 	closeFds       []int
 	lastDupFd      int
 	duplicatedFds  []int
+	fcntlCalls     []fcntlCall
 }
 
 var _ = Suite(&fdstoreTestSuite{})
@@ -58,6 +67,7 @@ func (s *fdstoreTestSuite) SetUpTest(c *C) {
 	s.closeFds = nil
 	s.lastDupFd = 1000
 	s.duplicatedFds = nil
+	s.fcntlCalls = nil
 
 	os.Setenv("LISTEN_PID", "1984")
 	os.Unsetenv("LISTEN_FDS")
@@ -90,13 +100,35 @@ func (s *fdstoreTestSuite) SetUpTest(c *C) {
 		s.sdNotifyCalls = append(s.sdNotifyCalls, call)
 		return nil
 	}))
-	s.AddCleanup(fdstore.MockUnixCloseOnExec(func(fd int) {
-		s.closeOnExecFds = append(s.closeOnExecFds, fd)
-	}))
-	s.AddCleanup(fdstore.MockUnixDup(func(oldfd int) (fd int, err error) {
-		s.duplicatedFds = append(s.duplicatedFds, oldfd)
-		s.lastDupFd++
-		return s.lastDupFd, nil
+	s.AddCleanup(fdstore.MockFcntl(func(fd uintptr, cmd, arg int) (int, error) {
+		s.fcntlCalls = append(s.fcntlCalls, fcntlCall{fd: fd, cmd: cmd, arg: arg})
+		switch cmd {
+		case unix.F_DUPFD_CLOEXEC:
+			if arg != 0 {
+				return -1, fmt.Errorf("unexpected arg for F_DUPFD_CLOEXEC: %d", arg)
+			}
+			call := fmt.Sprintf("fcntl-dupfd-cloexec: %d", fd)
+			if strutil.ListContains(s.errOn, call) {
+				return -1, errors.New("boom!")
+			}
+			s.duplicatedFds = append(s.duplicatedFds, int(fd))
+			s.lastDupFd++
+			// F_DUPFD_CLOEXEC sets close-on-exec on the new fd atomically.
+			s.closeOnExecFds = append(s.closeOnExecFds, s.lastDupFd)
+			return s.lastDupFd, nil
+		case unix.F_SETFD:
+			if arg != unix.FD_CLOEXEC {
+				return -1, fmt.Errorf("unexpected arg for F_SETFD: %d", arg)
+			}
+			call := fmt.Sprintf("fcntl-setfd-cloexec: %d", fd)
+			if strutil.ListContains(s.errOn, call) {
+				return -1, errors.New("boom!")
+			}
+			s.closeOnExecFds = append(s.closeOnExecFds, int(fd))
+			return 0, nil
+		default:
+			return -1, fmt.Errorf("unexpected fcntl cmd %d", cmd)
+		}
 	}))
 	s.AddCleanup(fdstore.MockOsFileClose(func(f *os.File) error {
 		s.closeFds = append(s.closeFds, int(f.Fd()))
@@ -476,4 +508,76 @@ func (s *fdstoreTestSuite) TestKnownFdNames(c *C) {
 	c.Assert(fdstore.KnownFdNames(), DeepEquals, map[fdstore.FdName]bool{
 		fdstore.FdName("memfd-secret-state"): true,
 	})
+}
+
+func (s *fdstoreTestSuite) TestFcntlFlags(c *C) {
+	os.Setenv("LISTEN_FDS", "1")
+	os.Setenv("LISTEN_FDNAMES", "memfd-secret-state")
+
+	store := fdstore.New()
+	_, err := store.Get(fdstore.FdNameMemfdSecretState)
+	c.Assert(err, IsNil)
+
+	// fd 3 gets close-on-exec set during init, then is duplicated
+	// with close-on-exec set atomically on Get.
+	c.Check(s.fcntlCalls, DeepEquals, []fcntlCall{
+		{fd: 3, cmd: unix.F_SETFD, arg: unix.FD_CLOEXEC},
+		{fd: 3, cmd: unix.F_DUPFD_CLOEXEC, arg: 0},
+	})
+}
+
+func (s *fdstoreTestSuite) TestInitCloseOnExecError(c *C) {
+	logbuf, restore := logger.MockLogger()
+	defer restore()
+
+	os.Setenv("LISTEN_FDS", "2")
+	os.Setenv("LISTEN_FDNAMES", "memfd-secret-state:snapd.socket")
+
+	// setting close-on-exec on fd 3 (memfd-secret-state) fails
+	s.errOn = []string{"fcntl-setfd-cloexec: 3"}
+
+	restore = fdstore.MockNetFileListener(func(f *os.File) (ln net.Listener, err error) {
+		return &fakeListener{f}, nil
+	})
+	defer restore()
+
+	store := fdstore.New()
+	// the entry whose close-on-exec failed is pruned
+	_, err := store.Get(fdstore.FdNameMemfdSecretState)
+	c.Assert(err, ErrorMatches, `cannot get file descriptor named "memfd-secret-state": file descriptor not found`)
+
+	c.Check(logbuf.String(), testutil.Contains, `cannot set close-on-exec on fd 3 ("memfd-secret-state"): boom!`)
+	c.Check(logbuf.String(), testutil.Contains, `removing unexpected fdstore entry "memfd-secret-state"`)
+
+	// the socket (fd 4) is unaffected
+	listeners, err := store.ActivationListeners()
+	c.Assert(err, IsNil)
+	c.Check(listeners, HasLen, 1)
+
+	c.Check(s.sdNotifyCalls, DeepEquals, []string{
+		"sd-notify: FDSTOREREMOVE=1\nFDNAME=memfd-secret-state",
+	})
+}
+
+func (s *fdstoreTestSuite) TestGetDupError(c *C) {
+	os.Setenv("LISTEN_FDS", "1")
+	os.Setenv("LISTEN_FDNAMES", "memfd-secret-state")
+
+	// duplicating fd 3 (memfd-secret-state) fails
+	s.errOn = []string{"fcntl-dupfd-cloexec: 3"}
+
+	store := fdstore.New()
+	_, err := store.Get(fdstore.FdNameMemfdSecretState)
+	c.Assert(err, ErrorMatches, "boom!")
+}
+
+func (s *fdstoreTestSuite) TestAddDupError(c *C) {
+	// duplicating the passed fd 7 fails
+	s.errOn = []string{"fcntl-dupfd-cloexec: 7"}
+
+	store := fdstore.New()
+	err := store.Add(fdstore.FdNameMemfdSecretState, os.NewFile(7, ""))
+	c.Assert(err, ErrorMatches, "boom!")
+	// nothing is passed to systemd on duplication failure
+	c.Check(s.sdNotifyCalls, HasLen, 0)
 }


### PR DESCRIPTION
Previously the fdstore relied on `unix.CloseOnExec`, which calls `fcntl(fd, F_SETFD, FD_CLOEXEC)` but silently discards any error. This addresses two TODOs asking for raw fcntl usage with proper error checking.

- Replace the error-swallowing `unix.CloseOnExec` / `unix.Dup` helpers with a single mockable fcntl seam.
- `duplicateFile` now duplicates the fd and sets close-on-exec atomically via `fcntl(fd, F_DUPFD_CLOEXEC, 0)`, avoiding a dup/CLOEXEC race, and returns any error to the caller (Get/Add).
- `initFdstore` now checks the F_SETFD result; on failure it logs and prunes the affected entry through the existing prune loop, so the function signature and its callers are unchanged.

JIRA: SNAPDENG-37396