### PR TITLE
i/builtin, o/snapstate: interfaces return an error msg if parallel instances is not supported

### DIFF
--- a/interfaces/builtin/common.go
+++ b/interfaces/builtin/common.go
@@ -94,8 +94,8 @@ type commonInterface struct {
 
 	conflictingConnectedInterfaces []string
 
-	unsupportedParallelInstancesPlug bool
-	unsupportedParallelInstancesSlot bool
+	parallelInstancesPlugErr error
+	parallelInstancesSlotErr error
 }
 
 var _ = interfaces.ConflictingConnectedInterfacesDefiner(&commonInterface{})
@@ -233,14 +233,14 @@ func (iface *commonInterface) ConflictsWithOtherConnectedInterfaces() []string {
 	return iface.conflictingConnectedInterfaces
 }
 
-// ParallelInstancesSupportedForPlug returns false if unsupportedParallelInstancesPlug
-// is set, ignoring plug attributes.
-func (iface *commonInterface) ParallelInstancesSupportedForPlug(_ *snap.PlugInfo) bool {
-	return !iface.unsupportedParallelInstancesPlug
+// ParallelInstancesSupportedForPlug returns parallelInstancesPlugErr, ignoring
+// plug attributes.
+func (iface *commonInterface) ParallelInstancesSupportedForPlug(_ *snap.PlugInfo) error {
+	return iface.parallelInstancesPlugErr
 }
 
-// ParallelInstancesSupportedForSlot returns false if unsupportedParallelInstancesSlot
-// is set, ignoring slot attributes.
-func (iface *commonInterface) ParallelInstancesSupportedForSlot(_ *snap.SlotInfo) bool {
-	return !iface.unsupportedParallelInstancesSlot
+// ParallelInstancesSupportedForSlot returns parallelInstancesSlotErr, ignoring
+// slot attributes.
+func (iface *commonInterface) ParallelInstancesSupportedForSlot(_ *snap.SlotInfo) error {
+	return iface.parallelInstancesSlotErr
 }

--- a/interfaces/builtin/common_test.go
+++ b/interfaces/builtin/common_test.go
@@ -20,6 +20,7 @@
 package builtin
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 
@@ -282,31 +283,31 @@ slots:
 func (s *commonIfaceSuite) TestParallelInstancesSupported(c *C) {
 	// default: both sides supported
 	iface := &commonInterface{name: "common"}
-	c.Check(iface.ParallelInstancesSupportedForPlug(nil), Equals, true)
-	c.Check(iface.ParallelInstancesSupportedForSlot(nil), Equals, true)
+	c.Check(iface.ParallelInstancesSupportedForPlug(nil), IsNil)
+	c.Check(iface.ParallelInstancesSupportedForSlot(nil), IsNil)
 
 	// plug-side unsupported
 	iface = &commonInterface{
-		name:                             "common",
-		unsupportedParallelInstancesPlug: true,
+		name:                     "common",
+		parallelInstancesPlugErr: errors.New("custom plug reason"),
 	}
-	c.Check(iface.ParallelInstancesSupportedForPlug(nil), Equals, false)
-	c.Check(iface.ParallelInstancesSupportedForSlot(nil), Equals, true)
+	c.Check(iface.ParallelInstancesSupportedForPlug(nil), ErrorMatches, "custom plug reason")
+	c.Check(iface.ParallelInstancesSupportedForSlot(nil), IsNil)
 
 	// slot-side unsupported
 	iface = &commonInterface{
-		name:                             "common",
-		unsupportedParallelInstancesSlot: true,
+		name:                     "common",
+		parallelInstancesSlotErr: errors.New("custom slot reason"),
 	}
-	c.Check(iface.ParallelInstancesSupportedForPlug(nil), Equals, true)
-	c.Check(iface.ParallelInstancesSupportedForSlot(nil), Equals, false)
+	c.Check(iface.ParallelInstancesSupportedForPlug(nil), IsNil)
+	c.Check(iface.ParallelInstancesSupportedForSlot(nil), ErrorMatches, "custom slot reason")
 
 	// both unsupported
 	iface = &commonInterface{
-		name:                             "common",
-		unsupportedParallelInstancesPlug: true,
-		unsupportedParallelInstancesSlot: true,
+		name:                     "common",
+		parallelInstancesPlugErr: errors.New("custom plug reason"),
+		parallelInstancesSlotErr: errors.New("custom slot reason"),
 	}
-	c.Check(iface.ParallelInstancesSupportedForPlug(nil), Equals, false)
-	c.Check(iface.ParallelInstancesSupportedForSlot(nil), Equals, false)
+	c.Check(iface.ParallelInstancesSupportedForPlug(nil), ErrorMatches, "custom plug reason")
+	c.Check(iface.ParallelInstancesSupportedForSlot(nil), ErrorMatches, "custom slot reason")
 }

--- a/interfaces/builtin/shared_memory.go
+++ b/interfaces/builtin/shared_memory.go
@@ -347,10 +347,13 @@ func (iface *sharedMemoryInterface) MountConnectedPlug(spec *mount.Specification
 	})
 }
 
-func (iface *sharedMemoryInterface) ParallelInstancesSupportedForPlug(plug *snap.PlugInfo) bool {
+func (iface *sharedMemoryInterface) ParallelInstancesSupportedForPlug(plug *snap.PlugInfo) error {
 	// only plugs with "private" attribute set to true are supported for parallel instances.
 	private, _ := plug.Attrs["private"].(bool)
-	return private
+	if !private {
+		return errors.New(`"private" attribute must be set to true`)
+	}
+	return nil
 }
 
 func (iface *sharedMemoryInterface) AutoConnect(plug *snap.PlugInfo, slot *snap.SlotInfo) bool {

--- a/interfaces/builtin/shared_memory_test.go
+++ b/interfaces/builtin/shared_memory_test.go
@@ -514,10 +514,10 @@ func (s *SharedMemoryInterfaceSuite) TestParallelInstancesSupportedForPlug(c *C)
 	c.Assert(ok, Equals, true)
 
 	// private=false does not support parallel instances
-	c.Check(definer.ParallelInstancesSupportedForPlug(s.plugInfo), Equals, false)
+	c.Check(definer.ParallelInstancesSupportedForPlug(s.plugInfo), ErrorMatches, `"private" attribute must be set to true`)
 
 	// private=true supports parallel instances
-	c.Check(definer.ParallelInstancesSupportedForPlug(s.privatePlugInfo), Equals, true)
+	c.Check(definer.ParallelInstancesSupportedForPlug(s.privatePlugInfo), IsNil)
 }
 
 func (s *SharedMemoryInterfaceSuite) TestInterfaces(c *C) {

--- a/interfaces/core.go
+++ b/interfaces/core.go
@@ -254,18 +254,20 @@ type ConflictingConnectedInterfacesDefiner interface {
 // whether they support plugs on snaps installed as parallel instances.
 // Interfaces not implementing this are assumed to support parallel instances.
 type ParallelInstancesPlugDefiner interface {
-	// ParallelInstancesSupportedForPlug returns whether the interface
-	// supports being plugged by a snap installed as a parallel instance.
-	ParallelInstancesSupportedForPlug(plug *snap.PlugInfo) bool
+	// ParallelInstancesSupportedForPlug returns nil if the interface
+	// supports being plugged by a snap installed as a parallel instance,
+	// or an error explaining why it does not otherwise.
+	ParallelInstancesSupportedForPlug(plug *snap.PlugInfo) error
 }
 
 // ParallelInstancesSlotDefiner can be implemented by Interfaces to declare
 // whether they support slots on snaps installed as parallel instances.
 // Interfaces not implementing this are assumed to support parallel instances.
 type ParallelInstancesSlotDefiner interface {
-	// ParallelInstancesSupportedForSlot returns whether the interface
-	// supports being slotted by a snap installed as a parallel instance.
-	ParallelInstancesSupportedForSlot(slot *snap.SlotInfo) bool
+	// ParallelInstancesSupportedForSlot returns nil if the interface
+	// supports being slotted by a snap installed as a parallel instance,
+	// or an error explaining why it does not otherwise.
+	ParallelInstancesSupportedForSlot(slot *snap.SlotInfo) error
 }
 
 // StaticInfo describes various static-info of a given interface.

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -616,10 +616,10 @@ func checkParallelInstancesSupport(st *state.State, info *snap.Info) error {
 			// non-definer interfaces are assumed to support parallel instances
 			continue
 		}
-		if !definer.ParallelInstancesSupportedForPlug(plugInfo) {
+		if err := definer.ParallelInstancesSupportedForPlug(plugInfo); err != nil {
 			return fmt.Errorf("cannot install snap %q as parallel instance: "+
-				"plug %q with interface %q is not supported for parallel instances",
-				info.InstanceName(), plugName, plugInfo.Interface)
+				"plug %q with interface %q is not supported for parallel instances: %v",
+				info.InstanceName(), plugName, plugInfo.Interface, err)
 		}
 	}
 
@@ -629,10 +629,10 @@ func checkParallelInstancesSupport(st *state.State, info *snap.Info) error {
 			// non-definer interfaces are assumed to support parallel instances
 			continue
 		}
-		if !definer.ParallelInstancesSupportedForSlot(slotInfo) {
+		if err := definer.ParallelInstancesSupportedForSlot(slotInfo); err != nil {
 			return fmt.Errorf("cannot install snap %q as parallel instance: "+
-				"slot %q with interface %q is not supported for parallel instances",
-				info.InstanceName(), slotName, slotInfo.Interface)
+				"slot %q with interface %q is not supported for parallel instances: %v",
+				info.InstanceName(), slotName, slotInfo.Interface, err)
 		}
 	}
 

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -1378,7 +1378,7 @@ func (s *snapmgrTestSuite) TestParallelInstanceInstallRejectedByInterfacePlug(c 
 	}
 
 	_, err = snapstate.Install(context.Background(), s.state, "some-snap_foo", nil, 0, snapstate.Flags{})
-	c.Assert(err, ErrorMatches, `cannot install snap "some-snap_foo" as parallel instance: plug "pi-nok-plug" with interface "pi-nok-plug-iface" is not supported for parallel instances`)
+	c.Assert(err, ErrorMatches, `cannot install snap "some-snap_foo" as parallel instance: plug "pi-nok-plug" with interface "pi-nok-plug-iface" is not supported for parallel instances: plug rejected`)
 }
 
 func (s *snapmgrTestSuite) TestParallelInstanceInstallRejectedByInterfaceSlot(c *C) {
@@ -1414,7 +1414,7 @@ func (s *snapmgrTestSuite) TestParallelInstanceInstallRejectedByInterfaceSlot(c 
 	}
 
 	_, err = snapstate.Install(context.Background(), s.state, "some-snap_foo", nil, 0, snapstate.Flags{})
-	c.Assert(err, ErrorMatches, `cannot install snap "some-snap_foo" as parallel instance: slot "pi-nok-slot" with interface "pi-nok-slot-iface" is not supported for parallel instances`)
+	c.Assert(err, ErrorMatches, `cannot install snap "some-snap_foo" as parallel instance: slot "pi-nok-slot" with interface "pi-nok-slot-iface" is not supported for parallel instances: slot rejected`)
 }
 
 func (s *snapmgrTestSuite) TestParallelInstanceInstallAllowedWithImplicitlySupportedInterface(c *C) {
@@ -1530,8 +1530,8 @@ func (t *testParallelInstancesPlugRejectingInterface) Name() string {
 	return "pi-nok-plug-iface"
 }
 
-func (t *testParallelInstancesPlugRejectingInterface) ParallelInstancesSupportedForPlug(plug *snap.PlugInfo) bool {
-	return false
+func (t *testParallelInstancesPlugRejectingInterface) ParallelInstancesSupportedForPlug(plug *snap.PlugInfo) error {
+	return errors.New("plug rejected")
 }
 
 // testParallelInstancesSlotRejectingInterface is a test interface that
@@ -1544,8 +1544,8 @@ func (t *testParallelInstancesSlotRejectingInterface) Name() string {
 	return "pi-nok-slot-iface"
 }
 
-func (t *testParallelInstancesSlotRejectingInterface) ParallelInstancesSupportedForSlot(slot *snap.SlotInfo) bool {
-	return false
+func (t *testParallelInstancesSlotRejectingInterface) ParallelInstancesSupportedForSlot(slot *snap.SlotInfo) error {
+	return errors.New("slot rejected")
 }
 
 // testParallelInstancesSupportedInterface is a test interface that
@@ -1558,12 +1558,12 @@ func (t *testParallelInstancesSupportedInterface) Name() string {
 	return "pi-ok-iface"
 }
 
-func (t *testParallelInstancesSupportedInterface) ParallelInstancesSupportedForPlug(plug *snap.PlugInfo) bool {
-	return true
+func (t *testParallelInstancesSupportedInterface) ParallelInstancesSupportedForPlug(plug *snap.PlugInfo) error {
+	return nil
 }
 
-func (t *testParallelInstancesSupportedInterface) ParallelInstancesSupportedForSlot(slot *snap.SlotInfo) bool {
-	return true
+func (t *testParallelInstancesSupportedInterface) ParallelInstancesSupportedForSlot(slot *snap.SlotInfo) error {
+	return nil
 }
 
 func (s *snapmgrTestSuite) TestInstallPathFailsEarlyOnEpochMismatch(c *C) {


### PR DESCRIPTION
Instead of simply returning a boolean flag, interfaces now provide an error msg as to why they do not support parallel instances. In addition to being self-documenting, this msg is also added to, for ex, the error returned to the user when trying to install a snap as a parallel instance when its interface doesn't support it.
[[Background](https://github.com/canonical/snapd/pull/17535#discussion_r3878065182)]

[SNAPDENG-37300](https://warthogs.atlassian.net/browse/SNAPDENG-37300)

[SNAPDENG-37300]: https://warthogs.atlassian.net/browse/SNAPDENG-37300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ