### PR TITLE
interfaces: support driver-libs interfaces on core26

### DIFF
--- a/cmd/snap-update-ns/system.go
+++ b/cmd/snap-update-ns/system.go
@@ -80,17 +80,19 @@ func (upCtx *SystemProfileUpdateContext) Assumptions() *Assumptions {
 	}
 	// Allow the driver-libs interfaces (interfaces/builtin/*_driver_libs.go,
 	// see the assemblyRoot constant in interfaces/builtin/helpers.go) to create
-	// their assembly-tree skeleton directly under /run/snapd/interfaces without
-	// tripping the trespassing check on the ancestor /run itself. /run is a
-	// live host directory (sockets, other daemons' runtime state) that the
-	// writable-mimic mechanism cannot safely reconstruct (it only supports
+	// their assembly-tree skeleton directly under /run/snapd/snap (mounted as a
+	// private tmpfs, see mountAssemblyRoot; assemblyRoot itself,
+	// /run/snapd/snap/interfaces, is just its current sole subdirectory)
+	// without tripping the trespassing check on the ancestor /run itself. /run
+	// is a live host directory (sockets, other daemons' runtime state) that
+	// the writable-mimic mechanism cannot safely reconstruct (it only supports
 	// dirs, regular files and symlinks - see planWritableMimic), so unlike
 	// /snap/$SNAP_NAME above, this directory's content is NOT mimic'd into a
 	// private per-snap copy: creating it directly here is intentional and
 	// mirrors the /run/systemd entry below. Only mount *targets* are ever
 	// placed here by driver-libs; connecting snaps still see the bind-mounted
 	// library content only within their own mount namespace.
-	as.AddUnrestrictedPaths(dirs.SnapRunDir + "/interfaces")
+	as.AddUnrestrictedPaths(dirs.SnapRuntimeAssemblyRoot)
 	// Allow snap-update-ns to write to host's /tmp directory. This is
 	// specifically here to allow two snaps to share X11 sockets that are placed
 	// in the /tmp/.X11-unix/ directory in the private /tmp directories provided

--- a/cmd/snap-update-ns/system.go
+++ b/cmd/snap-update-ns/system.go
@@ -78,6 +78,19 @@ func (upCtx *SystemProfileUpdateContext) Assumptions() *Assumptions {
 	if snapName := snap.InstanceSnap(instanceName); snapName != instanceName {
 		as.AddUnrestrictedPaths("/snap/" + snapName)
 	}
+	// Allow the driver-libs interfaces (interfaces/builtin/*_driver_libs.go,
+	// see the assemblyRoot constant in interfaces/builtin/helpers.go) to create
+	// their assembly-tree skeleton directly under /run/snapd/interfaces without
+	// tripping the trespassing check on the ancestor /run itself. /run is a
+	// live host directory (sockets, other daemons' runtime state) that the
+	// writable-mimic mechanism cannot safely reconstruct (it only supports
+	// dirs, regular files and symlinks - see planWritableMimic), so unlike
+	// /snap/$SNAP_NAME above, this directory's content is NOT mimic'd into a
+	// private per-snap copy: creating it directly here is intentional and
+	// mirrors the /run/systemd entry below. Only mount *targets* are ever
+	// placed here by driver-libs; connecting snaps still see the bind-mounted
+	// library content only within their own mount namespace.
+	as.AddUnrestrictedPaths(dirs.SnapRunDir + "/interfaces")
 	// Allow snap-update-ns to write to host's /tmp directory. This is
 	// specifically here to allow two snaps to share X11 sockets that are placed
 	// in the /tmp/.X11-unix/ directory in the private /tmp directories provided

--- a/cmd/snap-update-ns/system_test.go
+++ b/cmd/snap-update-ns/system_test.go
@@ -74,7 +74,7 @@ func (s *systemSuite) TestAssumptions(c *C) {
 	// Non-instances can access /tmp, /var/snap and /snap/$SNAP_NAME
 	upCtx := update.NewSystemProfileUpdateContext("foo", false)
 	as := upCtx.Assumptions()
-	c.Check(as.UnrestrictedPaths(), DeepEquals, []string{"/tmp", "/var/snap", "/snap/foo", "/dev/shm", "/run/systemd", "/var/lib/snapd/hostfs/tmp"})
+	c.Check(as.UnrestrictedPaths(), DeepEquals, []string{"/tmp", "/var/snap", "/snap/foo", "/dev/shm", "/run/systemd", "/run/snapd/interfaces", "/var/lib/snapd/hostfs/tmp"})
 	c.Check(as.ModeForPath("/stuff"), Equals, os.FileMode(0755))
 	c.Check(as.ModeForPath("/tmp"), Equals, os.FileMode(0755))
 	c.Check(as.ModeForPath("/var/lib/snapd/hostfs/tmp"), Equals, os.FileMode(0755))
@@ -88,7 +88,7 @@ func (s *systemSuite) TestAssumptions(c *C) {
 	// Instances can, in addition, access /snap/$SNAP_INSTANCE_NAME
 	upCtx = update.NewSystemProfileUpdateContext("foo_instance", false)
 	as = upCtx.Assumptions()
-	c.Check(as.UnrestrictedPaths(), DeepEquals, []string{"/tmp", "/var/snap", "/snap/foo_instance", "/dev/shm", "/run/systemd", "/snap/foo", "/var/lib/snapd/hostfs/tmp"})
+	c.Check(as.UnrestrictedPaths(), DeepEquals, []string{"/tmp", "/var/snap", "/snap/foo_instance", "/dev/shm", "/run/systemd", "/snap/foo", "/run/snapd/interfaces", "/var/lib/snapd/hostfs/tmp"})
 }
 
 func (s *systemSuite) TestLoadDesiredProfile(c *C) {

--- a/cmd/snap-update-ns/system_test.go
+++ b/cmd/snap-update-ns/system_test.go
@@ -74,7 +74,7 @@ func (s *systemSuite) TestAssumptions(c *C) {
 	// Non-instances can access /tmp, /var/snap and /snap/$SNAP_NAME
 	upCtx := update.NewSystemProfileUpdateContext("foo", false)
 	as := upCtx.Assumptions()
-	c.Check(as.UnrestrictedPaths(), DeepEquals, []string{"/tmp", "/var/snap", "/snap/foo", "/dev/shm", "/run/systemd", "/run/snapd/interfaces", "/var/lib/snapd/hostfs/tmp"})
+	c.Check(as.UnrestrictedPaths(), DeepEquals, []string{"/tmp", "/var/snap", "/snap/foo", "/dev/shm", "/run/systemd", "/run/snapd/snap", "/var/lib/snapd/hostfs/tmp"})
 	c.Check(as.ModeForPath("/stuff"), Equals, os.FileMode(0755))
 	c.Check(as.ModeForPath("/tmp"), Equals, os.FileMode(0755))
 	c.Check(as.ModeForPath("/var/lib/snapd/hostfs/tmp"), Equals, os.FileMode(0755))
@@ -88,7 +88,7 @@ func (s *systemSuite) TestAssumptions(c *C) {
 	// Instances can, in addition, access /snap/$SNAP_INSTANCE_NAME
 	upCtx = update.NewSystemProfileUpdateContext("foo_instance", false)
 	as = upCtx.Assumptions()
-	c.Check(as.UnrestrictedPaths(), DeepEquals, []string{"/tmp", "/var/snap", "/snap/foo_instance", "/dev/shm", "/run/systemd", "/snap/foo", "/run/snapd/interfaces", "/var/lib/snapd/hostfs/tmp"})
+	c.Check(as.UnrestrictedPaths(), DeepEquals, []string{"/tmp", "/var/snap", "/snap/foo_instance", "/dev/shm", "/run/systemd", "/snap/foo", "/run/snapd/snap", "/var/lib/snapd/hostfs/tmp"})
 }
 
 func (s *systemSuite) TestLoadDesiredProfile(c *C) {

--- a/dirs/dirs.go
+++ b/dirs/dirs.go
@@ -67,6 +67,19 @@ var (
 	SnapVoidDir          string
 	SnapPrivateTmpDir    string
 
+	// SnapRuntimeAssemblyRoot is a private, per-snap tmpfs mounted under
+	// /run/snapd for constructing content within a consuming snap's own mount
+	// namespace without it landing on the real host filesystem. It is
+	// mounted directly (bypassing snap-update-ns's trespassing check, see
+	// cmd/snap-update-ns/system.go) because it lives under the writable,
+	// non-read-only /run/snapd, so the usual writable-mimic mechanism cannot
+	// be relied on to construct it implicitly.
+	SnapRuntimeAssemblyRoot string
+	// SnapInterfacesAssemblyRoot is the driver-libs interfaces' subtree under
+	// SnapRuntimeAssemblyRoot (see interfaces/builtin/helpers.go's
+	// assemblyRoot), currently its sole subdirectory.
+	SnapInterfacesAssemblyRoot string
+
 	SnapInterfacesRequestsRunDir   string
 	SnapInterfacesRequestsStateDir string
 
@@ -606,6 +619,9 @@ func SetRootDir(rootdir string) {
 	SnapRunLockDir = filepath.Join(SnapRunDir, "/lock")
 
 	SnapBootstrapRunDir = filepath.Join(SnapRunDir, "snap-bootstrap")
+
+	SnapRuntimeAssemblyRoot = filepath.Join(SnapRunDir, "snap")
+	SnapInterfacesAssemblyRoot = filepath.Join(SnapRuntimeAssemblyRoot, "interfaces")
 
 	SnapInterfacesRequestsRunDir = filepath.Join(SnapRunDir, "interfaces-requests")
 	SnapInterfacesRequestsStateDir = filepath.Join(rootdir, snappyDir, "interfaces-requests")

--- a/interfaces/builtin/cuda_driver_libs.go
+++ b/interfaces/builtin/cuda_driver_libs.go
@@ -33,15 +33,17 @@ import (
 
 const cudaDriverLibsSummary = `allows exposing CUDA driver libraries to the system`
 
-// Plugs only supported for the system on classic for the moment (note this is
-// checked on "system" snap installation even though this is an implicit plug
-// in that case) - in the future we will allow snaps having this as plug and
-// this declaration will have to change.
+// Plug on classic may only be declared by the system snap (implicit plug); on
+// Ubuntu Core any snap may declare it (see allow-installation alternatives).
 const cudaDriverLibsBaseDeclarationPlugs = `
   cuda-driver-libs:
     allow-installation:
-      plug-snap-type:
-        - core
+      -
+        on-classic: true
+        plug-snap-type:
+          - core
+      -
+        on-classic: false
     allow-connection:
       slots-per-plug: *
     deny-auto-connection: true

--- a/interfaces/builtin/cuda_driver_libs.go
+++ b/interfaces/builtin/cuda_driver_libs.go
@@ -27,6 +27,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/compatibility"
 	"github.com/snapcore/snapd/interfaces/configfiles"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
+	"github.com/snapcore/snapd/interfaces/mount"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 )
@@ -89,6 +90,12 @@ func (iface *cudaDriverLibsInterface) BeforePrepareSlot(slot *snap.SlotInfo) err
 func (iface *cudaDriverLibsInterface) LdconfigConnectedPlug(spec *ldconfig.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// The plug can only be the system plug for the time being
 	return addLdconfigLibDirs(spec, slot)
+}
+
+func (iface *cudaDriverLibsInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	// On Ubuntu Core the provider content is bound into the assembly tree under
+	// the /opt/snapd/interfaces directory (see mountAssemblyLibDirs).
+	return mountAssemblyLibDirs(spec, slot, cudaDriverLibs)
 }
 
 var _ = interfaces.ConfigfilesUser(&cudaDriverLibsInterface{})

--- a/interfaces/builtin/cuda_driver_libs.go
+++ b/interfaces/builtin/cuda_driver_libs.go
@@ -20,6 +20,7 @@
 package builtin
 
 import (
+	"fmt"
 	"math"
 
 	"github.com/snapcore/snapd/interfaces"
@@ -56,6 +57,13 @@ const cudaDriverLibsBaseDeclarationSlots = `
 // cudaDriverLibsInterface allows exposing CUDA driver libraries to the system or snaps.
 type cudaDriverLibsInterface struct {
 	commonInterface
+}
+
+func (iface *cudaDriverLibsInterface) BeforePreparePlug(plug *snap.PlugInfo) error {
+	if !driverLibsSupported(plug.Snap.Base) {
+		return fmt.Errorf("%s interface is not supported on base %q", cudaDriverLibs, plug.Snap.Base)
+	}
+	return nil
 }
 
 func (iface *cudaDriverLibsInterface) BeforePrepareSlot(slot *snap.SlotInfo) error {

--- a/interfaces/builtin/cuda_driver_libs.go
+++ b/interfaces/builtin/cuda_driver_libs.go
@@ -24,6 +24,7 @@ import (
 	"math"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/compatibility"
 	"github.com/snapcore/snapd/interfaces/configfiles"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
@@ -96,6 +97,13 @@ func (iface *cudaDriverLibsInterface) MountConnectedPlug(spec *mount.Specificati
 	// On Ubuntu Core the provider content is bound into the assembly tree under
 	// the /opt/snapd/interfaces directory (see mountAssemblyLibDirs).
 	return mountAssemblyLibDirs(spec, slot, cudaDriverLibs)
+}
+
+func (iface *cudaDriverLibsInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	// Authorize snap-update-ns to construct (and eventually tear down) the
+	// assembly tree under /opt/snapd/interfaces. The default base template
+	// already grants /opt/** mrklix to the app itself, no extra snippet needed.
+	return addAppArmorAssemblyLibDirs(spec, slot, cudaDriverLibs)
 }
 
 var _ = interfaces.ConfigfilesUser(&cudaDriverLibsInterface{})

--- a/interfaces/builtin/cuda_driver_libs.go
+++ b/interfaces/builtin/cuda_driver_libs.go
@@ -100,9 +100,11 @@ func (iface *cudaDriverLibsInterface) MountConnectedPlug(spec *mount.Specificati
 }
 
 func (iface *cudaDriverLibsInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	// Authorize snap-update-ns to construct (and eventually tear down) the
-	// assembly tree under /opt/snapd/interfaces. The default base template
-	// already grants /opt/** mrklix to the app itself, no extra snippet needed.
+	// Grant the app read access to its own assembly subtree under
+	// /opt/snapd/interfaces (the core base template does not grant /opt/** to
+	// apps), then authorize snap-update-ns to construct (and eventually tear
+	// down) the assembly tree.
+	addAppArmorAssemblyAccess(spec, cudaDriverLibs)
 	return addAppArmorAssemblyLibDirs(spec, slot, cudaDriverLibs)
 }
 

--- a/interfaces/builtin/cuda_driver_libs.go
+++ b/interfaces/builtin/cuda_driver_libs.go
@@ -96,6 +96,9 @@ func (iface *cudaDriverLibsInterface) LdconfigConnectedPlug(spec *ldconfig.Speci
 func (iface *cudaDriverLibsInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// On Ubuntu Core the provider content is bound into the assembly tree under
 	// the /run/snapd/interfaces directory (see mountAssemblyLibDirs).
+	if err := mountAssemblyRoot(spec); err != nil {
+		return err
+	}
 	return mountAssemblyLibDirs(spec, slot, cudaDriverLibs)
 }
 
@@ -104,6 +107,7 @@ func (iface *cudaDriverLibsInterface) AppArmorConnectedPlug(spec *apparmor.Speci
 	// /run/snapd/interfaces (the core base template does not grant /opt/** to
 	// apps), then authorize snap-update-ns to construct (and eventually tear
 	// down) the assembly tree.
+	addAppArmorAssemblyRoot(spec)
 	addAppArmorAssemblyAccess(spec, cudaDriverLibs)
 	return addAppArmorAssemblyLibDirs(spec, slot, cudaDriverLibs)
 }

--- a/interfaces/builtin/cuda_driver_libs.go
+++ b/interfaces/builtin/cuda_driver_libs.go
@@ -95,13 +95,13 @@ func (iface *cudaDriverLibsInterface) LdconfigConnectedPlug(spec *ldconfig.Speci
 
 func (iface *cudaDriverLibsInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// On Ubuntu Core the provider content is bound into the assembly tree under
-	// the /opt/snapd/interfaces directory (see mountAssemblyLibDirs).
+	// the /run/snapd/interfaces directory (see mountAssemblyLibDirs).
 	return mountAssemblyLibDirs(spec, slot, cudaDriverLibs)
 }
 
 func (iface *cudaDriverLibsInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// Grant the app read access to its own assembly subtree under
-	// /opt/snapd/interfaces (the core base template does not grant /opt/** to
+	// /run/snapd/interfaces (the core base template does not grant /opt/** to
 	// apps), then authorize snap-update-ns to construct (and eventually tear
 	// down) the assembly tree.
 	addAppArmorAssemblyAccess(spec, cudaDriverLibs)

--- a/interfaces/builtin/cuda_driver_libs.go
+++ b/interfaces/builtin/cuda_driver_libs.go
@@ -95,7 +95,7 @@ func (iface *cudaDriverLibsInterface) LdconfigConnectedPlug(spec *ldconfig.Speci
 
 func (iface *cudaDriverLibsInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// On Ubuntu Core the provider content is bound into the assembly tree under
-	// the /run/snapd/interfaces directory (see mountAssemblyLibDirs).
+	// the /run/snapd/snap/interfaces directory (see mountAssemblyLibDirs).
 	if err := mountAssemblyRoot(spec); err != nil {
 		return err
 	}
@@ -104,7 +104,7 @@ func (iface *cudaDriverLibsInterface) MountConnectedPlug(spec *mount.Specificati
 
 func (iface *cudaDriverLibsInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// Grant the app read access to its own assembly subtree under
-	// /run/snapd/interfaces (the core base template does not grant /opt/** to
+	// /run/snapd/snap/interfaces (the core base template does not grant /opt/** to
 	// apps), then authorize snap-update-ns to construct (and eventually tear
 	// down) the assembly tree.
 	addAppArmorAssemblyRoot(spec)

--- a/interfaces/builtin/cuda_driver_libs_test.go
+++ b/interfaces/builtin/cuda_driver_libs_test.go
@@ -22,11 +22,13 @@ package builtin_test
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/configfiles"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
@@ -339,6 +341,25 @@ func (s *CudaDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 		"/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/3",
 		"/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/4",
 	})
+}
+
+func (s *CudaDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
+	spec := apparmor.NewSpecification(s.plug.AppSet())
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+
+	updateNS := strings.Join(spec.UpdateNS(), "")
+	// The bind-mount rules for each assembly library dir, with the {,-[0-9]*}
+	// clash suffixes.
+	lib1 := filepath.Join(dirs.SnapMountDir, "cuda-provider/5/lib1")
+	target0 := "/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/0"
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n", lib1, target0))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target0))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}/\",\n", target0))
+
+	// The writable-mimic is authorized for the target tree construction.
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  # Writable mimic %s\n", filepath.Dir(target0)))
+	// No app-read /opt snippet is added (the base template handles /opt).
+	c.Check(spec.SnippetForTag("snap.snapd.app"), Equals, "")
 }
 
 func (s *CudaDriverLibsInterfaceSuite) TestConfigfilesSpec(c *C) {

--- a/interfaces/builtin/cuda_driver_libs_test.go
+++ b/interfaces/builtin/cuda_driver_libs_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/configfiles"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
+	"github.com/snapcore/snapd/interfaces/mount"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
@@ -309,6 +310,35 @@ func (s *CudaDriverLibsInterfaceSuite) TestLdconfigSpec(c *C) {
 			filepath.Join(snap.ComponentMountDir("comp2", snap.R(22), "cuda-provider"), "lib2"),
 			snap.ComponentMountDir("comp2", snap.R(22), "cuda-provider"),
 		}})
+}
+
+func (s *CudaDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
+	spec := &mount.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+
+	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
+		// Library dirs are bound into the assembly tree, preserving the
+		// original directory order (idx) and keeping the original file names.
+		{Name: filepath.Join(dirs.SnapMountDir, "cuda-provider/5/lib1"),
+			Dir: "/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/0", Options: []string{"rbind", "ro"}},
+		{Name: filepath.Join(dirs.SnapMountDir, "cuda-provider/5/lib2"),
+			Dir: "/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/1", Options: []string{"rbind", "ro"}},
+		{Name: filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "cuda-provider"), "lib1"),
+			Dir: "/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/2", Options: []string{"rbind", "ro"}},
+		{Name: filepath.Join(snap.ComponentMountDir("comp2", snap.R(22), "cuda-provider"), "lib2"),
+			Dir: "/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/3", Options: []string{"rbind", "ro"}},
+		{Name: snap.ComponentMountDir("comp2", snap.R(22), "cuda-provider"),
+			Dir: "/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/4", Options: []string{"rbind", "ro"}},
+	})
+
+	// All bound library dirs are collected for SNAP_LIBRARY_PATH derivation.
+	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
+		"/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/0",
+		"/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/1",
+		"/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/2",
+		"/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/3",
+		"/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/4",
+	})
 }
 
 func (s *CudaDriverLibsInterfaceSuite) TestConfigfilesSpec(c *C) {

--- a/interfaces/builtin/cuda_driver_libs_test.go
+++ b/interfaces/builtin/cuda_driver_libs_test.go
@@ -53,6 +53,7 @@ var _ = Suite(&CudaDriverLibsInterfaceSuite{
 // This is in fact implicit in the system
 const cudaDriverLibsConsumerYaml = `name: snapd
 version: 0
+base: core26
 plugs:
   cuda:
     compatibility: cuda-(9..12)-ubuntu-2404
@@ -276,6 +277,25 @@ slots:
 func (s *CudaDriverLibsInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Check(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
 	c.Check(interfaces.BeforeConnectPlug(s.iface, s.plug), IsNil)
+}
+
+func (s *CudaDriverLibsInterfaceSuite) TestSanitizePlugUnsupportedBase(c *C) {
+	const consumerYaml = `name: snapd
+version: 0
+base: core24
+plugs:
+  cuda:
+    compatibility: cuda-(9..12)-ubuntu-2404
+    interface: cuda-driver-libs
+apps:
+  app:
+    plugs: [cuda]
+`
+	plug, plugInfo := MockConnectedPlug(c, consumerYaml,
+		&snap.SideInfo{Revision: snap.R(3)}, "cuda")
+	c.Check(interfaces.BeforeConnectPlug(s.iface, plug), IsNil)
+	c.Check(interfaces.BeforePreparePlug(s.iface, plugInfo), ErrorMatches,
+		`cuda-driver-libs interface is not supported on base "core24"`)
 }
 
 func (s *CudaDriverLibsInterfaceSuite) TestLdconfigSpec(c *C) {

--- a/interfaces/builtin/cuda_driver_libs_test.go
+++ b/interfaces/builtin/cuda_driver_libs_test.go
@@ -353,7 +353,7 @@ func (s *CudaDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 	// clash suffixes.
 	lib1 := filepath.Join(dirs.SnapMountDir, "cuda-provider/5/lib1")
 	target0 := "/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/lib1"
-	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n", lib1, target0))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(rw, bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n", lib1, target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}/\",\n", target0))
 

--- a/interfaces/builtin/cuda_driver_libs_test.go
+++ b/interfaces/builtin/cuda_driver_libs_test.go
@@ -75,9 +75,9 @@ slots:
     library-source:
       - $SNAP/lib1
       - ${SNAP}/lib2
-      - $SNAP_COMPONENT(comp1)/lib1
-      - $SNAP_COMPONENT(comp2)/lib2
-      - $SNAP_COMPONENT(comp2)/
+      - $SNAP_COMPONENT(comp1)/clib1
+      - $SNAP_COMPONENT(comp2)/clib2
+      - $SNAP_COMPONENT(comp2)/clib3
 components:
   comp1:
     type: standard
@@ -308,9 +308,9 @@ func (s *CudaDriverLibsInterfaceSuite) TestLdconfigSpec(c *C) {
 		{SnapName: "cuda-provider", SlotName: "cuda-slot"}: {
 			filepath.Join(dirs.SnapMountDir, "cuda-provider/5/lib1"),
 			filepath.Join(dirs.SnapMountDir, "cuda-provider/5/lib2"),
-			filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "cuda-provider"), "lib1"),
-			filepath.Join(snap.ComponentMountDir("comp2", snap.R(22), "cuda-provider"), "lib2"),
-			snap.ComponentMountDir("comp2", snap.R(22), "cuda-provider"),
+			filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "cuda-provider"), "clib1"),
+			filepath.Join(snap.ComponentMountDir("comp2", snap.R(22), "cuda-provider"), "clib2"),
+			filepath.Join(snap.ComponentMountDir("comp2", snap.R(22), "cuda-provider"), "clib3"),
 		}})
 }
 
@@ -319,27 +319,28 @@ func (s *CudaDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
-		// Library dirs are bound into the assembly tree, preserving the
-		// original directory order (idx) and keeping the original file names.
+		// Library dirs are bound into the assembly tree, pooled by their
+		// path-suffix after the $SNAP/$SNAP_COMPONENT prefix.
 		{Name: filepath.Join(dirs.SnapMountDir, "cuda-provider/5/lib1"),
-			Dir: "/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/0", Options: []string{"bind", "ro"}},
+			Dir: "/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/lib1", Options: []string{"bind", "ro"}},
 		{Name: filepath.Join(dirs.SnapMountDir, "cuda-provider/5/lib2"),
-			Dir: "/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/1", Options: []string{"bind", "ro"}},
-		{Name: filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "cuda-provider"), "lib1"),
-			Dir: "/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/2", Options: []string{"bind", "ro"}},
-		{Name: filepath.Join(snap.ComponentMountDir("comp2", snap.R(22), "cuda-provider"), "lib2"),
-			Dir: "/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/3", Options: []string{"bind", "ro"}},
-		{Name: snap.ComponentMountDir("comp2", snap.R(22), "cuda-provider"),
-			Dir: "/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/4", Options: []string{"bind", "ro"}},
+			Dir: "/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/lib2", Options: []string{"bind", "ro"}},
+		{Name: filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "cuda-provider"), "clib1"),
+			Dir: "/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/clib1", Options: []string{"bind", "ro"}},
+		{Name: filepath.Join(snap.ComponentMountDir("comp2", snap.R(22), "cuda-provider"), "clib2"),
+			Dir: "/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/clib2", Options: []string{"bind", "ro"}},
+		{Name: filepath.Join(snap.ComponentMountDir("comp2", snap.R(22), "cuda-provider"), "clib3"),
+			Dir: "/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/clib3", Options: []string{"bind", "ro"}},
 	})
 
-	// All bound library dirs are collected for SNAP_LIBRARY_PATH derivation.
+	// All bound library dirs are collected for SNAP_LIBRARY_PATH derivation
+	// (sorted).
 	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
-		"/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/0",
-		"/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/1",
-		"/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/2",
-		"/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/3",
-		"/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/4",
+		"/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/clib1",
+		"/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/clib2",
+		"/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/clib3",
+		"/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/lib1",
+		"/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/lib2",
 	})
 }
 
@@ -351,7 +352,7 @@ func (s *CudaDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 	// The bind-mount rules for each assembly library dir, with the {,-[0-9]*}
 	// clash suffixes.
 	lib1 := filepath.Join(dirs.SnapMountDir, "cuda-provider/5/lib1")
-	target0 := "/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/0"
+	target0 := "/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/lib1"
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n", lib1, target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}/\",\n", target0))
@@ -376,9 +377,9 @@ func (s *CudaDriverLibsInterfaceSuite) TestConfigfilesSpec(c *C) {
 			Content: []byte(
 				filepath.Join(dirs.SnapMountDir, "cuda-provider/5/lib1") + "\n" +
 					filepath.Join(dirs.SnapMountDir, "cuda-provider/5/lib2") + "\n" +
-					filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "cuda-provider"), "lib1") + "\n" +
-					filepath.Join(snap.ComponentMountDir("comp2", snap.R(22), "cuda-provider"), "lib2") + "\n" +
-					snap.ComponentMountDir("comp2", snap.R(22), "cuda-provider") + "\n"),
+					filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "cuda-provider"), "clib1") + "\n" +
+					filepath.Join(snap.ComponentMountDir("comp2", snap.R(22), "cuda-provider"), "clib2") + "\n" +
+					filepath.Join(snap.ComponentMountDir("comp2", snap.R(22), "cuda-provider"), "clib3") + "\n"),
 			Mode: 0644},
 	})
 }

--- a/interfaces/builtin/cuda_driver_libs_test.go
+++ b/interfaces/builtin/cuda_driver_libs_test.go
@@ -321,29 +321,29 @@ func (s *CudaDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
 		// The shared tmpfs mount at the assembly root, so that only the bare
 		// mountpoint directory (not the assembly tree content) is host-visible.
-		{Name: "tmpfs", Dir: "/run/snapd/interfaces", Type: "tmpfs", Options: []string{"mode=0755", "uid=0", "gid=0"}},
+		{Name: "tmpfs", Dir: "/run/snapd/snap", Type: "tmpfs", Options: []string{"mode=0755", "uid=0", "gid=0"}},
 		// Library dirs are bound into the assembly tree, pooled by their
 		// path-suffix after the $SNAP/$SNAP_COMPONENT prefix.
 		{Name: filepath.Join(dirs.SnapMountDir, "cuda-provider/5/lib1"),
-			Dir: "/run/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/lib1", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
+			Dir: "/run/snapd/snap/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/lib1", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
 		{Name: filepath.Join(dirs.SnapMountDir, "cuda-provider/5/lib2"),
-			Dir: "/run/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/lib2", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
+			Dir: "/run/snapd/snap/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/lib2", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
 		{Name: filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "cuda-provider"), "clib1"),
-			Dir: "/run/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/clib1", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
+			Dir: "/run/snapd/snap/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/clib1", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
 		{Name: filepath.Join(snap.ComponentMountDir("comp2", snap.R(22), "cuda-provider"), "clib2"),
-			Dir: "/run/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/clib2", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
+			Dir: "/run/snapd/snap/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/clib2", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
 		{Name: filepath.Join(snap.ComponentMountDir("comp2", snap.R(22), "cuda-provider"), "clib3"),
-			Dir: "/run/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/clib3", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
+			Dir: "/run/snapd/snap/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/clib3", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
 	})
 
 	// All bound library dirs are collected for SNAP_LIBRARY_PATH derivation
 	// (sorted).
 	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
-		"/run/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/clib1",
-		"/run/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/clib2",
-		"/run/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/clib3",
-		"/run/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/lib1",
-		"/run/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/lib2",
+		"/run/snapd/snap/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/clib1",
+		"/run/snapd/snap/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/clib2",
+		"/run/snapd/snap/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/clib3",
+		"/run/snapd/snap/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/lib1",
+		"/run/snapd/snap/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/lib2",
 	})
 }
 
@@ -355,7 +355,7 @@ func (s *CudaDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 	// The bind-mount rules for each assembly library dir, with the {,-[0-9]*}
 	// clash suffixes.
 	lib1 := filepath.Join(dirs.SnapMountDir, "cuda-provider/5/lib1")
-	target0 := "/run/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/lib1"
+	target0 := "/run/snapd/snap/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/lib1"
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(rw, bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n", lib1, target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}/\",\n", target0))
@@ -365,8 +365,8 @@ func (s *CudaDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 	// The app gets read access to its own assembly subtree only (the core base
 	// template does not grant /opt/** to apps).
 	app := spec.SnippetForTag("snap.snapd.app")
-	c.Check(app, testutil.Contains, "/run/snapd/interfaces/cuda-driver-libs/ r,")
-	c.Check(app, testutil.Contains, "/run/snapd/interfaces/cuda-driver-libs/** mrkix,")
+	c.Check(app, testutil.Contains, "/run/snapd/snap/interfaces/cuda-driver-libs/ r,")
+	c.Check(app, testutil.Contains, "/run/snapd/snap/interfaces/cuda-driver-libs/** mrkix,")
 }
 
 func (s *CudaDriverLibsInterfaceSuite) TestConfigfilesSpec(c *C) {

--- a/interfaces/builtin/cuda_driver_libs_test.go
+++ b/interfaces/builtin/cuda_driver_libs_test.go
@@ -325,15 +325,15 @@ func (s *CudaDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 		// Library dirs are bound into the assembly tree, pooled by their
 		// path-suffix after the $SNAP/$SNAP_COMPONENT prefix.
 		{Name: filepath.Join(dirs.SnapMountDir, "cuda-provider/5/lib1"),
-			Dir: "/run/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/lib1", Options: []string{"bind", "ro"}},
+			Dir: "/run/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/lib1", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
 		{Name: filepath.Join(dirs.SnapMountDir, "cuda-provider/5/lib2"),
-			Dir: "/run/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/lib2", Options: []string{"bind", "ro"}},
+			Dir: "/run/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/lib2", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
 		{Name: filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "cuda-provider"), "clib1"),
-			Dir: "/run/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/clib1", Options: []string{"bind", "ro"}},
+			Dir: "/run/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/clib1", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
 		{Name: filepath.Join(snap.ComponentMountDir("comp2", snap.R(22), "cuda-provider"), "clib2"),
-			Dir: "/run/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/clib2", Options: []string{"bind", "ro"}},
+			Dir: "/run/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/clib2", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
 		{Name: filepath.Join(snap.ComponentMountDir("comp2", snap.R(22), "cuda-provider"), "clib3"),
-			Dir: "/run/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/clib3", Options: []string{"bind", "ro"}},
+			Dir: "/run/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/clib3", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
 	})
 
 	// All bound library dirs are collected for SNAP_LIBRARY_PATH derivation

--- a/interfaces/builtin/cuda_driver_libs_test.go
+++ b/interfaces/builtin/cuda_driver_libs_test.go
@@ -319,6 +319,9 @@ func (s *CudaDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
+		// The shared tmpfs mount at the assembly root, so that only the bare
+		// mountpoint directory (not the assembly tree content) is host-visible.
+		{Name: "tmpfs", Dir: "/run/snapd/interfaces", Type: "tmpfs", Options: []string{"mode=0755", "uid=0", "gid=0"}},
 		// Library dirs are bound into the assembly tree, pooled by their
 		// path-suffix after the $SNAP/$SNAP_COMPONENT prefix.
 		{Name: filepath.Join(dirs.SnapMountDir, "cuda-provider/5/lib1"),

--- a/interfaces/builtin/cuda_driver_libs_test.go
+++ b/interfaces/builtin/cuda_driver_libs_test.go
@@ -322,15 +322,15 @@ func (s *CudaDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 		// Library dirs are bound into the assembly tree, preserving the
 		// original directory order (idx) and keeping the original file names.
 		{Name: filepath.Join(dirs.SnapMountDir, "cuda-provider/5/lib1"),
-			Dir: "/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/0", Options: []string{"rbind", "ro"}},
+			Dir: "/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/0", Options: []string{"bind", "ro"}},
 		{Name: filepath.Join(dirs.SnapMountDir, "cuda-provider/5/lib2"),
-			Dir: "/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/1", Options: []string{"rbind", "ro"}},
+			Dir: "/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/1", Options: []string{"bind", "ro"}},
 		{Name: filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "cuda-provider"), "lib1"),
-			Dir: "/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/2", Options: []string{"rbind", "ro"}},
+			Dir: "/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/2", Options: []string{"bind", "ro"}},
 		{Name: filepath.Join(snap.ComponentMountDir("comp2", snap.R(22), "cuda-provider"), "lib2"),
-			Dir: "/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/3", Options: []string{"rbind", "ro"}},
+			Dir: "/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/3", Options: []string{"bind", "ro"}},
 		{Name: snap.ComponentMountDir("comp2", snap.R(22), "cuda-provider"),
-			Dir: "/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/4", Options: []string{"rbind", "ro"}},
+			Dir: "/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/4", Options: []string{"bind", "ro"}},
 	})
 
 	// All bound library dirs are collected for SNAP_LIBRARY_PATH derivation.

--- a/interfaces/builtin/cuda_driver_libs_test.go
+++ b/interfaces/builtin/cuda_driver_libs_test.go
@@ -322,25 +322,25 @@ func (s *CudaDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 		// Library dirs are bound into the assembly tree, pooled by their
 		// path-suffix after the $SNAP/$SNAP_COMPONENT prefix.
 		{Name: filepath.Join(dirs.SnapMountDir, "cuda-provider/5/lib1"),
-			Dir: "/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/lib1", Options: []string{"bind", "ro"}},
+			Dir: "/run/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/lib1", Options: []string{"bind", "ro"}},
 		{Name: filepath.Join(dirs.SnapMountDir, "cuda-provider/5/lib2"),
-			Dir: "/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/lib2", Options: []string{"bind", "ro"}},
+			Dir: "/run/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/lib2", Options: []string{"bind", "ro"}},
 		{Name: filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "cuda-provider"), "clib1"),
-			Dir: "/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/clib1", Options: []string{"bind", "ro"}},
+			Dir: "/run/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/clib1", Options: []string{"bind", "ro"}},
 		{Name: filepath.Join(snap.ComponentMountDir("comp2", snap.R(22), "cuda-provider"), "clib2"),
-			Dir: "/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/clib2", Options: []string{"bind", "ro"}},
+			Dir: "/run/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/clib2", Options: []string{"bind", "ro"}},
 		{Name: filepath.Join(snap.ComponentMountDir("comp2", snap.R(22), "cuda-provider"), "clib3"),
-			Dir: "/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/clib3", Options: []string{"bind", "ro"}},
+			Dir: "/run/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/clib3", Options: []string{"bind", "ro"}},
 	})
 
 	// All bound library dirs are collected for SNAP_LIBRARY_PATH derivation
 	// (sorted).
 	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
-		"/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/clib1",
-		"/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/clib2",
-		"/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/clib3",
-		"/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/lib1",
-		"/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/lib2",
+		"/run/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/clib1",
+		"/run/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/clib2",
+		"/run/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/clib3",
+		"/run/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/lib1",
+		"/run/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/lib2",
 	})
 }
 
@@ -352,7 +352,7 @@ func (s *CudaDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 	// The bind-mount rules for each assembly library dir, with the {,-[0-9]*}
 	// clash suffixes.
 	lib1 := filepath.Join(dirs.SnapMountDir, "cuda-provider/5/lib1")
-	target0 := "/opt/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/lib1"
+	target0 := "/run/snapd/interfaces/cuda-driver-libs/lib/cuda-provider_cuda-slot/lib1"
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(rw, bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n", lib1, target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}/\",\n", target0))
@@ -362,8 +362,8 @@ func (s *CudaDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 	// The app gets read access to its own assembly subtree only (the core base
 	// template does not grant /opt/** to apps).
 	app := spec.SnippetForTag("snap.snapd.app")
-	c.Check(app, testutil.Contains, "/opt/snapd/interfaces/cuda-driver-libs/ r,")
-	c.Check(app, testutil.Contains, "/opt/snapd/interfaces/cuda-driver-libs/** mrkix,")
+	c.Check(app, testutil.Contains, "/run/snapd/interfaces/cuda-driver-libs/ r,")
+	c.Check(app, testutil.Contains, "/run/snapd/interfaces/cuda-driver-libs/** mrkix,")
 }
 
 func (s *CudaDriverLibsInterfaceSuite) TestConfigfilesSpec(c *C) {

--- a/interfaces/builtin/cuda_driver_libs_test.go
+++ b/interfaces/builtin/cuda_driver_libs_test.go
@@ -358,8 +358,11 @@ func (s *CudaDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 
 	// The writable-mimic is authorized for the target tree construction.
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  # Writable mimic %s\n", filepath.Dir(target0)))
-	// No app-read /opt snippet is added (the base template handles /opt).
-	c.Check(spec.SnippetForTag("snap.snapd.app"), Equals, "")
+	// The app gets read access to its own assembly subtree only (the core base
+	// template does not grant /opt/** to apps).
+	app := spec.SnippetForTag("snap.snapd.app")
+	c.Check(app, testutil.Contains, "/opt/snapd/interfaces/cuda-driver-libs/ r,")
+	c.Check(app, testutil.Contains, "/opt/snapd/interfaces/cuda-driver-libs/** mrkix,")
 }
 
 func (s *CudaDriverLibsInterfaceSuite) TestConfigfilesSpec(c *C) {

--- a/interfaces/builtin/egl_driver_libs.go
+++ b/interfaces/builtin/egl_driver_libs.go
@@ -25,6 +25,7 @@ import (
 	"math"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/compatibility"
 	"github.com/snapcore/snapd/interfaces/configfiles"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
@@ -116,6 +117,18 @@ func (iface *eglDriverLibsInterface) MountConnectedPlug(spec *mount.Specificatio
 	}
 	// The EGL vendor metadata is bound as files under the egl_vendor.d subtree.
 	return mountAssemblySourceFiles(spec, slot, eglDriverLibs,
+		sourceDirAttr{attrName: "icd-source"}, "egl_vendor.d", checkEglIcdFile, withPriority)
+}
+
+func (iface *eglDriverLibsInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	// Authorize snap-update-ns to construct (and eventually tear down) the
+	// assembly tree under /opt/snapd/interfaces. The default base template
+	// already grants /opt/** mrklix to the app itself, no extra snippet needed.
+	const withPriority = true
+	if err := addAppArmorAssemblyLibDirs(spec, slot, eglDriverLibs); err != nil {
+		return err
+	}
+	return addAppArmorAssemblySourceFiles(spec, slot, eglDriverLibs,
 		sourceDirAttr{attrName: "icd-source"}, "egl_vendor.d", checkEglIcdFile, withPriority)
 }
 

--- a/interfaces/builtin/egl_driver_libs.go
+++ b/interfaces/builtin/egl_driver_libs.go
@@ -28,6 +28,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/compatibility"
 	"github.com/snapcore/snapd/interfaces/configfiles"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
+	"github.com/snapcore/snapd/interfaces/mount"
 	"github.com/snapcore/snapd/interfaces/symlinks"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
@@ -104,6 +105,18 @@ func (iface *eglDriverLibsInterface) BeforePrepareSlot(slot *snap.SlotInfo) erro
 func (iface *eglDriverLibsInterface) LdconfigConnectedPlug(spec *ldconfig.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// The plug can only be the system plug for the time being
 	return addLdconfigLibDirs(spec, slot)
+}
+
+func (iface *eglDriverLibsInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	// On Ubuntu Core the provider content is bound into the assembly tree under
+	// the /opt/snapd/interfaces directory (see mountAssemblyLibDirs).
+	const withPriority = true
+	if err := mountAssemblyLibDirs(spec, slot, eglDriverLibs); err != nil {
+		return err
+	}
+	// The EGL vendor metadata is bound as files under the egl_vendor.d subtree.
+	return mountAssemblySourceFiles(spec, slot, eglDriverLibs,
+		sourceDirAttr{attrName: "icd-source"}, "egl_vendor.d", checkEglIcdFile, withPriority)
 }
 
 var _ = symlinks.ConnectedPlugCallback(&eglDriverLibsInterface{})

--- a/interfaces/builtin/egl_driver_libs.go
+++ b/interfaces/builtin/egl_driver_libs.go
@@ -61,6 +61,13 @@ type eglDriverLibsInterface struct {
 	commonInterface
 }
 
+func (iface *eglDriverLibsInterface) BeforePreparePlug(plug *snap.PlugInfo) error {
+	if !driverLibsSupported(plug.Snap.Base) {
+		return fmt.Errorf("%s interface is not supported on base %q", eglDriverLibs, plug.Snap.Base)
+	}
+	return nil
+}
+
 func (iface *eglDriverLibsInterface) BeforePrepareSlot(slot *snap.SlotInfo) error {
 	// Validate attributes
 	var priority int64

--- a/interfaces/builtin/egl_driver_libs.go
+++ b/interfaces/builtin/egl_driver_libs.go
@@ -35,15 +35,17 @@ import (
 
 const eglDriverLibsSummary = `allows exposing EGL driver libraries to the system`
 
-// Plugs only supported for the system on classic for the moment (note this is
-// checked on "system" snap installation even though this is an implicit plug
-// in that case) - in the future we will allow snaps having this as plug and
-// this declaration will have to change.
+// Plug on classic may only be declared by the system snap (implicit plug); on
+// Ubuntu Core any snap may declare it (see allow-installation alternatives).
 const eglDriverLibsBaseDeclarationPlugs = `
   egl-driver-libs:
     allow-installation:
-      plug-snap-type:
-        - core
+      -
+        on-classic: true
+        plug-snap-type:
+          - core
+      -
+        on-classic: false
     allow-connection:
       slots-per-plug: *
     deny-auto-connection: true

--- a/interfaces/builtin/egl_driver_libs.go
+++ b/interfaces/builtin/egl_driver_libs.go
@@ -111,6 +111,9 @@ func (iface *eglDriverLibsInterface) LdconfigConnectedPlug(spec *ldconfig.Specif
 func (iface *eglDriverLibsInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// On Ubuntu Core the provider content is bound into the assembly tree under
 	// the /run/snapd/interfaces directory (see mountAssemblyLibDirs).
+	if err := mountAssemblyRoot(spec); err != nil {
+		return err
+	}
 	const withPriority = true
 	if err := mountAssemblyLibDirs(spec, slot, eglDriverLibs); err != nil {
 		return err
@@ -125,6 +128,7 @@ func (iface *eglDriverLibsInterface) AppArmorConnectedPlug(spec *apparmor.Specif
 	// /run/snapd/interfaces (the core base template does not grant /opt/** to
 	// apps), then authorize snap-update-ns to construct (and eventually tear
 	// down) the assembly tree.
+	addAppArmorAssemblyRoot(spec)
 	addAppArmorAssemblyAccess(spec, eglDriverLibs)
 	// Grant read access to the loader-scanned metadata location (Pass 2).
 	addAppArmorRedistributionAccess(spec, eglDriverLibs)

--- a/interfaces/builtin/egl_driver_libs.go
+++ b/interfaces/builtin/egl_driver_libs.go
@@ -110,7 +110,7 @@ func (iface *eglDriverLibsInterface) LdconfigConnectedPlug(spec *ldconfig.Specif
 
 func (iface *eglDriverLibsInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// On Ubuntu Core the provider content is bound into the assembly tree under
-	// the /opt/snapd/interfaces directory (see mountAssemblyLibDirs).
+	// the /run/snapd/interfaces directory (see mountAssemblyLibDirs).
 	const withPriority = true
 	if err := mountAssemblyLibDirs(spec, slot, eglDriverLibs); err != nil {
 		return err
@@ -122,7 +122,7 @@ func (iface *eglDriverLibsInterface) MountConnectedPlug(spec *mount.Specificatio
 
 func (iface *eglDriverLibsInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// Grant the app read access to its own assembly subtree under
-	// /opt/snapd/interfaces (the core base template does not grant /opt/** to
+	// /run/snapd/interfaces (the core base template does not grant /opt/** to
 	// apps), then authorize snap-update-ns to construct (and eventually tear
 	// down) the assembly tree.
 	addAppArmorAssemblyAccess(spec, eglDriverLibs)

--- a/interfaces/builtin/egl_driver_libs.go
+++ b/interfaces/builtin/egl_driver_libs.go
@@ -121,9 +121,11 @@ func (iface *eglDriverLibsInterface) MountConnectedPlug(spec *mount.Specificatio
 }
 
 func (iface *eglDriverLibsInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	// Authorize snap-update-ns to construct (and eventually tear down) the
-	// assembly tree under /opt/snapd/interfaces. The default base template
-	// already grants /opt/** mrklix to the app itself, no extra snippet needed.
+	// Grant the app read access to its own assembly subtree under
+	// /opt/snapd/interfaces (the core base template does not grant /opt/** to
+	// apps), then authorize snap-update-ns to construct (and eventually tear
+	// down) the assembly tree.
+	addAppArmorAssemblyAccess(spec, eglDriverLibs)
 	const withPriority = true
 	if err := addAppArmorAssemblyLibDirs(spec, slot, eglDriverLibs); err != nil {
 		return err

--- a/interfaces/builtin/egl_driver_libs.go
+++ b/interfaces/builtin/egl_driver_libs.go
@@ -110,7 +110,7 @@ func (iface *eglDriverLibsInterface) LdconfigConnectedPlug(spec *ldconfig.Specif
 
 func (iface *eglDriverLibsInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// On Ubuntu Core the provider content is bound into the assembly tree under
-	// the /run/snapd/interfaces directory (see mountAssemblyLibDirs).
+	// the /run/snapd/snap/interfaces directory (see mountAssemblyLibDirs).
 	if err := mountAssemblyRoot(spec); err != nil {
 		return err
 	}
@@ -125,7 +125,7 @@ func (iface *eglDriverLibsInterface) MountConnectedPlug(spec *mount.Specificatio
 
 func (iface *eglDriverLibsInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// Grant the app read access to its own assembly subtree under
-	// /run/snapd/interfaces (the core base template does not grant /opt/** to
+	// /run/snapd/snap/interfaces (the core base template does not grant /opt/** to
 	// apps), then authorize snap-update-ns to construct (and eventually tear
 	// down) the assembly tree.
 	addAppArmorAssemblyRoot(spec)

--- a/interfaces/builtin/egl_driver_libs.go
+++ b/interfaces/builtin/egl_driver_libs.go
@@ -126,6 +126,8 @@ func (iface *eglDriverLibsInterface) AppArmorConnectedPlug(spec *apparmor.Specif
 	// apps), then authorize snap-update-ns to construct (and eventually tear
 	// down) the assembly tree.
 	addAppArmorAssemblyAccess(spec, eglDriverLibs)
+	// Grant read access to the loader-scanned metadata location (Pass 2).
+	addAppArmorRedistributionAccess(spec, eglDriverLibs)
 	const withPriority = true
 	if err := addAppArmorAssemblyLibDirs(spec, slot, eglDriverLibs); err != nil {
 		return err

--- a/interfaces/builtin/egl_driver_libs_test.go
+++ b/interfaces/builtin/egl_driver_libs_test.go
@@ -57,6 +57,7 @@ var _ = Suite(&EglDriverLibsInterfaceSuite{
 // This is in fact implicit in the system
 const eglDriverLibsConsumerYaml = `name: snapd
 version: 0
+base: core26
 plugs:
   egl:
     interface: egl-driver-libs
@@ -251,6 +252,24 @@ slots:
 func (s *EglDriverLibsInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Check(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
 	c.Check(interfaces.BeforeConnectPlug(s.iface, s.plug), IsNil)
+}
+
+func (s *EglDriverLibsInterfaceSuite) TestSanitizePlugUnsupportedBase(c *C) {
+	const consumerYaml = `name: snapd
+version: 0
+base: core24
+plugs:
+  egl:
+    interface: egl-driver-libs
+apps:
+  app:
+    plugs: [egl]
+`
+	plug, plugInfo := MockConnectedPlug(c, consumerYaml,
+		&snap.SideInfo{Revision: snap.R(3)}, "egl")
+	c.Check(interfaces.BeforeConnectPlug(s.iface, plug), IsNil)
+	c.Check(interfaces.BeforePreparePlug(s.iface, plugInfo), ErrorMatches,
+		`egl-driver-libs interface is not supported on base "core24"`)
 }
 
 func (s *EglDriverLibsInterfaceSuite) TestLdconfigSpec(c *C) {

--- a/interfaces/builtin/egl_driver_libs_test.go
+++ b/interfaces/builtin/egl_driver_libs_test.go
@@ -23,11 +23,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/configfiles"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
@@ -526,6 +528,51 @@ func (s *EglDriverLibsInterfaceSuite) TestSymlinksToComp2(c *C) {
 	c.Check(spec.Symlinks(), DeepEquals, map[string]symlinks.SymlinkToTarget{
 		"/etc/glvnd/egl_vendor.d": expected,
 	})
+}
+
+func (s *EglDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
+	// Populate the library dirs and the ICD files (egl_empty.d adds nothing).
+	libDir1 := filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib1")
+	c.Assert(os.MkdirAll(libDir1, 0755), IsNil)
+	for _, icdData := range []struct {
+		subDir string
+		gpu    string
+	}{
+		{"egl.d", "mesa"},
+	} {
+		icdDir := filepath.Join(dirs.SnapMountDir, "egl-provider/5", icdData.subDir)
+		c.Assert(os.MkdirAll(icdDir, 0755), IsNil)
+		os.WriteFile(filepath.Join(icdDir, icdData.gpu+".json"), []byte(fmt.Sprintf(`{
+    "file_format_version" : "1.0.0",
+    "ICD" : {
+        "library_path" : "libEGL_%s.so.0"
+    }
+}
+`, icdData.gpu)), 0655)
+		os.WriteFile(filepath.Join(libDir1, "libEGL_"+icdData.gpu+".so.0"), []byte{}, 0655)
+	}
+
+	spec := apparmor.NewSpecification(s.plug.AppSet())
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+
+	updateNS := strings.Join(spec.UpdateNS(), "")
+	// Library dir bind.
+	lib1 := filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib1")
+	target0 := "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/0"
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n", lib1, target0))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target0))
+
+	// ICD file bind (file semantics, no trailing slash) with the classic
+	// priority-prefixed encoded name.
+	icdSrc := filepath.Join(dirs.SnapMountDir, "egl-provider/5/egl.d/mesa.json")
+	icdTarget := "/opt/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json"
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(bind) \"%s\" -> \"%s{,-[0-9]*}\",\n", icdSrc, icdTarget))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}\",\n", icdTarget))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}\",\n", icdTarget))
+
+	// The writable-mimic is authorized for the share/egl_vendor.d tree.
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  # Writable mimic %s\n", filepath.Dir(icdTarget)))
+	c.Check(spec.SnippetForTag("snap.snapd.app"), Equals, "")
 }
 
 func (s *EglDriverLibsInterfaceSuite) TestConfigfilesSpec(c *C) {

--- a/interfaces/builtin/egl_driver_libs_test.go
+++ b/interfaces/builtin/egl_driver_libs_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/configfiles"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
+	"github.com/snapcore/snapd/interfaces/mount"
 	"github.com/snapcore/snapd/interfaces/symlinks"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/release"
@@ -282,6 +283,108 @@ func (s *EglDriverLibsInterfaceSuite) TestLdconfigSpec(c *C) {
 			filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "egl-provider"), "lib1"),
 			filepath.Join(snap.ComponentMountDir("comp2", snap.R(22), "egl-provider"), "lib2"),
 		}})
+}
+
+func (s *EglDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
+	// Populate the library dirs and the ICD files.
+	libDir1 := filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib1")
+	libDir2 := filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib2")
+	for _, libDir := range []string{libDir1, libDir2} {
+		c.Assert(os.MkdirAll(libDir, 0755), IsNil)
+	}
+	comp1LibDir := filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "egl-provider"), "lib1")
+	c.Assert(os.MkdirAll(comp1LibDir, 0755), IsNil)
+
+	// Write ICD files in egl.d and egl_alt.d (egl_empty.d contributes nothing).
+	for _, icdData := range []struct {
+		subDir string
+		gpu    string
+	}{
+		{"egl.d", "mesa"}, {"egl_alt.d", "radeon"},
+	} {
+		icdDir := filepath.Join(dirs.SnapMountDir, "egl-provider/5", icdData.subDir)
+		c.Assert(os.MkdirAll(icdDir, 0755), IsNil)
+		os.WriteFile(filepath.Join(icdDir, icdData.gpu+".json"), []byte(fmt.Sprintf(`{
+    "file_format_version" : "1.0.0",
+    "ICD" : {
+        "library_path" : "libEGL_%s.so.0"
+    }
+}
+`, icdData.gpu)), 0655)
+		libPath := filepath.Join(libDir1, "libEGL_"+icdData.gpu+".so.0")
+		os.WriteFile(libPath, []byte{}, 0655)
+	}
+
+	spec := &mount.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+
+	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
+		// Library dirs, preserving the original directory order (idx).
+		{Name: filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib1"),
+			Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/0", Options: []string{"rbind", "ro"}},
+		{Name: filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib2"),
+			Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/1", Options: []string{"rbind", "ro"}},
+		{Name: comp1LibDir,
+			Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/2", Options: []string{"rbind", "ro"}},
+		{Name: filepath.Join(snap.ComponentMountDir("comp2", snap.R(22), "egl-provider"), "lib2"),
+			Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/3", Options: []string{"rbind", "ro"}},
+		// ICD files, with the classic priority-prefixed encoded names.
+		{Name: filepath.Join(dirs.SnapMountDir, "egl-provider/5/egl.d/mesa.json"),
+			Dir: "/opt/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+		{Name: filepath.Join(dirs.SnapMountDir, "egl-provider/5/egl_alt.d/radeon.json"),
+			Dir: "/opt/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+	})
+
+	// The library dirs are collected for SNAP_LIBRARY_PATH derivation; the
+	// ICD file mounts are not library dirs.
+	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
+		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/0",
+		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/1",
+		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/2",
+		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/3",
+	})
+}
+
+func (s *EglDriverLibsInterfaceSuite) TestMountConnectedPlugMultiComponentFilter(c *C) {
+	// Only comp1 is installed; the comp2 icd and library sources are filtered out.
+	comps := []compRawInfo{
+		{"component: egl-provider+comp1\ntype: standard", snap.R(11)}}
+	s.slot, s.slotInfo = mockConnectedSlotWithComps(c, eglDriverLibsProvider,
+		&snap.SideInfo{Revision: snap.R(5)}, comps, "egl-slot")
+
+	libDir1 := filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib1")
+	libDir2 := filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib2")
+	comp1LibDir := filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "egl-provider"), "lib1")
+	for _, libDir := range []string{libDir1, libDir2, comp1LibDir} {
+		c.Assert(os.MkdirAll(libDir, 0755), IsNil)
+	}
+	os.WriteFile(filepath.Join(libDir1, "libEGL_mesa.so.0"), []byte{}, 0655)
+
+	icdDir := filepath.Join(dirs.SnapMountDir, "egl-provider/5/egl.d")
+	c.Assert(os.MkdirAll(icdDir, 0755), IsNil)
+	os.WriteFile(filepath.Join(icdDir, "mesa.json"), []byte(`{
+    "file_format_version" : "1.0.0",
+    "ICD" : {
+        "library_path" : "libEGL_mesa.so.0"
+    }
+}
+`), 0655)
+
+	spec := &mount.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+
+	// comp2 entries are absent, but the original indices (0..2) are kept.
+	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
+		{Name: libDir1, Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/0", Options: []string{"rbind", "ro"}},
+		{Name: libDir2, Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/1", Options: []string{"rbind", "ro"}},
+		{Name: comp1LibDir, Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/2", Options: []string{"rbind", "ro"}},
+		{Name: filepath.Join(icdDir, "mesa.json"), Dir: "/opt/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+	})
+	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
+		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/0",
+		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/1",
+		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/2",
+	})
 }
 
 func (s *EglDriverLibsInterfaceSuite) TestSymlinksSpec(c *C) {

--- a/interfaces/builtin/egl_driver_libs_test.go
+++ b/interfaces/builtin/egl_driver_libs_test.go
@@ -324,34 +324,34 @@ func (s *EglDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 		// Library dirs, pooled by path-suffix after the $SNAP/$SNAP_COMPONENT
 		// prefix (no per-index splitting).		// Library dirs, pooled by path-suffix.
 		{Name: filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib1"),
-			Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1", Options: []string{"bind", "ro"}},
+			Dir: "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1", Options: []string{"bind", "ro"}},
 		{Name: filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib2"),
-			Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib2", Options: []string{"bind", "ro"}},
+			Dir: "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib2", Options: []string{"bind", "ro"}},
 		{Name: comp1LibDir,
-			Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib1", Options: []string{"bind", "ro"}},
+			Dir: "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib1", Options: []string{"bind", "ro"}},
 		{Name: filepath.Join(snap.ComponentMountDir("comp2", snap.R(22), "egl-provider"), "clib2"),
-			Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib2", Options: []string{"bind", "ro"}},
+			Dir: "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib2", Options: []string{"bind", "ro"}},
 		// ICD files, with the classic priority-prefixed encoded names.
 		{Name: filepath.Join(dirs.SnapMountDir, "egl-provider/5/egl.d/mesa.json"),
-			Dir: "/opt/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+			Dir: "/run/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
 		// Pass 2: redistribution to the loader-scanned GLVND directory, re-binding
 		// the assembly target above.
-		{Name: "/opt/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json",
+		{Name: "/run/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json",
 			Dir: "/usr/share/glvnd/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
 		{Name: filepath.Join(dirs.SnapMountDir, "egl-provider/5/egl_alt.d/radeon.json"),
-			Dir: "/opt/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+			Dir: "/run/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
 		// Pass 2: redistribution for the radeon ICD too.
-		{Name: "/opt/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json",
+		{Name: "/run/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json",
 			Dir: "/usr/share/glvnd/egl_vendor.d/11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
 	})
 
 	// The library dirs are collected for SNAP_LIBRARY_PATH derivation (sorted);
 	// the ICD file mounts are not library dirs.
 	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
-		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib1",
-		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib2",
-		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1",
-		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib2",
+		"/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib1",
+		"/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib2",
+		"/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1",
+		"/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib2",
 	})
 }
 
@@ -385,18 +385,18 @@ func (s *EglDriverLibsInterfaceSuite) TestMountConnectedPlugMultiComponentFilter
 
 	// comp2 entries are absent; remaining entries keep their pooled targets.
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
-		{Name: libDir1, Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1", Options: []string{"bind", "ro"}},
-		{Name: libDir2, Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib2", Options: []string{"bind", "ro"}},
-		{Name: comp1LibDir, Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib1", Options: []string{"bind", "ro"}},
-		{Name: filepath.Join(icdDir, "mesa.json"), Dir: "/opt/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+		{Name: libDir1, Dir: "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1", Options: []string{"bind", "ro"}},
+		{Name: libDir2, Dir: "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib2", Options: []string{"bind", "ro"}},
+		{Name: comp1LibDir, Dir: "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib1", Options: []string{"bind", "ro"}},
+		{Name: filepath.Join(icdDir, "mesa.json"), Dir: "/run/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
 		// Pass 2: redistribution to the loader-scanned GLVND directory.
-		{Name: "/opt/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json",
+		{Name: "/run/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json",
 			Dir: "/usr/share/glvnd/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
 	})
 	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
-		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib1",
-		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1",
-		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib2",
+		"/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib1",
+		"/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1",
+		"/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib2",
 	})
 }
 
@@ -569,14 +569,14 @@ func (s *EglDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 	updateNS := strings.Join(spec.UpdateNS(), "")
 	// Library dir bind.
 	lib1 := filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib1")
-	target0 := "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1"
+	target0 := "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1"
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(rw, bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n", lib1, target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target0))
 
 	// ICD file bind (file semantics, no trailing slash) with the classic
 	// priority-prefixed encoded name.
 	icdSrc := filepath.Join(dirs.SnapMountDir, "egl-provider/5/egl.d/mesa.json")
-	icdTarget := "/opt/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json"
+	icdTarget := "/run/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json"
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(rw, bind) \"%s\" -> \"%s{,-[0-9]*}\",\n", icdSrc, icdTarget))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}\",\n", icdTarget))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}\",\n", icdTarget))
@@ -597,8 +597,8 @@ func (s *EglDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 	// template does not grant /opt/** to apps), plus the loader-scanned GLVND
 	// subtree for Pass 2 redistribution.
 	app := spec.SnippetForTag("snap.snapd.app")
-	c.Check(app, testutil.Contains, "/opt/snapd/interfaces/egl-driver-libs/ r,")
-	c.Check(app, testutil.Contains, "/opt/snapd/interfaces/egl-driver-libs/** mrkix,")
+	c.Check(app, testutil.Contains, "/run/snapd/interfaces/egl-driver-libs/ r,")
+	c.Check(app, testutil.Contains, "/run/snapd/interfaces/egl-driver-libs/** mrkix,")
 	c.Check(app, testutil.Contains, "/usr/share/glvnd/egl_vendor.d/{,**} r,")
 }
 

--- a/interfaces/builtin/egl_driver_libs_test.go
+++ b/interfaces/builtin/egl_driver_libs_test.go
@@ -323,38 +323,38 @@ func (s *EglDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
 		// The shared tmpfs mount at the assembly root, so that only the bare
 		// mountpoint directory (not the assembly tree content) is host-visible.
-		{Name: "tmpfs", Dir: "/run/snapd/interfaces", Type: "tmpfs", Options: []string{"mode=0755", "uid=0", "gid=0"}},
+		{Name: "tmpfs", Dir: "/run/snapd/snap", Type: "tmpfs", Options: []string{"mode=0755", "uid=0", "gid=0"}},
 		// Library dirs, pooled by path-suffix after the $SNAP/$SNAP_COMPONENT
 		// prefix (no per-index splitting).		// Library dirs, pooled by path-suffix.
 		{Name: filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib1"),
-			Dir: "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
+			Dir: "/run/snapd/snap/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
 		{Name: filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib2"),
-			Dir: "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib2", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
+			Dir: "/run/snapd/snap/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib2", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
 		{Name: comp1LibDir,
-			Dir: "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib1", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
+			Dir: "/run/snapd/snap/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib1", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
 		{Name: filepath.Join(snap.ComponentMountDir("comp2", snap.R(22), "egl-provider"), "clib2"),
-			Dir: "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib2", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
+			Dir: "/run/snapd/snap/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib2", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
 		// ICD files, with the classic priority-prefixed encoded names.
 		{Name: filepath.Join(dirs.SnapMountDir, "egl-provider/5/egl.d/mesa.json"),
-			Dir: "/run/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
+			Dir: "/run/snapd/snap/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
 		// Pass 2: redistribution to the loader-scanned GLVND directory, re-binding
 		// the assembly target above.
-		{Name: "/run/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json",
+		{Name: "/run/snapd/snap/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json",
 			Dir: "/usr/share/glvnd/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
 		{Name: filepath.Join(dirs.SnapMountDir, "egl-provider/5/egl_alt.d/radeon.json"),
-			Dir: "/run/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
+			Dir: "/run/snapd/snap/interfaces/egl-driver-libs/share/egl_vendor.d/11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
 		// Pass 2: redistribution for the radeon ICD too.
-		{Name: "/run/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json",
+		{Name: "/run/snapd/snap/interfaces/egl-driver-libs/share/egl_vendor.d/11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json",
 			Dir: "/usr/share/glvnd/egl_vendor.d/11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
 	})
 
 	// The library dirs are collected for SNAP_LIBRARY_PATH derivation (sorted);
 	// the ICD file mounts are not library dirs.
 	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
-		"/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib1",
-		"/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib2",
-		"/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1",
-		"/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib2",
+		"/run/snapd/snap/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib1",
+		"/run/snapd/snap/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib2",
+		"/run/snapd/snap/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1",
+		"/run/snapd/snap/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib2",
 	})
 }
 
@@ -390,19 +390,19 @@ func (s *EglDriverLibsInterfaceSuite) TestMountConnectedPlugMultiComponentFilter
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
 		// The shared tmpfs mount at the assembly root, so that only the bare
 		// mountpoint directory (not the assembly tree content) is host-visible.
-		{Name: "tmpfs", Dir: "/run/snapd/interfaces", Type: "tmpfs", Options: []string{"mode=0755", "uid=0", "gid=0"}},
-		{Name: libDir1, Dir: "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
-		{Name: libDir2, Dir: "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib2", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
-		{Name: comp1LibDir, Dir: "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib1", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
-		{Name: filepath.Join(icdDir, "mesa.json"), Dir: "/run/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
+		{Name: "tmpfs", Dir: "/run/snapd/snap", Type: "tmpfs", Options: []string{"mode=0755", "uid=0", "gid=0"}},
+		{Name: libDir1, Dir: "/run/snapd/snap/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
+		{Name: libDir2, Dir: "/run/snapd/snap/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib2", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
+		{Name: comp1LibDir, Dir: "/run/snapd/snap/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib1", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
+		{Name: filepath.Join(icdDir, "mesa.json"), Dir: "/run/snapd/snap/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
 		// Pass 2: redistribution to the loader-scanned GLVND directory.
-		{Name: "/run/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json",
+		{Name: "/run/snapd/snap/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json",
 			Dir: "/usr/share/glvnd/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
 	})
 	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
-		"/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib1",
-		"/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1",
-		"/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib2",
+		"/run/snapd/snap/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib1",
+		"/run/snapd/snap/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1",
+		"/run/snapd/snap/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib2",
 	})
 }
 
@@ -575,14 +575,14 @@ func (s *EglDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 	updateNS := strings.Join(spec.UpdateNS(), "")
 	// Library dir bind.
 	lib1 := filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib1")
-	target0 := "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1"
+	target0 := "/run/snapd/snap/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1"
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(rw, bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n", lib1, target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target0))
 
 	// ICD file bind (file semantics, no trailing slash) with the classic
 	// priority-prefixed encoded name.
 	icdSrc := filepath.Join(dirs.SnapMountDir, "egl-provider/5/egl.d/mesa.json")
-	icdTarget := "/run/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json"
+	icdTarget := "/run/snapd/snap/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json"
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(rw, bind) \"%s\" -> \"%s{,-[0-9]*}\",\n", icdSrc, icdTarget))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}\",\n", icdTarget))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}\",\n", icdTarget))
@@ -603,8 +603,8 @@ func (s *EglDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 	// template does not grant /opt/** to apps), plus the loader-scanned GLVND
 	// subtree for Pass 2 redistribution.
 	app := spec.SnippetForTag("snap.snapd.app")
-	c.Check(app, testutil.Contains, "/run/snapd/interfaces/egl-driver-libs/ r,")
-	c.Check(app, testutil.Contains, "/run/snapd/interfaces/egl-driver-libs/** mrkix,")
+	c.Check(app, testutil.Contains, "/run/snapd/snap/interfaces/egl-driver-libs/ r,")
+	c.Check(app, testutil.Contains, "/run/snapd/snap/interfaces/egl-driver-libs/** mrkix,")
 	c.Check(app, testutil.Contains, "/usr/share/glvnd/egl_vendor.d/{,**} r,")
 }
 

--- a/interfaces/builtin/egl_driver_libs_test.go
+++ b/interfaces/builtin/egl_driver_libs_test.go
@@ -327,25 +327,25 @@ func (s *EglDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 		// Library dirs, pooled by path-suffix after the $SNAP/$SNAP_COMPONENT
 		// prefix (no per-index splitting).		// Library dirs, pooled by path-suffix.
 		{Name: filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib1"),
-			Dir: "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1", Options: []string{"bind", "ro"}},
+			Dir: "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
 		{Name: filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib2"),
-			Dir: "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib2", Options: []string{"bind", "ro"}},
+			Dir: "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib2", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
 		{Name: comp1LibDir,
-			Dir: "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib1", Options: []string{"bind", "ro"}},
+			Dir: "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib1", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
 		{Name: filepath.Join(snap.ComponentMountDir("comp2", snap.R(22), "egl-provider"), "clib2"),
-			Dir: "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib2", Options: []string{"bind", "ro"}},
+			Dir: "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib2", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
 		// ICD files, with the classic priority-prefixed encoded names.
 		{Name: filepath.Join(dirs.SnapMountDir, "egl-provider/5/egl.d/mesa.json"),
-			Dir: "/run/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+			Dir: "/run/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
 		// Pass 2: redistribution to the loader-scanned GLVND directory, re-binding
 		// the assembly target above.
 		{Name: "/run/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json",
-			Dir: "/usr/share/glvnd/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+			Dir: "/usr/share/glvnd/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
 		{Name: filepath.Join(dirs.SnapMountDir, "egl-provider/5/egl_alt.d/radeon.json"),
-			Dir: "/run/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+			Dir: "/run/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
 		// Pass 2: redistribution for the radeon ICD too.
 		{Name: "/run/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json",
-			Dir: "/usr/share/glvnd/egl_vendor.d/11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+			Dir: "/usr/share/glvnd/egl_vendor.d/11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
 	})
 
 	// The library dirs are collected for SNAP_LIBRARY_PATH derivation (sorted);
@@ -391,13 +391,13 @@ func (s *EglDriverLibsInterfaceSuite) TestMountConnectedPlugMultiComponentFilter
 		// The shared tmpfs mount at the assembly root, so that only the bare
 		// mountpoint directory (not the assembly tree content) is host-visible.
 		{Name: "tmpfs", Dir: "/run/snapd/interfaces", Type: "tmpfs", Options: []string{"mode=0755", "uid=0", "gid=0"}},
-		{Name: libDir1, Dir: "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1", Options: []string{"bind", "ro"}},
-		{Name: libDir2, Dir: "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib2", Options: []string{"bind", "ro"}},
-		{Name: comp1LibDir, Dir: "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib1", Options: []string{"bind", "ro"}},
-		{Name: filepath.Join(icdDir, "mesa.json"), Dir: "/run/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+		{Name: libDir1, Dir: "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
+		{Name: libDir2, Dir: "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib2", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
+		{Name: comp1LibDir, Dir: "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib1", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
+		{Name: filepath.Join(icdDir, "mesa.json"), Dir: "/run/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
 		// Pass 2: redistribution to the loader-scanned GLVND directory.
 		{Name: "/run/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json",
-			Dir: "/usr/share/glvnd/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+			Dir: "/usr/share/glvnd/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
 	})
 	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
 		"/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib1",

--- a/interfaces/builtin/egl_driver_libs_test.go
+++ b/interfaces/builtin/egl_driver_libs_test.go
@@ -570,14 +570,14 @@ func (s *EglDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 	// Library dir bind.
 	lib1 := filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib1")
 	target0 := "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1"
-	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n", lib1, target0))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(rw, bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n", lib1, target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target0))
 
 	// ICD file bind (file semantics, no trailing slash) with the classic
 	// priority-prefixed encoded name.
 	icdSrc := filepath.Join(dirs.SnapMountDir, "egl-provider/5/egl.d/mesa.json")
 	icdTarget := "/opt/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json"
-	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(bind) \"%s\" -> \"%s{,-[0-9]*}\",\n", icdSrc, icdTarget))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(rw, bind) \"%s\" -> \"%s{,-[0-9]*}\",\n", icdSrc, icdTarget))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}\",\n", icdTarget))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}\",\n", icdTarget))
 
@@ -585,7 +585,7 @@ func (s *EglDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 	// directory, re-binding the assembly target.
 	icdLoaderTarget := "/usr/share/glvnd/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json"
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  # Driver-libs redistribution %s -> %s\n", icdTarget, icdLoaderTarget))
-	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(bind) \"%s\" -> \"%s{,-[0-9]*}\",\n", icdTarget, icdLoaderTarget))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(rw, bind) \"%s\" -> \"%s{,-[0-9]*}\",\n", icdTarget, icdLoaderTarget))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}\",\n", icdLoaderTarget))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}\",\n", icdLoaderTarget))
 

--- a/interfaces/builtin/egl_driver_libs_test.go
+++ b/interfaces/builtin/egl_driver_libs_test.go
@@ -321,6 +321,9 @@ func (s *EglDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
+		// The shared tmpfs mount at the assembly root, so that only the bare
+		// mountpoint directory (not the assembly tree content) is host-visible.
+		{Name: "tmpfs", Dir: "/run/snapd/interfaces", Type: "tmpfs", Options: []string{"mode=0755", "uid=0", "gid=0"}},
 		// Library dirs, pooled by path-suffix after the $SNAP/$SNAP_COMPONENT
 		// prefix (no per-index splitting).		// Library dirs, pooled by path-suffix.
 		{Name: filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib1"),
@@ -385,6 +388,9 @@ func (s *EglDriverLibsInterfaceSuite) TestMountConnectedPlugMultiComponentFilter
 
 	// comp2 entries are absent; remaining entries keep their pooled targets.
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
+		// The shared tmpfs mount at the assembly root, so that only the bare
+		// mountpoint directory (not the assembly tree content) is host-visible.
+		{Name: "tmpfs", Dir: "/run/snapd/interfaces", Type: "tmpfs", Options: []string{"mode=0755", "uid=0", "gid=0"}},
 		{Name: libDir1, Dir: "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1", Options: []string{"bind", "ro"}},
 		{Name: libDir2, Dir: "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib2", Options: []string{"bind", "ro"}},
 		{Name: comp1LibDir, Dir: "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib1", Options: []string{"bind", "ro"}},

--- a/interfaces/builtin/egl_driver_libs_test.go
+++ b/interfaces/builtin/egl_driver_libs_test.go
@@ -333,8 +333,15 @@ func (s *EglDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 		// ICD files, with the classic priority-prefixed encoded names.
 		{Name: filepath.Join(dirs.SnapMountDir, "egl-provider/5/egl.d/mesa.json"),
 			Dir: "/opt/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+		// Pass 2: redistribution to the loader-scanned GLVND directory, re-binding
+		// the assembly target above.
+		{Name: "/opt/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json",
+			Dir: "/usr/share/glvnd/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
 		{Name: filepath.Join(dirs.SnapMountDir, "egl-provider/5/egl_alt.d/radeon.json"),
 			Dir: "/opt/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+		// Pass 2: redistribution for the radeon ICD too.
+		{Name: "/opt/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json",
+			Dir: "/usr/share/glvnd/egl_vendor.d/11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
 	})
 
 	// The library dirs are collected for SNAP_LIBRARY_PATH derivation; the
@@ -381,6 +388,9 @@ func (s *EglDriverLibsInterfaceSuite) TestMountConnectedPlugMultiComponentFilter
 		{Name: libDir2, Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/1", Options: []string{"bind", "ro"}},
 		{Name: comp1LibDir, Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/2", Options: []string{"bind", "ro"}},
 		{Name: filepath.Join(icdDir, "mesa.json"), Dir: "/opt/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+		// Pass 2: redistribution to the loader-scanned GLVND directory.
+		{Name: "/opt/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json",
+			Dir: "/usr/share/glvnd/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
 	})
 	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
 		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/0",
@@ -570,13 +580,25 @@ func (s *EglDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}\",\n", icdTarget))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}\",\n", icdTarget))
 
+	// Pass 2: redistribution authorization for the loader-scanned GLVND
+	// directory, re-binding the assembly target.
+	icdLoaderTarget := "/usr/share/glvnd/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json"
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  # Driver-libs redistribution %s -> %s\n", icdTarget, icdLoaderTarget))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(bind) \"%s\" -> \"%s{,-[0-9]*}\",\n", icdTarget, icdLoaderTarget))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}\",\n", icdLoaderTarget))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}\",\n", icdLoaderTarget))
+
 	// The writable-mimic is authorized for the share/egl_vendor.d tree.
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  # Writable mimic %s\n", filepath.Dir(icdTarget)))
+	// The writable-mimic is authorized for the loader-scanned dir too.
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  # Writable mimic %s\n", filepath.Dir(icdLoaderTarget)))
 	// The app gets read access to its own assembly subtree only (the core base
-	// template does not grant /opt/** to apps).
+	// template does not grant /opt/** to apps), plus the loader-scanned GLVND
+	// subtree for Pass 2 redistribution.
 	app := spec.SnippetForTag("snap.snapd.app")
 	c.Check(app, testutil.Contains, "/opt/snapd/interfaces/egl-driver-libs/ r,")
 	c.Check(app, testutil.Contains, "/opt/snapd/interfaces/egl-driver-libs/** mrkix,")
+	c.Check(app, testutil.Contains, "/usr/share/glvnd/egl_vendor.d/{,**} r,")
 }
 
 func (s *EglDriverLibsInterfaceSuite) TestConfigfilesSpec(c *C) {

--- a/interfaces/builtin/egl_driver_libs_test.go
+++ b/interfaces/builtin/egl_driver_libs_test.go
@@ -323,13 +323,13 @@ func (s *EglDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
 		// Library dirs, preserving the original directory order (idx).
 		{Name: filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib1"),
-			Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/0", Options: []string{"rbind", "ro"}},
+			Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/0", Options: []string{"bind", "ro"}},
 		{Name: filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib2"),
-			Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/1", Options: []string{"rbind", "ro"}},
+			Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/1", Options: []string{"bind", "ro"}},
 		{Name: comp1LibDir,
-			Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/2", Options: []string{"rbind", "ro"}},
+			Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/2", Options: []string{"bind", "ro"}},
 		{Name: filepath.Join(snap.ComponentMountDir("comp2", snap.R(22), "egl-provider"), "lib2"),
-			Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/3", Options: []string{"rbind", "ro"}},
+			Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/3", Options: []string{"bind", "ro"}},
 		// ICD files, with the classic priority-prefixed encoded names.
 		{Name: filepath.Join(dirs.SnapMountDir, "egl-provider/5/egl.d/mesa.json"),
 			Dir: "/opt/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
@@ -377,9 +377,9 @@ func (s *EglDriverLibsInterfaceSuite) TestMountConnectedPlugMultiComponentFilter
 
 	// comp2 entries are absent, but the original indices (0..2) are kept.
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
-		{Name: libDir1, Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/0", Options: []string{"rbind", "ro"}},
-		{Name: libDir2, Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/1", Options: []string{"rbind", "ro"}},
-		{Name: comp1LibDir, Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/2", Options: []string{"rbind", "ro"}},
+		{Name: libDir1, Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/0", Options: []string{"bind", "ro"}},
+		{Name: libDir2, Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/1", Options: []string{"bind", "ro"}},
+		{Name: comp1LibDir, Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/2", Options: []string{"bind", "ro"}},
 		{Name: filepath.Join(icdDir, "mesa.json"), Dir: "/opt/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
 	})
 	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{

--- a/interfaces/builtin/egl_driver_libs_test.go
+++ b/interfaces/builtin/egl_driver_libs_test.go
@@ -85,8 +85,8 @@ slots:
     library-source:
       - $SNAP/lib1
       - ${SNAP}/lib2
-      - $SNAP_COMPONENT(comp1)/lib1
-      - $SNAP_COMPONENT(comp2)/lib2
+      - $SNAP_COMPONENT(comp1)/clib1
+      - $SNAP_COMPONENT(comp2)/clib2
 components:
   comp1:
     type: standard
@@ -282,8 +282,8 @@ func (s *EglDriverLibsInterfaceSuite) TestLdconfigSpec(c *C) {
 		{SnapName: "egl-provider", SlotName: "egl-slot"}: {
 			filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib1"),
 			filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib2"),
-			filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "egl-provider"), "lib1"),
-			filepath.Join(snap.ComponentMountDir("comp2", snap.R(22), "egl-provider"), "lib2"),
+			filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "egl-provider"), "clib1"),
+			filepath.Join(snap.ComponentMountDir("comp2", snap.R(22), "egl-provider"), "clib2"),
 		}})
 }
 
@@ -294,7 +294,7 @@ func (s *EglDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 	for _, libDir := range []string{libDir1, libDir2} {
 		c.Assert(os.MkdirAll(libDir, 0755), IsNil)
 	}
-	comp1LibDir := filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "egl-provider"), "lib1")
+	comp1LibDir := filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "egl-provider"), "clib1")
 	c.Assert(os.MkdirAll(comp1LibDir, 0755), IsNil)
 
 	// Write ICD files in egl.d and egl_alt.d (egl_empty.d contributes nothing).
@@ -321,15 +321,16 @@ func (s *EglDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
-		// Library dirs, preserving the original directory order (idx).
+		// Library dirs, pooled by path-suffix after the $SNAP/$SNAP_COMPONENT
+		// prefix (no per-index splitting).		// Library dirs, pooled by path-suffix.
 		{Name: filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib1"),
-			Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/0", Options: []string{"bind", "ro"}},
+			Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1", Options: []string{"bind", "ro"}},
 		{Name: filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib2"),
-			Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/1", Options: []string{"bind", "ro"}},
+			Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib2", Options: []string{"bind", "ro"}},
 		{Name: comp1LibDir,
-			Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/2", Options: []string{"bind", "ro"}},
-		{Name: filepath.Join(snap.ComponentMountDir("comp2", snap.R(22), "egl-provider"), "lib2"),
-			Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/3", Options: []string{"bind", "ro"}},
+			Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib1", Options: []string{"bind", "ro"}},
+		{Name: filepath.Join(snap.ComponentMountDir("comp2", snap.R(22), "egl-provider"), "clib2"),
+			Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib2", Options: []string{"bind", "ro"}},
 		// ICD files, with the classic priority-prefixed encoded names.
 		{Name: filepath.Join(dirs.SnapMountDir, "egl-provider/5/egl.d/mesa.json"),
 			Dir: "/opt/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
@@ -344,13 +345,13 @@ func (s *EglDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 			Dir: "/usr/share/glvnd/egl_vendor.d/11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
 	})
 
-	// The library dirs are collected for SNAP_LIBRARY_PATH derivation; the
-	// ICD file mounts are not library dirs.
+	// The library dirs are collected for SNAP_LIBRARY_PATH derivation (sorted);
+	// the ICD file mounts are not library dirs.
 	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
-		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/0",
-		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/1",
-		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/2",
-		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/3",
+		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib1",
+		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib2",
+		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1",
+		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib2",
 	})
 }
 
@@ -363,7 +364,7 @@ func (s *EglDriverLibsInterfaceSuite) TestMountConnectedPlugMultiComponentFilter
 
 	libDir1 := filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib1")
 	libDir2 := filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib2")
-	comp1LibDir := filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "egl-provider"), "lib1")
+	comp1LibDir := filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "egl-provider"), "clib1")
 	for _, libDir := range []string{libDir1, libDir2, comp1LibDir} {
 		c.Assert(os.MkdirAll(libDir, 0755), IsNil)
 	}
@@ -382,20 +383,20 @@ func (s *EglDriverLibsInterfaceSuite) TestMountConnectedPlugMultiComponentFilter
 	spec := &mount.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 
-	// comp2 entries are absent, but the original indices (0..2) are kept.
+	// comp2 entries are absent; remaining entries keep their pooled targets.
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
-		{Name: libDir1, Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/0", Options: []string{"bind", "ro"}},
-		{Name: libDir2, Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/1", Options: []string{"bind", "ro"}},
-		{Name: comp1LibDir, Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/2", Options: []string{"bind", "ro"}},
+		{Name: libDir1, Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1", Options: []string{"bind", "ro"}},
+		{Name: libDir2, Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib2", Options: []string{"bind", "ro"}},
+		{Name: comp1LibDir, Dir: "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib1", Options: []string{"bind", "ro"}},
 		{Name: filepath.Join(icdDir, "mesa.json"), Dir: "/opt/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
 		// Pass 2: redistribution to the loader-scanned GLVND directory.
 		{Name: "/opt/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json",
 			Dir: "/usr/share/glvnd/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
 	})
 	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
-		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/0",
-		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/1",
-		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/2",
+		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib1",
+		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1",
+		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib2",
 	})
 }
 
@@ -463,7 +464,7 @@ func (s *EglDriverLibsInterfaceSuite) TestSymlinksToComps(c *C) {
     }
 }
 `, icdData.gpu)), 0655)
-		libDir := filepath.Join(compMnt, "lib"+icdData.compSuff)
+		libDir := filepath.Join(compMnt, "clib"+icdData.compSuff)
 		c.Assert(os.MkdirAll(libDir, 0755), IsNil)
 		libPath := filepath.Join(libDir, "libEGL_"+icdData.gpu+".so.0")
 		os.WriteFile(libPath, []byte{}, 0655)
@@ -515,7 +516,7 @@ func (s *EglDriverLibsInterfaceSuite) TestSymlinksToComp2(c *C) {
     }
 }
 `, icdData.gpu)), 0655)
-		libDir := filepath.Join(compMnt, "lib"+icdData.compSuff)
+		libDir := filepath.Join(compMnt, "clib"+icdData.compSuff)
 		c.Assert(os.MkdirAll(libDir, 0755), IsNil)
 		libPath := filepath.Join(libDir, "libEGL_"+icdData.gpu+".so.0")
 		os.WriteFile(libPath, []byte{}, 0655)
@@ -568,7 +569,7 @@ func (s *EglDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 	updateNS := strings.Join(spec.UpdateNS(), "")
 	// Library dir bind.
 	lib1 := filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib1")
-	target0 := "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/0"
+	target0 := "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1"
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n", lib1, target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target0))
 
@@ -611,8 +612,8 @@ func (s *EglDriverLibsInterfaceSuite) TestConfigfilesSpec(c *C) {
 		filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/export/system_egl-provider_egl-slot_egl-driver-libs.library-source"): &osutil.MemoryFileState{
 			Content: []byte(filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib1") + "\n" +
 				filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib2") + "\n" +
-				filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "egl-provider"), "lib1") + "\n" +
-				filepath.Join(snap.ComponentMountDir("comp2", snap.R(22), "egl-provider"), "lib2") + "\n"),
+				filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "egl-provider"), "clib1") + "\n" +
+				filepath.Join(snap.ComponentMountDir("comp2", snap.R(22), "egl-provider"), "clib2") + "\n"),
 			Mode: 0644},
 	})
 }

--- a/interfaces/builtin/egl_driver_libs_test.go
+++ b/interfaces/builtin/egl_driver_libs_test.go
@@ -572,7 +572,11 @@ func (s *EglDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 
 	// The writable-mimic is authorized for the share/egl_vendor.d tree.
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  # Writable mimic %s\n", filepath.Dir(icdTarget)))
-	c.Check(spec.SnippetForTag("snap.snapd.app"), Equals, "")
+	// The app gets read access to its own assembly subtree only (the core base
+	// template does not grant /opt/** to apps).
+	app := spec.SnippetForTag("snap.snapd.app")
+	c.Check(app, testutil.Contains, "/opt/snapd/interfaces/egl-driver-libs/ r,")
+	c.Check(app, testutil.Contains, "/opt/snapd/interfaces/egl-driver-libs/** mrkix,")
 }
 
 func (s *EglDriverLibsInterfaceSuite) TestConfigfilesSpec(c *C) {

--- a/interfaces/builtin/export_test.go
+++ b/interfaces/builtin/export_test.go
@@ -37,6 +37,7 @@ var (
 	ImplicitSystemPermanentSlot = implicitSystemPermanentSlot
 	ImplicitSystemConnectedSlot = implicitSystemConnectedSlot
 	StringListAttribute         = stringListAttribute
+	DriverLibsSupported         = driverLibsSupported
 )
 
 type GbmDriverLibsInterface gbmDriverLibsInterface

--- a/interfaces/builtin/export_test.go
+++ b/interfaces/builtin/export_test.go
@@ -38,7 +38,33 @@ var (
 	ImplicitSystemConnectedSlot = implicitSystemConnectedSlot
 	StringListAttribute         = stringListAttribute
 	DriverLibsSupported         = driverLibsSupported
+
+	SourceDirEncodedName        = sourceDirEncodedName
+	MountAssemblyLibDirs        = mountAssemblyLibDirs
+	MountAssemblySourceFiles    = mountAssemblySourceFiles
+	MountAssemblyClientDriver   = mountAssemblyClientDriver
+	SymlinksForSourceDir        = symlinksForSourceDir
+	CheckEglIcdFile             = checkEglIcdFile
+	CheckVulkanIcdFile          = checkVulkanIcdFile
+	CheckVulkanLayersFile       = checkVulkanLayersFile
+	EglVendorPath               = eglVendorPath
 )
+
+// SourceDirAttr is the exported test alias for sourceDirAttr.
+type SourceDirAttr = sourceDirAttr
+
+// PathWithDirIdx is the exported test alias for pathWithDirIdx.
+type PathWithDirIdx = pathWithDirIdx
+
+// NewSourceDirAttr constructs a sourceDirAttr for tests.
+func NewSourceDirAttr(attrName string, isOptional bool) sourceDirAttr {
+	return sourceDirAttr{attrName: attrName, isOptional: isOptional}
+}
+
+// NewPathWithDirIdx constructs a pathWithDirIdx for tests.
+func NewPathWithDirIdx(path string, idx int) pathWithDirIdx {
+	return pathWithDirIdx{path: path, idx: idx}
+}
 
 type GbmDriverLibsInterface gbmDriverLibsInterface
 

--- a/interfaces/builtin/export_test.go
+++ b/interfaces/builtin/export_test.go
@@ -39,15 +39,15 @@ var (
 	StringListAttribute         = stringListAttribute
 	DriverLibsSupported         = driverLibsSupported
 
-	SourceDirEncodedName        = sourceDirEncodedName
-	MountAssemblyLibDirs        = mountAssemblyLibDirs
-	MountAssemblySourceFiles    = mountAssemblySourceFiles
-	MountAssemblyClientDriver   = mountAssemblyClientDriver
-	SymlinksForSourceDir        = symlinksForSourceDir
-	CheckEglIcdFile             = checkEglIcdFile
-	CheckVulkanIcdFile          = checkVulkanIcdFile
-	CheckVulkanLayersFile       = checkVulkanLayersFile
-	EglVendorPath               = eglVendorPath
+	SourceDirEncodedName      = sourceDirEncodedName
+	MountAssemblyLibDirs      = mountAssemblyLibDirs
+	MountAssemblySourceFiles  = mountAssemblySourceFiles
+	MountAssemblyClientDriver = mountAssemblyClientDriver
+	SymlinksForSourceDir      = symlinksForSourceDir
+	CheckEglIcdFile           = checkEglIcdFile
+	CheckVulkanIcdFile        = checkVulkanIcdFile
+	CheckVulkanLayersFile     = checkVulkanLayersFile
+	EglVendorPath             = eglVendorPath
 )
 
 // SourceDirAttr is the exported test alias for sourceDirAttr.

--- a/interfaces/builtin/gbm_driver_libs.go
+++ b/interfaces/builtin/gbm_driver_libs.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/compatibility"
 	"github.com/snapcore/snapd/interfaces/configfiles"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
+	"github.com/snapcore/snapd/interfaces/mount"
 	"github.com/snapcore/snapd/interfaces/symlinks"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/release"
@@ -121,6 +122,16 @@ func (iface *gbmDriverLibsInterface) BeforePrepareSlot(slot *snap.SlotInfo) erro
 func (iface *gbmDriverLibsInterface) LdconfigConnectedPlug(spec *ldconfig.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// The plug can only be the system plug for the time being
 	return addLdconfigLibDirs(spec, slot)
+}
+
+func (iface *gbmDriverLibsInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	// On Ubuntu Core the provider content is bound into the assembly tree under
+	// the /opt/snapd/interfaces directory (see mountAssemblyLibDirs).
+	if err := mountAssemblyLibDirs(spec, slot, gbmDriverLibs); err != nil {
+		return err
+	}
+	// The client driver is bound as a file under the share/gbm subtree.
+	return mountAssemblyClientDriver(spec, slot, gbmDriverLibs)
 }
 
 var _ = interfaces.SymlinksUser(&gbmDriverLibsInterface{})

--- a/interfaces/builtin/gbm_driver_libs.go
+++ b/interfaces/builtin/gbm_driver_libs.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/compatibility"
 	"github.com/snapcore/snapd/interfaces/configfiles"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
@@ -132,6 +133,16 @@ func (iface *gbmDriverLibsInterface) MountConnectedPlug(spec *mount.Specificatio
 	}
 	// The client driver is bound as a file under the share/gbm subtree.
 	return mountAssemblyClientDriver(spec, slot, gbmDriverLibs)
+}
+
+func (iface *gbmDriverLibsInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	// Authorize snap-update-ns to construct (and eventually tear down) the
+	// assembly tree under /opt/snapd/interfaces. The default base template
+	// already grants /opt/** mrklix to the app itself, no extra snippet needed.
+	if err := addAppArmorAssemblyLibDirs(spec, slot, gbmDriverLibs); err != nil {
+		return err
+	}
+	return addAppArmorAssemblyClientDriver(spec, slot, gbmDriverLibs)
 }
 
 var _ = interfaces.SymlinksUser(&gbmDriverLibsInterface{})

--- a/interfaces/builtin/gbm_driver_libs.go
+++ b/interfaces/builtin/gbm_driver_libs.go
@@ -67,6 +67,13 @@ type gbmDriverLibsInterface struct {
 
 var reClientDriver = regexp.MustCompile("^[-0-9a-zA-Z_.]+$").Match
 
+func (iface *gbmDriverLibsInterface) BeforePreparePlug(plug *snap.PlugInfo) error {
+	if !driverLibsSupported(plug.Snap.Base) {
+		return fmt.Errorf("%s interface is not supported on base %q", gbmDriverLibs, plug.Snap.Base)
+	}
+	return nil
+}
+
 func (iface *gbmDriverLibsInterface) BeforePrepareSlot(slot *snap.SlotInfo) error {
 	// Validate attributes
 	var clientDriver string

--- a/interfaces/builtin/gbm_driver_libs.go
+++ b/interfaces/builtin/gbm_driver_libs.go
@@ -39,15 +39,17 @@ import (
 
 const gbmDriverLibsSummary = `allows exposing GBM driver libraries to the system`
 
-// Plugs only supported for the system on classic for the moment (note this is
-// checked on "system" snap installation even though this is an implicit plug
-// in that case) - in the future we will allow snaps having this as plug and
-// this declaration will have to change.
+// Plug on classic may only be declared by the system snap (implicit plug); on
+// Ubuntu Core any snap may declare it (see allow-installation alternatives).
 const gbmDriverLibsBaseDeclarationPlugs = `
   gbm-driver-libs:
     allow-installation:
-      plug-snap-type:
-        - core
+      -
+        on-classic: true
+        plug-snap-type:
+          - core
+      -
+        on-classic: false
     allow-connection:
       slots-per-plug: *
     deny-auto-connection: true

--- a/interfaces/builtin/gbm_driver_libs.go
+++ b/interfaces/builtin/gbm_driver_libs.go
@@ -128,6 +128,9 @@ func (iface *gbmDriverLibsInterface) LdconfigConnectedPlug(spec *ldconfig.Specif
 func (iface *gbmDriverLibsInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// On Ubuntu Core the provider content is bound into the assembly tree under
 	// the /run/snapd/interfaces directory (see mountAssemblyLibDirs).
+	if err := mountAssemblyRoot(spec); err != nil {
+		return err
+	}
 	if err := mountAssemblyLibDirs(spec, slot, gbmDriverLibs); err != nil {
 		return err
 	}
@@ -140,6 +143,7 @@ func (iface *gbmDriverLibsInterface) AppArmorConnectedPlug(spec *apparmor.Specif
 	// /run/snapd/interfaces (the core base template does not grant /opt/** to
 	// apps), then authorize snap-update-ns to construct (and eventually tear
 	// down) the assembly tree.
+	addAppArmorAssemblyRoot(spec)
 	addAppArmorAssemblyAccess(spec, gbmDriverLibs)
 	// Grant read access to the loader-scanned metadata location (Pass 2).
 	addAppArmorRedistributionAccess(spec, gbmDriverLibs)

--- a/interfaces/builtin/gbm_driver_libs.go
+++ b/interfaces/builtin/gbm_driver_libs.go
@@ -136,9 +136,11 @@ func (iface *gbmDriverLibsInterface) MountConnectedPlug(spec *mount.Specificatio
 }
 
 func (iface *gbmDriverLibsInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	// Authorize snap-update-ns to construct (and eventually tear down) the
-	// assembly tree under /opt/snapd/interfaces. The default base template
-	// already grants /opt/** mrklix to the app itself, no extra snippet needed.
+	// Grant the app read access to its own assembly subtree under
+	// /opt/snapd/interfaces (the core base template does not grant /opt/** to
+	// apps), then authorize snap-update-ns to construct (and eventually tear
+	// down) the assembly tree.
+	addAppArmorAssemblyAccess(spec, gbmDriverLibs)
 	if err := addAppArmorAssemblyLibDirs(spec, slot, gbmDriverLibs); err != nil {
 		return err
 	}

--- a/interfaces/builtin/gbm_driver_libs.go
+++ b/interfaces/builtin/gbm_driver_libs.go
@@ -141,6 +141,8 @@ func (iface *gbmDriverLibsInterface) AppArmorConnectedPlug(spec *apparmor.Specif
 	// apps), then authorize snap-update-ns to construct (and eventually tear
 	// down) the assembly tree.
 	addAppArmorAssemblyAccess(spec, gbmDriverLibs)
+	// Grant read access to the loader-scanned metadata location (Pass 2).
+	addAppArmorRedistributionAccess(spec, gbmDriverLibs)
 	if err := addAppArmorAssemblyLibDirs(spec, slot, gbmDriverLibs); err != nil {
 		return err
 	}

--- a/interfaces/builtin/gbm_driver_libs.go
+++ b/interfaces/builtin/gbm_driver_libs.go
@@ -127,7 +127,7 @@ func (iface *gbmDriverLibsInterface) LdconfigConnectedPlug(spec *ldconfig.Specif
 
 func (iface *gbmDriverLibsInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// On Ubuntu Core the provider content is bound into the assembly tree under
-	// the /run/snapd/interfaces directory (see mountAssemblyLibDirs).
+	// the /run/snapd/snap/interfaces directory (see mountAssemblyLibDirs).
 	if err := mountAssemblyRoot(spec); err != nil {
 		return err
 	}
@@ -140,7 +140,7 @@ func (iface *gbmDriverLibsInterface) MountConnectedPlug(spec *mount.Specificatio
 
 func (iface *gbmDriverLibsInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// Grant the app read access to its own assembly subtree under
-	// /run/snapd/interfaces (the core base template does not grant /opt/** to
+	// /run/snapd/snap/interfaces (the core base template does not grant /opt/** to
 	// apps), then authorize snap-update-ns to construct (and eventually tear
 	// down) the assembly tree.
 	addAppArmorAssemblyRoot(spec)

--- a/interfaces/builtin/gbm_driver_libs.go
+++ b/interfaces/builtin/gbm_driver_libs.go
@@ -127,7 +127,7 @@ func (iface *gbmDriverLibsInterface) LdconfigConnectedPlug(spec *ldconfig.Specif
 
 func (iface *gbmDriverLibsInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// On Ubuntu Core the provider content is bound into the assembly tree under
-	// the /opt/snapd/interfaces directory (see mountAssemblyLibDirs).
+	// the /run/snapd/interfaces directory (see mountAssemblyLibDirs).
 	if err := mountAssemblyLibDirs(spec, slot, gbmDriverLibs); err != nil {
 		return err
 	}
@@ -137,7 +137,7 @@ func (iface *gbmDriverLibsInterface) MountConnectedPlug(spec *mount.Specificatio
 
 func (iface *gbmDriverLibsInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// Grant the app read access to its own assembly subtree under
-	// /opt/snapd/interfaces (the core base template does not grant /opt/** to
+	// /run/snapd/interfaces (the core base template does not grant /opt/** to
 	// apps), then authorize snap-update-ns to construct (and eventually tear
 	// down) the assembly tree.
 	addAppArmorAssemblyAccess(spec, gbmDriverLibs)

--- a/interfaces/builtin/gbm_driver_libs_test.go
+++ b/interfaces/builtin/gbm_driver_libs_test.go
@@ -23,11 +23,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/configfiles"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
@@ -300,6 +302,34 @@ func (s *GbmDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 		"/opt/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/0",
 		"/opt/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/1",
 	})
+}
+
+func (s *GbmDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
+	// Populate the library dirs and the client driver.
+	snapSourceDir := filepath.Join(dirs.SnapMountDir, "gbm-provider/5/lib2")
+	c.Assert(os.MkdirAll(snapSourceDir, 0755), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(snapSourceDir, "nvidia-drm_gbm.so"), []byte{}, 0644), IsNil)
+
+	spec := apparmor.NewSpecification(s.plug.AppSet())
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+
+	updateNS := strings.Join(spec.UpdateNS(), "")
+	// Library dir bind.
+	target0 := "/opt/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/0"
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n",
+		filepath.Join(dirs.SnapMountDir, "gbm-provider/5/lib1"), target0))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target0))
+
+	// Client driver file bind, keeping its original name.
+	clientSrc := filepath.Join(snapSourceDir, "nvidia-drm_gbm.so")
+	clientTarget := "/opt/snapd/interfaces/gbm-driver-libs/share/gbm/nvidia-drm_gbm.so"
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(bind) \"%s\" -> \"%s{,-[0-9]*}\",\n", clientSrc, clientTarget))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}\",\n", clientTarget))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}\",\n", clientTarget))
+
+	// The writable-mimic is authorized for the share/gbm tree.
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  # Writable mimic %s\n", filepath.Dir(clientTarget)))
+	c.Check(spec.SnippetForTag("snap.snapd.app"), Equals, "")
 }
 
 func (s *GbmDriverLibsInterfaceSuite) TestSymlinksSpec(c *C) {

--- a/interfaces/builtin/gbm_driver_libs_test.go
+++ b/interfaces/builtin/gbm_driver_libs_test.go
@@ -56,6 +56,7 @@ var _ = Suite(&GbmDriverLibsInterfaceSuite{
 // This is in fact implicit in the system
 const gbmDriverLibsConsumerYaml = `name: snapd
 version: 0
+base: core26
 plugs:
   gbm:
     interface: gbm-driver-libs
@@ -246,6 +247,24 @@ slots:
 func (s *GbmDriverLibsInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Check(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
 	c.Check(interfaces.BeforeConnectPlug(s.iface, s.plug), IsNil)
+}
+
+func (s *GbmDriverLibsInterfaceSuite) TestSanitizePlugUnsupportedBase(c *C) {
+	const consumerYaml = `name: snapd
+version: 0
+base: core24
+plugs:
+  gbm:
+    interface: gbm-driver-libs
+apps:
+  app:
+    plugs: [gbm]
+`
+	plug, plugInfo := MockConnectedPlug(c, consumerYaml,
+		&snap.SideInfo{Revision: snap.R(3)}, "gbm")
+	c.Check(interfaces.BeforeConnectPlug(s.iface, plug), IsNil)
+	c.Check(interfaces.BeforePreparePlug(s.iface, plugInfo), ErrorMatches,
+		`gbm-driver-libs interface is not supported on base "core24"`)
 }
 
 func (s *GbmDriverLibsInterfaceSuite) TestLdconfigSpec(c *C) {

--- a/interfaces/builtin/gbm_driver_libs_test.go
+++ b/interfaces/builtin/gbm_driver_libs_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/configfiles"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
+	"github.com/snapcore/snapd/interfaces/mount"
 	"github.com/snapcore/snapd/interfaces/symlinks"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
@@ -274,6 +275,31 @@ func (s *GbmDriverLibsInterfaceSuite) TestLdconfigSpec(c *C) {
 		{SnapName: "gbm-provider", SlotName: "gbm-slot"}: {
 			filepath.Join(dirs.SnapMountDir, "gbm-provider/5/lib1"),
 			filepath.Join(dirs.SnapMountDir, "gbm-provider/5/lib2")}})
+}
+
+func (s *GbmDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
+	// Populate the library dirs and the client driver.
+	snapSourceDir := filepath.Join(dirs.SnapMountDir, "gbm-provider/5/lib2")
+	c.Assert(os.MkdirAll(snapSourceDir, 0755), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(snapSourceDir, "nvidia-drm_gbm.so"), []byte{}, 0644), IsNil)
+
+	spec := &mount.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+
+	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
+		// Library dirs.
+		{Name: filepath.Join(dirs.SnapMountDir, "gbm-provider/5/lib1"),
+			Dir: "/opt/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/0", Options: []string{"rbind", "ro"}},
+		{Name: filepath.Join(dirs.SnapMountDir, "gbm-provider/5/lib2"),
+			Dir: "/opt/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/1", Options: []string{"rbind", "ro"}},
+		// Client driver bound as a file, keeping its original name.
+		{Name: filepath.Join(snapSourceDir, "nvidia-drm_gbm.so"),
+			Dir: "/opt/snapd/interfaces/gbm-driver-libs/share/gbm/nvidia-drm_gbm.so", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+	})
+	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
+		"/opt/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/0",
+		"/opt/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/1",
+	})
 }
 
 func (s *GbmDriverLibsInterfaceSuite) TestSymlinksSpec(c *C) {

--- a/interfaces/builtin/gbm_driver_libs_test.go
+++ b/interfaces/builtin/gbm_driver_libs_test.go
@@ -320,14 +320,14 @@ func (s *GbmDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 	updateNS := strings.Join(spec.UpdateNS(), "")
 	// Library dir bind.
 	target0 := "/opt/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/lib1"
-	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n",
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(rw, bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n",
 		filepath.Join(dirs.SnapMountDir, "gbm-provider/5/lib1"), target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target0))
 
 	// Client driver file bind, keeping its original name.
 	clientSrc := filepath.Join(snapSourceDir, "nvidia-drm_gbm.so")
 	clientTarget := "/opt/snapd/interfaces/gbm-driver-libs/share/gbm/nvidia-drm_gbm.so"
-	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(bind) \"%s\" -> \"%s{,-[0-9]*}\",\n", clientSrc, clientTarget))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(rw, bind) \"%s\" -> \"%s{,-[0-9]*}\",\n", clientSrc, clientTarget))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}\",\n", clientTarget))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}\",\n", clientTarget))
 
@@ -335,7 +335,7 @@ func (s *GbmDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 	// directory, re-binding the assembly target.
 	clientLoaderTarget := fmt.Sprintf("/usr/lib/%s-linux-gnu/gbm/nvidia-drm_gbm.so", osutil.MachineName())
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  # Driver-libs redistribution %s -> %s\n", clientTarget, clientLoaderTarget))
-	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(bind) \"%s\" -> \"%s{,-[0-9]*}\",\n", clientTarget, clientLoaderTarget))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(rw, bind) \"%s\" -> \"%s{,-[0-9]*}\",\n", clientTarget, clientLoaderTarget))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}\",\n", clientLoaderTarget))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}\",\n", clientLoaderTarget))
 

--- a/interfaces/builtin/gbm_driver_libs_test.go
+++ b/interfaces/builtin/gbm_driver_libs_test.go
@@ -297,6 +297,10 @@ func (s *GbmDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 		// Client driver bound as a file, keeping its original name.
 		{Name: filepath.Join(snapSourceDir, "nvidia-drm_gbm.so"),
 			Dir: "/opt/snapd/interfaces/gbm-driver-libs/share/gbm/nvidia-drm_gbm.so", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+		// Pass 2: redistribution to the loader-scanned GBM directory, re-binding
+		// the assembly target above.
+		{Name: "/opt/snapd/interfaces/gbm-driver-libs/share/gbm/nvidia-drm_gbm.so",
+			Dir: fmt.Sprintf("/usr/lib/%s-linux-gnu/gbm/nvidia-drm_gbm.so", osutil.MachineName()), Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
 	})
 	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
 		"/opt/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/0",
@@ -327,13 +331,25 @@ func (s *GbmDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}\",\n", clientTarget))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}\",\n", clientTarget))
 
+	// Pass 2: redistribution authorization for the loader-scanned GBM
+	// directory, re-binding the assembly target.
+	clientLoaderTarget := fmt.Sprintf("/usr/lib/%s-linux-gnu/gbm/nvidia-drm_gbm.so", osutil.MachineName())
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  # Driver-libs redistribution %s -> %s\n", clientTarget, clientLoaderTarget))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(bind) \"%s\" -> \"%s{,-[0-9]*}\",\n", clientTarget, clientLoaderTarget))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}\",\n", clientLoaderTarget))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}\",\n", clientLoaderTarget))
+
 	// The writable-mimic is authorized for the share/gbm tree.
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  # Writable mimic %s\n", filepath.Dir(clientTarget)))
+	// The writable-mimic is authorized for the loader-scanned gbm dir too.
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  # Writable mimic %s\n", filepath.Dir(clientLoaderTarget)))
 	// The app gets read access to its own assembly subtree only (the core base
-	// template does not grant /opt/** to apps).
+	// template does not grant /opt/** to apps), plus the loader-scanned GBM
+	// subtree for Pass 2 redistribution.
 	app := spec.SnippetForTag("snap.snapd.app")
 	c.Check(app, testutil.Contains, "/opt/snapd/interfaces/gbm-driver-libs/ r,")
 	c.Check(app, testutil.Contains, "/opt/snapd/interfaces/gbm-driver-libs/** mrkix,")
+	c.Check(app, testutil.Contains, "/usr/lib/@{multiarch}/gbm/{,**} r,")
 }
 
 func (s *GbmDriverLibsInterfaceSuite) TestSymlinksSpec(c *C) {

--- a/interfaces/builtin/gbm_driver_libs_test.go
+++ b/interfaces/builtin/gbm_driver_libs_test.go
@@ -291,9 +291,9 @@ func (s *GbmDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
 		// Library dirs.
 		{Name: filepath.Join(dirs.SnapMountDir, "gbm-provider/5/lib1"),
-			Dir: "/opt/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/0", Options: []string{"bind", "ro"}},
+			Dir: "/opt/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/lib1", Options: []string{"bind", "ro"}},
 		{Name: filepath.Join(dirs.SnapMountDir, "gbm-provider/5/lib2"),
-			Dir: "/opt/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/1", Options: []string{"bind", "ro"}},
+			Dir: "/opt/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/lib2", Options: []string{"bind", "ro"}},
 		// Client driver bound as a file, keeping its original name.
 		{Name: filepath.Join(snapSourceDir, "nvidia-drm_gbm.so"),
 			Dir: "/opt/snapd/interfaces/gbm-driver-libs/share/gbm/nvidia-drm_gbm.so", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
@@ -303,8 +303,8 @@ func (s *GbmDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 			Dir: fmt.Sprintf("/usr/lib/%s-linux-gnu/gbm/nvidia-drm_gbm.so", osutil.MachineName()), Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
 	})
 	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
-		"/opt/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/0",
-		"/opt/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/1",
+		"/opt/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/lib1",
+		"/opt/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/lib2",
 	})
 }
 
@@ -319,7 +319,7 @@ func (s *GbmDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 
 	updateNS := strings.Join(spec.UpdateNS(), "")
 	// Library dir bind.
-	target0 := "/opt/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/0"
+	target0 := "/opt/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/lib1"
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n",
 		filepath.Join(dirs.SnapMountDir, "gbm-provider/5/lib1"), target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target0))

--- a/interfaces/builtin/gbm_driver_libs_test.go
+++ b/interfaces/builtin/gbm_driver_libs_test.go
@@ -289,6 +289,9 @@ func (s *GbmDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
+		// The shared tmpfs mount at the assembly root, so that only the bare
+		// mountpoint directory (not the assembly tree content) is host-visible.
+		{Name: "tmpfs", Dir: "/run/snapd/interfaces", Type: "tmpfs", Options: []string{"mode=0755", "uid=0", "gid=0"}},
 		// Library dirs.
 		{Name: filepath.Join(dirs.SnapMountDir, "gbm-provider/5/lib1"),
 			Dir: "/run/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/lib1", Options: []string{"bind", "ro"}},

--- a/interfaces/builtin/gbm_driver_libs_test.go
+++ b/interfaces/builtin/gbm_driver_libs_test.go
@@ -291,20 +291,20 @@ func (s *GbmDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
 		// Library dirs.
 		{Name: filepath.Join(dirs.SnapMountDir, "gbm-provider/5/lib1"),
-			Dir: "/opt/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/lib1", Options: []string{"bind", "ro"}},
+			Dir: "/run/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/lib1", Options: []string{"bind", "ro"}},
 		{Name: filepath.Join(dirs.SnapMountDir, "gbm-provider/5/lib2"),
-			Dir: "/opt/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/lib2", Options: []string{"bind", "ro"}},
+			Dir: "/run/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/lib2", Options: []string{"bind", "ro"}},
 		// Client driver bound as a file, keeping its original name.
 		{Name: filepath.Join(snapSourceDir, "nvidia-drm_gbm.so"),
-			Dir: "/opt/snapd/interfaces/gbm-driver-libs/share/gbm/nvidia-drm_gbm.so", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+			Dir: "/run/snapd/interfaces/gbm-driver-libs/share/gbm/nvidia-drm_gbm.so", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
 		// Pass 2: redistribution to the loader-scanned GBM directory, re-binding
 		// the assembly target above.
-		{Name: "/opt/snapd/interfaces/gbm-driver-libs/share/gbm/nvidia-drm_gbm.so",
+		{Name: "/run/snapd/interfaces/gbm-driver-libs/share/gbm/nvidia-drm_gbm.so",
 			Dir: fmt.Sprintf("/usr/lib/%s-linux-gnu/gbm/nvidia-drm_gbm.so", osutil.MachineName()), Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
 	})
 	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
-		"/opt/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/lib1",
-		"/opt/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/lib2",
+		"/run/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/lib1",
+		"/run/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/lib2",
 	})
 }
 
@@ -319,14 +319,14 @@ func (s *GbmDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 
 	updateNS := strings.Join(spec.UpdateNS(), "")
 	// Library dir bind.
-	target0 := "/opt/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/lib1"
+	target0 := "/run/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/lib1"
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(rw, bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n",
 		filepath.Join(dirs.SnapMountDir, "gbm-provider/5/lib1"), target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target0))
 
 	// Client driver file bind, keeping its original name.
 	clientSrc := filepath.Join(snapSourceDir, "nvidia-drm_gbm.so")
-	clientTarget := "/opt/snapd/interfaces/gbm-driver-libs/share/gbm/nvidia-drm_gbm.so"
+	clientTarget := "/run/snapd/interfaces/gbm-driver-libs/share/gbm/nvidia-drm_gbm.so"
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(rw, bind) \"%s\" -> \"%s{,-[0-9]*}\",\n", clientSrc, clientTarget))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}\",\n", clientTarget))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}\",\n", clientTarget))
@@ -347,8 +347,8 @@ func (s *GbmDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 	// template does not grant /opt/** to apps), plus the loader-scanned GBM
 	// subtree for Pass 2 redistribution.
 	app := spec.SnippetForTag("snap.snapd.app")
-	c.Check(app, testutil.Contains, "/opt/snapd/interfaces/gbm-driver-libs/ r,")
-	c.Check(app, testutil.Contains, "/opt/snapd/interfaces/gbm-driver-libs/** mrkix,")
+	c.Check(app, testutil.Contains, "/run/snapd/interfaces/gbm-driver-libs/ r,")
+	c.Check(app, testutil.Contains, "/run/snapd/interfaces/gbm-driver-libs/** mrkix,")
 	c.Check(app, testutil.Contains, "/usr/lib/@{multiarch}/gbm/{,**} r,")
 }
 

--- a/interfaces/builtin/gbm_driver_libs_test.go
+++ b/interfaces/builtin/gbm_driver_libs_test.go
@@ -294,16 +294,16 @@ func (s *GbmDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 		{Name: "tmpfs", Dir: "/run/snapd/interfaces", Type: "tmpfs", Options: []string{"mode=0755", "uid=0", "gid=0"}},
 		// Library dirs.
 		{Name: filepath.Join(dirs.SnapMountDir, "gbm-provider/5/lib1"),
-			Dir: "/run/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/lib1", Options: []string{"bind", "ro"}},
+			Dir: "/run/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/lib1", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
 		{Name: filepath.Join(dirs.SnapMountDir, "gbm-provider/5/lib2"),
-			Dir: "/run/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/lib2", Options: []string{"bind", "ro"}},
+			Dir: "/run/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/lib2", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
 		// Client driver bound as a file, keeping its original name.
 		{Name: filepath.Join(snapSourceDir, "nvidia-drm_gbm.so"),
-			Dir: "/run/snapd/interfaces/gbm-driver-libs/share/gbm/nvidia-drm_gbm.so", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+			Dir: "/run/snapd/interfaces/gbm-driver-libs/share/gbm/nvidia-drm_gbm.so", Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
 		// Pass 2: redistribution to the loader-scanned GBM directory, re-binding
 		// the assembly target above.
 		{Name: "/run/snapd/interfaces/gbm-driver-libs/share/gbm/nvidia-drm_gbm.so",
-			Dir: fmt.Sprintf("/usr/lib/%s-linux-gnu/gbm/nvidia-drm_gbm.so", osutil.MachineName()), Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+			Dir: fmt.Sprintf("/usr/lib/%s-linux-gnu/gbm/nvidia-drm_gbm.so", osutil.MachineName()), Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
 	})
 	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
 		"/run/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/lib1",

--- a/interfaces/builtin/gbm_driver_libs_test.go
+++ b/interfaces/builtin/gbm_driver_libs_test.go
@@ -291,23 +291,23 @@ func (s *GbmDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
 		// The shared tmpfs mount at the assembly root, so that only the bare
 		// mountpoint directory (not the assembly tree content) is host-visible.
-		{Name: "tmpfs", Dir: "/run/snapd/interfaces", Type: "tmpfs", Options: []string{"mode=0755", "uid=0", "gid=0"}},
+		{Name: "tmpfs", Dir: "/run/snapd/snap", Type: "tmpfs", Options: []string{"mode=0755", "uid=0", "gid=0"}},
 		// Library dirs.
 		{Name: filepath.Join(dirs.SnapMountDir, "gbm-provider/5/lib1"),
-			Dir: "/run/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/lib1", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
+			Dir: "/run/snapd/snap/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/lib1", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
 		{Name: filepath.Join(dirs.SnapMountDir, "gbm-provider/5/lib2"),
-			Dir: "/run/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/lib2", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
+			Dir: "/run/snapd/snap/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/lib2", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
 		// Client driver bound as a file, keeping its original name.
 		{Name: filepath.Join(snapSourceDir, "nvidia-drm_gbm.so"),
-			Dir: "/run/snapd/interfaces/gbm-driver-libs/share/gbm/nvidia-drm_gbm.so", Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
+			Dir: "/run/snapd/snap/interfaces/gbm-driver-libs/share/gbm/nvidia-drm_gbm.so", Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
 		// Pass 2: redistribution to the loader-scanned GBM directory, re-binding
 		// the assembly target above.
-		{Name: "/run/snapd/interfaces/gbm-driver-libs/share/gbm/nvidia-drm_gbm.so",
+		{Name: "/run/snapd/snap/interfaces/gbm-driver-libs/share/gbm/nvidia-drm_gbm.so",
 			Dir: fmt.Sprintf("/usr/lib/%s-linux-gnu/gbm/nvidia-drm_gbm.so", osutil.MachineName()), Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
 	})
 	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
-		"/run/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/lib1",
-		"/run/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/lib2",
+		"/run/snapd/snap/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/lib1",
+		"/run/snapd/snap/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/lib2",
 	})
 }
 
@@ -322,14 +322,14 @@ func (s *GbmDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 
 	updateNS := strings.Join(spec.UpdateNS(), "")
 	// Library dir bind.
-	target0 := "/run/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/lib1"
+	target0 := "/run/snapd/snap/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/lib1"
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(rw, bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n",
 		filepath.Join(dirs.SnapMountDir, "gbm-provider/5/lib1"), target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target0))
 
 	// Client driver file bind, keeping its original name.
 	clientSrc := filepath.Join(snapSourceDir, "nvidia-drm_gbm.so")
-	clientTarget := "/run/snapd/interfaces/gbm-driver-libs/share/gbm/nvidia-drm_gbm.so"
+	clientTarget := "/run/snapd/snap/interfaces/gbm-driver-libs/share/gbm/nvidia-drm_gbm.so"
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(rw, bind) \"%s\" -> \"%s{,-[0-9]*}\",\n", clientSrc, clientTarget))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}\",\n", clientTarget))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}\",\n", clientTarget))
@@ -350,8 +350,8 @@ func (s *GbmDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 	// template does not grant /opt/** to apps), plus the loader-scanned GBM
 	// subtree for Pass 2 redistribution.
 	app := spec.SnippetForTag("snap.snapd.app")
-	c.Check(app, testutil.Contains, "/run/snapd/interfaces/gbm-driver-libs/ r,")
-	c.Check(app, testutil.Contains, "/run/snapd/interfaces/gbm-driver-libs/** mrkix,")
+	c.Check(app, testutil.Contains, "/run/snapd/snap/interfaces/gbm-driver-libs/ r,")
+	c.Check(app, testutil.Contains, "/run/snapd/snap/interfaces/gbm-driver-libs/** mrkix,")
 	c.Check(app, testutil.Contains, "/usr/lib/@{multiarch}/gbm/{,**} r,")
 }
 

--- a/interfaces/builtin/gbm_driver_libs_test.go
+++ b/interfaces/builtin/gbm_driver_libs_test.go
@@ -291,9 +291,9 @@ func (s *GbmDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
 		// Library dirs.
 		{Name: filepath.Join(dirs.SnapMountDir, "gbm-provider/5/lib1"),
-			Dir: "/opt/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/0", Options: []string{"rbind", "ro"}},
+			Dir: "/opt/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/0", Options: []string{"bind", "ro"}},
 		{Name: filepath.Join(dirs.SnapMountDir, "gbm-provider/5/lib2"),
-			Dir: "/opt/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/1", Options: []string{"rbind", "ro"}},
+			Dir: "/opt/snapd/interfaces/gbm-driver-libs/lib/gbm-provider_gbm-slot/1", Options: []string{"bind", "ro"}},
 		// Client driver bound as a file, keeping its original name.
 		{Name: filepath.Join(snapSourceDir, "nvidia-drm_gbm.so"),
 			Dir: "/opt/snapd/interfaces/gbm-driver-libs/share/gbm/nvidia-drm_gbm.so", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},

--- a/interfaces/builtin/gbm_driver_libs_test.go
+++ b/interfaces/builtin/gbm_driver_libs_test.go
@@ -329,7 +329,11 @@ func (s *GbmDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 
 	// The writable-mimic is authorized for the share/gbm tree.
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  # Writable mimic %s\n", filepath.Dir(clientTarget)))
-	c.Check(spec.SnippetForTag("snap.snapd.app"), Equals, "")
+	// The app gets read access to its own assembly subtree only (the core base
+	// template does not grant /opt/** to apps).
+	app := spec.SnippetForTag("snap.snapd.app")
+	c.Check(app, testutil.Contains, "/opt/snapd/interfaces/gbm-driver-libs/ r,")
+	c.Check(app, testutil.Contains, "/opt/snapd/interfaces/gbm-driver-libs/** mrkix,")
 }
 
 func (s *GbmDriverLibsInterfaceSuite) TestSymlinksSpec(c *C) {

--- a/interfaces/builtin/helpers.go
+++ b/interfaces/builtin/helpers.go
@@ -37,6 +37,20 @@ import (
 	"github.com/snapcore/snapd/systemd"
 )
 
+// driverLibsSupported reports whether driver-libs interfaces are supported
+// on snaps using the given base snap. The direct-connection delivery model
+// requires a base snap new enough to carry the expected ld.so.cache layout.
+func driverLibsSupported(baseSnap string) bool {
+	switch baseSnap {
+	case "bare": // not yet
+	case "", "core", "core18", "core20", "core22", "core24": // TBD
+	case "core22-desktop", "core24-desktop": // TBD
+	default:
+		return true
+	}
+	return false
+}
+
 // sourceDirAttr contains information about a *-source interface attribute.
 type sourceDirAttr struct {
 	// attribute naem

--- a/interfaces/builtin/helpers.go
+++ b/interfaces/builtin/helpers.go
@@ -25,12 +25,14 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/configfiles"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
+	"github.com/snapcore/snapd/interfaces/mount"
 	"github.com/snapcore/snapd/interfaces/symlinks"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
@@ -230,6 +232,148 @@ func sourceDirFilesCheck(slot *interfaces.ConnectedSlot, sourceDir string, check
 	return checked, nil
 }
 
+// assemblyRoot is the top-level directory under which the content of driver-libs
+// provider slots is bound into the consumer's view, one subtree per interface.
+// Libraries are bound under <assemblyRoot>/<iface>/lib/ and ICD/layer/client
+// driver metadata under <assemblyRoot>/<iface>/share/. The writable-mimic for
+// these paths is authorized via the snap-update-ns apparmor profile, see
+// AppArmorConnectedPlug of the driver-libs interfaces.
+const assemblyRoot = "/opt/snapd/interfaces"
+
+// sourceDirEncodedName returns the escaped name used to refer to a file found
+// in a *-source attribute of a driver-libs slot, in the export/assembly
+// directories. The name is derived from the snap/component instance name, the
+// slot name and the relative path of the file; when withPriority is set, it is
+// prefixed with the priority attribute plus the index of the source directory
+// in the *-source list, which determines lookup order.
+func sourceDirEncodedName(slot *interfaces.ConnectedSlot, pathDirIdx pathWithDirIdx, withPriority bool) (string, error) {
+	// First strip out mount dir
+	relPath, err := filepath.Rel(dirs.SnapMountDir, pathDirIdx.path)
+	if err != nil {
+		return "", err
+	}
+
+	// If path is in the snap, we ignore below the snap name and revision
+	// when building the name, if in component, we ignore
+	// <snap_name>/components/mnt/<comp_name>/<comp_rev>/ (5 dirs)
+	instance := slot.Snap().InstanceName()
+	splitNum := 3
+	compSuffix := ""
+	if strings.HasPrefix(pathDirIdx.path, snap.ComponentsBaseDir(instance)) {
+		splitNum = 6
+		compSuffix = "+"
+	}
+	dirs := strings.SplitN(relPath, "/", splitNum)
+	if len(dirs) < splitNum {
+		return "", fmt.Errorf("internal error: wrong file path: %s", relPath)
+	}
+	if compSuffix != "" {
+		compSuffix += dirs[3]
+	}
+
+	// Get last component from dirs and make path an easier to handle name
+	escapedRelPath := systemd.EscapeUnitNamePath(dirs[splitNum-1])
+	prefix := ""
+	if withPriority {
+		var priority int64
+		if err := slot.Attr("priority", &priority); err != nil {
+			return "", fmt.Errorf("invalid priority: %w", err)
+		}
+		// The priority depends on the list order of the directories
+		// in the *-source attribute.
+		prefix = fmt.Sprintf("%d_", priority+int64(pathDirIdx.idx))
+	}
+	return fmt.Sprintf("%ssnap_%s%s_%s_%s",
+		prefix, instance, compSuffix, slot.Name(), escapedRelPath), nil
+}
+
+// mountAssemblyLibDirs adds mount entries that bind each expanded library-source
+// directory of the slot into the per-interface assembly tree under
+// <assemblyRoot>/<iface>/lib/<provider>_<slot>/<idx>/, so that the libraries
+// keep their original file names (ld.so opens libraries by exact name). Each
+// target dir is also recorded via AddLibraryPathDir for the SNAP_LIBRARY_PATH
+// derivation (Pass 3).
+func mountAssemblyLibDirs(spec *mount.Specification, slot *interfaces.ConnectedSlot, ifaceName string) error {
+	libDirs := []string{}
+	if err := slot.Attr("library-source", &libDirs); err != nil {
+		return err
+	}
+
+	providerSlot := slot.Snap().InstanceName() + "_" + slot.Name()
+	expanded := slot.AppSet().ExpandSliceSnapVariablesWithOrder(libDirs)
+	for _, dir := range expanded {
+		target := filepath.Join(assemblyRoot, ifaceName, "lib", providerSlot, strconv.Itoa(dir.Idx))
+		if err := spec.AddMountEntry(osutil.MountEntry{
+			Name:    dir.Path,
+			Dir:     target,
+			Options: []string{"rbind", "ro"},
+		}); err != nil {
+			return err
+		}
+		spec.AddLibraryPathDir(target)
+	}
+	return nil
+}
+
+// mountAssemblySourceFiles mounts each source file found by sourceDirsCheck in
+// the sda attribute (icd-source / *-layer-source) as a read-only file bind into
+// the per-interface assembly tree under
+// <assemblyRoot>/<iface>/share/<subdir>/, using the very same encoded file
+// names as the classic symlinks (sourceDirEncodedName).
+func mountAssemblySourceFiles(
+	spec *mount.Specification, slot *interfaces.ConnectedSlot, ifaceName string,
+	sda sourceDirAttr, subdir string,
+	checker func(slot *interfaces.ConnectedSlot, content []byte) error,
+	withPriority bool,
+) error {
+	if withPriority {
+		var priority int64
+		if err := slot.Attr("priority", &priority); err != nil {
+			return fmt.Errorf("invalid priority: %w", err)
+		}
+	}
+
+	sourcePaths, err := sourceDirsCheck(slot, sda, checker)
+	if err != nil {
+		return fmt.Errorf("invalid %s: %w", sda.attrName, err)
+	}
+
+	for _, pathDirIdx := range sourcePaths {
+		encodedName, err := sourceDirEncodedName(slot, pathDirIdx, withPriority)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(assemblyRoot, ifaceName, "share", subdir, encodedName)
+		if err := spec.AddMountEntry(osutil.MountEntry{
+			Name:    pathDirIdx.path,
+			Dir:     target,
+			Options: []string{"bind", "ro", osutil.XSnapdKindFile()},
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// mountAssemblyClientDriver binds the client-driver library of the gbm slot as a
+// file into <assemblyRoot>/<iface>/share/gbm/, keeping its original file name.
+func mountAssemblyClientDriver(spec *mount.Specification, slot *interfaces.ConnectedSlot, ifaceName string) error {
+	var clientDriver string
+	if err := slot.Attr("client-driver", &clientDriver); err != nil {
+		return fmt.Errorf("invalid client-driver: %w", err)
+	}
+	path, err := filePathInLibDirs(slot, clientDriver)
+	if err != nil {
+		return err
+	}
+	target := filepath.Join(assemblyRoot, ifaceName, "share", "gbm", clientDriver)
+	return spec.AddMountEntry(osutil.MountEntry{
+		Name:    path,
+		Dir:     target,
+		Options: []string{"bind", "ro", osutil.XSnapdKindFile()},
+	})
+}
+
 // symlinksForSourceDir adds symlinks to be created in targetDir to spec, for the
 // files in the directories found in the sda attribute of slot. The checker function
 // function ensures that the files we are going to point to have the right content.
@@ -242,8 +386,8 @@ func symlinksForSourceDir(
 	checker func(slot *interfaces.ConnectedSlot, content []byte) error,
 	withPriority bool,
 ) error {
-	var priority int64
 	if withPriority {
+		var priority int64
 		if err := slot.Attr("priority", &priority); err != nil {
 			return fmt.Errorf("invalid priority: %w", err)
 		}
@@ -256,40 +400,11 @@ func symlinksForSourceDir(
 
 	// Create symlinks to snap content (which is fine as this is for super-privileged slots)
 	for _, pathDirIdx := range sourcePaths {
-		// First strip out mount dir
-		relPath, err := filepath.Rel(dirs.SnapMountDir, pathDirIdx.path)
+		encodedName, err := sourceDirEncodedName(slot, pathDirIdx, withPriority)
 		if err != nil {
 			return err
 		}
-
-		// If path is in the snap, we ignore below the snap name and revision
-		// when building the symlink name, if in component, we ignore
-		// <snap_name>/components/mnt/<comp_name>/<comp_rev>/ (5 dirs)
-		instance := slot.Snap().InstanceName()
-		splitNum := 3
-		compSuffix := ""
-		if strings.HasPrefix(pathDirIdx.path, snap.ComponentsBaseDir(instance)) {
-			splitNum = 6
-			compSuffix = "+"
-		}
-		dirs := strings.SplitN(relPath, "/", splitNum)
-		if len(dirs) < splitNum {
-			return fmt.Errorf("internal error: wrong file path: %s", relPath)
-		}
-		if compSuffix != "" {
-			compSuffix += dirs[3]
-		}
-
-		// Get last component from dirs and make path an easier to handle name
-		escapedRelPath := systemd.EscapeUnitNamePath(dirs[splitNum-1])
-		prefix := ""
-		if withPriority {
-			// The priority depends on the list order of the directories
-			// in the *-source attribute.
-			prefix = fmt.Sprintf("%d_", priority+int64(pathDirIdx.idx))
-		}
-		linkPath := filepath.Join(targetDir, fmt.Sprintf("%ssnap_%s%s_%s_%s",
-			prefix, instance, compSuffix, slot.Name(), escapedRelPath))
+		linkPath := filepath.Join(targetDir, encodedName)
 		if err := spec.AddSymlink(pathDirIdx.path, linkPath); err != nil {
 			return err
 		}

--- a/interfaces/builtin/helpers.go
+++ b/interfaces/builtin/helpers.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/configfiles"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
 	"github.com/snapcore/snapd/interfaces/mount"
@@ -372,6 +373,103 @@ func mountAssemblyClientDriver(spec *mount.Specification, slot *interfaces.Conne
 		Dir:     target,
 		Options: []string{"bind", "ro", osutil.XSnapdKindFile()},
 	})
+}
+
+// assemblyAppArmorEntry emits the snap-update-ns apparmor rules authorizing a
+// read-only bind of source into target inside the snap-update-ns mount
+// namespace, following the pattern used by the content interface (see
+// content.go). The {,-[0-9]*} suffix grants the same permissions to the
+// unclash-renamed targets (-2, -3, ...). isDir selects the directory vs file
+// bind variant (trailing slashes and directory semantics).
+func assemblyAppArmorEntry(emit func(f string, args ...any), source, target string, isDir bool) {
+	if isDir {
+		emit("  mount options=(bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n", source, target)
+		emit("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target)
+		emit("  mount options=(rprivate) -> \"%s{,-[0-9]*}/\",\n", target)
+		emit("  umount \"%s{,-[0-9]*}/\",\n", target)
+	} else {
+		emit("  mount options=(bind) \"%s\" -> \"%s{,-[0-9]*}\",\n", source, target)
+		emit("  remount options=(bind, ro) \"%s{,-[0-9]*}\",\n", target)
+		emit("  mount options=(rprivate) -> \"%s{,-[0-9]*}\",\n", target)
+		emit("  umount \"%s{,-[0-9]*}\",\n", target)
+	}
+	// Authorize snap-update-ns to construct the writable-mimic of the target
+	// (and of any unclash-renamed variant) at runtime; the mimic scope itself
+	// is decided by snap-update-ns.
+	apparmor.GenWritableProfile(emit, target, 1)
+	apparmor.GenWritableProfile(emit, fmt.Sprintf("%s-[0-9]*", target), 1)
+}
+
+// addAppArmorAssemblyLibDirs emits the snap-update-ns apparmor rules for the
+// library dirs bound into the assembly tree (see mountAssemblyLibDirs for the
+// mount side).
+func addAppArmorAssemblyLibDirs(spec *apparmor.Specification, slot *interfaces.ConnectedSlot, ifaceName string) error {
+	libDirs := []string{}
+	if err := slot.Attr("library-source", &libDirs); err != nil {
+		return err
+	}
+
+	providerSlot := slot.Snap().InstanceName() + "_" + slot.Name()
+	emit := spec.AddUpdateNSf
+	expanded := slot.AppSet().ExpandSliceSnapVariablesWithOrder(libDirs)
+	for _, dir := range expanded {
+		target := filepath.Join(assemblyRoot, ifaceName, "lib", providerSlot, strconv.Itoa(dir.Idx))
+		emit("  # Driver-libs assembly library dir %s\n", target)
+		assemblyAppArmorEntry(emit, dir.Path, target, true)
+	}
+	return nil
+}
+
+// addAppArmorAssemblySourceFiles emits the snap-update-ns apparmor rules for the
+// metadata source files (icd-source / *-layer-source) bound into the assembly
+// tree (see mountAssemblySourceFiles for the mount side).
+func addAppArmorAssemblySourceFiles(
+	spec *apparmor.Specification, slot *interfaces.ConnectedSlot, ifaceName string,
+	sda sourceDirAttr, subdir string,
+	checker func(slot *interfaces.ConnectedSlot, content []byte) error,
+	withPriority bool,
+) error {
+	if withPriority {
+		var priority int64
+		if err := slot.Attr("priority", &priority); err != nil {
+			return fmt.Errorf("invalid priority: %w", err)
+		}
+	}
+
+	sourcePaths, err := sourceDirsCheck(slot, sda, checker)
+	if err != nil {
+		return fmt.Errorf("invalid %s: %w", sda.attrName, err)
+	}
+
+	emit := spec.AddUpdateNSf
+	for _, pathDirIdx := range sourcePaths {
+		encodedName, err := sourceDirEncodedName(slot, pathDirIdx, withPriority)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(assemblyRoot, ifaceName, "share", subdir, encodedName)
+		emit("  # Driver-libs assembly metadata file %s\n", target)
+		assemblyAppArmorEntry(emit, pathDirIdx.path, target, false)
+	}
+	return nil
+}
+
+// addAppArmorAssemblyClientDriver emits the snap-update-ns apparmor rules for
+// the gbm client-driver file bound into the assembly tree (see
+// mountAssemblyClientDriver for the mount side).
+func addAppArmorAssemblyClientDriver(spec *apparmor.Specification, slot *interfaces.ConnectedSlot, ifaceName string) error {
+	var clientDriver string
+	if err := slot.Attr("client-driver", &clientDriver); err != nil {
+		return fmt.Errorf("invalid client-driver: %w", err)
+	}
+	path, err := filePathInLibDirs(slot, clientDriver)
+	if err != nil {
+		return err
+	}
+	target := filepath.Join(assemblyRoot, ifaceName, "share", "gbm", clientDriver)
+	spec.AddUpdateNSf("  # Driver-libs assembly client driver %s\n", target)
+	assemblyAppArmorEntry(spec.AddUpdateNSf, path, target, false)
+	return nil
 }
 
 // symlinksForSourceDir adds symlinks to be created in targetDir to spec, for the

--- a/interfaces/builtin/helpers.go
+++ b/interfaces/builtin/helpers.go
@@ -444,6 +444,22 @@ func assemblyAppArmorEntry(emit func(f string, args ...any), source, target stri
 	apparmor.GenWritableProfile(emit, fmt.Sprintf("%s-[0-9]*", target), 1)
 }
 
+// addAppArmorRedistributionAccess grants the application read access to the
+// loader-scanned system locations where Pass 2 redistributes this interface's
+// metadata, so the in-process loaders (Vulkan/GLVND/GBM) can discover the ICDs
+// and layers env-free. Only the specific subtrees the interface populates are
+// granted (least privilege, per-interface).
+func addAppArmorRedistributionAccess(spec *apparmor.Specification, ifaceName string) {
+	switch ifaceName {
+	case eglDriverLibs:
+		spec.AddSnippet("  /usr/share/glvnd/egl_vendor.d/{,**} r,\n")
+	case vulkanDriverLibs:
+		spec.AddSnippet("  /usr/share/vulkan/{,icd.d,implicit_layer.d,explicit_layer.d}/{,**} r,\n")
+	case gbmDriverLibs:
+		spec.AddSnippet("  /usr/lib/@{multiarch}/gbm/{,**} r,\n")
+	}
+}
+
 // addAppArmorAssemblyAccess grants the application read access to the per-interface
 // driver-libs assembly tree under /opt/snapd/interfaces/<iface>/. The core base
 // template (unlike the non-core/classic template) does not grant /opt/** to apps, so
@@ -511,6 +527,13 @@ func addAppArmorAssemblySourceFiles(
 		target := filepath.Join(assemblyRoot, ifaceName, "share", subdir, encodedName)
 		emit("  # Driver-libs assembly metadata file %s\n", target)
 		assemblyAppArmorEntry(emit, pathDirIdx.path, target, false)
+		// Pass 2: authorize snap-update-ns to redistribute the metadata to the
+		// canonical loader-scanned system location (see loaderScannedTarget).
+		if loaderDir := loaderScannedTarget(subdir); loaderDir != "" {
+			loaderTarget := filepath.Join(loaderDir, encodedName)
+			emit("  # Driver-libs redistribution %s -> %s\n", target, loaderTarget)
+			assemblyAppArmorEntry(emit, target, loaderTarget, false)
+		}
 	}
 	return nil
 }
@@ -530,6 +553,11 @@ func addAppArmorAssemblyClientDriver(spec *apparmor.Specification, slot *interfa
 	target := filepath.Join(assemblyRoot, ifaceName, "share", "gbm", clientDriver)
 	spec.AddUpdateNSf("  # Driver-libs assembly client driver %s\n", target)
 	assemblyAppArmorEntry(spec.AddUpdateNSf, path, target, false)
+	// Pass 2: authorize snap-update-ns to redistribute the client-driver
+	// metadata to the loader-scanned GBM directory.
+	loaderTarget := filepath.Join(loaderScannedTarget("gbm"), clientDriver)
+	spec.AddUpdateNSf("  # Driver-libs redistribution %s -> %s\n", target, loaderTarget)
+	assemblyAppArmorEntry(spec.AddUpdateNSf, target, loaderTarget, false)
 	return nil
 }
 

--- a/interfaces/builtin/helpers.go
+++ b/interfaces/builtin/helpers.go
@@ -307,7 +307,7 @@ func mountAssemblyLibDirs(spec *mount.Specification, slot *interfaces.ConnectedS
 		if err := spec.AddMountEntry(osutil.MountEntry{
 			Name:    dir.Path,
 			Dir:     target,
-			Options: []string{"rbind", "ro"},
+			Options: []string{"bind", "ro"},
 		}); err != nil {
 			return err
 		}

--- a/interfaces/builtin/helpers.go
+++ b/interfaces/builtin/helpers.go
@@ -316,6 +316,26 @@ func mountAssemblyLibDirs(spec *mount.Specification, slot *interfaces.ConnectedS
 	return nil
 }
 
+// loaderScannedTarget returns the canonical loader-scanned system path that
+// the given assembly share/ subdir is redistributed to (Pass 2), or "" if the
+// subdir is not redistributed (e.g. library dirs, which are discovered via
+// SNAP_LIBRARY_PATH in Pass 3).
+func loaderScannedTarget(subdir string) string {
+	switch subdir {
+	case "egl_vendor.d":
+		return "/usr/share/glvnd/egl_vendor.d"
+	case "vulkan/icd.d":
+		return "/usr/share/vulkan/icd.d"
+	case "vulkan/implicit_layer.d":
+		return "/usr/share/vulkan/implicit_layer.d"
+	case "vulkan/explicit_layer.d":
+		return "/usr/share/vulkan/explicit_layer.d"
+	case "gbm":
+		return fmt.Sprintf("/usr/lib/%s-linux-gnu/gbm", osutil.MachineName())
+	}
+	return ""
+}
+
 // mountAssemblySourceFiles mounts each source file found by sourceDirsCheck in
 // the sda attribute (icd-source / *-layer-source) as a read-only file bind into
 // the per-interface assembly tree under
@@ -352,6 +372,20 @@ func mountAssemblySourceFiles(
 		}); err != nil {
 			return err
 		}
+		// Pass 2: the metadata is also redistributed to the canonical
+		// loader-scanned system location, re-binding the assembly target above
+		// (single source of truth) so the Vulkan/GLVND/GBM loaders discover it
+		// env-free.
+		if loaderDir := loaderScannedTarget(subdir); loaderDir != "" {
+			loaderTarget := filepath.Join(loaderDir, encodedName)
+			if err := spec.AddMountEntry(osutil.MountEntry{
+				Name:    target, // source = assembly target (bound above)
+				Dir:     loaderTarget,
+				Options: []string{"bind", "ro", osutil.XSnapdKindFile()},
+			}); err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }
@@ -368,9 +402,19 @@ func mountAssemblyClientDriver(spec *mount.Specification, slot *interfaces.Conne
 		return err
 	}
 	target := filepath.Join(assemblyRoot, ifaceName, "share", "gbm", clientDriver)
-	return spec.AddMountEntry(osutil.MountEntry{
+	if err := spec.AddMountEntry(osutil.MountEntry{
 		Name:    path,
 		Dir:     target,
+		Options: []string{"bind", "ro", osutil.XSnapdKindFile()},
+	}); err != nil {
+		return err
+	}
+	// Pass 2: the client-driver metadata is also redistributed to the
+	// loader-scanned GBM directory, re-binding the assembly target above.
+	loaderTarget := filepath.Join(loaderScannedTarget("gbm"), clientDriver)
+	return spec.AddMountEntry(osutil.MountEntry{
+		Name:    target, // source = assembly target (bound above)
+		Dir:     loaderTarget,
 		Options: []string{"bind", "ro", osutil.XSnapdKindFile()},
 	})
 }

--- a/interfaces/builtin/helpers.go
+++ b/interfaces/builtin/helpers.go
@@ -454,6 +454,14 @@ func mountAssemblyClientDriver(spec *mount.Specification, slot *interfaces.Conne
 // unclash-renamed targets (-2, -3, ...). isDir selects the directory vs file
 // bind variant (trailing slashes and directory semantics).
 func assemblyAppArmorEntry(emit func(f string, args ...any), source, target string, isDir bool) {
+	// Escape backslashes for AppArmor double-quoted strings. Metadata file
+	// targets use systemd.EscapeUnitNamePath for their filenames, which
+	// produces literal \xNN sequences (e.g. hyphen becomes \x2d). Inside
+	// AppArmor double quotes, \xNN is interpreted as a hex escape, so the
+	// literal \xNN in the path must be escaped as \\xNN to match the actual
+	// filesystem path.
+	source = strings.ReplaceAll(source, "\\", "\\\\")
+	target = strings.ReplaceAll(target, "\\", "\\\\")
 	if isDir {
 		emit("  mount options=(rw, bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n", source, target)
 		emit("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target)

--- a/interfaces/builtin/helpers.go
+++ b/interfaces/builtin/helpers.go
@@ -400,6 +400,23 @@ func assemblyAppArmorEntry(emit func(f string, args ...any), source, target stri
 	apparmor.GenWritableProfile(emit, fmt.Sprintf("%s-[0-9]*", target), 1)
 }
 
+// addAppArmorAssemblyAccess grants the application read access to the per-interface
+// driver-libs assembly tree under /opt/snapd/interfaces/<iface>/. The core base
+// template (unlike the non-core/classic template) does not grant /opt/** to apps, so
+// each driver-libs interface must grant access to its own subtree explicitly. Only the
+// library/metadata files bind-mounted by the mount backend are exposed; the app can
+// read its own interface's subtree but not other interfaces' or /opt/snapd broadly.
+func addAppArmorAssemblyAccess(spec *apparmor.Specification, ifaceName string) {
+	spec.AddSnippet(fmt.Sprintf(`
+  # Driver-libs assembly tree for %s: read the bind-mounted provider
+  # libraries and ICD/layer metadata under /opt/snapd/interfaces/%s/.
+  /opt/snapd/ r,
+  /opt/snapd/interfaces/ r,
+  /opt/snapd/interfaces/%s/ r,
+  /opt/snapd/interfaces/%s/** mrkix,
+`, ifaceName, ifaceName, ifaceName, ifaceName))
+}
+
 // addAppArmorAssemblyLibDirs emits the snap-update-ns apparmor rules for the
 // library dirs bound into the assembly tree (see mountAssemblyLibDirs for the
 // mount side).

--- a/interfaces/builtin/helpers.go
+++ b/interfaces/builtin/helpers.go
@@ -238,7 +238,7 @@ func sourceDirFilesCheck(slot *interfaces.ConnectedSlot, sourceDir string, check
 // driver metadata under <assemblyRoot>/<iface>/share/. The writable-mimic for
 // these paths is authorized via the snap-update-ns apparmor profile, see
 // AppArmorConnectedPlug of the driver-libs interfaces.
-const assemblyRoot = "/opt/snapd/interfaces"
+const assemblyRoot = "/run/snapd/interfaces"
 
 // libraryRelPath returns the path of a library/source dir relative to its
 // $SNAP or $SNAP_COMPONENT(<comp>) prefix, i.e. the path-suffix to preserve
@@ -501,20 +501,20 @@ func addAppArmorRedistributionAccess(spec *apparmor.Specification, ifaceName str
 }
 
 // addAppArmorAssemblyAccess grants the application read access to the per-interface
-// driver-libs assembly tree under /opt/snapd/interfaces/<iface>/. The core base
-// template (unlike the non-core/classic template) does not grant /opt/** to apps, so
-// each driver-libs interface must grant access to its own subtree explicitly. Only the
-// library/metadata files bind-mounted by the mount backend are exposed; the app can
-// read its own interface's subtree but not other interfaces' or /opt/snapd broadly.
+// driver-libs assembly tree under assemblyRoot/<iface>/. The core base
+// template (unlike the non-core/classic template) does not grant /opt/** or /run/** to
+// apps, so each driver-libs interface must grant access to its own subtree explicitly.
+// Only the library/metadata files bind-mounted by the mount backend are exposed; the
+// app can read its own interface's subtree but not other interfaces' or assemblyRoot broadly.
 func addAppArmorAssemblyAccess(spec *apparmor.Specification, ifaceName string) {
 	spec.AddSnippet(fmt.Sprintf(`
-  # Driver-libs assembly tree for %s: read the bind-mounted provider
-  # libraries and ICD/layer metadata under /opt/snapd/interfaces/%s/.
-  /opt/snapd/ r,
-  /opt/snapd/interfaces/ r,
-  /opt/snapd/interfaces/%s/ r,
-  /opt/snapd/interfaces/%s/** mrkix,
-`, ifaceName, ifaceName, ifaceName, ifaceName))
+  # Driver-libs assembly tree for %[3]s: read the bind-mounted provider
+  # libraries and ICD/layer metadata under %[2]s/%[3]s/.
+  %[1]s/ r,
+  %[2]s/ r,
+  %[2]s/%[3]s/ r,
+  %[2]s/%[3]s/** mrkix,
+`, filepath.Dir(assemblyRoot), assemblyRoot, ifaceName))
 }
 
 // addAppArmorAssemblyLibDirs emits the snap-update-ns apparmor rules for the

--- a/interfaces/builtin/helpers.go
+++ b/interfaces/builtin/helpers.go
@@ -455,12 +455,12 @@ func mountAssemblyClientDriver(spec *mount.Specification, slot *interfaces.Conne
 // bind variant (trailing slashes and directory semantics).
 func assemblyAppArmorEntry(emit func(f string, args ...any), source, target string, isDir bool) {
 	if isDir {
-		emit("  mount options=(bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n", source, target)
+		emit("  mount options=(rw, bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n", source, target)
 		emit("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target)
 		emit("  mount options=(rprivate) -> \"%s{,-[0-9]*}/\",\n", target)
 		emit("  umount \"%s{,-[0-9]*}/\",\n", target)
 	} else {
-		emit("  mount options=(bind) \"%s\" -> \"%s{,-[0-9]*}\",\n", source, target)
+		emit("  mount options=(rw, bind) \"%s\" -> \"%s{,-[0-9]*}\",\n", source, target)
 		emit("  remount options=(bind, ro) \"%s{,-[0-9]*}\",\n", target)
 		emit("  mount options=(rprivate) -> \"%s{,-[0-9]*}\",\n", target)
 		emit("  umount \"%s{,-[0-9]*}\",\n", target)

--- a/interfaces/builtin/helpers.go
+++ b/interfaces/builtin/helpers.go
@@ -241,6 +241,29 @@ func sourceDirFilesCheck(slot *interfaces.ConnectedSlot, sourceDir string, check
 // AppArmorConnectedPlug of the driver-libs interfaces.
 const assemblyRoot = "/opt/snapd/interfaces"
 
+// libraryRelPath returns the path of a library/source dir relative to its
+// $SNAP or $SNAP_COMPONENT(<comp>) prefix, i.e. the path-suffix to preserve
+// when pooling under the assembly tree (mirrors classic snap-confine's
+// sc_populate_libgl_with_hostfs_symlinks). It reuses the same prefix-strip
+// logic as sourceDirEncodedName but keeps the result a real path (no
+// systemd-flatten to a single basename).
+func libraryRelPath(slot *interfaces.ConnectedSlot, path string) (string, error) {
+	relPath, err := filepath.Rel(dirs.SnapMountDir, path)
+	if err != nil {
+		return "", err
+	}
+	instance := slot.Snap().InstanceName()
+	splitNum := 3
+	if strings.HasPrefix(path, snap.ComponentsBaseDir(instance)) {
+		splitNum = 6
+	}
+	dirs := strings.SplitN(relPath, "/", splitNum)
+	if len(dirs) < splitNum {
+		return "", fmt.Errorf("internal error: wrong library path: %s", relPath)
+	}
+	return dirs[splitNum-1], nil
+}
+
 // sourceDirEncodedName returns the escaped name used to refer to a file found
 // in a *-source attribute of a driver-libs slot, in the export/assembly
 // directories. The name is derived from the snap/component instance name, the
@@ -290,9 +313,11 @@ func sourceDirEncodedName(slot *interfaces.ConnectedSlot, pathDirIdx pathWithDir
 
 // mountAssemblyLibDirs adds mount entries that bind each expanded library-source
 // directory of the slot into the per-interface assembly tree under
-// <assemblyRoot>/<iface>/lib/<provider>_<slot>/<idx>/, so that the libraries
-// keep their original file names (ld.so opens libraries by exact name). Each
-// target dir is also recorded via AddLibraryPathDir for the SNAP_LIBRARY_PATH
+// <assemblyRoot>/<iface>/lib/<provider>_<slot>/<rel-path-after-$SNAP>/, pooling
+// entries by path-suffix (mirrors classic snap-confine's
+// sc_populate_libgl_with_hostfs_symlinks), so that the libraries keep their
+// original relative layout (ld.so opens libraries by exact name). Each target
+// dir is also recorded via AddLibraryPathDir for the SNAP_LIBRARY_PATH
 // derivation (Pass 3).
 func mountAssemblyLibDirs(spec *mount.Specification, slot *interfaces.ConnectedSlot, ifaceName string) error {
 	libDirs := []string{}
@@ -303,7 +328,11 @@ func mountAssemblyLibDirs(spec *mount.Specification, slot *interfaces.ConnectedS
 	providerSlot := slot.Snap().InstanceName() + "_" + slot.Name()
 	expanded := slot.AppSet().ExpandSliceSnapVariablesWithOrder(libDirs)
 	for _, dir := range expanded {
-		target := filepath.Join(assemblyRoot, ifaceName, "lib", providerSlot, strconv.Itoa(dir.Idx))
+		rel, err := libraryRelPath(slot, dir.Path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(assemblyRoot, ifaceName, "lib", providerSlot, rel)
 		if err := spec.AddMountEntry(osutil.MountEntry{
 			Name:    dir.Path,
 			Dir:     target,

--- a/interfaces/builtin/helpers.go
+++ b/interfaces/builtin/helpers.go
@@ -452,9 +452,13 @@ func assemblyAppArmorEntry(emit func(f string, args ...any), source, target stri
 func addAppArmorRedistributionAccess(spec *apparmor.Specification, ifaceName string) {
 	switch ifaceName {
 	case eglDriverLibs:
-		spec.AddSnippet("  /usr/share/glvnd/egl_vendor.d/{,**} r,\n")
+		spec.AddSnippet(`
+  /usr/share/glvnd/ r,
+  /usr/share/glvnd/egl_vendor.d/{,**} r,`)
 	case vulkanDriverLibs:
-		spec.AddSnippet("  /usr/share/vulkan/{,icd.d,implicit_layer.d,explicit_layer.d}/{,**} r,\n")
+		spec.AddSnippet(`
+  /usr/share/vulkan/ r,
+  /usr/share/vulkan/{,icd.d,implicit_layer.d,explicit_layer.d}/{,**} r,`)
 	case gbmDriverLibs:
 		spec.AddSnippet("  /usr/lib/@{multiarch}/gbm/{,**} r,\n")
 	}

--- a/interfaces/builtin/helpers.go
+++ b/interfaces/builtin/helpers.go
@@ -25,7 +25,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/snapcore/snapd/dirs"
@@ -523,7 +522,11 @@ func addAppArmorAssemblyLibDirs(spec *apparmor.Specification, slot *interfaces.C
 	emit := spec.AddUpdateNSf
 	expanded := slot.AppSet().ExpandSliceSnapVariablesWithOrder(libDirs)
 	for _, dir := range expanded {
-		target := filepath.Join(assemblyRoot, ifaceName, "lib", providerSlot, strconv.Itoa(dir.Idx))
+		rel, err := libraryRelPath(slot, dir.Path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(assemblyRoot, ifaceName, "lib", providerSlot, rel)
 		emit("  # Driver-libs assembly library dir %s\n", target)
 		assemblyAppArmorEntry(emit, dir.Path, target, true)
 	}

--- a/interfaces/builtin/helpers.go
+++ b/interfaces/builtin/helpers.go
@@ -318,6 +318,47 @@ func sourceDirEncodedName(slot *interfaces.ConnectedSlot, pathDirIdx pathWithDir
 // original relative layout (ld.so opens libraries by exact name). Each target
 // dir is also recorded via AddLibraryPathDir for the SNAP_LIBRARY_PATH
 // derivation (Pass 3).
+// mountAssemblyRoot adds the shared tmpfs mount entry for assemblyRoot itself.
+//
+// assemblyRoot lives under /run/snapd/interfaces, a real (writable, non-
+// read-only) host directory. Creating the assembly tree's *content* directly
+// there would land on the host's actual filesystem, persistent and shared
+// across every consuming snap (see the trespassing whitelist for assemblyRoot
+// in cmd/snap-update-ns/system.go, which is what allows the *mountpoint*
+// directory itself to be created without tripping the trespassing check on
+// the ancestor /run). This entry mounts a fresh tmpfs exactly at assemblyRoot
+// so that the mountpoint directory is the only thing that is ever host-visible
+// (an empty placeholder); everything created underneath — library dirs, ICD
+// metadata — lives on this tmpfs, which is a brand new mount and therefore
+// private to the connecting snap's own mount namespace by default (new mounts
+// are never automatically shared with their siblings or the host).
+//
+// Explicit mode/uid/gid options are required, not cosmetic: an entry with an
+// empty Options list serializes to the fstab placeholder string "defaults"
+// (osutil/mountentry.go's String()); once the mount profile round-trips
+// through the persisted fstab file, that placeholder is read back as a
+// literal (single) option string "defaults", which is not a real tmpfs mount
+// option and makes the mount(2) syscall fail with EINVAL. Giving explicit,
+// real tmpfs options (recognized by the kernel's tmpfs option parser) avoids
+// this entirely, and also makes the tmpfs look like an ordinary root:root
+// 0755 directory, matching planWritableMimic's synthetic tmpfs entries
+// (cmd/snap-update-ns/utils.go).
+//
+// Every driver-libs interface's MountConnectedPlug calls this before adding
+// its own entries under assemblyRoot. If a snap connects to more than one
+// driver-libs interface the identical entry gets added multiple times, but
+// mount.Specification.MountEntries (via unclashMountEntries) merges entries
+// that share the same Dir, Name and Type into one, so only a single tmpfs
+// mount is ever actually applied.
+func mountAssemblyRoot(spec *mount.Specification) error {
+	return spec.AddMountEntry(osutil.MountEntry{
+		Name:    "tmpfs",
+		Dir:     assemblyRoot,
+		Type:    "tmpfs",
+		Options: []string{"mode=0755", "uid=0", "gid=0"},
+	})
+}
+
 func mountAssemblyLibDirs(spec *mount.Specification, slot *interfaces.ConnectedSlot, ifaceName string) error {
 	libDirs := []string{}
 	if err := slot.Attr("library-source", &libDirs); err != nil {
@@ -506,6 +547,23 @@ func addAppArmorRedistributionAccess(spec *apparmor.Specification, ifaceName str
 // apps, so each driver-libs interface must grant access to its own subtree explicitly.
 // Only the library/metadata files bind-mounted by the mount backend are exposed; the
 // app can read its own interface's subtree but not other interfaces' or assemblyRoot broadly.
+// addAppArmorAssemblyRoot authorizes snap-update-ns to mount the shared tmpfs
+// at assemblyRoot (see mountAssemblyRoot), mirroring the apparmor rules a
+// snap.yaml "layout: {type: tmpfs}" entry gets (interfaces/apparmor/spec.go's
+// emitLayout, case layout.Type == "tmpfs"). Unlike a layout tmpfs mimic target,
+// assemblyRoot's parent (/run/snapd) is already writable and covered by the
+// trespassing whitelist, so no GenWritableProfile/mimic authorization is
+// needed here for creating the mountpoint itself.
+func addAppArmorAssemblyRoot(spec *apparmor.Specification) {
+	spec.AddUpdateNSf(`
+  # Driver-libs assembly tree root: a private tmpfs so that only the bare
+  # mountpoint directory, not its content, is ever host-visible.
+  mount fstype=tmpfs tmpfs -> "%[1]s/",
+  mount options=(rprivate) -> "%[1]s/",
+  umount "%[1]s/",
+`, assemblyRoot)
+}
+
 func addAppArmorAssemblyAccess(spec *apparmor.Specification, ifaceName string) {
 	spec.AddSnippet(fmt.Sprintf(`
   # Driver-libs assembly tree for %[3]s: read the bind-mounted provider

--- a/interfaces/builtin/helpers.go
+++ b/interfaces/builtin/helpers.go
@@ -350,6 +350,22 @@ func sourceDirEncodedName(slot *interfaces.ConnectedSlot, pathDirIdx pathWithDir
 // mount.Specification.MountEntries (via unclashMountEntries) merges entries
 // that share the same Dir, Name and Type into one, so only a single tmpfs
 // mount is ever actually applied.
+//
+// This entry is deliberately left with x-snapd.origin unset ("non-layout"),
+// while every assembly bind and redistribution bind entry under it is tagged
+// osutil.XSnapdOriginLayout() (see mountAssemblyLibDirs/mountAssemblySourceFiles/
+// mountAssemblyClientDriver). cmd/snap-update-ns/update.go applies mount
+// changes in origin-based passes: "non-layout" (untagged) entries are fully
+// prepared *and* applied as one bucket before the separate "layout" bucket's
+// own prepare-then-apply cycle even starts. If our tmpfs root shared the
+// "non-layout" bucket with its own children, the children's directory
+// creation (during the shared prepare sub-pass) would happen *before* the
+// tmpfs root's own mount (deferred to the separate, later apply sub-pass) --
+// landing on the real host directory, which the tmpfs then hides once it
+// mounts, causing every nested bind to fail with ENOENT (reproduced on
+// device). Keeping the root alone in "non-layout" guarantees it is fully
+// mounted (prepared *and* applied) before the "layout" bucket's own prepare
+// step for its children even begins.
 func mountAssemblyRoot(spec *mount.Specification) error {
 	return spec.AddMountEntry(osutil.MountEntry{
 		Name:    "tmpfs",
@@ -376,7 +392,7 @@ func mountAssemblyLibDirs(spec *mount.Specification, slot *interfaces.ConnectedS
 		if err := spec.AddMountEntry(osutil.MountEntry{
 			Name:    dir.Path,
 			Dir:     target,
-			Options: []string{"bind", "ro"},
+			Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()},
 		}); err != nil {
 			return err
 		}
@@ -437,7 +453,7 @@ func mountAssemblySourceFiles(
 		if err := spec.AddMountEntry(osutil.MountEntry{
 			Name:    pathDirIdx.path,
 			Dir:     target,
-			Options: []string{"bind", "ro", osutil.XSnapdKindFile()},
+			Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()},
 		}); err != nil {
 			return err
 		}
@@ -450,7 +466,7 @@ func mountAssemblySourceFiles(
 			if err := spec.AddMountEntry(osutil.MountEntry{
 				Name:    target, // source = assembly target (bound above)
 				Dir:     loaderTarget,
-				Options: []string{"bind", "ro", osutil.XSnapdKindFile()},
+				Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()},
 			}); err != nil {
 				return err
 			}
@@ -474,7 +490,7 @@ func mountAssemblyClientDriver(spec *mount.Specification, slot *interfaces.Conne
 	if err := spec.AddMountEntry(osutil.MountEntry{
 		Name:    path,
 		Dir:     target,
-		Options: []string{"bind", "ro", osutil.XSnapdKindFile()},
+		Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()},
 	}); err != nil {
 		return err
 	}
@@ -484,7 +500,7 @@ func mountAssemblyClientDriver(spec *mount.Specification, slot *interfaces.Conne
 	return spec.AddMountEntry(osutil.MountEntry{
 		Name:    target, // source = assembly target (bound above)
 		Dir:     loaderTarget,
-		Options: []string{"bind", "ro", osutil.XSnapdKindFile()},
+		Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()},
 	})
 }
 

--- a/interfaces/builtin/helpers.go
+++ b/interfaces/builtin/helpers.go
@@ -238,7 +238,7 @@ func sourceDirFilesCheck(slot *interfaces.ConnectedSlot, sourceDir string, check
 // driver metadata under <assemblyRoot>/<iface>/share/. The writable-mimic for
 // these paths is authorized via the snap-update-ns apparmor profile, see
 // AppArmorConnectedPlug of the driver-libs interfaces.
-const assemblyRoot = "/run/snapd/interfaces"
+var assemblyRoot = dirs.SnapInterfacesAssemblyRoot
 
 // libraryRelPath returns the path of a library/source dir relative to its
 // $SNAP or $SNAP_COMPONENT(<comp>) prefix, i.e. the path-suffix to preserve
@@ -318,20 +318,26 @@ func sourceDirEncodedName(slot *interfaces.ConnectedSlot, pathDirIdx pathWithDir
 // original relative layout (ld.so opens libraries by exact name). Each target
 // dir is also recorded via AddLibraryPathDir for the SNAP_LIBRARY_PATH
 // derivation (Pass 3).
-// mountAssemblyRoot adds the shared tmpfs mount entry for assemblyRoot itself.
+// mountAssemblyRoot adds the shared tmpfs mount entry anchoring the assembly
+// tree, mounted one level up from assemblyRoot itself (i.e. at
+// filepath.Dir(assemblyRoot) == /run/snapd/snap), so that /run/snapd/snap is
+// a private per-snap tmpfs and assemblyRoot ("interfaces") is just its
+// current sole subdirectory, leaving room for other private, per-snap state
+// at the same /run/snapd/snap/ level in the future.
 //
-// assemblyRoot lives under /run/snapd/interfaces, a real (writable, non-
-// read-only) host directory. Creating the assembly tree's *content* directly
-// there would land on the host's actual filesystem, persistent and shared
-// across every consuming snap (see the trespassing whitelist for assemblyRoot
-// in cmd/snap-update-ns/system.go, which is what allows the *mountpoint*
+// /run/snapd/snap is a real (writable, non-read-only) host directory.
+// Creating the assembly tree's *content* directly there would land on the
+// host's actual filesystem, persistent and shared across every consuming
+// snap (see the trespassing whitelist for /run/snapd/snap in
+// cmd/snap-update-ns/system.go, which is what allows the *mountpoint*
 // directory itself to be created without tripping the trespassing check on
-// the ancestor /run). This entry mounts a fresh tmpfs exactly at assemblyRoot
-// so that the mountpoint directory is the only thing that is ever host-visible
-// (an empty placeholder); everything created underneath — library dirs, ICD
-// metadata — lives on this tmpfs, which is a brand new mount and therefore
-// private to the connecting snap's own mount namespace by default (new mounts
-// are never automatically shared with their siblings or the host).
+// the ancestor /run). This entry mounts a fresh tmpfs exactly at
+// /run/snapd/snap so that the mountpoint directory is the only thing that is
+// ever host-visible (an empty placeholder); everything created underneath —
+// assemblyRoot and its library dirs, ICD metadata — lives on this tmpfs,
+// which is a brand new mount and therefore private to the connecting snap's
+// own mount namespace by default (new mounts are never automatically shared
+// with their siblings or the host).
 //
 // Explicit mode/uid/gid options are required, not cosmetic: an entry with an
 // empty Options list serializes to the fstab placeholder string "defaults"
@@ -369,7 +375,7 @@ func sourceDirEncodedName(slot *interfaces.ConnectedSlot, pathDirIdx pathWithDir
 func mountAssemblyRoot(spec *mount.Specification) error {
 	return spec.AddMountEntry(osutil.MountEntry{
 		Name:    "tmpfs",
-		Dir:     assemblyRoot,
+		Dir:     filepath.Dir(assemblyRoot),
 		Type:    "tmpfs",
 		Options: []string{"mode=0755", "uid=0", "gid=0"},
 	})
@@ -577,7 +583,7 @@ func addAppArmorAssemblyRoot(spec *apparmor.Specification) {
   mount fstype=tmpfs tmpfs -> "%[1]s/",
   mount options=(rprivate) -> "%[1]s/",
   umount "%[1]s/",
-`, assemblyRoot)
+`, filepath.Dir(assemblyRoot))
 }
 
 func addAppArmorAssemblyAccess(spec *apparmor.Specification, ifaceName string) {

--- a/interfaces/builtin/helpers_mount_test.go
+++ b/interfaces/builtin/helpers_mount_test.go
@@ -1,0 +1,338 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/mount"
+	"github.com/snapcore/snapd/interfaces/symlinks"
+	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+	"github.com/snapcore/snapd/testutil"
+)
+
+type mountAssemblyHelpersSuite struct {
+	testutil.BaseTest
+
+	testRoot string
+}
+
+var _ = Suite(&mountAssemblyHelpersSuite{})
+
+// egl-style provider: has a required priority attribute, an icd-source and
+// library-source with snap, component and empty dirs entries.
+const mountAssemblyEglProviderYaml = `name: egl-provider
+version: 0
+slots:
+  egl-slot:
+    interface: egl-driver-libs
+    priority: 10
+    compatibility: egl-1-5-ubuntu-2404
+    icd-source:
+      - $SNAP/egl.d/
+      - $SNAP/egl_alt.d/
+      - $SNAP/egl_empty.d/
+      - $SNAP_COMPONENT(comp1)/egl.d
+      - $SNAP_COMPONENT(comp2)/egl.d
+    library-source:
+      - $SNAP/lib1
+      - ${SNAP}/lib2
+      - $SNAP_COMPONENT(comp1)/lib1
+      - $SNAP_COMPONENT(comp2)/lib2
+components:
+  comp1:
+    type: standard
+  comp2:
+    type: standard
+`
+
+// vulkan-style provider without a priority attribute.
+const mountAssemblyVulkanProviderYaml = `name: vulkan-provider
+version: 0
+slots:
+  vulkan-slot:
+    interface: vulkan-driver-libs
+    compatibility: vulkan-1-(2..5)-ubuntu-2404
+    icd-source:
+      - $SNAP/vulkan/icd.d/
+    library-source:
+      - $SNAP/lib1
+`
+
+// gbm-style provider with a client-driver.
+const mountAssemblyGbmProviderYaml = `name: gbm-provider
+version: 0
+slots:
+  gbm-slot:
+    interface: gbm-driver-libs
+    client-driver: libgallium_driver.so
+    library-source:
+      - $SNAP/lib1
+`
+
+func (s *mountAssemblyHelpersSuite) SetUpTest(c *C) {
+	s.BaseTest.SetUpTest(c)
+
+	s.testRoot = c.MkDir()
+	os.MkdirAll(filepath.Join(s.testRoot, dirs.DefaultSnapMountDir), 0755)
+	dirs.SetRootDir(s.testRoot)
+	s.AddCleanup(func() { dirs.SetRootDir("/") })
+}
+
+type mockComp struct {
+	name string
+	rev  snap.Revision
+}
+
+func (s *mountAssemblyHelpersSuite) mockSlotWithComps(c *C, yaml string, rev snap.Revision, comps ...mockComp) *interfaces.ConnectedSlot {
+	info := snaptest.MockInfo(c, yaml, &snap.SideInfo{Revision: rev})
+	compInfos := make([]*snap.ComponentInfo, 0, len(comps))
+	for _, comp := range comps {
+		compInfos = append(compInfos, snaptest.MockComponentInfo(c,
+			fmt.Sprintf("component: %s+%s\ntype: standard", info.SnapName(), comp.name),
+			snap.ComponentSideInfo{Revision: comp.rev}))
+	}
+	set, err := interfaces.NewSnapAppSet(info, compInfos)
+	c.Assert(err, IsNil)
+
+	var slotName string
+	for name := range info.Slots {
+		slotName = name
+	}
+	if slotName == "" {
+		panic(fmt.Sprintf("no slots in yaml %q", yaml))
+	}
+	return interfaces.NewConnectedSlot(info.Slots[slotName], set, nil, nil)
+}
+
+func (s *mountAssemblyHelpersSuite) TestSourceDirEncodedName(c *C) {
+	slot := s.mockSlotWithComps(c, mountAssemblyEglProviderYaml, snap.R(5))
+
+	// Snap-file, with priority: name is prefixed with priority+dir index.
+	name, err := sourceDirEncodedName(slot, pathWithDirIdx{
+		path: filepath.Join(dirs.SnapMountDir, "egl-provider/5/egl.d/mesa.json"), idx: 0}, true)
+	c.Assert(err, IsNil)
+	c.Check(name, Equals, "10_snap_egl-provider_egl-slot_egl.d-mesa.json")
+
+	// A different source dir gets the next index.
+	name, err = sourceDirEncodedName(slot, pathWithDirIdx{
+		path: filepath.Join(dirs.SnapMountDir, "egl-provider/5/egl_alt.d/radeon.json"), idx: 1}, true)
+	c.Assert(err, IsNil)
+	c.Check(name, Equals, "11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json")
+
+	// Without priority no numeric prefix is used.
+	name, err = sourceDirEncodedName(slot, pathWithDirIdx{
+		path: filepath.Join(dirs.SnapMountDir, "egl-provider/5/egl.d/mesa.json"), idx: 0}, false)
+	c.Assert(err, IsNil)
+	c.Check(name, Equals, "snap_egl-provider_egl-slot_egl.d-mesa.json")
+
+	// Component file: the component name is embedded and the original list
+	// index (not the filtered position) is used for the priority prefix.
+	compPath := filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "egl-provider"), "egl.d", "nvidia.json")
+	name, err = sourceDirEncodedName(slot, pathWithDirIdx{path: compPath, idx: 3}, true)
+	c.Assert(err, IsNil)
+	c.Check(name, Equals, "13_snap_egl-provider+comp1_egl-slot_egl.d-nvidia.json")
+
+	// withPriority on a slot without the priority attribute errors out.
+	vulkanSlot := s.mockSlotWithComps(c, mountAssemblyVulkanProviderYaml, snap.R(4))
+	_, err = sourceDirEncodedName(vulkanSlot, pathWithDirIdx{
+		path: filepath.Join(dirs.SnapMountDir, "vulkan-provider/4/vulkan/icd.d/intel.json"), idx: 0}, true)
+	c.Check(err, ErrorMatches, `invalid priority: snap "vulkan-provider" does not have attribute "priority" for interface "vulkan-driver-libs"`)
+
+	// A path that does not reach below the snap mount dir cannot be encoded.
+	_, err = sourceDirEncodedName(slot, pathWithDirIdx{path: dirs.SnapMountDir, idx: 0}, false)
+	c.Check(err, ErrorMatches, `internal error: wrong file path: \.`)
+}
+
+func (s *mountAssemblyHelpersSuite) TestMountAssemblyLibDirs(c *C) {
+	// Only comp1 is installed, the comp2 library source dir is filtered out
+	// but its index keeps the original position in the library-source list.
+	slot := s.mockSlotWithComps(c, mountAssemblyEglProviderYaml, snap.R(5), mockComp{"comp1", snap.R(11)})
+
+	spec := &mount.Specification{}
+	c.Assert(mountAssemblyLibDirs(spec, slot, "egl-driver-libs"), IsNil)
+
+	comp1Lib1 := filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "egl-provider"), "lib1")
+	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
+		{
+			Name:    filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib1"),
+			Dir:     "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/0",
+			Options: []string{"rbind", "ro"},
+		},
+		{
+			Name:    filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib2"),
+			Dir:     "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/1",
+			Options: []string{"rbind", "ro"},
+		},
+		{
+			Name:    comp1Lib1,
+			Dir:     "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/2",
+			Options: []string{"rbind", "ro"},
+		},
+	})
+
+	// Library path dirs are collected for the SNAP_LIBRARY_PATH derivation.
+	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
+		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/0",
+		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/1",
+		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/2",
+	})
+}
+
+func (s *mountAssemblyHelpersSuite) TestMountAssemblySourceFiles(c *C) {
+	slot := s.mockSlotWithComps(c, mountAssemblyEglProviderYaml, snap.R(5))
+
+	// Populate the icd dirs, the library dirs and an ignored file.
+	icdDir := filepath.Join(dirs.SnapMountDir, "egl-provider/5/egl.d")
+	altDir := filepath.Join(dirs.SnapMountDir, "egl-provider/5/egl_alt.d")
+	c.Assert(os.MkdirAll(icdDir, 0755), IsNil)
+	c.Assert(os.MkdirAll(altDir, 0755), IsNil)
+
+	mesaIcd := filepath.Join(icdDir, "mesa.json")
+	os.WriteFile(mesaIcd, []byte(`{
+    "file_format_version" : "1.0.0",
+    "ICD" : {
+        "library_path" : "libEGL_mesa.so.0"
+    }
+}
+`), 0644)
+	radeonIcd := filepath.Join(altDir, "radeon.json")
+	os.WriteFile(radeonIcd, []byte(`{
+    "file_format_version" : "1.0.0",
+    "ICD" : {
+        "library_path" : "libEGL_radeon.so.0"
+    }
+}
+`), 0644)
+	// A non-json file is ignored.
+	os.WriteFile(filepath.Join(icdDir, "foo.bar"), []byte{}, 0644)
+
+	libDir := filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib1")
+	c.Assert(os.MkdirAll(libDir, 0755), IsNil)
+	os.WriteFile(filepath.Join(libDir, "libEGL_mesa.so.0"), []byte{}, 0644)
+	os.WriteFile(filepath.Join(libDir, "libEGL_radeon.so.0"), []byte{}, 0644)
+
+	spec := &mount.Specification{}
+	c.Assert(mountAssemblySourceFiles(spec, slot, "egl-driver-libs",
+		sourceDirAttr{attrName: "icd-source"}, "egl_vendor.d", checkEglIcdFile, true), IsNil)
+
+	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
+		{
+			Name:    mesaIcd,
+			Dir:     "/opt/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json",
+			Options: []string{"bind", "ro", osutil.XSnapdKindFile()},
+		},
+		{
+			Name:    radeonIcd,
+			Dir:     "/opt/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json",
+			Options: []string{"bind", "ro", osutil.XSnapdKindFile()},
+		},
+	})
+	// Source files do not contribute library path dirs.
+	c.Assert(spec.LibraryPathDirs(), IsNil)
+
+	// The mount names are byte-identical to the classic symlink names.
+	symlinksSpec := &symlinks.Specification{}
+	c.Assert(symlinksForSourceDir(symlinksSpec, slot,
+		sourceDirAttr{attrName: "icd-source"}, eglVendorPath, checkEglIcdFile, true), IsNil)
+	expectedNames := map[string]bool{}
+	for link := range symlinksSpec.Symlinks()[eglVendorPath] {
+		expectedNames[link] = true
+	}
+	c.Assert(expectedNames, DeepEquals, map[string]bool{
+		"10_snap_egl-provider_egl-slot_egl.d-mesa.json":       true,
+		"11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json": true,
+	})
+	for _, entry := range spec.MountEntries() {
+		c.Check(expectedNames[filepath.Base(entry.Dir)], Equals, true,
+			Commentf("mount target %q has no matching symlink name", entry.Dir))
+	}
+}
+
+func (s *mountAssemblyHelpersSuite) TestMountAssemblySourceFilesVulkan(c *C) {
+	slot := s.mockSlotWithComps(c, mountAssemblyVulkanProviderYaml, snap.R(4))
+
+	// Vulkan slots have no priority attribute, so the names have no prefix.
+	icdDir := filepath.Join(dirs.SnapMountDir, "vulkan-provider/4/vulkan/icd.d")
+	c.Assert(os.MkdirAll(icdDir, 0755), IsNil)
+	intelIcd := filepath.Join(icdDir, "intel.json")
+	os.WriteFile(intelIcd, []byte(`{
+    "file_format_version" : "1.0.0",
+    "ICD" : {
+        "api_version" : "1.2.0",
+        "library_path" : "libvulkan_intel.so"
+    }
+}
+`), 0644)
+	libDir := filepath.Join(dirs.SnapMountDir, "vulkan-provider/4/lib1")
+	c.Assert(os.MkdirAll(libDir, 0755), IsNil)
+	os.WriteFile(filepath.Join(libDir, "libvulkan_intel.so"), []byte{}, 0644)
+
+	spec := &mount.Specification{}
+	c.Assert(mountAssemblySourceFiles(spec, slot, "vulkan-driver-libs",
+		sourceDirAttr{attrName: "icd-source"}, "vulkan/icd.d", checkVulkanIcdFile, false), IsNil)
+
+	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
+		{
+			Name:    intelIcd,
+			Dir:     "/opt/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-intel.json",
+			Options: []string{"bind", "ro", osutil.XSnapdKindFile()},
+		},
+	})
+
+	// An optional *-source attribute that is absent contributes nothing.
+	implicitSpec := &mount.Specification{}
+	c.Assert(mountAssemblySourceFiles(implicitSpec, slot, "vulkan-driver-libs",
+		sourceDirAttr{attrName: "implicit-layer-source", isOptional: true}, "vulkan/implicit_layer.d", checkVulkanLayersFile, false), IsNil)
+	c.Assert(implicitSpec.MountEntries(), HasLen, 0)
+}
+
+func (s *mountAssemblyHelpersSuite) TestMountAssemblyClientDriver(c *C) {
+	slot := s.mockSlotWithComps(c, mountAssemblyGbmProviderYaml, snap.R(6))
+
+	libDir := filepath.Join(dirs.SnapMountDir, "gbm-provider/6/lib1")
+	c.Assert(os.MkdirAll(libDir, 0755), IsNil)
+	driverPath := filepath.Join(libDir, "libgallium_driver.so")
+	os.WriteFile(driverPath, []byte{}, 0644)
+
+	spec := &mount.Specification{}
+	c.Assert(mountAssemblyClientDriver(spec, slot, "gbm-driver-libs"), IsNil)
+	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
+		{
+			Name:    driverPath,
+			Dir:     "/opt/snapd/interfaces/gbm-driver-libs/share/gbm/libgallium_driver.so",
+			Options: []string{"bind", "ro", osutil.XSnapdKindFile()},
+		},
+	})
+	c.Assert(spec.LibraryPathDirs(), IsNil)
+
+	// A missing client-driver in the library dirs is an error.
+	emptySlot := s.mockSlotWithComps(c, mountAssemblyGbmProviderYaml, snap.R(7))
+	c.Assert(mountAssemblyClientDriver(&mount.Specification{}, emptySlot, "gbm-driver-libs"),
+		ErrorMatches, `"libgallium_driver.so" not found in the library-source directories`)
+}

--- a/interfaces/builtin/helpers_mount_test.go
+++ b/interfaces/builtin/helpers_mount_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package builtin
+package builtin_test
 
 import (
 	"fmt"
@@ -29,6 +29,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/mount"
+	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/symlinks"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
@@ -134,38 +135,34 @@ func (s *mountAssemblyHelpersSuite) TestSourceDirEncodedName(c *C) {
 	slot := s.mockSlotWithComps(c, mountAssemblyEglProviderYaml, snap.R(5))
 
 	// Snap-file, with priority: name is prefixed with priority+dir index.
-	name, err := sourceDirEncodedName(slot, pathWithDirIdx{
-		path: filepath.Join(dirs.SnapMountDir, "egl-provider/5/egl.d/mesa.json"), idx: 0}, true)
+	name, err := builtin.SourceDirEncodedName(slot, builtin.NewPathWithDirIdx(filepath.Join(dirs.SnapMountDir, "egl-provider/5/egl.d/mesa.json"), 0), true)
 	c.Assert(err, IsNil)
 	c.Check(name, Equals, "10_snap_egl-provider_egl-slot_egl.d-mesa.json")
 
 	// A different source dir gets the next index.
-	name, err = sourceDirEncodedName(slot, pathWithDirIdx{
-		path: filepath.Join(dirs.SnapMountDir, "egl-provider/5/egl_alt.d/radeon.json"), idx: 1}, true)
+	name, err = builtin.SourceDirEncodedName(slot, builtin.NewPathWithDirIdx(filepath.Join(dirs.SnapMountDir, "egl-provider/5/egl_alt.d/radeon.json"), 1), true)
 	c.Assert(err, IsNil)
 	c.Check(name, Equals, "11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json")
 
 	// Without priority no numeric prefix is used.
-	name, err = sourceDirEncodedName(slot, pathWithDirIdx{
-		path: filepath.Join(dirs.SnapMountDir, "egl-provider/5/egl.d/mesa.json"), idx: 0}, false)
+	name, err = builtin.SourceDirEncodedName(slot, builtin.NewPathWithDirIdx(filepath.Join(dirs.SnapMountDir, "egl-provider/5/egl.d/mesa.json"), 0), false)
 	c.Assert(err, IsNil)
 	c.Check(name, Equals, "snap_egl-provider_egl-slot_egl.d-mesa.json")
 
 	// Component file: the component name is embedded and the original list
 	// index (not the filtered position) is used for the priority prefix.
 	compPath := filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "egl-provider"), "egl.d", "nvidia.json")
-	name, err = sourceDirEncodedName(slot, pathWithDirIdx{path: compPath, idx: 3}, true)
+	name, err = builtin.SourceDirEncodedName(slot, builtin.NewPathWithDirIdx(compPath, 3), true)
 	c.Assert(err, IsNil)
 	c.Check(name, Equals, "13_snap_egl-provider+comp1_egl-slot_egl.d-nvidia.json")
 
 	// withPriority on a slot without the priority attribute errors out.
 	vulkanSlot := s.mockSlotWithComps(c, mountAssemblyVulkanProviderYaml, snap.R(4))
-	_, err = sourceDirEncodedName(vulkanSlot, pathWithDirIdx{
-		path: filepath.Join(dirs.SnapMountDir, "vulkan-provider/4/vulkan/icd.d/intel.json"), idx: 0}, true)
+	_, err = builtin.SourceDirEncodedName(vulkanSlot, builtin.NewPathWithDirIdx(filepath.Join(dirs.SnapMountDir, "vulkan-provider/4/vulkan/icd.d/intel.json"), 0), true)
 	c.Check(err, ErrorMatches, `invalid priority: snap "vulkan-provider" does not have attribute "priority" for interface "vulkan-driver-libs"`)
 
 	// A path that does not reach below the snap mount dir cannot be encoded.
-	_, err = sourceDirEncodedName(slot, pathWithDirIdx{path: dirs.SnapMountDir, idx: 0}, false)
+	_, err = builtin.SourceDirEncodedName(slot, builtin.NewPathWithDirIdx(dirs.SnapMountDir, 0), false)
 	c.Check(err, ErrorMatches, `internal error: wrong file path: \.`)
 }
 
@@ -175,7 +172,7 @@ func (s *mountAssemblyHelpersSuite) TestMountAssemblyLibDirs(c *C) {
 	slot := s.mockSlotWithComps(c, mountAssemblyEglProviderYaml, snap.R(5), mockComp{"comp1", snap.R(11)})
 
 	spec := &mount.Specification{}
-	c.Assert(mountAssemblyLibDirs(spec, slot, "egl-driver-libs"), IsNil)
+	c.Assert(builtin.MountAssemblyLibDirs(spec, slot, "egl-driver-libs"), IsNil)
 
 	comp1Lib1 := filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "egl-provider"), "clib1")
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
@@ -238,8 +235,8 @@ func (s *mountAssemblyHelpersSuite) TestMountAssemblySourceFiles(c *C) {
 	os.WriteFile(filepath.Join(libDir, "libEGL_radeon.so.0"), []byte{}, 0644)
 
 	spec := &mount.Specification{}
-	c.Assert(mountAssemblySourceFiles(spec, slot, "egl-driver-libs",
-		sourceDirAttr{attrName: "icd-source"}, "egl_vendor.d", checkEglIcdFile, true), IsNil)
+	c.Assert(builtin.MountAssemblySourceFiles(spec, slot, "egl-driver-libs",
+		builtin.NewSourceDirAttr("icd-source", false), "egl_vendor.d", builtin.CheckEglIcdFile, true), IsNil)
 
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
 		{
@@ -270,10 +267,10 @@ func (s *mountAssemblyHelpersSuite) TestMountAssemblySourceFiles(c *C) {
 
 	// The mount names are byte-identical to the classic symlink names.
 	symlinksSpec := &symlinks.Specification{}
-	c.Assert(symlinksForSourceDir(symlinksSpec, slot,
-		sourceDirAttr{attrName: "icd-source"}, eglVendorPath, checkEglIcdFile, true), IsNil)
+	c.Assert(builtin.SymlinksForSourceDir(symlinksSpec, slot,
+		builtin.NewSourceDirAttr("icd-source", false), builtin.EglVendorPath, builtin.CheckEglIcdFile, true), IsNil)
 	expectedNames := map[string]bool{}
-	for link := range symlinksSpec.Symlinks()[eglVendorPath] {
+	for link := range symlinksSpec.Symlinks()[builtin.EglVendorPath] {
 		expectedNames[link] = true
 	}
 	c.Assert(expectedNames, DeepEquals, map[string]bool{
@@ -306,8 +303,8 @@ func (s *mountAssemblyHelpersSuite) TestMountAssemblySourceFilesVulkan(c *C) {
 	os.WriteFile(filepath.Join(libDir, "libvulkan_intel.so"), []byte{}, 0644)
 
 	spec := &mount.Specification{}
-	c.Assert(mountAssemblySourceFiles(spec, slot, "vulkan-driver-libs",
-		sourceDirAttr{attrName: "icd-source"}, "vulkan/icd.d", checkVulkanIcdFile, false), IsNil)
+	c.Assert(builtin.MountAssemblySourceFiles(spec, slot, "vulkan-driver-libs",
+		builtin.NewSourceDirAttr("icd-source", false), "vulkan/icd.d", builtin.CheckVulkanIcdFile, false), IsNil)
 
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
 		{
@@ -325,8 +322,8 @@ func (s *mountAssemblyHelpersSuite) TestMountAssemblySourceFilesVulkan(c *C) {
 
 	// An optional *-source attribute that is absent contributes nothing.
 	implicitSpec := &mount.Specification{}
-	c.Assert(mountAssemblySourceFiles(implicitSpec, slot, "vulkan-driver-libs",
-		sourceDirAttr{attrName: "implicit-layer-source", isOptional: true}, "vulkan/implicit_layer.d", checkVulkanLayersFile, false), IsNil)
+	c.Assert(builtin.MountAssemblySourceFiles(implicitSpec, slot, "vulkan-driver-libs",
+		builtin.NewSourceDirAttr("implicit-layer-source", true), "vulkan/implicit_layer.d", builtin.CheckVulkanLayersFile, false), IsNil)
 	c.Assert(implicitSpec.MountEntries(), HasLen, 0)
 }
 
@@ -339,7 +336,7 @@ func (s *mountAssemblyHelpersSuite) TestMountAssemblyClientDriver(c *C) {
 	os.WriteFile(driverPath, []byte{}, 0644)
 
 	spec := &mount.Specification{}
-	c.Assert(mountAssemblyClientDriver(spec, slot, "gbm-driver-libs"), IsNil)
+	c.Assert(builtin.MountAssemblyClientDriver(spec, slot, "gbm-driver-libs"), IsNil)
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
 		{
 			Name:    driverPath,
@@ -357,6 +354,6 @@ func (s *mountAssemblyHelpersSuite) TestMountAssemblyClientDriver(c *C) {
 
 	// A missing client-driver in the library dirs is an error.
 	emptySlot := s.mockSlotWithComps(c, mountAssemblyGbmProviderYaml, snap.R(7))
-	c.Assert(mountAssemblyClientDriver(&mount.Specification{}, emptySlot, "gbm-driver-libs"),
+	c.Assert(builtin.MountAssemblyClientDriver(&mount.Specification{}, emptySlot, "gbm-driver-libs"),
 		ErrorMatches, `"libgallium_driver.so" not found in the library-source directories`)
 }

--- a/interfaces/builtin/helpers_mount_test.go
+++ b/interfaces/builtin/helpers_mount_test.go
@@ -182,17 +182,17 @@ func (s *mountAssemblyHelpersSuite) TestMountAssemblyLibDirs(c *C) {
 		{
 			Name:    filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib1"),
 			Dir:     "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/0",
-			Options: []string{"rbind", "ro"},
+			Options: []string{"bind", "ro"},
 		},
 		{
 			Name:    filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib2"),
 			Dir:     "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/1",
-			Options: []string{"rbind", "ro"},
+			Options: []string{"bind", "ro"},
 		},
 		{
 			Name:    comp1Lib1,
 			Dir:     "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/2",
-			Options: []string{"rbind", "ro"},
+			Options: []string{"bind", "ro"},
 		},
 	})
 

--- a/interfaces/builtin/helpers_mount_test.go
+++ b/interfaces/builtin/helpers_mount_test.go
@@ -179,17 +179,17 @@ func (s *mountAssemblyHelpersSuite) TestMountAssemblyLibDirs(c *C) {
 		{
 			Name:    filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib1"),
 			Dir:     "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1",
-			Options: []string{"bind", "ro"},
+			Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()},
 		},
 		{
 			Name:    filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib2"),
 			Dir:     "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib2",
-			Options: []string{"bind", "ro"},
+			Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()},
 		},
 		{
 			Name:    comp1Lib1,
 			Dir:     "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib1",
-			Options: []string{"bind", "ro"},
+			Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()},
 		},
 	})
 
@@ -242,24 +242,24 @@ func (s *mountAssemblyHelpersSuite) TestMountAssemblySourceFiles(c *C) {
 		{
 			Name:    mesaIcd,
 			Dir:     "/run/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json",
-			Options: []string{"bind", "ro", osutil.XSnapdKindFile()},
+			Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()},
 		},
 		// Pass 2: redistribution to the loader-scanned GLVND directory.
 		{
 			Name:    "/run/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json",
 			Dir:     "/usr/share/glvnd/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json",
-			Options: []string{"bind", "ro", osutil.XSnapdKindFile()},
+			Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()},
 		},
 		{
 			Name:    radeonIcd,
 			Dir:     "/run/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json",
-			Options: []string{"bind", "ro", osutil.XSnapdKindFile()},
+			Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()},
 		},
 		// Pass 2: redistribution for the radeon ICD too.
 		{
 			Name:    "/run/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json",
 			Dir:     "/usr/share/glvnd/egl_vendor.d/11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json",
-			Options: []string{"bind", "ro", osutil.XSnapdKindFile()},
+			Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()},
 		},
 	})
 	// Source files do not contribute library path dirs.
@@ -310,13 +310,13 @@ func (s *mountAssemblyHelpersSuite) TestMountAssemblySourceFilesVulkan(c *C) {
 		{
 			Name:    intelIcd,
 			Dir:     "/run/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-intel.json",
-			Options: []string{"bind", "ro", osutil.XSnapdKindFile()},
+			Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()},
 		},
 		// Pass 2: redistribution to the loader-scanned Vulkan search dir.
 		{
 			Name:    "/run/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-intel.json",
 			Dir:     "/usr/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-intel.json",
-			Options: []string{"bind", "ro", osutil.XSnapdKindFile()},
+			Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()},
 		},
 	})
 
@@ -341,13 +341,13 @@ func (s *mountAssemblyHelpersSuite) TestMountAssemblyClientDriver(c *C) {
 		{
 			Name:    driverPath,
 			Dir:     "/run/snapd/interfaces/gbm-driver-libs/share/gbm/libgallium_driver.so",
-			Options: []string{"bind", "ro", osutil.XSnapdKindFile()},
+			Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()},
 		},
 		// Pass 2: redistribution to the loader-scanned GBM directory.
 		{
 			Name:    "/run/snapd/interfaces/gbm-driver-libs/share/gbm/libgallium_driver.so",
 			Dir:     fmt.Sprintf("/usr/lib/%s-linux-gnu/gbm/libgallium_driver.so", osutil.MachineName()),
-			Options: []string{"bind", "ro", osutil.XSnapdKindFile()},
+			Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()},
 		},
 	})
 	c.Assert(spec.LibraryPathDirs(), IsNil)

--- a/interfaces/builtin/helpers_mount_test.go
+++ b/interfaces/builtin/helpers_mount_test.go
@@ -28,8 +28,8 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
-	"github.com/snapcore/snapd/interfaces/mount"
 	"github.com/snapcore/snapd/interfaces/builtin"
+	"github.com/snapcore/snapd/interfaces/mount"
 	"github.com/snapcore/snapd/interfaces/symlinks"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/snap"
@@ -178,26 +178,26 @@ func (s *mountAssemblyHelpersSuite) TestMountAssemblyLibDirs(c *C) {
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
 		{
 			Name:    filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib1"),
-			Dir:     "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1",
+			Dir:     "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1",
 			Options: []string{"bind", "ro"},
 		},
 		{
 			Name:    filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib2"),
-			Dir:     "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib2",
+			Dir:     "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib2",
 			Options: []string{"bind", "ro"},
 		},
 		{
 			Name:    comp1Lib1,
-			Dir:     "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib1",
+			Dir:     "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib1",
 			Options: []string{"bind", "ro"},
 		},
 	})
 
 	// Library path dirs are collected for the SNAP_LIBRARY_PATH derivation (sorted).
 	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
-		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib1",
-		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1",
-		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib2",
+		"/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib1",
+		"/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1",
+		"/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib2",
 	})
 }
 
@@ -241,23 +241,23 @@ func (s *mountAssemblyHelpersSuite) TestMountAssemblySourceFiles(c *C) {
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
 		{
 			Name:    mesaIcd,
-			Dir:     "/opt/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json",
+			Dir:     "/run/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json",
 			Options: []string{"bind", "ro", osutil.XSnapdKindFile()},
 		},
 		// Pass 2: redistribution to the loader-scanned GLVND directory.
 		{
-			Name:    "/opt/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json",
+			Name:    "/run/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json",
 			Dir:     "/usr/share/glvnd/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json",
 			Options: []string{"bind", "ro", osutil.XSnapdKindFile()},
 		},
 		{
 			Name:    radeonIcd,
-			Dir:     "/opt/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json",
+			Dir:     "/run/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json",
 			Options: []string{"bind", "ro", osutil.XSnapdKindFile()},
 		},
 		// Pass 2: redistribution for the radeon ICD too.
 		{
-			Name:    "/opt/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json",
+			Name:    "/run/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json",
 			Dir:     "/usr/share/glvnd/egl_vendor.d/11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json",
 			Options: []string{"bind", "ro", osutil.XSnapdKindFile()},
 		},
@@ -309,12 +309,12 @@ func (s *mountAssemblyHelpersSuite) TestMountAssemblySourceFilesVulkan(c *C) {
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
 		{
 			Name:    intelIcd,
-			Dir:     "/opt/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-intel.json",
+			Dir:     "/run/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-intel.json",
 			Options: []string{"bind", "ro", osutil.XSnapdKindFile()},
 		},
 		// Pass 2: redistribution to the loader-scanned Vulkan search dir.
 		{
-			Name:    "/opt/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-intel.json",
+			Name:    "/run/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-intel.json",
 			Dir:     "/usr/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-intel.json",
 			Options: []string{"bind", "ro", osutil.XSnapdKindFile()},
 		},
@@ -340,12 +340,12 @@ func (s *mountAssemblyHelpersSuite) TestMountAssemblyClientDriver(c *C) {
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
 		{
 			Name:    driverPath,
-			Dir:     "/opt/snapd/interfaces/gbm-driver-libs/share/gbm/libgallium_driver.so",
+			Dir:     "/run/snapd/interfaces/gbm-driver-libs/share/gbm/libgallium_driver.so",
 			Options: []string{"bind", "ro", osutil.XSnapdKindFile()},
 		},
 		// Pass 2: redistribution to the loader-scanned GBM directory.
 		{
-			Name:    "/opt/snapd/interfaces/gbm-driver-libs/share/gbm/libgallium_driver.so",
+			Name:    "/run/snapd/interfaces/gbm-driver-libs/share/gbm/libgallium_driver.so",
 			Dir:     fmt.Sprintf("/usr/lib/%s-linux-gnu/gbm/libgallium_driver.so", osutil.MachineName()),
 			Options: []string{"bind", "ro", osutil.XSnapdKindFile()},
 		},

--- a/interfaces/builtin/helpers_mount_test.go
+++ b/interfaces/builtin/helpers_mount_test.go
@@ -247,9 +247,21 @@ func (s *mountAssemblyHelpersSuite) TestMountAssemblySourceFiles(c *C) {
 			Dir:     "/opt/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json",
 			Options: []string{"bind", "ro", osutil.XSnapdKindFile()},
 		},
+		// Pass 2: redistribution to the loader-scanned GLVND directory.
+		{
+			Name:    "/opt/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json",
+			Dir:     "/usr/share/glvnd/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json",
+			Options: []string{"bind", "ro", osutil.XSnapdKindFile()},
+		},
 		{
 			Name:    radeonIcd,
 			Dir:     "/opt/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json",
+			Options: []string{"bind", "ro", osutil.XSnapdKindFile()},
+		},
+		// Pass 2: redistribution for the radeon ICD too.
+		{
+			Name:    "/opt/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json",
+			Dir:     "/usr/share/glvnd/egl_vendor.d/11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json",
 			Options: []string{"bind", "ro", osutil.XSnapdKindFile()},
 		},
 	})
@@ -303,6 +315,12 @@ func (s *mountAssemblyHelpersSuite) TestMountAssemblySourceFilesVulkan(c *C) {
 			Dir:     "/opt/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-intel.json",
 			Options: []string{"bind", "ro", osutil.XSnapdKindFile()},
 		},
+		// Pass 2: redistribution to the loader-scanned Vulkan search dir.
+		{
+			Name:    "/opt/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-intel.json",
+			Dir:     "/usr/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-intel.json",
+			Options: []string{"bind", "ro", osutil.XSnapdKindFile()},
+		},
 	})
 
 	// An optional *-source attribute that is absent contributes nothing.
@@ -326,6 +344,12 @@ func (s *mountAssemblyHelpersSuite) TestMountAssemblyClientDriver(c *C) {
 		{
 			Name:    driverPath,
 			Dir:     "/opt/snapd/interfaces/gbm-driver-libs/share/gbm/libgallium_driver.so",
+			Options: []string{"bind", "ro", osutil.XSnapdKindFile()},
+		},
+		// Pass 2: redistribution to the loader-scanned GBM directory.
+		{
+			Name:    "/opt/snapd/interfaces/gbm-driver-libs/share/gbm/libgallium_driver.so",
+			Dir:     fmt.Sprintf("/usr/lib/%s-linux-gnu/gbm/libgallium_driver.so", osutil.MachineName()),
 			Options: []string{"bind", "ro", osutil.XSnapdKindFile()},
 		},
 	})

--- a/interfaces/builtin/helpers_mount_test.go
+++ b/interfaces/builtin/helpers_mount_test.go
@@ -62,8 +62,8 @@ slots:
     library-source:
       - $SNAP/lib1
       - ${SNAP}/lib2
-      - $SNAP_COMPONENT(comp1)/lib1
-      - $SNAP_COMPONENT(comp2)/lib2
+      - $SNAP_COMPONENT(comp1)/clib1
+      - $SNAP_COMPONENT(comp2)/clib2
 components:
   comp1:
     type: standard
@@ -177,30 +177,30 @@ func (s *mountAssemblyHelpersSuite) TestMountAssemblyLibDirs(c *C) {
 	spec := &mount.Specification{}
 	c.Assert(mountAssemblyLibDirs(spec, slot, "egl-driver-libs"), IsNil)
 
-	comp1Lib1 := filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "egl-provider"), "lib1")
+	comp1Lib1 := filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "egl-provider"), "clib1")
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
 		{
 			Name:    filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib1"),
-			Dir:     "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/0",
+			Dir:     "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1",
 			Options: []string{"bind", "ro"},
 		},
 		{
 			Name:    filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib2"),
-			Dir:     "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/1",
+			Dir:     "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib2",
 			Options: []string{"bind", "ro"},
 		},
 		{
 			Name:    comp1Lib1,
-			Dir:     "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/2",
+			Dir:     "/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib1",
 			Options: []string{"bind", "ro"},
 		},
 	})
 
-	// Library path dirs are collected for the SNAP_LIBRARY_PATH derivation.
+	// Library path dirs are collected for the SNAP_LIBRARY_PATH derivation (sorted).
 	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
-		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/0",
-		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/1",
-		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/2",
+		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib1",
+		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1",
+		"/opt/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib2",
 	})
 }
 

--- a/interfaces/builtin/helpers_mount_test.go
+++ b/interfaces/builtin/helpers_mount_test.go
@@ -178,26 +178,26 @@ func (s *mountAssemblyHelpersSuite) TestMountAssemblyLibDirs(c *C) {
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
 		{
 			Name:    filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib1"),
-			Dir:     "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1",
+			Dir:     "/run/snapd/snap/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1",
 			Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()},
 		},
 		{
 			Name:    filepath.Join(dirs.SnapMountDir, "egl-provider/5/lib2"),
-			Dir:     "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib2",
+			Dir:     "/run/snapd/snap/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib2",
 			Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()},
 		},
 		{
 			Name:    comp1Lib1,
-			Dir:     "/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib1",
+			Dir:     "/run/snapd/snap/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib1",
 			Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()},
 		},
 	})
 
 	// Library path dirs are collected for the SNAP_LIBRARY_PATH derivation (sorted).
 	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
-		"/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib1",
-		"/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1",
-		"/run/snapd/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib2",
+		"/run/snapd/snap/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/clib1",
+		"/run/snapd/snap/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib1",
+		"/run/snapd/snap/interfaces/egl-driver-libs/lib/egl-provider_egl-slot/lib2",
 	})
 }
 
@@ -241,23 +241,23 @@ func (s *mountAssemblyHelpersSuite) TestMountAssemblySourceFiles(c *C) {
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
 		{
 			Name:    mesaIcd,
-			Dir:     "/run/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json",
+			Dir:     "/run/snapd/snap/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json",
 			Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()},
 		},
 		// Pass 2: redistribution to the loader-scanned GLVND directory.
 		{
-			Name:    "/run/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json",
+			Name:    "/run/snapd/snap/interfaces/egl-driver-libs/share/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json",
 			Dir:     "/usr/share/glvnd/egl_vendor.d/10_snap_egl-provider_egl-slot_egl.d-mesa.json",
 			Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()},
 		},
 		{
 			Name:    radeonIcd,
-			Dir:     "/run/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json",
+			Dir:     "/run/snapd/snap/interfaces/egl-driver-libs/share/egl_vendor.d/11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json",
 			Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()},
 		},
 		// Pass 2: redistribution for the radeon ICD too.
 		{
-			Name:    "/run/snapd/interfaces/egl-driver-libs/share/egl_vendor.d/11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json",
+			Name:    "/run/snapd/snap/interfaces/egl-driver-libs/share/egl_vendor.d/11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json",
 			Dir:     "/usr/share/glvnd/egl_vendor.d/11_snap_egl-provider_egl-slot_egl_alt.d-radeon.json",
 			Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()},
 		},
@@ -309,12 +309,12 @@ func (s *mountAssemblyHelpersSuite) TestMountAssemblySourceFilesVulkan(c *C) {
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
 		{
 			Name:    intelIcd,
-			Dir:     "/run/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-intel.json",
+			Dir:     "/run/snapd/snap/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-intel.json",
 			Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()},
 		},
 		// Pass 2: redistribution to the loader-scanned Vulkan search dir.
 		{
-			Name:    "/run/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-intel.json",
+			Name:    "/run/snapd/snap/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-intel.json",
 			Dir:     "/usr/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-intel.json",
 			Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()},
 		},
@@ -340,12 +340,12 @@ func (s *mountAssemblyHelpersSuite) TestMountAssemblyClientDriver(c *C) {
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
 		{
 			Name:    driverPath,
-			Dir:     "/run/snapd/interfaces/gbm-driver-libs/share/gbm/libgallium_driver.so",
+			Dir:     "/run/snapd/snap/interfaces/gbm-driver-libs/share/gbm/libgallium_driver.so",
 			Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()},
 		},
 		// Pass 2: redistribution to the loader-scanned GBM directory.
 		{
-			Name:    "/run/snapd/interfaces/gbm-driver-libs/share/gbm/libgallium_driver.so",
+			Name:    "/run/snapd/snap/interfaces/gbm-driver-libs/share/gbm/libgallium_driver.so",
 			Dir:     fmt.Sprintf("/usr/lib/%s-linux-gnu/gbm/libgallium_driver.so", osutil.MachineName()),
 			Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()},
 		},

--- a/interfaces/builtin/helpers_test.go
+++ b/interfaces/builtin/helpers_test.go
@@ -1,0 +1,41 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package builtin_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/interfaces/builtin"
+)
+
+type driverLibsHelpersSuite struct{}
+
+var _ = Suite(&driverLibsHelpersSuite{})
+
+func (s *driverLibsHelpersSuite) TestDriverLibsSupported(c *C) {
+	// Bases that are not new enough for the direct-connection model.
+	for _, base := range []string{"", "bare", "core", "core18", "core20", "core22", "core24", "core22-desktop", "core24-desktop"} {
+		c.Check(builtin.DriverLibsSupported(base), Equals, false, Commentf("base %q should be unsupported", base))
+	}
+	// Bases new enough (core26 and beyond) are supported.
+	for _, base := range []string{"core26", "core28", "core26-desktop"} {
+		c.Check(builtin.DriverLibsSupported(base), Equals, true, Commentf("base %q should be supported", base))
+	}
+}

--- a/interfaces/builtin/nvidia_video_driver_libs.go
+++ b/interfaces/builtin/nvidia_video_driver_libs.go
@@ -24,6 +24,7 @@ import (
 	"math"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/compatibility"
 	"github.com/snapcore/snapd/interfaces/configfiles"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
@@ -102,6 +103,13 @@ func (iface *nvidiaVideoDriverLibsInterface) MountConnectedPlug(spec *mount.Spec
 	// On Ubuntu Core the provider content is bound into the assembly tree under
 	// the /opt/snapd/interfaces directory (see mountAssemblyLibDirs).
 	return mountAssemblyLibDirs(spec, slot, nvidiaVideoDriverLibs)
+}
+
+func (iface *nvidiaVideoDriverLibsInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	// Authorize snap-update-ns to construct (and eventually tear down) the
+	// assembly tree under /opt/snapd/interfaces. The default base template
+	// already grants /opt/** mrklix to the app itself, no extra snippet needed.
+	return addAppArmorAssemblyLibDirs(spec, slot, nvidiaVideoDriverLibs)
 }
 
 var _ = interfaces.ConfigfilesUser(&nvidiaVideoDriverLibsInterface{})

--- a/interfaces/builtin/nvidia_video_driver_libs.go
+++ b/interfaces/builtin/nvidia_video_driver_libs.go
@@ -20,6 +20,7 @@
 package builtin
 
 import (
+	"fmt"
 	"math"
 
 	"github.com/snapcore/snapd/interfaces"
@@ -56,6 +57,13 @@ const nvidiaVideoDriverLibsBaseDeclarationSlots = `
 // nvidiaVideoDriverLibsInterface allows exposing Nvidia video driver libraries to the system or snaps.
 type nvidiaVideoDriverLibsInterface struct {
 	commonInterface
+}
+
+func (iface *nvidiaVideoDriverLibsInterface) BeforePreparePlug(plug *snap.PlugInfo) error {
+	if !driverLibsSupported(plug.Snap.Base) {
+		return fmt.Errorf("%s interface is not supported on base %q", nvidiaVideoDriverLibs, plug.Snap.Base)
+	}
+	return nil
 }
 
 func (iface *nvidiaVideoDriverLibsInterface) BeforePrepareSlot(slot *snap.SlotInfo) error {

--- a/interfaces/builtin/nvidia_video_driver_libs.go
+++ b/interfaces/builtin/nvidia_video_driver_libs.go
@@ -27,6 +27,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/compatibility"
 	"github.com/snapcore/snapd/interfaces/configfiles"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
+	"github.com/snapcore/snapd/interfaces/mount"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 )
@@ -95,6 +96,12 @@ func (iface *nvidiaVideoDriverLibsInterface) BeforePrepareSlot(slot *snap.SlotIn
 func (iface *nvidiaVideoDriverLibsInterface) LdconfigConnectedPlug(spec *ldconfig.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// The plug can only be the system plug for the time being
 	return addLdconfigLibDirs(spec, slot)
+}
+
+func (iface *nvidiaVideoDriverLibsInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	// On Ubuntu Core the provider content is bound into the assembly tree under
+	// the /opt/snapd/interfaces directory (see mountAssemblyLibDirs).
+	return mountAssemblyLibDirs(spec, slot, nvidiaVideoDriverLibs)
 }
 
 var _ = interfaces.ConfigfilesUser(&nvidiaVideoDriverLibsInterface{})

--- a/interfaces/builtin/nvidia_video_driver_libs.go
+++ b/interfaces/builtin/nvidia_video_driver_libs.go
@@ -33,15 +33,17 @@ import (
 
 const nvidiaVideoDriverLibsSummary = `allows exposing Nvidia video decoding/encoding driver libraries to the system`
 
-// Plugs only supported for the system on classic for the moment (note this is
-// checked on "system" snap installation even though this is an implicit plug
-// in that case) - in the future we will allow snaps having this as plug and
-// this declaration will have to change.
+// Plug on classic may only be declared by the system snap (implicit plug); on
+// Ubuntu Core any snap may declare it (see allow-installation alternatives).
 const nvidiaVideoDriverLibsBaseDeclarationPlugs = `
   nvidia-video-driver-libs:
     allow-installation:
-      plug-snap-type:
-        - core
+      -
+        on-classic: true
+        plug-snap-type:
+          - core
+      -
+        on-classic: false
     allow-connection:
       slots-per-plug: *
     deny-auto-connection: true

--- a/interfaces/builtin/nvidia_video_driver_libs.go
+++ b/interfaces/builtin/nvidia_video_driver_libs.go
@@ -106,9 +106,11 @@ func (iface *nvidiaVideoDriverLibsInterface) MountConnectedPlug(spec *mount.Spec
 }
 
 func (iface *nvidiaVideoDriverLibsInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	// Authorize snap-update-ns to construct (and eventually tear down) the
-	// assembly tree under /opt/snapd/interfaces. The default base template
-	// already grants /opt/** mrklix to the app itself, no extra snippet needed.
+	// Grant the app read access to its own assembly subtree under
+	// /opt/snapd/interfaces (the core base template does not grant /opt/** to
+	// apps), then authorize snap-update-ns to construct (and eventually tear
+	// down) the assembly tree.
+	addAppArmorAssemblyAccess(spec, nvidiaVideoDriverLibs)
 	return addAppArmorAssemblyLibDirs(spec, slot, nvidiaVideoDriverLibs)
 }
 

--- a/interfaces/builtin/nvidia_video_driver_libs.go
+++ b/interfaces/builtin/nvidia_video_driver_libs.go
@@ -101,13 +101,13 @@ func (iface *nvidiaVideoDriverLibsInterface) LdconfigConnectedPlug(spec *ldconfi
 
 func (iface *nvidiaVideoDriverLibsInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// On Ubuntu Core the provider content is bound into the assembly tree under
-	// the /opt/snapd/interfaces directory (see mountAssemblyLibDirs).
+	// the /run/snapd/interfaces directory (see mountAssemblyLibDirs).
 	return mountAssemblyLibDirs(spec, slot, nvidiaVideoDriverLibs)
 }
 
 func (iface *nvidiaVideoDriverLibsInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// Grant the app read access to its own assembly subtree under
-	// /opt/snapd/interfaces (the core base template does not grant /opt/** to
+	// /run/snapd/interfaces (the core base template does not grant /opt/** to
 	// apps), then authorize snap-update-ns to construct (and eventually tear
 	// down) the assembly tree.
 	addAppArmorAssemblyAccess(spec, nvidiaVideoDriverLibs)

--- a/interfaces/builtin/nvidia_video_driver_libs.go
+++ b/interfaces/builtin/nvidia_video_driver_libs.go
@@ -101,7 +101,7 @@ func (iface *nvidiaVideoDriverLibsInterface) LdconfigConnectedPlug(spec *ldconfi
 
 func (iface *nvidiaVideoDriverLibsInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// On Ubuntu Core the provider content is bound into the assembly tree under
-	// the /run/snapd/interfaces directory (see mountAssemblyLibDirs).
+	// the /run/snapd/snap/interfaces directory (see mountAssemblyLibDirs).
 	if err := mountAssemblyRoot(spec); err != nil {
 		return err
 	}
@@ -110,7 +110,7 @@ func (iface *nvidiaVideoDriverLibsInterface) MountConnectedPlug(spec *mount.Spec
 
 func (iface *nvidiaVideoDriverLibsInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// Grant the app read access to its own assembly subtree under
-	// /run/snapd/interfaces (the core base template does not grant /opt/** to
+	// /run/snapd/snap/interfaces (the core base template does not grant /opt/** to
 	// apps), then authorize snap-update-ns to construct (and eventually tear
 	// down) the assembly tree.
 	addAppArmorAssemblyRoot(spec)

--- a/interfaces/builtin/nvidia_video_driver_libs.go
+++ b/interfaces/builtin/nvidia_video_driver_libs.go
@@ -102,6 +102,9 @@ func (iface *nvidiaVideoDriverLibsInterface) LdconfigConnectedPlug(spec *ldconfi
 func (iface *nvidiaVideoDriverLibsInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// On Ubuntu Core the provider content is bound into the assembly tree under
 	// the /run/snapd/interfaces directory (see mountAssemblyLibDirs).
+	if err := mountAssemblyRoot(spec); err != nil {
+		return err
+	}
 	return mountAssemblyLibDirs(spec, slot, nvidiaVideoDriverLibs)
 }
 
@@ -110,6 +113,7 @@ func (iface *nvidiaVideoDriverLibsInterface) AppArmorConnectedPlug(spec *apparmo
 	// /run/snapd/interfaces (the core base template does not grant /opt/** to
 	// apps), then authorize snap-update-ns to construct (and eventually tear
 	// down) the assembly tree.
+	addAppArmorAssemblyRoot(spec)
 	addAppArmorAssemblyAccess(spec, nvidiaVideoDriverLibs)
 	return addAppArmorAssemblyLibDirs(spec, slot, nvidiaVideoDriverLibs)
 }

--- a/interfaces/builtin/nvidia_video_driver_libs_test.go
+++ b/interfaces/builtin/nvidia_video_driver_libs_test.go
@@ -22,11 +22,13 @@ package builtin_test
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/configfiles"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
@@ -214,6 +216,20 @@ func (s *NvidiaVideoDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 		"/opt/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/0",
 		"/opt/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/1",
 	})
+}
+
+func (s *NvidiaVideoDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
+	spec := apparmor.NewSpecification(s.plug.AppSet())
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+
+	updateNS := strings.Join(spec.UpdateNS(), "")
+	lib1 := filepath.Join(dirs.SnapMountDir, "nvidia-video-provider/5/lib1")
+	target0 := "/opt/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/0"
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n", lib1, target0))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target0))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}/\",\n", target0))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  # Writable mimic %s\n", filepath.Dir(target0)))
+	c.Check(spec.SnippetForTag("snap.snapd.app"), Equals, "")
 }
 
 func (s *NvidiaVideoDriverLibsInterfaceSuite) TestConfigfilesSpec(c *C) {

--- a/interfaces/builtin/nvidia_video_driver_libs_test.go
+++ b/interfaces/builtin/nvidia_video_driver_libs_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/configfiles"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
+	"github.com/snapcore/snapd/interfaces/mount"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
@@ -197,6 +198,22 @@ func (s *NvidiaVideoDriverLibsInterfaceSuite) TestLdconfigSpec(c *C) {
 	c.Check(spec.LibDirs(), DeepEquals, map[ldconfig.SnapSlot][]string{
 		{SnapName: "nvidia-video-provider", SlotName: "nvidia-video-slot"}: {filepath.Join(dirs.SnapMountDir, "nvidia-video-provider/5/lib1"),
 			filepath.Join(dirs.SnapMountDir, "nvidia-video-provider/5/lib2")}})
+}
+
+func (s *NvidiaVideoDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
+	spec := &mount.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+
+	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
+		{Name: filepath.Join(dirs.SnapMountDir, "nvidia-video-provider/5/lib1"),
+			Dir: "/opt/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/0", Options: []string{"rbind", "ro"}},
+		{Name: filepath.Join(dirs.SnapMountDir, "nvidia-video-provider/5/lib2"),
+			Dir: "/opt/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/1", Options: []string{"rbind", "ro"}},
+	})
+	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
+		"/opt/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/0",
+		"/opt/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/1",
+	})
 }
 
 func (s *NvidiaVideoDriverLibsInterfaceSuite) TestConfigfilesSpec(c *C) {

--- a/interfaces/builtin/nvidia_video_driver_libs_test.go
+++ b/interfaces/builtin/nvidia_video_driver_libs_test.go
@@ -53,6 +53,7 @@ var _ = Suite(&NvidiaVideoDriverLibsInterfaceSuite{
 // This is in fact implicit in the system
 const nvidiaVideoDriverLibsConsumerYaml = `name: snapd
 version: 0
+base: core26
 plugs:
   nvidia-video:
     compatibility: nvidia-video-(6..12)-(0..2)-ubuntu-2404
@@ -169,6 +170,25 @@ slots:
 func (s *NvidiaVideoDriverLibsInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Check(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
 	c.Check(interfaces.BeforeConnectPlug(s.iface, s.plug), IsNil)
+}
+
+func (s *NvidiaVideoDriverLibsInterfaceSuite) TestSanitizePlugUnsupportedBase(c *C) {
+	const consumerYaml = `name: snapd
+version: 0
+base: core24
+plugs:
+  nvidia-video:
+    compatibility: nvidia-video-(6..12)-(0..2)-ubuntu-2404
+    interface: nvidia-video-driver-libs
+apps:
+  app:
+    plugs: [nvidia-video]
+`
+	plug, plugInfo := MockConnectedPlug(c, consumerYaml,
+		&snap.SideInfo{Revision: snap.R(3)}, "nvidia-video")
+	c.Check(interfaces.BeforeConnectPlug(s.iface, plug), IsNil)
+	c.Check(interfaces.BeforePreparePlug(s.iface, plugInfo), ErrorMatches,
+		`nvidia-video-driver-libs interface is not supported on base "core24"`)
 }
 
 func (s *NvidiaVideoDriverLibsInterfaceSuite) TestLdconfigSpec(c *C) {

--- a/interfaces/builtin/nvidia_video_driver_libs_test.go
+++ b/interfaces/builtin/nvidia_video_driver_libs_test.go
@@ -209,15 +209,15 @@ func (s *NvidiaVideoDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
 		// The shared tmpfs mount at the assembly root, so that only the bare
 		// mountpoint directory (not the assembly tree content) is host-visible.
-		{Name: "tmpfs", Dir: "/run/snapd/interfaces", Type: "tmpfs", Options: []string{"mode=0755", "uid=0", "gid=0"}},
+		{Name: "tmpfs", Dir: "/run/snapd/snap", Type: "tmpfs", Options: []string{"mode=0755", "uid=0", "gid=0"}},
 		{Name: filepath.Join(dirs.SnapMountDir, "nvidia-video-provider/5/lib1"),
-			Dir: "/run/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/lib1", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
+			Dir: "/run/snapd/snap/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/lib1", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
 		{Name: filepath.Join(dirs.SnapMountDir, "nvidia-video-provider/5/lib2"),
-			Dir: "/run/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/lib2", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
+			Dir: "/run/snapd/snap/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/lib2", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
 	})
 	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
-		"/run/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/lib1",
-		"/run/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/lib2",
+		"/run/snapd/snap/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/lib1",
+		"/run/snapd/snap/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/lib2",
 	})
 }
 
@@ -227,7 +227,7 @@ func (s *NvidiaVideoDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C
 
 	updateNS := strings.Join(spec.UpdateNS(), "")
 	lib1 := filepath.Join(dirs.SnapMountDir, "nvidia-video-provider/5/lib1")
-	target0 := "/run/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/lib1"
+	target0 := "/run/snapd/snap/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/lib1"
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(rw, bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n", lib1, target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}/\",\n", target0))
@@ -235,8 +235,8 @@ func (s *NvidiaVideoDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C
 	// The app gets read access to its own assembly subtree only (the core base
 	// template does not grant /opt/** to apps).
 	app := spec.SnippetForTag("snap.snapd.app")
-	c.Check(app, testutil.Contains, "/run/snapd/interfaces/nvidia-video-driver-libs/ r,")
-	c.Check(app, testutil.Contains, "/run/snapd/interfaces/nvidia-video-driver-libs/** mrkix,")
+	c.Check(app, testutil.Contains, "/run/snapd/snap/interfaces/nvidia-video-driver-libs/ r,")
+	c.Check(app, testutil.Contains, "/run/snapd/snap/interfaces/nvidia-video-driver-libs/** mrkix,")
 }
 
 func (s *NvidiaVideoDriverLibsInterfaceSuite) TestConfigfilesSpec(c *C) {

--- a/interfaces/builtin/nvidia_video_driver_libs_test.go
+++ b/interfaces/builtin/nvidia_video_driver_libs_test.go
@@ -225,7 +225,7 @@ func (s *NvidiaVideoDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C
 	updateNS := strings.Join(spec.UpdateNS(), "")
 	lib1 := filepath.Join(dirs.SnapMountDir, "nvidia-video-provider/5/lib1")
 	target0 := "/opt/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/lib1"
-	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n", lib1, target0))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(rw, bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n", lib1, target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}/\",\n", target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  # Writable mimic %s\n", filepath.Dir(target0)))

--- a/interfaces/builtin/nvidia_video_driver_libs_test.go
+++ b/interfaces/builtin/nvidia_video_driver_libs_test.go
@@ -208,13 +208,13 @@ func (s *NvidiaVideoDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
 		{Name: filepath.Join(dirs.SnapMountDir, "nvidia-video-provider/5/lib1"),
-			Dir: "/opt/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/lib1", Options: []string{"bind", "ro"}},
+			Dir: "/run/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/lib1", Options: []string{"bind", "ro"}},
 		{Name: filepath.Join(dirs.SnapMountDir, "nvidia-video-provider/5/lib2"),
-			Dir: "/opt/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/lib2", Options: []string{"bind", "ro"}},
+			Dir: "/run/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/lib2", Options: []string{"bind", "ro"}},
 	})
 	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
-		"/opt/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/lib1",
-		"/opt/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/lib2",
+		"/run/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/lib1",
+		"/run/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/lib2",
 	})
 }
 
@@ -224,7 +224,7 @@ func (s *NvidiaVideoDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C
 
 	updateNS := strings.Join(spec.UpdateNS(), "")
 	lib1 := filepath.Join(dirs.SnapMountDir, "nvidia-video-provider/5/lib1")
-	target0 := "/opt/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/lib1"
+	target0 := "/run/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/lib1"
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(rw, bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n", lib1, target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}/\",\n", target0))
@@ -232,8 +232,8 @@ func (s *NvidiaVideoDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C
 	// The app gets read access to its own assembly subtree only (the core base
 	// template does not grant /opt/** to apps).
 	app := spec.SnippetForTag("snap.snapd.app")
-	c.Check(app, testutil.Contains, "/opt/snapd/interfaces/nvidia-video-driver-libs/ r,")
-	c.Check(app, testutil.Contains, "/opt/snapd/interfaces/nvidia-video-driver-libs/** mrkix,")
+	c.Check(app, testutil.Contains, "/run/snapd/interfaces/nvidia-video-driver-libs/ r,")
+	c.Check(app, testutil.Contains, "/run/snapd/interfaces/nvidia-video-driver-libs/** mrkix,")
 }
 
 func (s *NvidiaVideoDriverLibsInterfaceSuite) TestConfigfilesSpec(c *C) {

--- a/interfaces/builtin/nvidia_video_driver_libs_test.go
+++ b/interfaces/builtin/nvidia_video_driver_libs_test.go
@@ -207,6 +207,9 @@ func (s *NvidiaVideoDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
+		// The shared tmpfs mount at the assembly root, so that only the bare
+		// mountpoint directory (not the assembly tree content) is host-visible.
+		{Name: "tmpfs", Dir: "/run/snapd/interfaces", Type: "tmpfs", Options: []string{"mode=0755", "uid=0", "gid=0"}},
 		{Name: filepath.Join(dirs.SnapMountDir, "nvidia-video-provider/5/lib1"),
 			Dir: "/run/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/lib1", Options: []string{"bind", "ro"}},
 		{Name: filepath.Join(dirs.SnapMountDir, "nvidia-video-provider/5/lib2"),

--- a/interfaces/builtin/nvidia_video_driver_libs_test.go
+++ b/interfaces/builtin/nvidia_video_driver_libs_test.go
@@ -208,13 +208,13 @@ func (s *NvidiaVideoDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
 		{Name: filepath.Join(dirs.SnapMountDir, "nvidia-video-provider/5/lib1"),
-			Dir: "/opt/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/0", Options: []string{"bind", "ro"}},
+			Dir: "/opt/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/lib1", Options: []string{"bind", "ro"}},
 		{Name: filepath.Join(dirs.SnapMountDir, "nvidia-video-provider/5/lib2"),
-			Dir: "/opt/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/1", Options: []string{"bind", "ro"}},
+			Dir: "/opt/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/lib2", Options: []string{"bind", "ro"}},
 	})
 	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
-		"/opt/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/0",
-		"/opt/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/1",
+		"/opt/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/lib1",
+		"/opt/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/lib2",
 	})
 }
 
@@ -224,7 +224,7 @@ func (s *NvidiaVideoDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C
 
 	updateNS := strings.Join(spec.UpdateNS(), "")
 	lib1 := filepath.Join(dirs.SnapMountDir, "nvidia-video-provider/5/lib1")
-	target0 := "/opt/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/0"
+	target0 := "/opt/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/lib1"
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n", lib1, target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}/\",\n", target0))

--- a/interfaces/builtin/nvidia_video_driver_libs_test.go
+++ b/interfaces/builtin/nvidia_video_driver_libs_test.go
@@ -229,7 +229,11 @@ func (s *NvidiaVideoDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}/\",\n", target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  # Writable mimic %s\n", filepath.Dir(target0)))
-	c.Check(spec.SnippetForTag("snap.snapd.app"), Equals, "")
+	// The app gets read access to its own assembly subtree only (the core base
+	// template does not grant /opt/** to apps).
+	app := spec.SnippetForTag("snap.snapd.app")
+	c.Check(app, testutil.Contains, "/opt/snapd/interfaces/nvidia-video-driver-libs/ r,")
+	c.Check(app, testutil.Contains, "/opt/snapd/interfaces/nvidia-video-driver-libs/** mrkix,")
 }
 
 func (s *NvidiaVideoDriverLibsInterfaceSuite) TestConfigfilesSpec(c *C) {

--- a/interfaces/builtin/nvidia_video_driver_libs_test.go
+++ b/interfaces/builtin/nvidia_video_driver_libs_test.go
@@ -211,9 +211,9 @@ func (s *NvidiaVideoDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 		// mountpoint directory (not the assembly tree content) is host-visible.
 		{Name: "tmpfs", Dir: "/run/snapd/interfaces", Type: "tmpfs", Options: []string{"mode=0755", "uid=0", "gid=0"}},
 		{Name: filepath.Join(dirs.SnapMountDir, "nvidia-video-provider/5/lib1"),
-			Dir: "/run/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/lib1", Options: []string{"bind", "ro"}},
+			Dir: "/run/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/lib1", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
 		{Name: filepath.Join(dirs.SnapMountDir, "nvidia-video-provider/5/lib2"),
-			Dir: "/run/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/lib2", Options: []string{"bind", "ro"}},
+			Dir: "/run/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/lib2", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
 	})
 	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
 		"/run/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/lib1",

--- a/interfaces/builtin/nvidia_video_driver_libs_test.go
+++ b/interfaces/builtin/nvidia_video_driver_libs_test.go
@@ -208,9 +208,9 @@ func (s *NvidiaVideoDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
 		{Name: filepath.Join(dirs.SnapMountDir, "nvidia-video-provider/5/lib1"),
-			Dir: "/opt/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/0", Options: []string{"rbind", "ro"}},
+			Dir: "/opt/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/0", Options: []string{"bind", "ro"}},
 		{Name: filepath.Join(dirs.SnapMountDir, "nvidia-video-provider/5/lib2"),
-			Dir: "/opt/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/1", Options: []string{"rbind", "ro"}},
+			Dir: "/opt/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/1", Options: []string{"bind", "ro"}},
 	})
 	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
 		"/opt/snapd/interfaces/nvidia-video-driver-libs/lib/nvidia-video-provider_nvidia-video-slot/0",

--- a/interfaces/builtin/opengl_driver_libs.go
+++ b/interfaces/builtin/opengl_driver_libs.go
@@ -27,6 +27,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/compatibility"
 	"github.com/snapcore/snapd/interfaces/configfiles"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
+	"github.com/snapcore/snapd/interfaces/mount"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 )
@@ -91,6 +92,12 @@ func (iface *openglDriverLibsInterface) BeforePrepareSlot(slot *snap.SlotInfo) e
 func (iface *openglDriverLibsInterface) LdconfigConnectedPlug(spec *ldconfig.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// The plug can only be the system plug for the time being
 	return addLdconfigLibDirs(spec, slot)
+}
+
+func (iface *openglDriverLibsInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	// On Ubuntu Core the provider content is bound into the assembly tree under
+	// the /opt/snapd/interfaces directory (see mountAssemblyLibDirs).
+	return mountAssemblyLibDirs(spec, slot, openglDriverLibs)
 }
 
 const openglDriverLibs = "opengl-driver-libs"

--- a/interfaces/builtin/opengl_driver_libs.go
+++ b/interfaces/builtin/opengl_driver_libs.go
@@ -33,15 +33,17 @@ import (
 
 const openglDriverLibsSummary = `allows exposing OpenGL driver libraries to the system`
 
-// Plugs only supported for the system on classic for the moment (note this is
-// checked on "system" snap installation even though this is an implicit plug
-// in that case) - in the future we will allow snaps having this as plug and
-// this declaration will have to change.
+// Plug on classic may only be declared by the system snap (implicit plug); on
+// Ubuntu Core any snap may declare it (see allow-installation alternatives).
 const openglDriverLibsBaseDeclarationPlugs = `
   opengl-driver-libs:
     allow-installation:
-      plug-snap-type:
-        - core
+      -
+        on-classic: true
+        plug-snap-type:
+          - core
+      -
+        on-classic: false
     allow-connection:
       slots-per-plug: *
     deny-auto-connection: true

--- a/interfaces/builtin/opengl_driver_libs.go
+++ b/interfaces/builtin/opengl_driver_libs.go
@@ -24,6 +24,7 @@ import (
 	"math"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/compatibility"
 	"github.com/snapcore/snapd/interfaces/configfiles"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
@@ -98,6 +99,13 @@ func (iface *openglDriverLibsInterface) MountConnectedPlug(spec *mount.Specifica
 	// On Ubuntu Core the provider content is bound into the assembly tree under
 	// the /opt/snapd/interfaces directory (see mountAssemblyLibDirs).
 	return mountAssemblyLibDirs(spec, slot, openglDriverLibs)
+}
+
+func (iface *openglDriverLibsInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	// Authorize snap-update-ns to construct (and eventually tear down) the
+	// assembly tree under /opt/snapd/interfaces. The default base template
+	// already grants /opt/** mrklix to the app itself, no extra snippet needed.
+	return addAppArmorAssemblyLibDirs(spec, slot, openglDriverLibs)
 }
 
 const openglDriverLibs = "opengl-driver-libs"

--- a/interfaces/builtin/opengl_driver_libs.go
+++ b/interfaces/builtin/opengl_driver_libs.go
@@ -20,6 +20,7 @@
 package builtin
 
 import (
+	"fmt"
 	"math"
 
 	"github.com/snapcore/snapd/interfaces"
@@ -56,6 +57,13 @@ const openglDriverLibsBaseDeclarationSlots = `
 // openglDriverLibsInterface allows exposing OPENGL driver libraries to the system or snaps.
 type openglDriverLibsInterface struct {
 	commonInterface
+}
+
+func (iface *openglDriverLibsInterface) BeforePreparePlug(plug *snap.PlugInfo) error {
+	if !driverLibsSupported(plug.Snap.Base) {
+		return fmt.Errorf("%s interface is not supported on base %q", openglDriverLibs, plug.Snap.Base)
+	}
+	return nil
 }
 
 func (iface *openglDriverLibsInterface) BeforePrepareSlot(slot *snap.SlotInfo) error {

--- a/interfaces/builtin/opengl_driver_libs.go
+++ b/interfaces/builtin/opengl_driver_libs.go
@@ -97,7 +97,7 @@ func (iface *openglDriverLibsInterface) LdconfigConnectedPlug(spec *ldconfig.Spe
 
 func (iface *openglDriverLibsInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// On Ubuntu Core the provider content is bound into the assembly tree under
-	// the /run/snapd/interfaces directory (see mountAssemblyLibDirs).
+	// the /run/snapd/snap/interfaces directory (see mountAssemblyLibDirs).
 	if err := mountAssemblyRoot(spec); err != nil {
 		return err
 	}
@@ -106,7 +106,7 @@ func (iface *openglDriverLibsInterface) MountConnectedPlug(spec *mount.Specifica
 
 func (iface *openglDriverLibsInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// Grant the app read access to its own assembly subtree under
-	// /run/snapd/interfaces (the core base template does not grant /opt/** to
+	// /run/snapd/snap/interfaces (the core base template does not grant /opt/** to
 	// apps), then authorize snap-update-ns to construct (and eventually tear
 	// down) the assembly tree.
 	addAppArmorAssemblyRoot(spec)

--- a/interfaces/builtin/opengl_driver_libs.go
+++ b/interfaces/builtin/opengl_driver_libs.go
@@ -102,9 +102,11 @@ func (iface *openglDriverLibsInterface) MountConnectedPlug(spec *mount.Specifica
 }
 
 func (iface *openglDriverLibsInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	// Authorize snap-update-ns to construct (and eventually tear down) the
-	// assembly tree under /opt/snapd/interfaces. The default base template
-	// already grants /opt/** mrklix to the app itself, no extra snippet needed.
+	// Grant the app read access to its own assembly subtree under
+	// /opt/snapd/interfaces (the core base template does not grant /opt/** to
+	// apps), then authorize snap-update-ns to construct (and eventually tear
+	// down) the assembly tree.
+	addAppArmorAssemblyAccess(spec, openglDriverLibs)
 	return addAppArmorAssemblyLibDirs(spec, slot, openglDriverLibs)
 }
 

--- a/interfaces/builtin/opengl_driver_libs.go
+++ b/interfaces/builtin/opengl_driver_libs.go
@@ -97,13 +97,13 @@ func (iface *openglDriverLibsInterface) LdconfigConnectedPlug(spec *ldconfig.Spe
 
 func (iface *openglDriverLibsInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// On Ubuntu Core the provider content is bound into the assembly tree under
-	// the /opt/snapd/interfaces directory (see mountAssemblyLibDirs).
+	// the /run/snapd/interfaces directory (see mountAssemblyLibDirs).
 	return mountAssemblyLibDirs(spec, slot, openglDriverLibs)
 }
 
 func (iface *openglDriverLibsInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// Grant the app read access to its own assembly subtree under
-	// /opt/snapd/interfaces (the core base template does not grant /opt/** to
+	// /run/snapd/interfaces (the core base template does not grant /opt/** to
 	// apps), then authorize snap-update-ns to construct (and eventually tear
 	// down) the assembly tree.
 	addAppArmorAssemblyAccess(spec, openglDriverLibs)

--- a/interfaces/builtin/opengl_driver_libs.go
+++ b/interfaces/builtin/opengl_driver_libs.go
@@ -98,6 +98,9 @@ func (iface *openglDriverLibsInterface) LdconfigConnectedPlug(spec *ldconfig.Spe
 func (iface *openglDriverLibsInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// On Ubuntu Core the provider content is bound into the assembly tree under
 	// the /run/snapd/interfaces directory (see mountAssemblyLibDirs).
+	if err := mountAssemblyRoot(spec); err != nil {
+		return err
+	}
 	return mountAssemblyLibDirs(spec, slot, openglDriverLibs)
 }
 
@@ -106,6 +109,7 @@ func (iface *openglDriverLibsInterface) AppArmorConnectedPlug(spec *apparmor.Spe
 	// /run/snapd/interfaces (the core base template does not grant /opt/** to
 	// apps), then authorize snap-update-ns to construct (and eventually tear
 	// down) the assembly tree.
+	addAppArmorAssemblyRoot(spec)
 	addAppArmorAssemblyAccess(spec, openglDriverLibs)
 	return addAppArmorAssemblyLibDirs(spec, slot, openglDriverLibs)
 }

--- a/interfaces/builtin/opengl_driver_libs_test.go
+++ b/interfaces/builtin/opengl_driver_libs_test.go
@@ -55,6 +55,7 @@ var _ = Suite(&OpenglDriverLibsInterfaceSuite{
 // This is in fact implicit in the system
 const openglDriverLibsConsumerYaml = `name: snapd
 version: 0
+base: core26
 plugs:
   opengl:
     interface: opengl-driver-libs
@@ -159,6 +160,24 @@ slots:
 func (s *OpenglDriverLibsInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Check(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
 	c.Check(interfaces.BeforeConnectPlug(s.iface, s.plug), IsNil)
+}
+
+func (s *OpenglDriverLibsInterfaceSuite) TestSanitizePlugUnsupportedBase(c *C) {
+	const consumerYaml = `name: snapd
+version: 0
+base: core24
+plugs:
+  opengl:
+    interface: opengl-driver-libs
+apps:
+  app:
+    plugs: [opengl]
+`
+	plug, plugInfo := MockConnectedPlug(c, consumerYaml,
+		&snap.SideInfo{Revision: snap.R(3)}, "opengl")
+	c.Check(interfaces.BeforeConnectPlug(s.iface, plug), IsNil)
+	c.Check(interfaces.BeforePreparePlug(s.iface, plugInfo), ErrorMatches,
+		`opengl-driver-libs interface is not supported on base "core24"`)
 }
 
 func (s *OpenglDriverLibsInterfaceSuite) TestLdconfigSpec(c *C) {

--- a/interfaces/builtin/opengl_driver_libs_test.go
+++ b/interfaces/builtin/opengl_driver_libs_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/configfiles"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
+	"github.com/snapcore/snapd/interfaces/mount"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
@@ -187,6 +188,22 @@ func (s *OpenglDriverLibsInterfaceSuite) TestLdconfigSpec(c *C) {
 		{SnapName: "opengl-provider", SlotName: "opengl-slot"}: {
 			filepath.Join(dirs.SnapMountDir, "opengl-provider/5/lib1"),
 			filepath.Join(dirs.SnapMountDir, "opengl-provider/5/lib2")}})
+}
+
+func (s *OpenglDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
+	spec := &mount.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+
+	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
+		{Name: filepath.Join(dirs.SnapMountDir, "opengl-provider/5/lib1"),
+			Dir: "/opt/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/0", Options: []string{"rbind", "ro"}},
+		{Name: filepath.Join(dirs.SnapMountDir, "opengl-provider/5/lib2"),
+			Dir: "/opt/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/1", Options: []string{"rbind", "ro"}},
+	})
+	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
+		"/opt/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/0",
+		"/opt/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/1",
+	})
 }
 
 func (s *OpenglDriverLibsInterfaceSuite) TestConfigfilesSpec(c *C) {

--- a/interfaces/builtin/opengl_driver_libs_test.go
+++ b/interfaces/builtin/opengl_driver_libs_test.go
@@ -20,13 +20,16 @@
 package builtin_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/configfiles"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
@@ -204,6 +207,20 @@ func (s *OpenglDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 		"/opt/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/0",
 		"/opt/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/1",
 	})
+}
+
+func (s *OpenglDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
+	spec := apparmor.NewSpecification(s.plug.AppSet())
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+
+	updateNS := strings.Join(spec.UpdateNS(), "")
+	lib1 := filepath.Join(dirs.SnapMountDir, "opengl-provider/5/lib1")
+	target0 := "/opt/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/0"
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n", lib1, target0))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target0))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}/\",\n", target0))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  # Writable mimic %s\n", filepath.Dir(target0)))
+	c.Check(spec.SnippetForTag("snap.snapd.app"), Equals, "")
 }
 
 func (s *OpenglDriverLibsInterfaceSuite) TestConfigfilesSpec(c *C) {

--- a/interfaces/builtin/opengl_driver_libs_test.go
+++ b/interfaces/builtin/opengl_driver_libs_test.go
@@ -199,9 +199,9 @@ func (s *OpenglDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
 		{Name: filepath.Join(dirs.SnapMountDir, "opengl-provider/5/lib1"),
-			Dir: "/opt/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/0", Options: []string{"rbind", "ro"}},
+			Dir: "/opt/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/0", Options: []string{"bind", "ro"}},
 		{Name: filepath.Join(dirs.SnapMountDir, "opengl-provider/5/lib2"),
-			Dir: "/opt/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/1", Options: []string{"rbind", "ro"}},
+			Dir: "/opt/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/1", Options: []string{"bind", "ro"}},
 	})
 	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
 		"/opt/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/0",

--- a/interfaces/builtin/opengl_driver_libs_test.go
+++ b/interfaces/builtin/opengl_driver_libs_test.go
@@ -216,7 +216,7 @@ func (s *OpenglDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 	updateNS := strings.Join(spec.UpdateNS(), "")
 	lib1 := filepath.Join(dirs.SnapMountDir, "opengl-provider/5/lib1")
 	target0 := "/opt/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/lib1"
-	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n", lib1, target0))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(rw, bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n", lib1, target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}/\",\n", target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  # Writable mimic %s\n", filepath.Dir(target0)))

--- a/interfaces/builtin/opengl_driver_libs_test.go
+++ b/interfaces/builtin/opengl_driver_libs_test.go
@@ -220,7 +220,11 @@ func (s *OpenglDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}/\",\n", target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  # Writable mimic %s\n", filepath.Dir(target0)))
-	c.Check(spec.SnippetForTag("snap.snapd.app"), Equals, "")
+	// The app gets read access to its own assembly subtree only (the core base
+	// template does not grant /opt/** to apps).
+	app := spec.SnippetForTag("snap.snapd.app")
+	c.Check(app, testutil.Contains, "/opt/snapd/interfaces/opengl-driver-libs/ r,")
+	c.Check(app, testutil.Contains, "/opt/snapd/interfaces/opengl-driver-libs/** mrkix,")
 }
 
 func (s *OpenglDriverLibsInterfaceSuite) TestConfigfilesSpec(c *C) {

--- a/interfaces/builtin/opengl_driver_libs_test.go
+++ b/interfaces/builtin/opengl_driver_libs_test.go
@@ -198,6 +198,9 @@ func (s *OpenglDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
+		// The shared tmpfs mount at the assembly root, so that only the bare
+		// mountpoint directory (not the assembly tree content) is host-visible.
+		{Name: "tmpfs", Dir: "/run/snapd/interfaces", Type: "tmpfs", Options: []string{"mode=0755", "uid=0", "gid=0"}},
 		{Name: filepath.Join(dirs.SnapMountDir, "opengl-provider/5/lib1"),
 			Dir: "/run/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/lib1", Options: []string{"bind", "ro"}},
 		{Name: filepath.Join(dirs.SnapMountDir, "opengl-provider/5/lib2"),

--- a/interfaces/builtin/opengl_driver_libs_test.go
+++ b/interfaces/builtin/opengl_driver_libs_test.go
@@ -200,15 +200,15 @@ func (s *OpenglDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
 		// The shared tmpfs mount at the assembly root, so that only the bare
 		// mountpoint directory (not the assembly tree content) is host-visible.
-		{Name: "tmpfs", Dir: "/run/snapd/interfaces", Type: "tmpfs", Options: []string{"mode=0755", "uid=0", "gid=0"}},
+		{Name: "tmpfs", Dir: "/run/snapd/snap", Type: "tmpfs", Options: []string{"mode=0755", "uid=0", "gid=0"}},
 		{Name: filepath.Join(dirs.SnapMountDir, "opengl-provider/5/lib1"),
-			Dir: "/run/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/lib1", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
+			Dir: "/run/snapd/snap/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/lib1", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
 		{Name: filepath.Join(dirs.SnapMountDir, "opengl-provider/5/lib2"),
-			Dir: "/run/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/lib2", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
+			Dir: "/run/snapd/snap/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/lib2", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
 	})
 	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
-		"/run/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/lib1",
-		"/run/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/lib2",
+		"/run/snapd/snap/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/lib1",
+		"/run/snapd/snap/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/lib2",
 	})
 }
 
@@ -218,7 +218,7 @@ func (s *OpenglDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 
 	updateNS := strings.Join(spec.UpdateNS(), "")
 	lib1 := filepath.Join(dirs.SnapMountDir, "opengl-provider/5/lib1")
-	target0 := "/run/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/lib1"
+	target0 := "/run/snapd/snap/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/lib1"
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(rw, bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n", lib1, target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}/\",\n", target0))
@@ -226,8 +226,8 @@ func (s *OpenglDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 	// The app gets read access to its own assembly subtree only (the core base
 	// template does not grant /opt/** to apps).
 	app := spec.SnippetForTag("snap.snapd.app")
-	c.Check(app, testutil.Contains, "/run/snapd/interfaces/opengl-driver-libs/ r,")
-	c.Check(app, testutil.Contains, "/run/snapd/interfaces/opengl-driver-libs/** mrkix,")
+	c.Check(app, testutil.Contains, "/run/snapd/snap/interfaces/opengl-driver-libs/ r,")
+	c.Check(app, testutil.Contains, "/run/snapd/snap/interfaces/opengl-driver-libs/** mrkix,")
 }
 
 func (s *OpenglDriverLibsInterfaceSuite) TestConfigfilesSpec(c *C) {

--- a/interfaces/builtin/opengl_driver_libs_test.go
+++ b/interfaces/builtin/opengl_driver_libs_test.go
@@ -202,9 +202,9 @@ func (s *OpenglDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 		// mountpoint directory (not the assembly tree content) is host-visible.
 		{Name: "tmpfs", Dir: "/run/snapd/interfaces", Type: "tmpfs", Options: []string{"mode=0755", "uid=0", "gid=0"}},
 		{Name: filepath.Join(dirs.SnapMountDir, "opengl-provider/5/lib1"),
-			Dir: "/run/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/lib1", Options: []string{"bind", "ro"}},
+			Dir: "/run/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/lib1", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
 		{Name: filepath.Join(dirs.SnapMountDir, "opengl-provider/5/lib2"),
-			Dir: "/run/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/lib2", Options: []string{"bind", "ro"}},
+			Dir: "/run/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/lib2", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
 	})
 	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
 		"/run/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/lib1",

--- a/interfaces/builtin/opengl_driver_libs_test.go
+++ b/interfaces/builtin/opengl_driver_libs_test.go
@@ -199,13 +199,13 @@ func (s *OpenglDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
 		{Name: filepath.Join(dirs.SnapMountDir, "opengl-provider/5/lib1"),
-			Dir: "/opt/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/0", Options: []string{"bind", "ro"}},
+			Dir: "/opt/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/lib1", Options: []string{"bind", "ro"}},
 		{Name: filepath.Join(dirs.SnapMountDir, "opengl-provider/5/lib2"),
-			Dir: "/opt/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/1", Options: []string{"bind", "ro"}},
+			Dir: "/opt/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/lib2", Options: []string{"bind", "ro"}},
 	})
 	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
-		"/opt/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/0",
-		"/opt/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/1",
+		"/opt/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/lib1",
+		"/opt/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/lib2",
 	})
 }
 
@@ -215,7 +215,7 @@ func (s *OpenglDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 
 	updateNS := strings.Join(spec.UpdateNS(), "")
 	lib1 := filepath.Join(dirs.SnapMountDir, "opengl-provider/5/lib1")
-	target0 := "/opt/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/0"
+	target0 := "/opt/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/lib1"
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n", lib1, target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}/\",\n", target0))

--- a/interfaces/builtin/opengl_driver_libs_test.go
+++ b/interfaces/builtin/opengl_driver_libs_test.go
@@ -199,13 +199,13 @@ func (s *OpenglDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
 		{Name: filepath.Join(dirs.SnapMountDir, "opengl-provider/5/lib1"),
-			Dir: "/opt/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/lib1", Options: []string{"bind", "ro"}},
+			Dir: "/run/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/lib1", Options: []string{"bind", "ro"}},
 		{Name: filepath.Join(dirs.SnapMountDir, "opengl-provider/5/lib2"),
-			Dir: "/opt/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/lib2", Options: []string{"bind", "ro"}},
+			Dir: "/run/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/lib2", Options: []string{"bind", "ro"}},
 	})
 	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
-		"/opt/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/lib1",
-		"/opt/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/lib2",
+		"/run/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/lib1",
+		"/run/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/lib2",
 	})
 }
 
@@ -215,7 +215,7 @@ func (s *OpenglDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 
 	updateNS := strings.Join(spec.UpdateNS(), "")
 	lib1 := filepath.Join(dirs.SnapMountDir, "opengl-provider/5/lib1")
-	target0 := "/opt/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/lib1"
+	target0 := "/run/snapd/interfaces/opengl-driver-libs/lib/opengl-provider_opengl-slot/lib1"
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(rw, bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n", lib1, target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}/\",\n", target0))
@@ -223,8 +223,8 @@ func (s *OpenglDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 	// The app gets read access to its own assembly subtree only (the core base
 	// template does not grant /opt/** to apps).
 	app := spec.SnippetForTag("snap.snapd.app")
-	c.Check(app, testutil.Contains, "/opt/snapd/interfaces/opengl-driver-libs/ r,")
-	c.Check(app, testutil.Contains, "/opt/snapd/interfaces/opengl-driver-libs/** mrkix,")
+	c.Check(app, testutil.Contains, "/run/snapd/interfaces/opengl-driver-libs/ r,")
+	c.Check(app, testutil.Contains, "/run/snapd/interfaces/opengl-driver-libs/** mrkix,")
 }
 
 func (s *OpenglDriverLibsInterfaceSuite) TestConfigfilesSpec(c *C) {

--- a/interfaces/builtin/opengles_driver_libs.go
+++ b/interfaces/builtin/opengles_driver_libs.go
@@ -34,15 +34,17 @@ import (
 
 const openglesDriverLibsSummary = `allows exposing OpenGLES driver libraries to the system`
 
-// Plugs only supported for the system on classic for the moment (note this is
-// checked on "system" snap installation even though this is an implicit plug
-// in that case) - in the future we will allow snaps having this as plug and
-// this declaration will have to change.
+// Plug on classic may only be declared by the system snap (implicit plug); on
+// Ubuntu Core any snap may declare it (see allow-installation alternatives).
 const openglesDriverLibsBaseDeclarationPlugs = `
   opengles-driver-libs:
     allow-installation:
-      plug-snap-type:
-        - core
+      -
+        on-classic: true
+        plug-snap-type:
+          - core
+      -
+        on-classic: false
     allow-connection:
       slots-per-plug: *
     deny-auto-connection: true

--- a/interfaces/builtin/opengles_driver_libs.go
+++ b/interfaces/builtin/opengles_driver_libs.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/snapcore/snapd/interfaces"
 
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/compatibility"
 	"github.com/snapcore/snapd/interfaces/configfiles"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
@@ -99,6 +100,13 @@ func (iface *openglesDriverLibsInterface) MountConnectedPlug(spec *mount.Specifi
 	// On Ubuntu Core the provider content is bound into the assembly tree under
 	// the /opt/snapd/interfaces directory (see mountAssemblyLibDirs).
 	return mountAssemblyLibDirs(spec, slot, openglesDriverLibs)
+}
+
+func (iface *openglesDriverLibsInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	// Authorize snap-update-ns to construct (and eventually tear down) the
+	// assembly tree under /opt/snapd/interfaces. The default base template
+	// already grants /opt/** mrklix to the app itself, no extra snippet needed.
+	return addAppArmorAssemblyLibDirs(spec, slot, openglesDriverLibs)
 }
 
 const openglesDriverLibs = "opengles-driver-libs"

--- a/interfaces/builtin/opengles_driver_libs.go
+++ b/interfaces/builtin/opengles_driver_libs.go
@@ -20,6 +20,7 @@
 package builtin
 
 import (
+	"fmt"
 	"math"
 
 	"github.com/snapcore/snapd/interfaces"
@@ -57,6 +58,13 @@ const openglesDriverLibsBaseDeclarationSlots = `
 // openglesDriverLibsInterface allows exposing OpenGLES driver libraries to the system or snaps.
 type openglesDriverLibsInterface struct {
 	commonInterface
+}
+
+func (iface *openglesDriverLibsInterface) BeforePreparePlug(plug *snap.PlugInfo) error {
+	if !driverLibsSupported(plug.Snap.Base) {
+		return fmt.Errorf("%s interface is not supported on base %q", openglesDriverLibs, plug.Snap.Base)
+	}
+	return nil
 }
 
 func (iface *openglesDriverLibsInterface) BeforePrepareSlot(slot *snap.SlotInfo) error {

--- a/interfaces/builtin/opengles_driver_libs.go
+++ b/interfaces/builtin/opengles_driver_libs.go
@@ -28,6 +28,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/compatibility"
 	"github.com/snapcore/snapd/interfaces/configfiles"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
+	"github.com/snapcore/snapd/interfaces/mount"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 )
@@ -92,6 +93,12 @@ func (iface *openglesDriverLibsInterface) BeforePrepareSlot(slot *snap.SlotInfo)
 func (iface *openglesDriverLibsInterface) LdconfigConnectedPlug(spec *ldconfig.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// The plug can only be the system plug for the time being
 	return addLdconfigLibDirs(spec, slot)
+}
+
+func (iface *openglesDriverLibsInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	// On Ubuntu Core the provider content is bound into the assembly tree under
+	// the /opt/snapd/interfaces directory (see mountAssemblyLibDirs).
+	return mountAssemblyLibDirs(spec, slot, openglesDriverLibs)
 }
 
 const openglesDriverLibs = "opengles-driver-libs"

--- a/interfaces/builtin/opengles_driver_libs.go
+++ b/interfaces/builtin/opengles_driver_libs.go
@@ -103,9 +103,11 @@ func (iface *openglesDriverLibsInterface) MountConnectedPlug(spec *mount.Specifi
 }
 
 func (iface *openglesDriverLibsInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	// Authorize snap-update-ns to construct (and eventually tear down) the
-	// assembly tree under /opt/snapd/interfaces. The default base template
-	// already grants /opt/** mrklix to the app itself, no extra snippet needed.
+	// Grant the app read access to its own assembly subtree under
+	// /opt/snapd/interfaces (the core base template does not grant /opt/** to
+	// apps), then authorize snap-update-ns to construct (and eventually tear
+	// down) the assembly tree.
+	addAppArmorAssemblyAccess(spec, openglesDriverLibs)
 	return addAppArmorAssemblyLibDirs(spec, slot, openglesDriverLibs)
 }
 

--- a/interfaces/builtin/opengles_driver_libs.go
+++ b/interfaces/builtin/opengles_driver_libs.go
@@ -98,7 +98,7 @@ func (iface *openglesDriverLibsInterface) LdconfigConnectedPlug(spec *ldconfig.S
 
 func (iface *openglesDriverLibsInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// On Ubuntu Core the provider content is bound into the assembly tree under
-	// the /run/snapd/interfaces directory (see mountAssemblyLibDirs).
+	// the /run/snapd/snap/interfaces directory (see mountAssemblyLibDirs).
 	if err := mountAssemblyRoot(spec); err != nil {
 		return err
 	}
@@ -107,7 +107,7 @@ func (iface *openglesDriverLibsInterface) MountConnectedPlug(spec *mount.Specifi
 
 func (iface *openglesDriverLibsInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// Grant the app read access to its own assembly subtree under
-	// /run/snapd/interfaces (the core base template does not grant /opt/** to
+	// /run/snapd/snap/interfaces (the core base template does not grant /opt/** to
 	// apps), then authorize snap-update-ns to construct (and eventually tear
 	// down) the assembly tree.
 	addAppArmorAssemblyRoot(spec)

--- a/interfaces/builtin/opengles_driver_libs.go
+++ b/interfaces/builtin/opengles_driver_libs.go
@@ -99,6 +99,9 @@ func (iface *openglesDriverLibsInterface) LdconfigConnectedPlug(spec *ldconfig.S
 func (iface *openglesDriverLibsInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// On Ubuntu Core the provider content is bound into the assembly tree under
 	// the /run/snapd/interfaces directory (see mountAssemblyLibDirs).
+	if err := mountAssemblyRoot(spec); err != nil {
+		return err
+	}
 	return mountAssemblyLibDirs(spec, slot, openglesDriverLibs)
 }
 
@@ -107,6 +110,7 @@ func (iface *openglesDriverLibsInterface) AppArmorConnectedPlug(spec *apparmor.S
 	// /run/snapd/interfaces (the core base template does not grant /opt/** to
 	// apps), then authorize snap-update-ns to construct (and eventually tear
 	// down) the assembly tree.
+	addAppArmorAssemblyRoot(spec)
 	addAppArmorAssemblyAccess(spec, openglesDriverLibs)
 	return addAppArmorAssemblyLibDirs(spec, slot, openglesDriverLibs)
 }

--- a/interfaces/builtin/opengles_driver_libs.go
+++ b/interfaces/builtin/opengles_driver_libs.go
@@ -98,13 +98,13 @@ func (iface *openglesDriverLibsInterface) LdconfigConnectedPlug(spec *ldconfig.S
 
 func (iface *openglesDriverLibsInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// On Ubuntu Core the provider content is bound into the assembly tree under
-	// the /opt/snapd/interfaces directory (see mountAssemblyLibDirs).
+	// the /run/snapd/interfaces directory (see mountAssemblyLibDirs).
 	return mountAssemblyLibDirs(spec, slot, openglesDriverLibs)
 }
 
 func (iface *openglesDriverLibsInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// Grant the app read access to its own assembly subtree under
-	// /opt/snapd/interfaces (the core base template does not grant /opt/** to
+	// /run/snapd/interfaces (the core base template does not grant /opt/** to
 	// apps), then authorize snap-update-ns to construct (and eventually tear
 	// down) the assembly tree.
 	addAppArmorAssemblyAccess(spec, openglesDriverLibs)

--- a/interfaces/builtin/opengles_driver_libs_test.go
+++ b/interfaces/builtin/opengles_driver_libs_test.go
@@ -20,13 +20,16 @@
 package builtin_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/configfiles"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
@@ -206,6 +209,20 @@ func (s *OpenglesDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 		"/opt/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/0",
 		"/opt/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/1",
 	})
+}
+
+func (s *OpenglesDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
+	spec := apparmor.NewSpecification(s.plug.AppSet())
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+
+	updateNS := strings.Join(spec.UpdateNS(), "")
+	lib1 := filepath.Join(dirs.SnapMountDir, "opengles-provider/5/lib1")
+	target0 := "/opt/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/0"
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n", lib1, target0))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target0))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}/\",\n", target0))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  # Writable mimic %s\n", filepath.Dir(target0)))
+	c.Check(spec.SnippetForTag("snap.snapd.app"), Equals, "")
 }
 
 func (s *OpenglesDriverLibsInterfaceSuite) TestConfigfilesSpec(c *C) {

--- a/interfaces/builtin/opengles_driver_libs_test.go
+++ b/interfaces/builtin/opengles_driver_libs_test.go
@@ -55,6 +55,7 @@ var _ = Suite(&OpenglesDriverLibsInterfaceSuite{
 // This is in fact implicit in the system
 const openglesDriverLibsConsumerYaml = `name: snapd
 version: 0
+base: core26
 plugs:
   opengles:
     interface: opengles-driver-libs
@@ -160,6 +161,25 @@ slots:
 func (s *OpenglesDriverLibsInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Check(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
 	c.Check(interfaces.BeforeConnectPlug(s.iface, s.plug), IsNil)
+}
+
+func (s *OpenglesDriverLibsInterfaceSuite) TestSanitizePlugUnsupportedBase(c *C) {
+	const consumerYaml = `name: snapd
+version: 0
+base: core24
+plugs:
+  opengles:
+    compatibility: opengles-ubuntu-2510
+    interface: opengles-driver-libs
+apps:
+  app:
+    plugs: [opengles]
+`
+	plug, plugInfo := MockConnectedPlug(c, consumerYaml,
+		&snap.SideInfo{Revision: snap.R(3)}, "opengles")
+	c.Check(interfaces.BeforeConnectPlug(s.iface, plug), IsNil)
+	c.Check(interfaces.BeforePreparePlug(s.iface, plugInfo), ErrorMatches,
+		`opengles-driver-libs interface is not supported on base "core24"`)
 }
 
 func (s *OpenglesDriverLibsInterfaceSuite) TestLdconfigSpec(c *C) {

--- a/interfaces/builtin/opengles_driver_libs_test.go
+++ b/interfaces/builtin/opengles_driver_libs_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/configfiles"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
+	"github.com/snapcore/snapd/interfaces/mount"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
@@ -189,6 +190,22 @@ func (s *OpenglesDriverLibsInterfaceSuite) TestLdconfigSpec(c *C) {
 		{SnapName: "opengles-provider", SlotName: "opengles-slot"}: {
 			filepath.Join(dirs.SnapMountDir, "opengles-provider/5/lib1"),
 			filepath.Join(dirs.SnapMountDir, "opengles-provider/5/lib2")}})
+}
+
+func (s *OpenglesDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
+	spec := &mount.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+
+	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
+		{Name: filepath.Join(dirs.SnapMountDir, "opengles-provider/5/lib1"),
+			Dir: "/opt/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/0", Options: []string{"rbind", "ro"}},
+		{Name: filepath.Join(dirs.SnapMountDir, "opengles-provider/5/lib2"),
+			Dir: "/opt/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/1", Options: []string{"rbind", "ro"}},
+	})
+	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
+		"/opt/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/0",
+		"/opt/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/1",
+	})
 }
 
 func (s *OpenglesDriverLibsInterfaceSuite) TestConfigfilesSpec(c *C) {

--- a/interfaces/builtin/opengles_driver_libs_test.go
+++ b/interfaces/builtin/opengles_driver_libs_test.go
@@ -200,6 +200,9 @@ func (s *OpenglesDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
+		// The shared tmpfs mount at the assembly root, so that only the bare
+		// mountpoint directory (not the assembly tree content) is host-visible.
+		{Name: "tmpfs", Dir: "/run/snapd/interfaces", Type: "tmpfs", Options: []string{"mode=0755", "uid=0", "gid=0"}},
 		{Name: filepath.Join(dirs.SnapMountDir, "opengles-provider/5/lib1"),
 			Dir: "/run/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/lib1", Options: []string{"bind", "ro"}},
 		{Name: filepath.Join(dirs.SnapMountDir, "opengles-provider/5/lib2"),

--- a/interfaces/builtin/opengles_driver_libs_test.go
+++ b/interfaces/builtin/opengles_driver_libs_test.go
@@ -202,15 +202,15 @@ func (s *OpenglesDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
 		// The shared tmpfs mount at the assembly root, so that only the bare
 		// mountpoint directory (not the assembly tree content) is host-visible.
-		{Name: "tmpfs", Dir: "/run/snapd/interfaces", Type: "tmpfs", Options: []string{"mode=0755", "uid=0", "gid=0"}},
+		{Name: "tmpfs", Dir: "/run/snapd/snap", Type: "tmpfs", Options: []string{"mode=0755", "uid=0", "gid=0"}},
 		{Name: filepath.Join(dirs.SnapMountDir, "opengles-provider/5/lib1"),
-			Dir: "/run/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/lib1", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
+			Dir: "/run/snapd/snap/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/lib1", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
 		{Name: filepath.Join(dirs.SnapMountDir, "opengles-provider/5/lib2"),
-			Dir: "/run/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/lib2", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
+			Dir: "/run/snapd/snap/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/lib2", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
 	})
 	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
-		"/run/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/lib1",
-		"/run/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/lib2",
+		"/run/snapd/snap/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/lib1",
+		"/run/snapd/snap/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/lib2",
 	})
 }
 
@@ -220,7 +220,7 @@ func (s *OpenglesDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 
 	updateNS := strings.Join(spec.UpdateNS(), "")
 	lib1 := filepath.Join(dirs.SnapMountDir, "opengles-provider/5/lib1")
-	target0 := "/run/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/lib1"
+	target0 := "/run/snapd/snap/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/lib1"
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(rw, bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n", lib1, target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}/\",\n", target0))
@@ -228,8 +228,8 @@ func (s *OpenglesDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 	// The app gets read access to its own assembly subtree only (the core base
 	// template does not grant /opt/** to apps).
 	app := spec.SnippetForTag("snap.snapd.app")
-	c.Check(app, testutil.Contains, "/run/snapd/interfaces/opengles-driver-libs/ r,")
-	c.Check(app, testutil.Contains, "/run/snapd/interfaces/opengles-driver-libs/** mrkix,")
+	c.Check(app, testutil.Contains, "/run/snapd/snap/interfaces/opengles-driver-libs/ r,")
+	c.Check(app, testutil.Contains, "/run/snapd/snap/interfaces/opengles-driver-libs/** mrkix,")
 }
 
 func (s *OpenglesDriverLibsInterfaceSuite) TestConfigfilesSpec(c *C) {

--- a/interfaces/builtin/opengles_driver_libs_test.go
+++ b/interfaces/builtin/opengles_driver_libs_test.go
@@ -222,7 +222,11 @@ func (s *OpenglesDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}/\",\n", target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  # Writable mimic %s\n", filepath.Dir(target0)))
-	c.Check(spec.SnippetForTag("snap.snapd.app"), Equals, "")
+	// The app gets read access to its own assembly subtree only (the core base
+	// template does not grant /opt/** to apps).
+	app := spec.SnippetForTag("snap.snapd.app")
+	c.Check(app, testutil.Contains, "/opt/snapd/interfaces/opengles-driver-libs/ r,")
+	c.Check(app, testutil.Contains, "/opt/snapd/interfaces/opengles-driver-libs/** mrkix,")
 }
 
 func (s *OpenglesDriverLibsInterfaceSuite) TestConfigfilesSpec(c *C) {

--- a/interfaces/builtin/opengles_driver_libs_test.go
+++ b/interfaces/builtin/opengles_driver_libs_test.go
@@ -201,13 +201,13 @@ func (s *OpenglesDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
 		{Name: filepath.Join(dirs.SnapMountDir, "opengles-provider/5/lib1"),
-			Dir: "/opt/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/lib1", Options: []string{"bind", "ro"}},
+			Dir: "/run/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/lib1", Options: []string{"bind", "ro"}},
 		{Name: filepath.Join(dirs.SnapMountDir, "opengles-provider/5/lib2"),
-			Dir: "/opt/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/lib2", Options: []string{"bind", "ro"}},
+			Dir: "/run/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/lib2", Options: []string{"bind", "ro"}},
 	})
 	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
-		"/opt/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/lib1",
-		"/opt/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/lib2",
+		"/run/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/lib1",
+		"/run/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/lib2",
 	})
 }
 
@@ -217,7 +217,7 @@ func (s *OpenglesDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 
 	updateNS := strings.Join(spec.UpdateNS(), "")
 	lib1 := filepath.Join(dirs.SnapMountDir, "opengles-provider/5/lib1")
-	target0 := "/opt/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/lib1"
+	target0 := "/run/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/lib1"
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(rw, bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n", lib1, target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}/\",\n", target0))
@@ -225,8 +225,8 @@ func (s *OpenglesDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 	// The app gets read access to its own assembly subtree only (the core base
 	// template does not grant /opt/** to apps).
 	app := spec.SnippetForTag("snap.snapd.app")
-	c.Check(app, testutil.Contains, "/opt/snapd/interfaces/opengles-driver-libs/ r,")
-	c.Check(app, testutil.Contains, "/opt/snapd/interfaces/opengles-driver-libs/** mrkix,")
+	c.Check(app, testutil.Contains, "/run/snapd/interfaces/opengles-driver-libs/ r,")
+	c.Check(app, testutil.Contains, "/run/snapd/interfaces/opengles-driver-libs/** mrkix,")
 }
 
 func (s *OpenglesDriverLibsInterfaceSuite) TestConfigfilesSpec(c *C) {

--- a/interfaces/builtin/opengles_driver_libs_test.go
+++ b/interfaces/builtin/opengles_driver_libs_test.go
@@ -218,7 +218,7 @@ func (s *OpenglesDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 	updateNS := strings.Join(spec.UpdateNS(), "")
 	lib1 := filepath.Join(dirs.SnapMountDir, "opengles-provider/5/lib1")
 	target0 := "/opt/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/lib1"
-	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n", lib1, target0))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(rw, bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n", lib1, target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}/\",\n", target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  # Writable mimic %s\n", filepath.Dir(target0)))

--- a/interfaces/builtin/opengles_driver_libs_test.go
+++ b/interfaces/builtin/opengles_driver_libs_test.go
@@ -201,9 +201,9 @@ func (s *OpenglesDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
 		{Name: filepath.Join(dirs.SnapMountDir, "opengles-provider/5/lib1"),
-			Dir: "/opt/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/0", Options: []string{"rbind", "ro"}},
+			Dir: "/opt/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/0", Options: []string{"bind", "ro"}},
 		{Name: filepath.Join(dirs.SnapMountDir, "opengles-provider/5/lib2"),
-			Dir: "/opt/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/1", Options: []string{"rbind", "ro"}},
+			Dir: "/opt/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/1", Options: []string{"bind", "ro"}},
 	})
 	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
 		"/opt/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/0",

--- a/interfaces/builtin/opengles_driver_libs_test.go
+++ b/interfaces/builtin/opengles_driver_libs_test.go
@@ -204,9 +204,9 @@ func (s *OpenglesDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 		// mountpoint directory (not the assembly tree content) is host-visible.
 		{Name: "tmpfs", Dir: "/run/snapd/interfaces", Type: "tmpfs", Options: []string{"mode=0755", "uid=0", "gid=0"}},
 		{Name: filepath.Join(dirs.SnapMountDir, "opengles-provider/5/lib1"),
-			Dir: "/run/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/lib1", Options: []string{"bind", "ro"}},
+			Dir: "/run/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/lib1", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
 		{Name: filepath.Join(dirs.SnapMountDir, "opengles-provider/5/lib2"),
-			Dir: "/run/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/lib2", Options: []string{"bind", "ro"}},
+			Dir: "/run/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/lib2", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
 	})
 	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
 		"/run/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/lib1",

--- a/interfaces/builtin/opengles_driver_libs_test.go
+++ b/interfaces/builtin/opengles_driver_libs_test.go
@@ -201,13 +201,13 @@ func (s *OpenglesDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
 		{Name: filepath.Join(dirs.SnapMountDir, "opengles-provider/5/lib1"),
-			Dir: "/opt/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/0", Options: []string{"bind", "ro"}},
+			Dir: "/opt/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/lib1", Options: []string{"bind", "ro"}},
 		{Name: filepath.Join(dirs.SnapMountDir, "opengles-provider/5/lib2"),
-			Dir: "/opt/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/1", Options: []string{"bind", "ro"}},
+			Dir: "/opt/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/lib2", Options: []string{"bind", "ro"}},
 	})
 	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
-		"/opt/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/0",
-		"/opt/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/1",
+		"/opt/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/lib1",
+		"/opt/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/lib2",
 	})
 }
 
@@ -217,7 +217,7 @@ func (s *OpenglesDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 
 	updateNS := strings.Join(spec.UpdateNS(), "")
 	lib1 := filepath.Join(dirs.SnapMountDir, "opengles-provider/5/lib1")
-	target0 := "/opt/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/0"
+	target0 := "/opt/snapd/interfaces/opengles-driver-libs/lib/opengles-provider_opengles-slot/lib1"
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n", lib1, target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}/\",\n", target0))

--- a/interfaces/builtin/vulkan_driver_libs.go
+++ b/interfaces/builtin/vulkan_driver_libs.go
@@ -38,15 +38,17 @@ import (
 
 const vulkanDriverLibsSummary = `allows exposing vulkan driver libraries to the system`
 
-// Plugs only supported for the system on classic for the moment (note this is
-// checked on "system" snap installation even though this is an implicit plug
-// in that case) - in the future we will allow snaps having this as plug and
-// this declaration will have to change.
+// Plug on classic may only be declared by the system snap (implicit plug); on
+// Ubuntu Core any snap may declare it (see allow-installation alternatives).
 const vulkanDriverLibsBaseDeclarationPlugs = `
   vulkan-driver-libs:
     allow-installation:
-      plug-snap-type:
-        - core
+      -
+        on-classic: true
+        plug-snap-type:
+          - core
+      -
+        on-classic: false
     allow-connection:
       slots-per-plug: *
     deny-auto-connection: true

--- a/interfaces/builtin/vulkan_driver_libs.go
+++ b/interfaces/builtin/vulkan_driver_libs.go
@@ -64,6 +64,13 @@ type vulkanDriverLibsInterface struct {
 	commonInterface
 }
 
+func (iface *vulkanDriverLibsInterface) BeforePreparePlug(plug *snap.PlugInfo) error {
+	if !driverLibsSupported(plug.Snap.Base) {
+		return fmt.Errorf("%s interface is not supported on base %q", vulkanDriverLibs, plug.Snap.Base)
+	}
+	return nil
+}
+
 func (iface *vulkanDriverLibsInterface) BeforePrepareSlot(slot *snap.SlotInfo) error {
 	// Validate attributes
 

--- a/interfaces/builtin/vulkan_driver_libs.go
+++ b/interfaces/builtin/vulkan_driver_libs.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/compatibility"
 	"github.com/snapcore/snapd/interfaces/configfiles"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
+	"github.com/snapcore/snapd/interfaces/mount"
 	"github.com/snapcore/snapd/interfaces/symlinks"
 	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
@@ -107,6 +108,36 @@ func (iface *vulkanDriverLibsInterface) BeforePrepareSlot(slot *snap.SlotInfo) e
 func (iface *vulkanDriverLibsInterface) LdconfigConnectedPlug(spec *ldconfig.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// The plug can only be the system plug for the time being
 	return addLdconfigLibDirs(spec, slot)
+}
+
+func (iface *vulkanDriverLibsInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	// On Ubuntu Core the provider content is bound into the assembly tree under
+	// the /opt/snapd/interfaces directory (see mountAssemblyLibDirs). Vulkan
+	// slots have no priority attribute, so no numeric prefix is used in the
+	// encoded metadata file names.
+	const withPriority = false
+	if err := mountAssemblyLibDirs(spec, slot, vulkanDriverLibs); err != nil {
+		return err
+	}
+	// The ICD and implicit/explicit layer metadata files are bound under the
+	// share subtrees.
+	for _, sda := range []struct {
+		attrName   string
+		isOptional bool
+		subdir     string
+		checker    func(slot *interfaces.ConnectedSlot, content []byte) error
+	}{
+		{"icd-source", false, "vulkan/icd.d", checkVulkanIcdFile},
+		{"implicit-layer-source", true, "vulkan/implicit_layer.d", checkVulkanLayersFile},
+		{"explicit-layer-source", true, "vulkan/explicit_layer.d", checkVulkanLayersFile},
+	} {
+		if err := mountAssemblySourceFiles(spec, slot, vulkanDriverLibs,
+			sourceDirAttr{attrName: sda.attrName, isOptional: sda.isOptional},
+			sda.subdir, sda.checker, withPriority); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 var _ = symlinks.ConnectedPlugCallback(&vulkanDriverLibsInterface{})

--- a/interfaces/builtin/vulkan_driver_libs.go
+++ b/interfaces/builtin/vulkan_driver_libs.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/compatibility"
 	"github.com/snapcore/snapd/interfaces/configfiles"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
@@ -132,6 +133,33 @@ func (iface *vulkanDriverLibsInterface) MountConnectedPlug(spec *mount.Specifica
 		{"explicit-layer-source", true, "vulkan/explicit_layer.d", checkVulkanLayersFile},
 	} {
 		if err := mountAssemblySourceFiles(spec, slot, vulkanDriverLibs,
+			sourceDirAttr{attrName: sda.attrName, isOptional: sda.isOptional},
+			sda.subdir, sda.checker, withPriority); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (iface *vulkanDriverLibsInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+	// Authorize snap-update-ns to construct (and eventually tear down) the
+	// assembly tree under /opt/snapd/interfaces. The default base template
+	// already grants /opt/** mrklix to the app itself, no extra snippet needed.
+	const withPriority = false
+	if err := addAppArmorAssemblyLibDirs(spec, slot, vulkanDriverLibs); err != nil {
+		return err
+	}
+	for _, sda := range []struct {
+		attrName   string
+		isOptional bool
+		subdir     string
+		checker    func(slot *interfaces.ConnectedSlot, content []byte) error
+	}{
+		{"icd-source", false, "vulkan/icd.d", checkVulkanIcdFile},
+		{"implicit-layer-source", true, "vulkan/implicit_layer.d", checkVulkanLayersFile},
+		{"explicit-layer-source", true, "vulkan/explicit_layer.d", checkVulkanLayersFile},
+	} {
+		if err := addAppArmorAssemblySourceFiles(spec, slot, vulkanDriverLibs,
 			sourceDirAttr{attrName: sda.attrName, isOptional: sda.isOptional},
 			sda.subdir, sda.checker, withPriority); err != nil {
 			return err

--- a/interfaces/builtin/vulkan_driver_libs.go
+++ b/interfaces/builtin/vulkan_driver_libs.go
@@ -147,6 +147,8 @@ func (iface *vulkanDriverLibsInterface) AppArmorConnectedPlug(spec *apparmor.Spe
 	// apps), then authorize snap-update-ns to construct (and eventually tear
 	// down) the assembly tree.
 	addAppArmorAssemblyAccess(spec, vulkanDriverLibs)
+	// Grant read access to the loader-scanned metadata location (Pass 2).
+	addAppArmorRedistributionAccess(spec, vulkanDriverLibs)
 	const withPriority = false
 	if err := addAppArmorAssemblyLibDirs(spec, slot, vulkanDriverLibs); err != nil {
 		return err

--- a/interfaces/builtin/vulkan_driver_libs.go
+++ b/interfaces/builtin/vulkan_driver_libs.go
@@ -113,7 +113,7 @@ func (iface *vulkanDriverLibsInterface) LdconfigConnectedPlug(spec *ldconfig.Spe
 
 func (iface *vulkanDriverLibsInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// On Ubuntu Core the provider content is bound into the assembly tree under
-	// the /run/snapd/interfaces directory (see mountAssemblyLibDirs). Vulkan
+	// the /run/snapd/snap/interfaces directory (see mountAssemblyLibDirs). Vulkan
 	// slots have no priority attribute, so no numeric prefix is used in the
 	// encoded metadata file names.
 	if err := mountAssemblyRoot(spec); err != nil {
@@ -146,7 +146,7 @@ func (iface *vulkanDriverLibsInterface) MountConnectedPlug(spec *mount.Specifica
 
 func (iface *vulkanDriverLibsInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// Grant the app read access to its own assembly subtree under
-	// /run/snapd/interfaces (the core base template does not grant /opt/** to
+	// /run/snapd/snap/interfaces (the core base template does not grant /opt/** to
 	// apps), then authorize snap-update-ns to construct (and eventually tear
 	// down) the assembly tree.
 	addAppArmorAssemblyRoot(spec)

--- a/interfaces/builtin/vulkan_driver_libs.go
+++ b/interfaces/builtin/vulkan_driver_libs.go
@@ -116,6 +116,9 @@ func (iface *vulkanDriverLibsInterface) MountConnectedPlug(spec *mount.Specifica
 	// the /run/snapd/interfaces directory (see mountAssemblyLibDirs). Vulkan
 	// slots have no priority attribute, so no numeric prefix is used in the
 	// encoded metadata file names.
+	if err := mountAssemblyRoot(spec); err != nil {
+		return err
+	}
 	const withPriority = false
 	if err := mountAssemblyLibDirs(spec, slot, vulkanDriverLibs); err != nil {
 		return err
@@ -146,6 +149,7 @@ func (iface *vulkanDriverLibsInterface) AppArmorConnectedPlug(spec *apparmor.Spe
 	// /run/snapd/interfaces (the core base template does not grant /opt/** to
 	// apps), then authorize snap-update-ns to construct (and eventually tear
 	// down) the assembly tree.
+	addAppArmorAssemblyRoot(spec)
 	addAppArmorAssemblyAccess(spec, vulkanDriverLibs)
 	// Grant read access to the loader-scanned metadata location (Pass 2).
 	addAppArmorRedistributionAccess(spec, vulkanDriverLibs)

--- a/interfaces/builtin/vulkan_driver_libs.go
+++ b/interfaces/builtin/vulkan_driver_libs.go
@@ -142,9 +142,11 @@ func (iface *vulkanDriverLibsInterface) MountConnectedPlug(spec *mount.Specifica
 }
 
 func (iface *vulkanDriverLibsInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	// Authorize snap-update-ns to construct (and eventually tear down) the
-	// assembly tree under /opt/snapd/interfaces. The default base template
-	// already grants /opt/** mrklix to the app itself, no extra snippet needed.
+	// Grant the app read access to its own assembly subtree under
+	// /opt/snapd/interfaces (the core base template does not grant /opt/** to
+	// apps), then authorize snap-update-ns to construct (and eventually tear
+	// down) the assembly tree.
+	addAppArmorAssemblyAccess(spec, vulkanDriverLibs)
 	const withPriority = false
 	if err := addAppArmorAssemblyLibDirs(spec, slot, vulkanDriverLibs); err != nil {
 		return err

--- a/interfaces/builtin/vulkan_driver_libs.go
+++ b/interfaces/builtin/vulkan_driver_libs.go
@@ -113,7 +113,7 @@ func (iface *vulkanDriverLibsInterface) LdconfigConnectedPlug(spec *ldconfig.Spe
 
 func (iface *vulkanDriverLibsInterface) MountConnectedPlug(spec *mount.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// On Ubuntu Core the provider content is bound into the assembly tree under
-	// the /opt/snapd/interfaces directory (see mountAssemblyLibDirs). Vulkan
+	// the /run/snapd/interfaces directory (see mountAssemblyLibDirs). Vulkan
 	// slots have no priority attribute, so no numeric prefix is used in the
 	// encoded metadata file names.
 	const withPriority = false
@@ -143,7 +143,7 @@ func (iface *vulkanDriverLibsInterface) MountConnectedPlug(spec *mount.Specifica
 
 func (iface *vulkanDriverLibsInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	// Grant the app read access to its own assembly subtree under
-	// /opt/snapd/interfaces (the core base template does not grant /opt/** to
+	// /run/snapd/interfaces (the core base template does not grant /opt/** to
 	// apps), then authorize snap-update-ns to construct (and eventually tear
 	// down) the assembly tree.
 	addAppArmorAssemblyAccess(spec, vulkanDriverLibs)

--- a/interfaces/builtin/vulkan_driver_libs_test.go
+++ b/interfaces/builtin/vulkan_driver_libs_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
+	"github.com/snapcore/snapd/interfaces/apparmor"
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/configfiles"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
@@ -348,6 +349,66 @@ func (s *VulkanDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 		"/opt/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/1",
 		"/opt/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/2",
 	})
+}
+
+func (s *VulkanDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
+	// Populate the library dirs, the ICD file and an implicit + explicit layer.
+	libDir2 := filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5/lib2")
+	c.Assert(os.MkdirAll(libDir2, 0755), IsNil)
+	for _, lib := range []string{"libvulkan_mesa.so.0", "libvulkan_nvidia.so.0"} {
+		os.WriteFile(filepath.Join(libDir2, lib), []byte{}, 0655)
+	}
+
+	icdDir := filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5/vulkan/icd.d")
+	c.Assert(os.MkdirAll(icdDir, 0755), IsNil)
+	os.WriteFile(filepath.Join(icdDir, "mesa.json"), []byte(`{
+    "file_format_version" : "1.0.0",
+    "ICD" : {
+        "library_path" : "libvulkan_mesa.so.0",
+        "api_version" : "1.4.303"
+    }
+}
+`), 0655)
+
+	implicitDir := filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5/vulkan/implicit_layer.d")
+	c.Assert(os.MkdirAll(implicitDir, 0755), IsNil)
+	os.WriteFile(filepath.Join(implicitDir, "gpu_layer.json"), []byte(`{
+    "file_format_version" : "1.0.1",
+    "layers" : [
+       {
+         "name": "layer1",
+         "library_path" : "libvulkan_nvidia.so.0",
+         "api_version" : "1.4.303"
+       }
+     ]
+}
+`), 0644)
+
+	spec := apparmor.NewSpecification(s.plug.AppSet())
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+
+	updateNS := strings.Join(spec.UpdateNS(), "")
+	// Library dir bind.
+	target0 := "/opt/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/0"
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n",
+		filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5/lib1"), target0))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target0))
+
+	// ICD file bind with an unprefixed encoded name (vulkan has no priority).
+	icdSrc := filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5/vulkan/icd.d/mesa.json")
+	icdTarget := "/opt/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-mesa.json"
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(bind) \"%s\" -> \"%s{,-[0-9]*}\",\n", icdSrc, icdTarget))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}\",\n", icdTarget))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}\",\n", icdTarget))
+
+	// Implicit layer file bind.
+	layerSrc := filepath.Join(implicitDir, "gpu_layer.json")
+	layerTarget := "/opt/snapd/interfaces/vulkan-driver-libs/share/vulkan/implicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-implicit_layer.d-gpu_layer.json"
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(bind) \"%s\" -> \"%s{,-[0-9]*}\",\n", layerSrc, layerTarget))
+
+	// The writable-mimic is authorized for the share tree.
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  # Writable mimic %s\n", filepath.Dir(icdTarget)))
+	c.Check(spec.SnippetForTag("snap.snapd.app"), Equals, "")
 }
 
 func (s *VulkanDriverLibsInterfaceSuite) TestSymlinksSpec(c *C) {

--- a/interfaces/builtin/vulkan_driver_libs_test.go
+++ b/interfaces/builtin/vulkan_driver_libs_test.go
@@ -58,6 +58,7 @@ var _ = Suite(&VulkanDriverLibsInterfaceSuite{
 // This is in fact implicit in the system
 const vulkanDriverLibsConsumerYaml = `name: snapd
 version: 0
+base: core26
 plugs:
   vulkan:
     interface: vulkan-driver-libs
@@ -228,6 +229,24 @@ slots:
 func (s *VulkanDriverLibsInterfaceSuite) TestSanitizePlug(c *C) {
 	c.Check(interfaces.BeforePreparePlug(s.iface, s.plugInfo), IsNil)
 	c.Check(interfaces.BeforeConnectPlug(s.iface, s.plug), IsNil)
+}
+
+func (s *VulkanDriverLibsInterfaceSuite) TestSanitizePlugUnsupportedBase(c *C) {
+	const consumerYaml = `name: snapd
+version: 0
+base: core24
+plugs:
+  vulkan:
+    interface: vulkan-driver-libs
+apps:
+  app:
+    plugs: [vulkan]
+`
+	plug, plugInfo := MockConnectedPlug(c, consumerYaml,
+		&snap.SideInfo{Revision: snap.R(3)}, "vulkan")
+	c.Check(interfaces.BeforeConnectPlug(s.iface, plug), IsNil)
+	c.Check(interfaces.BeforePreparePlug(s.iface, plugInfo), ErrorMatches,
+		`vulkan-driver-libs interface is not supported on base "core24"`)
 }
 
 func (s *VulkanDriverLibsInterfaceSuite) TestLdconfigSpec(c *C) {

--- a/interfaces/builtin/vulkan_driver_libs_test.go
+++ b/interfaces/builtin/vulkan_driver_libs_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/builtin"
 	"github.com/snapcore/snapd/interfaces/configfiles"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
+	"github.com/snapcore/snapd/interfaces/mount"
 	"github.com/snapcore/snapd/interfaces/symlinks"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/release"
@@ -258,6 +259,95 @@ func (s *VulkanDriverLibsInterfaceSuite) TestLdconfigSpec(c *C) {
 			filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5/lib2"),
 			filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "vulkan-provider"), "lib1"),
 		}})
+}
+
+func (s *VulkanDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
+	// Library dirs.
+	libDir1 := filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5/lib1")
+	libDir2 := filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5/lib2")
+	compLibDir := filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "vulkan-provider"), "lib1")
+	for _, libDir := range []string{libDir1, libDir2, compLibDir} {
+		c.Assert(os.MkdirAll(libDir, 0755), IsNil)
+	}
+	for _, lib := range []string{"libvulkan_mesa.so.0", "libvulkan_radeon.so.0", "libvulkan_nvidia.so.0"} {
+		os.WriteFile(filepath.Join(libDir2, lib), []byte{}, 0655)
+	}
+
+	// ICD files in vulkan/icd.d and vulkan_alt.d (vulkan_empty.d adds nothing).
+	for _, icdData := range []struct {
+		gpu    string
+		subDir string
+	}{
+		{"mesa", "vulkan/icd.d"}, {"radeon", "vulkan_alt.d"},
+	} {
+		icdDir := filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5", icdData.subDir)
+		c.Assert(os.MkdirAll(icdDir, 0755), IsNil)
+		os.WriteFile(filepath.Join(icdDir, icdData.gpu+".json"),
+			[]byte(fmt.Sprintf(`{
+    "file_format_version" : "1.0.0",
+    "ICD" : {
+        "library_path" : "libvulkan_%s.so.0",
+        "api_version" : "1.4.303"
+    }
+}
+`, icdData.gpu)), 0655)
+	}
+
+	// Implicit and explicit layers.
+	implicitDir := filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5/vulkan/implicit_layer.d")
+	c.Assert(os.MkdirAll(implicitDir, 0755), IsNil)
+	os.WriteFile(filepath.Join(implicitDir, "gpu_layer.json"), []byte(`{
+    "file_format_version" : "1.0.1",
+    "layers" : [
+       {
+         "name": "layer1",
+         "library_path" : "libvulkan_nvidia.so.0",
+         "api_version" : "1.4.303"
+       }
+     ]
+}
+`), 0644)
+	explicitDir := filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5/vulkan/explicit_layer.d")
+	c.Assert(os.MkdirAll(explicitDir, 0755), IsNil)
+	os.WriteFile(filepath.Join(explicitDir, "exp_layer.json"), []byte(`{
+    "file_format_version" : "1.0.1",
+    "layers" : [
+       {
+         "name": "layer1",
+         "library_path" : "libvulkan_nvidia.so.0",
+         "api_version" : "1.4.303"
+       }
+     ]
+}
+`), 0644)
+
+	spec := &mount.Specification{}
+	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
+
+	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
+		// Library dirs.
+		{Name: libDir1, Dir: "/opt/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/0", Options: []string{"rbind", "ro"}},
+		{Name: libDir2, Dir: "/opt/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/1", Options: []string{"rbind", "ro"}},
+		{Name: compLibDir, Dir: "/opt/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/2", Options: []string{"rbind", "ro"}},
+		// ICD files, without a numeric prefix (vulkan has no priority).
+		{Name: filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5/vulkan/icd.d/mesa.json"),
+			Dir: "/opt/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+		{Name: filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5/vulkan_alt.d/radeon.json"),
+			Dir: "/opt/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan_alt.d-radeon.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+		// Implicit layer.
+		{Name: filepath.Join(implicitDir, "gpu_layer.json"),
+			Dir: "/opt/snapd/interfaces/vulkan-driver-libs/share/vulkan/implicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-implicit_layer.d-gpu_layer.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+		// Explicit layer.
+		{Name: filepath.Join(explicitDir, "exp_layer.json"),
+			Dir: "/opt/snapd/interfaces/vulkan-driver-libs/share/vulkan/explicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-explicit_layer.d-exp_layer.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+	})
+
+	// Only the library dirs feed SNAP_LIBRARY_PATH.
+	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
+		"/opt/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/0",
+		"/opt/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/1",
+		"/opt/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/2",
+	})
 }
 
 func (s *VulkanDriverLibsInterfaceSuite) TestSymlinksSpec(c *C) {

--- a/interfaces/builtin/vulkan_driver_libs_test.go
+++ b/interfaces/builtin/vulkan_driver_libs_test.go
@@ -327,9 +327,9 @@ func (s *VulkanDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
 		// Library dirs.
-		{Name: libDir1, Dir: "/opt/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/0", Options: []string{"rbind", "ro"}},
-		{Name: libDir2, Dir: "/opt/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/1", Options: []string{"rbind", "ro"}},
-		{Name: compLibDir, Dir: "/opt/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/2", Options: []string{"rbind", "ro"}},
+		{Name: libDir1, Dir: "/opt/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/0", Options: []string{"bind", "ro"}},
+		{Name: libDir2, Dir: "/opt/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/1", Options: []string{"bind", "ro"}},
+		{Name: compLibDir, Dir: "/opt/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/2", Options: []string{"bind", "ro"}},
 		// ICD files, without a numeric prefix (vulkan has no priority).
 		{Name: filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5/vulkan/icd.d/mesa.json"),
 			Dir: "/opt/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},

--- a/interfaces/builtin/vulkan_driver_libs_test.go
+++ b/interfaces/builtin/vulkan_driver_libs_test.go
@@ -327,39 +327,39 @@ func (s *VulkanDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
 		// Library dirs.
-		{Name: libDir1, Dir: "/opt/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/lib1", Options: []string{"bind", "ro"}},
-		{Name: libDir2, Dir: "/opt/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/lib2", Options: []string{"bind", "ro"}},
-		{Name: compLibDir, Dir: "/opt/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/clib1", Options: []string{"bind", "ro"}},
+		{Name: libDir1, Dir: "/run/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/lib1", Options: []string{"bind", "ro"}},
+		{Name: libDir2, Dir: "/run/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/lib2", Options: []string{"bind", "ro"}},
+		{Name: compLibDir, Dir: "/run/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/clib1", Options: []string{"bind", "ro"}},
 		// ICD files, without a numeric prefix (vulkan has no priority).
 		{Name: filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5/vulkan/icd.d/mesa.json"),
-			Dir: "/opt/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+			Dir: "/run/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
 		// Pass 2: redistribution to the loader-scanned Vulkan search dir.
-		{Name: "/opt/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-mesa.json",
+		{Name: "/run/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-mesa.json",
 			Dir: "/usr/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
 		{Name: filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5/vulkan_alt.d/radeon.json"),
-			Dir: "/opt/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan_alt.d-radeon.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+			Dir: "/run/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan_alt.d-radeon.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
 		// Pass 2: redistribution for the radeon ICD too.
-		{Name: "/opt/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan_alt.d-radeon.json",
+		{Name: "/run/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan_alt.d-radeon.json",
 			Dir: "/usr/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan_alt.d-radeon.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
 		// Implicit layer.
 		{Name: filepath.Join(implicitDir, "gpu_layer.json"),
-			Dir: "/opt/snapd/interfaces/vulkan-driver-libs/share/vulkan/implicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-implicit_layer.d-gpu_layer.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+			Dir: "/run/snapd/interfaces/vulkan-driver-libs/share/vulkan/implicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-implicit_layer.d-gpu_layer.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
 		// Pass 2: redistribution for the implicit layer.
-		{Name: "/opt/snapd/interfaces/vulkan-driver-libs/share/vulkan/implicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-implicit_layer.d-gpu_layer.json",
+		{Name: "/run/snapd/interfaces/vulkan-driver-libs/share/vulkan/implicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-implicit_layer.d-gpu_layer.json",
 			Dir: "/usr/share/vulkan/implicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-implicit_layer.d-gpu_layer.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
 		// Explicit layer.
 		{Name: filepath.Join(explicitDir, "exp_layer.json"),
-			Dir: "/opt/snapd/interfaces/vulkan-driver-libs/share/vulkan/explicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-explicit_layer.d-exp_layer.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+			Dir: "/run/snapd/interfaces/vulkan-driver-libs/share/vulkan/explicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-explicit_layer.d-exp_layer.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
 		// Pass 2: redistribution for the explicit layer.
-		{Name: "/opt/snapd/interfaces/vulkan-driver-libs/share/vulkan/explicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-explicit_layer.d-exp_layer.json",
+		{Name: "/run/snapd/interfaces/vulkan-driver-libs/share/vulkan/explicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-explicit_layer.d-exp_layer.json",
 			Dir: "/usr/share/vulkan/explicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-explicit_layer.d-exp_layer.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
 	})
 
 	// Only the library dirs feed SNAP_LIBRARY_PATH (sorted).
 	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
-		"/opt/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/clib1",
-		"/opt/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/lib1",
-		"/opt/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/lib2",
+		"/run/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/clib1",
+		"/run/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/lib1",
+		"/run/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/lib2",
 	})
 }
 
@@ -401,14 +401,14 @@ func (s *VulkanDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 
 	updateNS := strings.Join(spec.UpdateNS(), "")
 	// Library dir bind.
-	target0 := "/opt/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/lib1"
+	target0 := "/run/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/lib1"
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(rw, bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n",
 		filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5/lib1"), target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target0))
 
 	// ICD file bind with an unprefixed encoded name (vulkan has no priority).
 	icdSrc := filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5/vulkan/icd.d/mesa.json")
-	icdTarget := "/opt/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-mesa.json"
+	icdTarget := "/run/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-mesa.json"
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(rw, bind) \"%s\" -> \"%s{,-[0-9]*}\",\n", icdSrc, icdTarget))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}\",\n", icdTarget))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}\",\n", icdTarget))
@@ -423,7 +423,7 @@ func (s *VulkanDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 
 	// Implicit layer file bind.
 	layerSrc := filepath.Join(implicitDir, "gpu_layer.json")
-	layerTarget := "/opt/snapd/interfaces/vulkan-driver-libs/share/vulkan/implicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-implicit_layer.d-gpu_layer.json"
+	layerTarget := "/run/snapd/interfaces/vulkan-driver-libs/share/vulkan/implicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-implicit_layer.d-gpu_layer.json"
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(rw, bind) \"%s\" -> \"%s{,-[0-9]*}\",\n", layerSrc, layerTarget))
 	// Pass 2: redistribution authorization for the implicit layer too.
 	layerLoaderTarget := "/usr/share/vulkan/implicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-implicit_layer.d-gpu_layer.json"
@@ -441,8 +441,8 @@ func (s *VulkanDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 	// template does not grant /opt/** to apps), plus the loader-scanned Vulkan
 	// search dirs for Pass 2 redistribution.
 	app := spec.SnippetForTag("snap.snapd.app")
-	c.Check(app, testutil.Contains, "/opt/snapd/interfaces/vulkan-driver-libs/ r,")
-	c.Check(app, testutil.Contains, "/opt/snapd/interfaces/vulkan-driver-libs/** mrkix,")
+	c.Check(app, testutil.Contains, "/run/snapd/interfaces/vulkan-driver-libs/ r,")
+	c.Check(app, testutil.Contains, "/run/snapd/interfaces/vulkan-driver-libs/** mrkix,")
 	c.Check(app, testutil.Contains, "/usr/share/vulkan/{,icd.d,implicit_layer.d,explicit_layer.d}/{,**} r,")
 }
 

--- a/interfaces/builtin/vulkan_driver_libs_test.go
+++ b/interfaces/builtin/vulkan_driver_libs_test.go
@@ -89,7 +89,7 @@ slots:
     library-source:
       - $SNAP/lib1
       - ${SNAP}/lib2
-      - $SNAP_COMPONENT(comp1)/lib1
+      - $SNAP_COMPONENT(comp1)/clib1
 components:
   comp1:
     type: standard
@@ -258,7 +258,7 @@ func (s *VulkanDriverLibsInterfaceSuite) TestLdconfigSpec(c *C) {
 		{SnapName: "vulkan-provider", SlotName: "vulkan-slot"}: {
 			filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5/lib1"),
 			filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5/lib2"),
-			filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "vulkan-provider"), "lib1"),
+			filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "vulkan-provider"), "clib1"),
 		}})
 }
 
@@ -266,7 +266,7 @@ func (s *VulkanDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 	// Library dirs.
 	libDir1 := filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5/lib1")
 	libDir2 := filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5/lib2")
-	compLibDir := filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "vulkan-provider"), "lib1")
+	compLibDir := filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "vulkan-provider"), "clib1")
 	for _, libDir := range []string{libDir1, libDir2, compLibDir} {
 		c.Assert(os.MkdirAll(libDir, 0755), IsNil)
 	}
@@ -327,9 +327,9 @@ func (s *VulkanDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
 		// Library dirs.
-		{Name: libDir1, Dir: "/opt/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/0", Options: []string{"bind", "ro"}},
-		{Name: libDir2, Dir: "/opt/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/1", Options: []string{"bind", "ro"}},
-		{Name: compLibDir, Dir: "/opt/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/2", Options: []string{"bind", "ro"}},
+		{Name: libDir1, Dir: "/opt/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/lib1", Options: []string{"bind", "ro"}},
+		{Name: libDir2, Dir: "/opt/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/lib2", Options: []string{"bind", "ro"}},
+		{Name: compLibDir, Dir: "/opt/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/clib1", Options: []string{"bind", "ro"}},
 		// ICD files, without a numeric prefix (vulkan has no priority).
 		{Name: filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5/vulkan/icd.d/mesa.json"),
 			Dir: "/opt/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
@@ -355,11 +355,11 @@ func (s *VulkanDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 			Dir: "/usr/share/vulkan/explicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-explicit_layer.d-exp_layer.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
 	})
 
-	// Only the library dirs feed SNAP_LIBRARY_PATH.
+	// Only the library dirs feed SNAP_LIBRARY_PATH (sorted).
 	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
-		"/opt/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/0",
-		"/opt/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/1",
-		"/opt/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/2",
+		"/opt/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/clib1",
+		"/opt/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/lib1",
+		"/opt/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/lib2",
 	})
 }
 
@@ -401,7 +401,7 @@ func (s *VulkanDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 
 	updateNS := strings.Join(spec.UpdateNS(), "")
 	// Library dir bind.
-	target0 := "/opt/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/0"
+	target0 := "/opt/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/lib1"
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n",
 		filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5/lib1"), target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target0))
@@ -549,7 +549,7 @@ func (s *VulkanDriverLibsInterfaceSuite) TestSymlinksToComps(c *C) {
 `, gpu)), 0655)
 
 	// Write provider library
-	libDir := filepath.Join(compMnt, "lib1")
+	libDir := filepath.Join(compMnt, "clib1")
 	c.Assert(os.MkdirAll(libDir, 0755), IsNil)
 	libPath := filepath.Join(libDir, "libvulkan_"+gpu+".so.0")
 	os.WriteFile(libPath, []byte{}, 0655)
@@ -888,7 +888,7 @@ func (s *VulkanDriverLibsInterfaceSuite) TestConfigfilesSpec(c *C) {
 		filepath.Join(dirs.GlobalRootDir, "/var/lib/snapd/export/system_vulkan-provider_vulkan-slot_vulkan-driver-libs.library-source"): &osutil.MemoryFileState{
 			Content: []byte(filepath.Join(dirs.SnapMountDir, "vulkan-provider/5/lib1") + "\n" +
 				filepath.Join(dirs.SnapMountDir, "vulkan-provider/5/lib2") + "\n" +
-				filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "vulkan-provider"), "lib1") + "\n",
+				filepath.Join(snap.ComponentMountDir("comp1", snap.R(11), "vulkan-provider"), "clib1") + "\n",
 			), Mode: 0644},
 	})
 }

--- a/interfaces/builtin/vulkan_driver_libs_test.go
+++ b/interfaces/builtin/vulkan_driver_libs_test.go
@@ -408,7 +408,11 @@ func (s *VulkanDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 
 	// The writable-mimic is authorized for the share tree.
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  # Writable mimic %s\n", filepath.Dir(icdTarget)))
-	c.Check(spec.SnippetForTag("snap.snapd.app"), Equals, "")
+	// The app gets read access to its own assembly subtree only (the core base
+	// template does not grant /opt/** to apps).
+	app := spec.SnippetForTag("snap.snapd.app")
+	c.Check(app, testutil.Contains, "/opt/snapd/interfaces/vulkan-driver-libs/ r,")
+	c.Check(app, testutil.Contains, "/opt/snapd/interfaces/vulkan-driver-libs/** mrkix,")
 }
 
 func (s *VulkanDriverLibsInterfaceSuite) TestSymlinksSpec(c *C) {

--- a/interfaces/builtin/vulkan_driver_libs_test.go
+++ b/interfaces/builtin/vulkan_driver_libs_test.go
@@ -328,41 +328,41 @@ func (s *VulkanDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
 		// The shared tmpfs mount at the assembly root, so that only the bare
 		// mountpoint directory (not the assembly tree content) is host-visible.
-		{Name: "tmpfs", Dir: "/run/snapd/interfaces", Type: "tmpfs", Options: []string{"mode=0755", "uid=0", "gid=0"}},
+		{Name: "tmpfs", Dir: "/run/snapd/snap", Type: "tmpfs", Options: []string{"mode=0755", "uid=0", "gid=0"}},
 		// Library dirs.
-		{Name: libDir1, Dir: "/run/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/lib1", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
-		{Name: libDir2, Dir: "/run/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/lib2", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
-		{Name: compLibDir, Dir: "/run/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/clib1", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
+		{Name: libDir1, Dir: "/run/snapd/snap/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/lib1", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
+		{Name: libDir2, Dir: "/run/snapd/snap/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/lib2", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
+		{Name: compLibDir, Dir: "/run/snapd/snap/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/clib1", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
 		// ICD files, without a numeric prefix (vulkan has no priority).
 		{Name: filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5/vulkan/icd.d/mesa.json"),
-			Dir: "/run/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
+			Dir: "/run/snapd/snap/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
 		// Pass 2: redistribution to the loader-scanned Vulkan search dir.
-		{Name: "/run/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-mesa.json",
+		{Name: "/run/snapd/snap/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-mesa.json",
 			Dir: "/usr/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
 		{Name: filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5/vulkan_alt.d/radeon.json"),
-			Dir: "/run/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan_alt.d-radeon.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
+			Dir: "/run/snapd/snap/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan_alt.d-radeon.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
 		// Pass 2: redistribution for the radeon ICD too.
-		{Name: "/run/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan_alt.d-radeon.json",
+		{Name: "/run/snapd/snap/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan_alt.d-radeon.json",
 			Dir: "/usr/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan_alt.d-radeon.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
 		// Implicit layer.
 		{Name: filepath.Join(implicitDir, "gpu_layer.json"),
-			Dir: "/run/snapd/interfaces/vulkan-driver-libs/share/vulkan/implicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-implicit_layer.d-gpu_layer.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
+			Dir: "/run/snapd/snap/interfaces/vulkan-driver-libs/share/vulkan/implicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-implicit_layer.d-gpu_layer.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
 		// Pass 2: redistribution for the implicit layer.
-		{Name: "/run/snapd/interfaces/vulkan-driver-libs/share/vulkan/implicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-implicit_layer.d-gpu_layer.json",
+		{Name: "/run/snapd/snap/interfaces/vulkan-driver-libs/share/vulkan/implicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-implicit_layer.d-gpu_layer.json",
 			Dir: "/usr/share/vulkan/implicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-implicit_layer.d-gpu_layer.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
 		// Explicit layer.
 		{Name: filepath.Join(explicitDir, "exp_layer.json"),
-			Dir: "/run/snapd/interfaces/vulkan-driver-libs/share/vulkan/explicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-explicit_layer.d-exp_layer.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
+			Dir: "/run/snapd/snap/interfaces/vulkan-driver-libs/share/vulkan/explicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-explicit_layer.d-exp_layer.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
 		// Pass 2: redistribution for the explicit layer.
-		{Name: "/run/snapd/interfaces/vulkan-driver-libs/share/vulkan/explicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-explicit_layer.d-exp_layer.json",
+		{Name: "/run/snapd/snap/interfaces/vulkan-driver-libs/share/vulkan/explicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-explicit_layer.d-exp_layer.json",
 			Dir: "/usr/share/vulkan/explicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-explicit_layer.d-exp_layer.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
 	})
 
 	// Only the library dirs feed SNAP_LIBRARY_PATH (sorted).
 	c.Assert(spec.LibraryPathDirs(), DeepEquals, []string{
-		"/run/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/clib1",
-		"/run/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/lib1",
-		"/run/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/lib2",
+		"/run/snapd/snap/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/clib1",
+		"/run/snapd/snap/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/lib1",
+		"/run/snapd/snap/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/lib2",
 	})
 }
 
@@ -404,14 +404,14 @@ func (s *VulkanDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 
 	updateNS := strings.Join(spec.UpdateNS(), "")
 	// Library dir bind.
-	target0 := "/run/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/lib1"
+	target0 := "/run/snapd/snap/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/lib1"
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(rw, bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n",
 		filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5/lib1"), target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target0))
 
 	// ICD file bind with an unprefixed encoded name (vulkan has no priority).
 	icdSrc := filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5/vulkan/icd.d/mesa.json")
-	icdTarget := "/run/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-mesa.json"
+	icdTarget := "/run/snapd/snap/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-mesa.json"
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(rw, bind) \"%s\" -> \"%s{,-[0-9]*}\",\n", icdSrc, icdTarget))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}\",\n", icdTarget))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}\",\n", icdTarget))
@@ -426,7 +426,7 @@ func (s *VulkanDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 
 	// Implicit layer file bind.
 	layerSrc := filepath.Join(implicitDir, "gpu_layer.json")
-	layerTarget := "/run/snapd/interfaces/vulkan-driver-libs/share/vulkan/implicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-implicit_layer.d-gpu_layer.json"
+	layerTarget := "/run/snapd/snap/interfaces/vulkan-driver-libs/share/vulkan/implicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-implicit_layer.d-gpu_layer.json"
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(rw, bind) \"%s\" -> \"%s{,-[0-9]*}\",\n", layerSrc, layerTarget))
 	// Pass 2: redistribution authorization for the implicit layer too.
 	layerLoaderTarget := "/usr/share/vulkan/implicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-implicit_layer.d-gpu_layer.json"
@@ -444,8 +444,8 @@ func (s *VulkanDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 	// template does not grant /opt/** to apps), plus the loader-scanned Vulkan
 	// search dirs for Pass 2 redistribution.
 	app := spec.SnippetForTag("snap.snapd.app")
-	c.Check(app, testutil.Contains, "/run/snapd/interfaces/vulkan-driver-libs/ r,")
-	c.Check(app, testutil.Contains, "/run/snapd/interfaces/vulkan-driver-libs/** mrkix,")
+	c.Check(app, testutil.Contains, "/run/snapd/snap/interfaces/vulkan-driver-libs/ r,")
+	c.Check(app, testutil.Contains, "/run/snapd/snap/interfaces/vulkan-driver-libs/** mrkix,")
 	c.Check(app, testutil.Contains, "/usr/share/vulkan/{,icd.d,implicit_layer.d,explicit_layer.d}/{,**} r,")
 }
 

--- a/interfaces/builtin/vulkan_driver_libs_test.go
+++ b/interfaces/builtin/vulkan_driver_libs_test.go
@@ -333,14 +333,26 @@ func (s *VulkanDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 		// ICD files, without a numeric prefix (vulkan has no priority).
 		{Name: filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5/vulkan/icd.d/mesa.json"),
 			Dir: "/opt/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+		// Pass 2: redistribution to the loader-scanned Vulkan search dir.
+		{Name: "/opt/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-mesa.json",
+			Dir: "/usr/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
 		{Name: filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5/vulkan_alt.d/radeon.json"),
 			Dir: "/opt/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan_alt.d-radeon.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+		// Pass 2: redistribution for the radeon ICD too.
+		{Name: "/opt/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan_alt.d-radeon.json",
+			Dir: "/usr/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan_alt.d-radeon.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
 		// Implicit layer.
 		{Name: filepath.Join(implicitDir, "gpu_layer.json"),
 			Dir: "/opt/snapd/interfaces/vulkan-driver-libs/share/vulkan/implicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-implicit_layer.d-gpu_layer.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+		// Pass 2: redistribution for the implicit layer.
+		{Name: "/opt/snapd/interfaces/vulkan-driver-libs/share/vulkan/implicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-implicit_layer.d-gpu_layer.json",
+			Dir: "/usr/share/vulkan/implicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-implicit_layer.d-gpu_layer.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
 		// Explicit layer.
 		{Name: filepath.Join(explicitDir, "exp_layer.json"),
 			Dir: "/opt/snapd/interfaces/vulkan-driver-libs/share/vulkan/explicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-explicit_layer.d-exp_layer.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+		// Pass 2: redistribution for the explicit layer.
+		{Name: "/opt/snapd/interfaces/vulkan-driver-libs/share/vulkan/explicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-explicit_layer.d-exp_layer.json",
+			Dir: "/usr/share/vulkan/explicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-explicit_layer.d-exp_layer.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
 	})
 
 	// Only the library dirs feed SNAP_LIBRARY_PATH.
@@ -401,18 +413,37 @@ func (s *VulkanDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}\",\n", icdTarget))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}\",\n", icdTarget))
 
+	// Pass 2: redistribution authorization for the loader-scanned Vulkan
+	// search directory, re-binding the assembly target.
+	icdLoaderTarget := "/usr/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-mesa.json"
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  # Driver-libs redistribution %s -> %s\n", icdTarget, icdLoaderTarget))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(bind) \"%s\" -> \"%s{,-[0-9]*}\",\n", icdTarget, icdLoaderTarget))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}\",\n", icdLoaderTarget))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}\",\n", icdLoaderTarget))
+
 	// Implicit layer file bind.
 	layerSrc := filepath.Join(implicitDir, "gpu_layer.json")
 	layerTarget := "/opt/snapd/interfaces/vulkan-driver-libs/share/vulkan/implicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-implicit_layer.d-gpu_layer.json"
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(bind) \"%s\" -> \"%s{,-[0-9]*}\",\n", layerSrc, layerTarget))
+	// Pass 2: redistribution authorization for the implicit layer too.
+	layerLoaderTarget := "/usr/share/vulkan/implicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-implicit_layer.d-gpu_layer.json"
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  # Driver-libs redistribution %s -> %s\n", layerTarget, layerLoaderTarget))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(bind) \"%s\" -> \"%s{,-[0-9]*}\",\n", layerTarget, layerLoaderTarget))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}\",\n", layerLoaderTarget))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}\",\n", layerLoaderTarget))
 
 	// The writable-mimic is authorized for the share tree.
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  # Writable mimic %s\n", filepath.Dir(icdTarget)))
+	// The writable-mimic is authorized for the loader-scanned dirs too.
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  # Writable mimic %s\n", filepath.Dir(icdLoaderTarget)))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  # Writable mimic %s\n", filepath.Dir(layerLoaderTarget)))
 	// The app gets read access to its own assembly subtree only (the core base
-	// template does not grant /opt/** to apps).
+	// template does not grant /opt/** to apps), plus the loader-scanned Vulkan
+	// search dirs for Pass 2 redistribution.
 	app := spec.SnippetForTag("snap.snapd.app")
 	c.Check(app, testutil.Contains, "/opt/snapd/interfaces/vulkan-driver-libs/ r,")
 	c.Check(app, testutil.Contains, "/opt/snapd/interfaces/vulkan-driver-libs/** mrkix,")
+	c.Check(app, testutil.Contains, "/usr/share/vulkan/{,icd.d,implicit_layer.d,explicit_layer.d}/{,**} r,")
 }
 
 func (s *VulkanDriverLibsInterfaceSuite) TestSymlinksSpec(c *C) {

--- a/interfaces/builtin/vulkan_driver_libs_test.go
+++ b/interfaces/builtin/vulkan_driver_libs_test.go
@@ -402,14 +402,14 @@ func (s *VulkanDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 	updateNS := strings.Join(spec.UpdateNS(), "")
 	// Library dir bind.
 	target0 := "/opt/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/lib1"
-	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n",
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(rw, bind) \"%s/\" -> \"%s{,-[0-9]*}/\",\n",
 		filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5/lib1"), target0))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}/\",\n", target0))
 
 	// ICD file bind with an unprefixed encoded name (vulkan has no priority).
 	icdSrc := filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5/vulkan/icd.d/mesa.json")
 	icdTarget := "/opt/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-mesa.json"
-	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(bind) \"%s\" -> \"%s{,-[0-9]*}\",\n", icdSrc, icdTarget))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(rw, bind) \"%s\" -> \"%s{,-[0-9]*}\",\n", icdSrc, icdTarget))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}\",\n", icdTarget))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}\",\n", icdTarget))
 
@@ -417,18 +417,18 @@ func (s *VulkanDriverLibsInterfaceSuite) TestAppArmorConnectedPlugSpec(c *C) {
 	// search directory, re-binding the assembly target.
 	icdLoaderTarget := "/usr/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-mesa.json"
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  # Driver-libs redistribution %s -> %s\n", icdTarget, icdLoaderTarget))
-	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(bind) \"%s\" -> \"%s{,-[0-9]*}\",\n", icdTarget, icdLoaderTarget))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(rw, bind) \"%s\" -> \"%s{,-[0-9]*}\",\n", icdTarget, icdLoaderTarget))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}\",\n", icdLoaderTarget))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}\",\n", icdLoaderTarget))
 
 	// Implicit layer file bind.
 	layerSrc := filepath.Join(implicitDir, "gpu_layer.json")
 	layerTarget := "/opt/snapd/interfaces/vulkan-driver-libs/share/vulkan/implicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-implicit_layer.d-gpu_layer.json"
-	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(bind) \"%s\" -> \"%s{,-[0-9]*}\",\n", layerSrc, layerTarget))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(rw, bind) \"%s\" -> \"%s{,-[0-9]*}\",\n", layerSrc, layerTarget))
 	// Pass 2: redistribution authorization for the implicit layer too.
 	layerLoaderTarget := "/usr/share/vulkan/implicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-implicit_layer.d-gpu_layer.json"
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  # Driver-libs redistribution %s -> %s\n", layerTarget, layerLoaderTarget))
-	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(bind) \"%s\" -> \"%s{,-[0-9]*}\",\n", layerTarget, layerLoaderTarget))
+	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  mount options=(rw, bind) \"%s\" -> \"%s{,-[0-9]*}\",\n", layerTarget, layerLoaderTarget))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  remount options=(bind, ro) \"%s{,-[0-9]*}\",\n", layerLoaderTarget))
 	c.Check(updateNS, testutil.Contains, fmt.Sprintf("  umount \"%s{,-[0-9]*}\",\n", layerLoaderTarget))
 

--- a/interfaces/builtin/vulkan_driver_libs_test.go
+++ b/interfaces/builtin/vulkan_driver_libs_test.go
@@ -330,32 +330,32 @@ func (s *VulkanDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 		// mountpoint directory (not the assembly tree content) is host-visible.
 		{Name: "tmpfs", Dir: "/run/snapd/interfaces", Type: "tmpfs", Options: []string{"mode=0755", "uid=0", "gid=0"}},
 		// Library dirs.
-		{Name: libDir1, Dir: "/run/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/lib1", Options: []string{"bind", "ro"}},
-		{Name: libDir2, Dir: "/run/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/lib2", Options: []string{"bind", "ro"}},
-		{Name: compLibDir, Dir: "/run/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/clib1", Options: []string{"bind", "ro"}},
+		{Name: libDir1, Dir: "/run/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/lib1", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
+		{Name: libDir2, Dir: "/run/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/lib2", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
+		{Name: compLibDir, Dir: "/run/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/clib1", Options: []string{"bind", "ro", osutil.XSnapdOriginLayout()}},
 		// ICD files, without a numeric prefix (vulkan has no priority).
 		{Name: filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5/vulkan/icd.d/mesa.json"),
-			Dir: "/run/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+			Dir: "/run/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
 		// Pass 2: redistribution to the loader-scanned Vulkan search dir.
 		{Name: "/run/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-mesa.json",
-			Dir: "/usr/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+			Dir: "/usr/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan-icd.d-mesa.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
 		{Name: filepath.Join(dirs.GlobalRootDir, "snap/vulkan-provider/5/vulkan_alt.d/radeon.json"),
-			Dir: "/run/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan_alt.d-radeon.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+			Dir: "/run/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan_alt.d-radeon.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
 		// Pass 2: redistribution for the radeon ICD too.
 		{Name: "/run/snapd/interfaces/vulkan-driver-libs/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan_alt.d-radeon.json",
-			Dir: "/usr/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan_alt.d-radeon.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+			Dir: "/usr/share/vulkan/icd.d/snap_vulkan-provider_vulkan-slot_vulkan_alt.d-radeon.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
 		// Implicit layer.
 		{Name: filepath.Join(implicitDir, "gpu_layer.json"),
-			Dir: "/run/snapd/interfaces/vulkan-driver-libs/share/vulkan/implicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-implicit_layer.d-gpu_layer.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+			Dir: "/run/snapd/interfaces/vulkan-driver-libs/share/vulkan/implicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-implicit_layer.d-gpu_layer.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
 		// Pass 2: redistribution for the implicit layer.
 		{Name: "/run/snapd/interfaces/vulkan-driver-libs/share/vulkan/implicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-implicit_layer.d-gpu_layer.json",
-			Dir: "/usr/share/vulkan/implicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-implicit_layer.d-gpu_layer.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+			Dir: "/usr/share/vulkan/implicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-implicit_layer.d-gpu_layer.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
 		// Explicit layer.
 		{Name: filepath.Join(explicitDir, "exp_layer.json"),
-			Dir: "/run/snapd/interfaces/vulkan-driver-libs/share/vulkan/explicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-explicit_layer.d-exp_layer.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+			Dir: "/run/snapd/interfaces/vulkan-driver-libs/share/vulkan/explicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-explicit_layer.d-exp_layer.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
 		// Pass 2: redistribution for the explicit layer.
 		{Name: "/run/snapd/interfaces/vulkan-driver-libs/share/vulkan/explicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-explicit_layer.d-exp_layer.json",
-			Dir: "/usr/share/vulkan/explicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-explicit_layer.d-exp_layer.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile()}},
+			Dir: "/usr/share/vulkan/explicit_layer.d/snap_vulkan-provider_vulkan-slot_vulkan-explicit_layer.d-exp_layer.json", Options: []string{"bind", "ro", osutil.XSnapdKindFile(), osutil.XSnapdOriginLayout()}},
 	})
 
 	// Only the library dirs feed SNAP_LIBRARY_PATH (sorted).

--- a/interfaces/builtin/vulkan_driver_libs_test.go
+++ b/interfaces/builtin/vulkan_driver_libs_test.go
@@ -326,6 +326,9 @@ func (s *VulkanDriverLibsInterfaceSuite) TestMountConnectedPlugSpec(c *C) {
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.slot), IsNil)
 
 	c.Assert(spec.MountEntries(), DeepEquals, []osutil.MountEntry{
+		// The shared tmpfs mount at the assembly root, so that only the bare
+		// mountpoint directory (not the assembly tree content) is host-visible.
+		{Name: "tmpfs", Dir: "/run/snapd/interfaces", Type: "tmpfs", Options: []string{"mode=0755", "uid=0", "gid=0"}},
 		// Library dirs.
 		{Name: libDir1, Dir: "/run/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/lib1", Options: []string{"bind", "ro"}},
 		{Name: libDir2, Dir: "/run/snapd/interfaces/vulkan-driver-libs/lib/vulkan-provider_vulkan-slot/lib2", Options: []string{"bind", "ro"}},

--- a/interfaces/configfiles/backend.go
+++ b/interfaces/configfiles/backend.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/timings"
 )
 
@@ -57,6 +58,15 @@ func (b *Backend) Prepare(_ *interfaces.SnapAppSet) error {
 //
 // If the method fails it should be re-tried (with a sensible strategy) by the caller.
 func (b *Backend) Setup(appSet *interfaces.SnapAppSet, opts interfaces.ConfinementOptions, sctx interfaces.SetupContext, repo *interfaces.Repository, tm timings.Measurer) error {
+	if !release.OnClassic {
+		// The configfiles backend delivers metadata files into the
+		// classic rootfs. On Core, driver-libs content is delivered via
+		// the mount backend instead, so there is nothing to do here (and
+		// we skip SnapSpecification, which would otherwise trip the
+		// system-snap-only plug guard).
+		return nil
+	}
+
 	cfgPatterns := []string{}
 	for _, iface := range repo.AllInterfaces() {
 		if cfgIface, ok := iface.(interfaces.ConfigfilesUser); ok {

--- a/interfaces/configfiles/backend_test.go
+++ b/interfaces/configfiles/backend_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/interfaces/configfiles"
 	"github.com/snapcore/snapd/interfaces/ifacetest"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
@@ -134,6 +135,14 @@ type: snapd
 apps:
   app:
     plugs: [egl-driver-libs, other-driver-libs]
+`
+
+const eglNonSystemConsumer = `name: test-snapd-driver-libs
+version: 0
+type: app
+apps:
+  app:
+    plugs: [egl-driver-libs]
 `
 
 func checkConfigfilesFile(c *C, path, content string) {
@@ -261,6 +270,47 @@ func (s *backendSuite) TestTwoPlugs(c *C) {
 	// Only files for the connected slots are around
 	c.Check(filepath.Join(dirs.GlobalRootDir, "/etc/conf1.d/snap.a.conf"), testutil.FileAbsent)
 	checkConfigfilesFile(c, "/etc/conf2.d/snap.a.conf", "a")
+}
+
+func (s *backendSuite) TestSetupNoOpOnNonClassic(c *C) {
+	// On non-classic systems the configfiles backend delivers nothing into the
+	// classic rootfs (driver libraries are provided via the mount backend
+	// instead), so Backend.Setup() must be a no-op. In particular, it must not
+	// reject a non-system consumer snap that declares a driver-libs plug
+	// (regression test for the old "configfiles plugs can be defined only by
+	// the system snap" error that aborted the install of such a snap on
+	// Core).
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	iface := &ifacetest.TestConfigFilesInterface{
+		TestInterface: ifacetest.TestInterface{
+			InterfaceName: "egl-driver-libs",
+			ConfigfilesConnectedPlugCallback: func(spec *configfiles.Specification,
+				plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+				spec.AddPathContent(
+					filepath.Join(dirs.GlobalRootDir, "/etc/conf1.d/snap.a.conf"),
+					&osutil.MemoryFileState{Content: []byte("aaaa"), Mode: 0655})
+				return nil
+			},
+		},
+		PathPatternsCallback: func() []string {
+			return []string{filepath.Join(dirs.GlobalRootDir, "/etc/conf1.d/snap.*.conf")}
+		},
+	}
+	c.Assert(s.Repo.AddInterface(iface), IsNil)
+
+	appSet, plugInfos := s.mockPlugs(c, eglNonSystemConsumer, []string{"egl-driver-libs"})
+	_, slotInfo := s.mockSlot(c, eglProvider1, "egl-driver-libs")
+	connRef := interfaces.NewConnRef(plugInfos[0], slotInfo)
+	_, err := s.Repo.Connect(connRef, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+
+	c.Assert(s.Backend.Setup(appSet, interfaces.ConfinementOptions{},
+		interfaces.SetupContext{Reason: interfaces.SnapSetupReasonOther}, s.Repo, nil), IsNil)
+
+	// No configuration file is produced on non-classic.
+	c.Check(filepath.Join(dirs.GlobalRootDir, "/etc/conf1.d/snap.a.conf"), testutil.FileAbsent)
 }
 
 func (s *backendSuite) TestUnmatchedPattern(c *C) {

--- a/interfaces/configfiles/spec.go
+++ b/interfaces/configfiles/spec.go
@@ -20,7 +20,6 @@
 package configfiles
 
 import (
-	"errors"
 	"fmt"
 	"path/filepath"
 
@@ -83,12 +82,8 @@ type ConnectedPlugCallback interface {
 		slot *interfaces.ConnectedSlot) error
 }
 
-func getConnectedPlugCallback(iface interfaces.Interface, instanceName string) (
-	ConnectedPlugCallback, error) {
+func getConnectedPlugCallback(iface interfaces.Interface) (ConnectedPlugCallback, error) {
 	if iface, ok := iface.(ConnectedPlugCallback); ok {
-		if !interfaces.IsTheSystemSnap(instanceName) {
-			return nil, errors.New("internal error: configfiles plugs can be defined only by the system snap")
-		}
 		return iface, nil
 	}
 	return nil, nil
@@ -96,7 +91,7 @@ func getConnectedPlugCallback(iface interfaces.Interface, instanceName string) (
 
 // AddConnectedPlug records configfiles-specific side-effects of having a connected plug.
 func (spec *Specification) AddConnectedPlug(iface interfaces.Interface, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	connectedPlugCallback, err := getConnectedPlugCallback(iface, plug.Snap().InstanceName())
+	connectedPlugCallback, err := getConnectedPlugCallback(iface)
 	if err != nil {
 		return err
 	}
@@ -112,9 +107,6 @@ func (spec *Specification) AddConnectedSlot(iface interfaces.Interface, plug *in
 		ConfigfilesConnectedSlot(spec *Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
 	}
 	if iface, ok := iface.(definer); ok {
-		if !interfaces.IsTheSystemSnap(plug.Snap().InstanceName()) {
-			return errors.New("internal error: configfiles plugs can be defined only by the system snap")
-		}
 		return iface.ConfigfilesConnectedSlot(spec, plug, slot)
 	}
 	return nil
@@ -124,7 +116,7 @@ func (spec *Specification) AddConnectedSlot(iface interfaces.Interface, plug *in
 func (spec *Specification) AddPermanentPlug(iface interfaces.Interface, plug *snap.PlugInfo) error {
 	// Note that ConnectedPlugCallback must be implemented, so we
 	// check for it instead of using ConfigfilesPermanentPlug.
-	connectedPlugCallback, err := getConnectedPlugCallback(iface, plug.Snap.InstanceName())
+	connectedPlugCallback, err := getConnectedPlugCallback(iface)
 	if err != nil {
 		return err
 	}
@@ -137,9 +129,6 @@ func (spec *Specification) AddPermanentPlug(iface interfaces.Interface, plug *sn
 		ConfigfilesPermanentPlug(spec *Specification, plug *snap.PlugInfo) error
 	}
 	if iface, ok := iface.(definer); ok {
-		if !interfaces.IsTheSystemSnap(plug.Snap.InstanceName()) {
-			return errors.New("internal error: configfiles plugs can be defined only by the system snap")
-		}
 		return iface.ConfigfilesPermanentPlug(spec, plug)
 	}
 	return nil

--- a/interfaces/configfiles/spec_test.go
+++ b/interfaces/configfiles/spec_test.go
@@ -115,7 +115,7 @@ func (s *specSuite) TestSpecificationIface(c *C) {
 	})
 }
 
-func (s *specSuite) TestPlugNotFromSystem(c *C) {
+func (s *specSuite) TestPlugNotFromSystemNoError(c *C) {
 	const plugYaml = `name: notsystem
 version: 1
 apps:
@@ -124,13 +124,18 @@ apps:
 `
 	s.plug, s.plugInfo = ifacetest.MockConnectedPlug(c, plugYaml, nil, "name")
 
+	// The system-snap-only guard on the plug side callbacks was removed.
+	// The discernment now lives in the backends' Backend.Setup() gate on
+	// release.OnClassic: on classic only the system snap can declare these
+	// plugs (per the base declaration), and on non-classic the backends
+	// never reach specification generation at all. So a plug from a
+	// non-system snap is no longer rejected here; if the interface
+	// implements the backend callback, it now runs like for any other snap.
 	var r interfaces.Specification = s.spec
-	c.Assert(r.AddConnectedPlug(s.iface1, s.plug, s.slot), ErrorMatches,
-		"internal error: configfiles plugs can be defined only by the system snap")
-	c.Assert(r.AddConnectedSlot(s.iface1, s.plug, s.slot), ErrorMatches,
-		"internal error: configfiles plugs can be defined only by the system snap")
-	c.Assert(r.AddPermanentPlug(s.iface1, s.plugInfo), ErrorMatches,
-		"internal error: configfiles plugs can be defined only by the system snap")
+	c.Assert(r.AddConnectedPlug(s.iface1, s.plug, s.slot), IsNil)
+	c.Assert(r.AddConnectedSlot(s.iface1, s.plug, s.slot), IsNil)
+	c.Assert(r.AddPermanentPlug(s.iface1, s.plugInfo), IsNil)
+	c.Assert(s.spec.Plugs(), DeepEquals, []string{"name"})
 }
 
 func (s *specSuite) TestAddPathContentErrors(c *C) {

--- a/interfaces/ldconfig/backend.go
+++ b/interfaces/ldconfig/backend.go
@@ -29,6 +29,7 @@ import (
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/timings"
 )
 
@@ -57,6 +58,15 @@ func (b *Backend) Prepare(_ *interfaces.SnapAppSet) error {
 //
 // If the method fails it should be re-tried (with a sensible strategy) by the caller.
 func (b *Backend) Setup(appSet *interfaces.SnapAppSet, opts interfaces.ConfinementOptions, sctx interfaces.SetupContext, repo *interfaces.Repository, tm timings.Measurer) error {
+	if !release.OnClassic {
+		// The ldconfig backend delivers libraries into the classic
+		// rootfs. On Core, driver-libs content is delivered via the mount
+		// backend instead, so there is nothing to do here (and we skip
+		// SnapSpecification, which would otherwise trip the
+		// system-snap-only plug guard).
+		return nil
+	}
+
 	// Get the snippets that apply to this snap
 	spec, err := repo.SnapSpecification(b.Name(), appSet, opts)
 	if err != nil {

--- a/interfaces/ldconfig/backend_test.go
+++ b/interfaces/ldconfig/backend_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/ifacetest"
 	"github.com/snapcore/snapd/interfaces/ldconfig"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
@@ -114,6 +115,16 @@ apps:
     plugs: [cuda-driver-libs]
 `
 
+const cudaNonSystemConsumer = `name: test-snapd-driver-libs
+version: 0
+type: app
+plugs:
+  cuda-driver-libs:
+apps:
+  app:
+    plugs: [cuda-driver-libs]
+`
+
 func (s *backendSuite) TestInstallingCreatesLdconf(c *C) {
 	// Default content for /etc/ld.so.conf.d/
 	confDir := filepath.Join(dirs.GlobalRootDir, "etc", "ld.so.conf.d")
@@ -185,6 +196,39 @@ func (s *backendSuite) TestInstallingCreatesLdconf(c *C) {
 
 	// libc config has not been touched
 	c.Check(libcConfPath, testutil.FilePresent)
+}
+
+func (s *backendSuite) TestSetupNoOpOnNonClassic(c *C) {
+	// On non-classic systems the ldconfig backend delivers nothing into the
+	// rootfs (driver libraries are provided via the mount backend instead), so
+	// Backend.Setup() must be a no-op. In particular, it must not reject a
+	// non-system consumer snap that declares a driver-libs plug (regression
+	// test for the old "ldconfig plugs can be defined only by the system snap"
+	// error that aborted the install of such a snap on Core).
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	s.Iface.InterfaceName = "cuda-driver-libs"
+	s.Iface.LdconfigConnectedPlugCallback = func(spec *ldconfig.Specification,
+		plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+		spec.AddLibDirs([]string{"/dir1/lib1"})
+		return nil
+	}
+	c.Assert(s.Repo.AddInterface(s.Iface), IsNil)
+
+	appSet, plugInfo := s.mockPlug(c, cudaNonSystemConsumer, nil, "cuda-driver-libs")
+	_, slotInfo := s.mockSlot(c, cudaProvider1, nil, "cuda-driver-libs")
+	connRef := interfaces.NewConnRef(plugInfo, slotInfo)
+	_, err := s.Repo.Connect(connRef, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+
+	c.Assert(s.Backend.Setup(appSet, interfaces.ConfinementOptions{},
+		interfaces.SetupContext{Reason: interfaces.SnapSetupReasonOther}, s.Repo, nil), IsNil)
+
+	// No ldconfig configuration file is produced and ldconfig is never run.
+	confPath := filepath.Join(dirs.GlobalRootDir, "etc", "ld.so.conf.d", "snap.system.conf")
+	c.Assert(confPath, testutil.FileAbsent)
+	c.Assert(s.ldconfigCmd.Calls(), IsNil)
 }
 
 func (s *backendSuite) TestSandboxFeatures(c *C) {

--- a/interfaces/ldconfig/spec.go
+++ b/interfaces/ldconfig/spec.go
@@ -79,12 +79,8 @@ type ConnectedPlugCallback interface {
 		slot *interfaces.ConnectedSlot) error
 }
 
-func getConnectedPlugCallback(iface interfaces.Interface, instanceName string) (
-	ConnectedPlugCallback, error) {
+func getConnectedPlugCallback(iface interfaces.Interface) (ConnectedPlugCallback, error) {
 	if iface, ok := iface.(ConnectedPlugCallback); ok {
-		if !interfaces.IsTheSystemSnap(instanceName) {
-			return nil, errors.New("internal error: ldconfig plugs can be defined only by the system snap")
-		}
 		return iface, nil
 	}
 	return nil, nil
@@ -92,7 +88,7 @@ func getConnectedPlugCallback(iface interfaces.Interface, instanceName string) (
 
 // AddConnectedPlug records ldconfig-specific side-effects of having a connected plug.
 func (spec *Specification) AddConnectedPlug(iface interfaces.Interface, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	connectedPlugCallback, err := getConnectedPlugCallback(iface, plug.Snap().InstanceName())
+	connectedPlugCallback, err := getConnectedPlugCallback(iface)
 	if err != nil {
 		return err
 	}
@@ -112,9 +108,6 @@ func (spec *Specification) AddConnectedSlot(iface interfaces.Interface, plug *in
 			slot *interfaces.ConnectedSlot) error
 	}
 	if iface, ok := iface.(definer); ok {
-		if !interfaces.IsTheSystemSnap(plug.Snap().InstanceName()) {
-			return errors.New("internal error: ldconfig plugs can be defined only by the system snap")
-		}
 		return iface.LdconfigConnectedSlot(spec, plug, slot)
 	}
 	return nil
@@ -124,7 +117,7 @@ func (spec *Specification) AddConnectedSlot(iface interfaces.Interface, plug *in
 func (spec *Specification) AddPermanentPlug(iface interfaces.Interface, plug *snap.PlugInfo) error {
 	// Note that ConnectedPlugCallback must be implemented, so we
 	// check for it instead of using LdconfigPermanentPlug.
-	connectedPlugCallback, err := getConnectedPlugCallback(iface, plug.Snap.InstanceName())
+	connectedPlugCallback, err := getConnectedPlugCallback(iface)
 	if err != nil {
 		return err
 	}
@@ -137,9 +130,6 @@ func (spec *Specification) AddPermanentPlug(iface interfaces.Interface, plug *sn
 		LdconfigPermanentPlug(spec *Specification, plug *snap.PlugInfo) error
 	}
 	if iface, ok := iface.(definer); ok {
-		if !interfaces.IsTheSystemSnap(plug.Snap.InstanceName()) {
-			return errors.New("internal error: ldconfig plugs can be defined only by the system snap")
-		}
 		return iface.LdconfigPermanentPlug(spec, plug)
 	}
 	return nil

--- a/interfaces/ldconfig/spec_test.go
+++ b/interfaces/ldconfig/spec_test.go
@@ -104,7 +104,7 @@ func (s *specSuite) TestSpecificationIface(c *C) {
 	})
 }
 
-func (s *specSuite) TestPlugNotFromSystem(c *C) {
+func (s *specSuite) TestPlugNotFromSystemNoError(c *C) {
 	const plugYaml = `name: notsystem
 version: 1
 apps:
@@ -113,11 +113,16 @@ apps:
 `
 	s.plug, s.plugInfo = ifacetest.MockConnectedPlug(c, plugYaml, nil, "name")
 
+	// The system-snap-only guard on the plug side callbacks was removed.
+	// The discernment now lives in the backends' Backend.Setup() gate on
+	// release.OnClassic: on classic only the system snap can declare these
+	// plugs (per the base declaration), and on non-classic the backends
+	// never reach specification generation at all. So a plug from a
+	// non-system snap is no longer rejected here; if the interface
+	// implements the backend callback, it now runs like for any other snap.
 	var r interfaces.Specification = s.spec
-	c.Assert(r.AddConnectedPlug(s.iface1, s.plug, s.slot), ErrorMatches,
-		"internal error: ldconfig plugs can be defined only by the system snap")
-	c.Assert(r.AddConnectedSlot(s.iface1, s.plug, s.slot), ErrorMatches,
-		"internal error: ldconfig plugs can be defined only by the system snap")
-	c.Assert(r.AddPermanentPlug(s.iface1, s.plugInfo), ErrorMatches,
-		"internal error: ldconfig plugs can be defined only by the system snap")
+	c.Assert(r.AddConnectedPlug(s.iface1, s.plug, s.slot), IsNil)
+	c.Assert(r.AddConnectedSlot(s.iface1, s.plug, s.slot), IsNil)
+	c.Assert(r.AddPermanentPlug(s.iface1, s.plugInfo), IsNil)
+	c.Assert(s.spec.Plugs(), DeepEquals, []string{"name"})
 }

--- a/interfaces/mount/spec.go
+++ b/interfaces/mount/spec.go
@@ -46,6 +46,12 @@ type Specification struct {
 	general  []osutil.MountEntry
 	user     []osutil.MountEntry
 	overname []osutil.MountEntry
+
+	// libraryPathDirs collects the directories under /opt/snapd/interfaces that
+	// host driver libraries assembled from a provider snap. These dirs feed the
+	// SNAP_LIBRARY_PATH derivation (Pass 3); they are collected in-memory here and
+	// never written to the mount profile themselves.
+	libraryPathDirs []string
 }
 
 // AddMountEntry adds a new mount entry.
@@ -64,6 +70,32 @@ func (spec *Specification) AddUserMountEntry(e osutil.MountEntry) error {
 func (spec *Specification) AddOvernameMountEntry(e osutil.MountEntry) error {
 	spec.overname = append(spec.overname, e)
 	return nil
+}
+
+// AddLibraryPathDir records a directory that should be included in the
+// SNAP_LIBRARY_PATH of the snap. It is collected in-memory alongside the mount
+// entries during the same spec pass; it is not itself rendered into the mount
+// profile.
+func (spec *Specification) AddLibraryPathDir(dir string) {
+	spec.libraryPathDirs = append(spec.libraryPathDirs, dir)
+}
+
+// LibraryPathDirs returns a sorted, deduplicated copy of the directories added
+// via AddLibraryPathDir.
+func (spec *Specification) LibraryPathDirs() []string {
+	if len(spec.libraryPathDirs) == 0 {
+		return nil
+	}
+	dirs := make([]string, 0, len(spec.libraryPathDirs))
+	seen := make(map[string]bool, len(spec.libraryPathDirs))
+	for _, d := range spec.libraryPathDirs {
+		if !seen[d] {
+			seen[d] = true
+			dirs = append(dirs, d)
+		}
+	}
+	sort.Strings(dirs)
+	return dirs
 }
 
 func mountEntryFromLayout(layout *snap.Layout) osutil.MountEntry {

--- a/interfaces/mount/spec_test.go
+++ b/interfaces/mount/spec_test.go
@@ -342,3 +342,30 @@ func (s *specSuite) TestAddUserEnsureErrorValidate(c *C) {
 	err := s.spec.AddUserEnsureDirs(ensureDirSpecs)
 	c.Assert(err, ErrorMatches, `internal error: cannot use ensure-dir mount specification: directory that must exist "\$SNAP_HOME" prefix "\$SNAP_HOME" is not allowed`)
 }
+
+func (s *specSuite) TestLibraryPathDirs(c *C) {
+	// Nothing added yet.
+	c.Assert(s.spec.LibraryPathDirs(), IsNil)
+
+	// Added dirs are collected in insertion order internally.
+	s.spec.AddLibraryPathDir("/opt/snapd/interfaces/vulkan-driver-libs/lib/foo_vulkan/1")
+	s.spec.AddLibraryPathDir("/opt/snapd/interfaces/vulkan-driver-libs/lib/foo_vulkan/2")
+	// Returns a sorted, deduplicated copy.
+	s.spec.AddLibraryPathDir("/opt/snapd/interfaces/vulkan-driver-libs/lib/foo_vulkan/1")
+	s.spec.AddLibraryPathDir("/opt/snapd/interfaces/opengl-driver-libs/lib/bar_opengl/1")
+
+	expected := []string{
+		"/opt/snapd/interfaces/opengl-driver-libs/lib/bar_opengl/1",
+		"/opt/snapd/interfaces/vulkan-driver-libs/lib/foo_vulkan/1",
+		"/opt/snapd/interfaces/vulkan-driver-libs/lib/foo_vulkan/2",
+	}
+	c.Assert(s.spec.LibraryPathDirs(), DeepEquals, expected)
+
+	// A second call does not mutate the underlying collection and returns
+	// an equal (but independently sorted) copy.
+	c.Assert(s.spec.LibraryPathDirs(), DeepEquals, expected)
+
+	// Adding after the calls still reflects the full set.
+	s.spec.AddLibraryPathDir("/opt/snapd/interfaces/egl-driver-libs/lib/baz_egl/1")
+	c.Assert(len(s.spec.LibraryPathDirs()), Equals, 4)
+}

--- a/interfaces/symlinks/backend.go
+++ b/interfaces/symlinks/backend.go
@@ -34,6 +34,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/timings"
 )
 
@@ -59,6 +60,15 @@ func (b *Backend) Prepare(_ *interfaces.SnapAppSet) error {
 
 // Setup will make the symlinks backend generate the specified symlinks.
 func (b *Backend) Setup(appSet *interfaces.SnapAppSet, opts interfaces.ConfinementOptions, sctx interfaces.SetupContext, repo *interfaces.Repository, tm timings.Measurer) error {
+	if !release.OnClassic {
+		// The symlinks backend delivers symlinks into the classic
+		// rootfs. On Core, driver-libs content is delivered via the mount
+		// backend instead, so there is nothing to do here (and we skip
+		// SnapSpecification, which would otherwise trip the
+		// system-snap-only plug guard).
+		return nil
+	}
+
 	symlinkDirs := map[string]bool{}
 	for _, iface := range repo.AllInterfaces() {
 		if symlnIface, ok := iface.(interfaces.SymlinksUser); ok {

--- a/interfaces/symlinks/backend_test.go
+++ b/interfaces/symlinks/backend_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/snapcore/snapd/interfaces"
 	"github.com/snapcore/snapd/interfaces/ifacetest"
 	"github.com/snapcore/snapd/interfaces/symlinks"
+	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/snaptest"
 	"github.com/snapcore/snapd/testutil"
@@ -135,6 +136,14 @@ type: snapd
 apps:
   app:
     plugs: [some-driver-libs, other-driver-libs]
+`
+
+const someNonSystemConsumer = `name: test-snapd-driver-libs
+version: 0
+type: app
+apps:
+  app:
+    plugs: [some-driver-libs]
 `
 
 func checkSymlink(c *C, target, name string) {
@@ -274,6 +283,45 @@ func (s *backendSuite) TestTwoPlugs(c *C) {
 	// Only symlinks for the connected slots are around
 	c.Check(filepath.Join(dirs.GlobalRootDir, "/usr/lib/foo/bar.so"), testutil.LFileAbsent)
 	checkSymlink(c, "/snap/somesnap2/1/target2.so", "/usr/lib/foo2/bar2.so")
+}
+
+func (s *backendSuite) TestSetupNoOpOnNonClassic(c *C) {
+	// On non-classic systems the symlinks backend delivers nothing into the
+	// classic rootfs (driver libraries are provided via the mount backend
+	// instead), so Backend.Setup() must be a no-op. In particular, it must not
+	// reject a non-system consumer snap that declares a driver-libs plug
+	// (regression test for the old "symlinks plugs can be defined only by the
+	// system snap" error that aborted the install of such a snap on Core).
+	restore := release.MockOnClassic(false)
+	defer restore()
+
+	iface := &ifacetest.TestSymlinksInterface{
+		TestInterface: ifacetest.TestInterface{
+			InterfaceName: "some-driver-libs",
+			SymlinksConnectedPlugCallback: func(spec *symlinks.Specification,
+				plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
+				return spec.AddSymlink(
+					filepath.Join(dirs.GlobalRootDir, "/snap/somesnap/1/target.so"),
+					filepath.Join(dirs.GlobalRootDir, "/usr/lib/foo/bar.so"))
+			},
+		},
+		DirectoriesCallback: func() []string {
+			return []string{filepath.Join(dirs.GlobalRootDir, "/usr/lib/foo")}
+		},
+	}
+	c.Assert(s.Repo.AddInterface(iface), IsNil)
+
+	appSet, plugInfos := s.mockPlugs(c, someNonSystemConsumer, []string{"some-driver-libs"})
+	_, slotInfo := s.mockSlot(c, someProvider1, "some-driver-libs")
+	connRef := interfaces.NewConnRef(plugInfos[0], slotInfo)
+	_, err := s.Repo.Connect(connRef, nil, nil, nil, nil, nil)
+	c.Assert(err, IsNil)
+
+	c.Assert(s.Backend.Setup(appSet, interfaces.ConfinementOptions{},
+		interfaces.SetupContext{Reason: interfaces.SnapSetupReasonOther}, s.Repo, nil), IsNil)
+
+	// No symlink is produced on non-classic.
+	c.Check(filepath.Join(dirs.GlobalRootDir, "/usr/lib/foo/bar.so"), testutil.LFileAbsent)
 }
 
 func (s *backendSuite) TestUnregisteredDirectory(c *C) {

--- a/interfaces/symlinks/spec.go
+++ b/interfaces/symlinks/spec.go
@@ -20,7 +20,6 @@
 package symlinks
 
 import (
-	"errors"
 	"fmt"
 	"path/filepath"
 
@@ -95,12 +94,8 @@ type ConnectedPlugCallback interface {
 		slot *interfaces.ConnectedSlot) error
 }
 
-func getConnectedPlugCallback(iface interfaces.Interface, instanceName string) (
-	ConnectedPlugCallback, error) {
+func getConnectedPlugCallback(iface interfaces.Interface) (ConnectedPlugCallback, error) {
 	if iface, ok := iface.(ConnectedPlugCallback); ok {
-		if !interfaces.IsTheSystemSnap(instanceName) {
-			return nil, errors.New("internal error: symlinks plugs can be defined only by the system snap")
-		}
 		return iface, nil
 	}
 	return nil, nil
@@ -108,7 +103,7 @@ func getConnectedPlugCallback(iface interfaces.Interface, instanceName string) (
 
 // AddConnectedPlug records symlinks-specific side-effects of having a connected plug.
 func (spec *Specification) AddConnectedPlug(iface interfaces.Interface, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
-	connectedPlugCallback, err := getConnectedPlugCallback(iface, plug.Snap().InstanceName())
+	connectedPlugCallback, err := getConnectedPlugCallback(iface)
 	if err != nil {
 		return err
 	}
@@ -124,9 +119,6 @@ func (spec *Specification) AddConnectedSlot(iface interfaces.Interface, plug *in
 		SymlinksConnectedSlot(spec *Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error
 	}
 	if iface, ok := iface.(definer); ok {
-		if !interfaces.IsTheSystemSnap(plug.Snap().InstanceName()) {
-			return errors.New("internal error: symlinks plugs can be defined only by the system snap")
-		}
 		return iface.SymlinksConnectedSlot(spec, plug, slot)
 	}
 	return nil
@@ -136,7 +128,7 @@ func (spec *Specification) AddConnectedSlot(iface interfaces.Interface, plug *in
 func (spec *Specification) AddPermanentPlug(iface interfaces.Interface, plug *snap.PlugInfo) error {
 	// Note that ConnectedPlugCallback must be implemented, so we
 	// check for it instead of using SymlinksPermanentPlug.
-	connectedPlugCallback, err := getConnectedPlugCallback(iface, plug.Snap.InstanceName())
+	connectedPlugCallback, err := getConnectedPlugCallback(iface)
 	if err != nil {
 		return err
 	}
@@ -149,9 +141,6 @@ func (spec *Specification) AddPermanentPlug(iface interfaces.Interface, plug *sn
 		SymlinksPermanentPlug(spec *Specification, plug *snap.PlugInfo) error
 	}
 	if iface, ok := iface.(definer); ok {
-		if !interfaces.IsTheSystemSnap(plug.Snap.InstanceName()) {
-			return errors.New("internal error: symlinks plugs can be defined only by the system snap")
-		}
 		return iface.SymlinksPermanentPlug(spec, plug)
 	}
 	return nil

--- a/interfaces/symlinks/spec_test.go
+++ b/interfaces/symlinks/spec_test.go
@@ -111,7 +111,7 @@ func (s *specSuite) TestSpecificationIface(c *C) {
 	})
 }
 
-func (s *specSuite) TestPlugNotFromSystem(c *C) {
+func (s *specSuite) TestPlugNotFromSystemNoError(c *C) {
 	const plugYaml = `name: notsystem
 version: 1
 apps:
@@ -120,13 +120,18 @@ apps:
 `
 	s.plug, s.plugInfo = ifacetest.MockConnectedPlug(c, plugYaml, nil, "name")
 
+	// The system-snap-only guard on the plug side callbacks was removed.
+	// The discernment now lives in the backends' Backend.Setup() gate on
+	// release.OnClassic: on classic only the system snap can declare these
+	// plugs (per the base declaration), and on non-classic the backends
+	// never reach specification generation at all. So a plug from a
+	// non-system snap is no longer rejected here; if the interface
+	// implements the backend callback, it now runs like for any other snap.
 	var r interfaces.Specification = s.spec
-	c.Assert(r.AddConnectedPlug(s.iface1, s.plug, s.slot), ErrorMatches,
-		"internal error: symlinks plugs can be defined only by the system snap")
-	c.Assert(r.AddConnectedSlot(s.iface1, s.plug, s.slot), ErrorMatches,
-		"internal error: symlinks plugs can be defined only by the system snap")
-	c.Assert(r.AddPermanentPlug(s.iface1, s.plugInfo), ErrorMatches,
-		"internal error: symlinks plugs can be defined only by the system snap")
+	c.Assert(r.AddConnectedPlug(s.iface1, s.plug, s.slot), IsNil)
+	c.Assert(r.AddConnectedSlot(s.iface1, s.plug, s.slot), IsNil)
+	c.Assert(r.AddPermanentPlug(s.iface1, s.plugInfo), IsNil)
+	c.Assert(s.spec.Plugs(), DeepEquals, []string{"name"})
 }
 
 func (s *specSuite) TestAddSymlinkErrors(c *C) {

--- a/tests/core/interfaces-driver-libs/comp1/egl.d/vendor.json
+++ b/tests/core/interfaces-driver-libs/comp1/egl.d/vendor.json
@@ -1,0 +1,6 @@
+{
+    "file_format_version" : "1.0.0",
+    "ICD" : {
+        "library_path" : "libsquare.so"
+    }
+}

--- a/tests/core/interfaces-driver-libs/comp1/meta/component.yaml
+++ b/tests/core/interfaces-driver-libs/comp1/meta/component.yaml
@@ -1,0 +1,5 @@
+component: libs-provider-core26+comp1
+type: standard
+version: 1.0
+summary: Component 1
+description: First component for libs-provider-core26

--- a/tests/core/interfaces-driver-libs/comp2/egl.d/vendor.json
+++ b/tests/core/interfaces-driver-libs/comp2/egl.d/vendor.json
@@ -1,0 +1,6 @@
+{
+    "file_format_version" : "1.0.0",
+    "ICD" : {
+        "library_path" : "libmultiply.so"
+    }
+}

--- a/tests/core/interfaces-driver-libs/comp2/meta/component.yaml
+++ b/tests/core/interfaces-driver-libs/comp2/meta/component.yaml
@@ -1,0 +1,5 @@
+component: libs-provider-core26+comp2
+type: standard
+version: 1.0
+summary: Component 2
+description: Second component for libs-provider-core26

--- a/tests/core/interfaces-driver-libs/libs-provider-core26/egl.d/vendor.json
+++ b/tests/core/interfaces-driver-libs/libs-provider-core26/egl.d/vendor.json
@@ -1,0 +1,6 @@
+{
+    "file_format_version" : "1.0.0",
+    "ICD" : {
+        "library_path" : "libhost.so"
+    }
+}

--- a/tests/core/interfaces-driver-libs/libs-provider-core26/meta/snap.yaml
+++ b/tests/core/interfaces-driver-libs/libs-provider-core26/meta/snap.yaml
@@ -1,0 +1,39 @@
+name: libs-provider-core26
+version: 1.0
+base: core26
+slots:
+  cuda-driver-libs:
+    compatibility: cuda-(9..12)-ubuntu-2604
+    library-source:
+      - $SNAP/libs
+      - $SNAP_COMPONENT(comp1)/libs
+      - $SNAP_COMPONENT(comp2)/libs
+  egl-driver-libs:
+    priority: 15
+    compatibility: egl-1-5-ubuntu-2604
+    icd-source:
+      - $SNAP/egl.d
+      - $SNAP_COMPONENT(comp1)/egl.d
+      - $SNAP_COMPONENT(comp2)/egl.d
+    library-source:
+      - $SNAP/libs
+      - $SNAP_COMPONENT(comp1)/libs
+      - $SNAP_COMPONENT(comp2)/libs
+  vulkan-driver-libs:
+    compatibility: vulkan-1-2-ubuntu-2604
+    icd-source:
+      - $SNAP/vulkan/icd.d
+    implicit-layer-source:
+      - $SNAP/vulkan/implicit_layer.d
+    library-source:
+      - $SNAP/vulkan/lib
+  gbm-driver-libs:
+    client-driver: nvidia-drm_gbm.so
+    compatibility: gbmbackend-(0..2)-arch64-ubuntu-2604
+    library-source:
+      - $SNAP/gbm/lib
+components:
+  comp1:
+    type: standard
+  comp2:
+    type: standard

--- a/tests/core/interfaces-driver-libs/libs-provider-core26/vulkan/icd.d/icd.json
+++ b/tests/core/interfaces-driver-libs/libs-provider-core26/vulkan/icd.d/icd.json
@@ -1,0 +1,7 @@
+{
+    "file_format_version" : "1.0.0",
+    "ICD" : {
+        "library_path" : "libvulkanhost.so",
+        "api_version" : "1.2.170"
+    }
+}

--- a/tests/core/interfaces-driver-libs/libs-provider-core26/vulkan/implicit_layer.d/layer.json
+++ b/tests/core/interfaces-driver-libs/libs-provider-core26/vulkan/implicit_layer.d/layer.json
@@ -1,0 +1,10 @@
+{
+    "file_format_version" : "1.0.0",
+    "layer" : {
+        "name" : "VK_LAYER_libs_provider_core26",
+        "type" : "GLOBAL",
+        "library_path" : "libvulkanhost.so",
+        "api_version" : "1.2.170",
+        "implementation_version" : "1"
+    }
+}

--- a/tests/core/interfaces-driver-libs/task.yaml
+++ b/tests/core/interfaces-driver-libs/task.yaml
@@ -1,0 +1,205 @@
+summary: Test driver-libs interfaces direct-connection delivery on Ubuntu Core
+
+details: |
+    Verify the direct-connection mount-based delivery mechanism for the
+    driver-libs interfaces on Ubuntu Core 26+: when a consumer snap plugs a
+    driver-libs interface and connects directly to a provider snap's slot
+    (cuda-driver-libs, egl-driver-libs, vulkan-driver-libs, gbm-driver-libs -
+    one representative per mountAssembly* code shape in
+    interfaces/builtin/helpers.go), the provider's libraries and ICD/layer
+    metadata are bind-mounted into the consumer's own mount namespace under
+    /run/snapd/snap/interfaces/, anchored by a private tmpfs at
+    /run/snapd/snap, and the loader-scanned metadata is also redistributed to
+    the canonical system locations (/usr/share/vulkan/icd.d/,
+    /usr/share/glvnd/egl_vendor.d/, /usr/lib/<arch>/gbm/). Also verify that
+    none of this is visible on the host outside the connected snap's own
+    mount namespace, and that both entry points into cmd/snap-update-ns
+    (snapd's direct re-invocation on connect, and snap-confine's bootstrap
+    construction after a namespace discard) produce the same result, and
+    that disconnect / snap remove clean everything up.
+
+systems: [ubuntu-core-26-64]
+
+environment:
+    PROVIDER_SNAP: libs-provider-core26
+    CONSUMER_SNAP: test-snapd-driver-libs
+    COMP1: comp1
+    COMP2: comp2
+
+prepare: |
+    snap pack "$PROVIDER_SNAP"
+    snap pack "$COMP1"
+    snap pack "$COMP2"
+
+restore: |
+    snap remove --purge "$CONSUMER_SNAP" || true
+    snap remove --purge "$PROVIDER_SNAP" || true
+
+execute: |
+    ARCH_TRIPLET="$(uname -m)-linux-gnu"
+
+    ASSEMBLY_ROOT=/run/snapd/snap/interfaces
+
+    CUDA_LIB_ROOT="$ASSEMBLY_ROOT/cuda-driver-libs/lib/${PROVIDER_SNAP}_cuda-driver-libs"
+    EGL_LIB_ROOT="$ASSEMBLY_ROOT/egl-driver-libs/lib/${PROVIDER_SNAP}_egl-driver-libs"
+    VULKAN_LIB="$ASSEMBLY_ROOT/vulkan-driver-libs/lib/${PROVIDER_SNAP}_vulkan-driver-libs/vulkan/lib/libvulkanhost.so"
+    GBM_CLIENT_DRIVER=nvidia-drm_gbm.so
+    GBM_LIB="$ASSEMBLY_ROOT/gbm-driver-libs/lib/${PROVIDER_SNAP}_gbm-driver-libs/gbm/lib/$GBM_CLIENT_DRIVER"
+
+    # Encoded metadata file names, derived from sourceDirEncodedName in
+    # interfaces/builtin/helpers.go: "<priority+idx>_snap_<instance>[+<comp>]_<slot>_<escaped-rel-path>".
+    # egl-driver-libs has priority: 15 and 3 icd-source dirs (idx 0,1,2), so
+    # they get priority-derived numeric prefixes 15_, 16_, 17_ in list order.
+    EGL_SNAP_ENCODED="15_snap_${PROVIDER_SNAP}_egl-driver-libs_egl.d-vendor.json"
+    EGL_COMP1_ENCODED="16_snap_${PROVIDER_SNAP}+${COMP1}_egl-driver-libs_egl.d-vendor.json"
+    EGL_COMP2_ENCODED="17_snap_${PROVIDER_SNAP}+${COMP2}_egl-driver-libs_egl.d-vendor.json"
+    # vulkan-driver-libs has no priority attribute, so no numeric prefix.
+    VULKAN_ICD_ENCODED="snap_${PROVIDER_SNAP}_vulkan-driver-libs_vulkan-icd.d-icd.json"
+    VULKAN_LAYER_ENCODED="snap_${PROVIDER_SNAP}_vulkan-driver-libs_vulkan-implicit_layer.d-layer.json"
+
+    EGL_SHARE_DIR="$ASSEMBLY_ROOT/egl-driver-libs/share/egl_vendor.d"
+    VULKAN_ICD_SHARE_DIR="$ASSEMBLY_ROOT/vulkan-driver-libs/share/vulkan/icd.d"
+    VULKAN_LAYER_SHARE_DIR="$ASSEMBLY_ROOT/vulkan-driver-libs/share/vulkan/implicit_layer.d"
+    GBM_SHARE="$ASSEMBLY_ROOT/gbm-driver-libs/share/gbm/$GBM_CLIENT_DRIVER"
+
+    EGL_REDIST_DIR=/usr/share/glvnd/egl_vendor.d
+    VULKAN_ICD_REDIST_DIR=/usr/share/vulkan/icd.d
+    VULKAN_LAYER_REDIST_DIR=/usr/share/vulkan/implicit_layer.d
+    GBM_REDIST="/usr/lib/$ARCH_TRIPLET/gbm/$GBM_CLIENT_DRIVER"
+
+    run_in_consumer_ns() {
+        "$CONSUMER_SNAP".sh -c "$1"
+    }
+
+    # Nothing at all should exist under the assembly root until at least one
+    # driver-libs plug is connected.
+    check_nothing_mounted_inside_ns() {
+        run_in_consumer_ns 'test ! -e /run/snapd/snap/interfaces'
+    }
+
+    # Before any connection is made, the assembly root may or may not exist
+    # yet on the host (nothing has triggered its creation), but the
+    # per-interface subtree must never appear there.
+    check_host_clean_before_connect() {
+        not test -e "$ASSEMBLY_ROOT"
+    }
+
+    # After at least one connection has existed, /run/snapd/snap is expected
+    # to exist as a bare mountpoint (it is on the trespassing whitelist), but
+    # its content (the per-interface assembly trees, and anything
+    # redistributed to loader-scanned system locations) must never be
+    # visible on the host: it is all mount-namespace-scoped, bound over the
+    # read-only base rootfs and invisible outside the connected snap's own
+    # namespace.
+    check_host_isolated() {
+        test -d /run/snapd/snap
+        not test -e "$ASSEMBLY_ROOT"
+
+        not test -e "$EGL_REDIST_DIR/$EGL_SNAP_ENCODED"
+        not test -e "$EGL_REDIST_DIR/$EGL_COMP1_ENCODED"
+        not test -e "$EGL_REDIST_DIR/$EGL_COMP2_ENCODED"
+        not test -e "$VULKAN_ICD_REDIST_DIR/$VULKAN_ICD_ENCODED"
+        not test -e "$VULKAN_LAYER_REDIST_DIR/$VULKAN_LAYER_ENCODED"
+        not test -e "$GBM_REDIST"
+    }
+
+    # All 4 interfaces connected: verify the full assembly tree, inside the
+    # consumer's own mount namespace.
+    check_connected_state_inside_ns() {
+        # cuda-driver-libs: library-source only (simplest shape). The
+        # $SNAP-sourced library sits at the deterministic, unsuffixed path;
+        # the component-sourced libraries are pooled alongside it (their
+        # directory clashes with the $SNAP one on the "libs" leaf name and
+        # get an unclash-renamed target, so locate them by name instead of
+        # hardcoding the renamed suffix).
+        run_in_consumer_ns "test -f $CUDA_LIB_ROOT/libs/libhost.so"
+        run_in_consumer_ns "find $CUDA_LIB_ROOT -name libsquare.so" | MATCH .
+        run_in_consumer_ns "find $CUDA_LIB_ROOT -name libmultiply.so" | MATCH .
+
+        # egl-driver-libs: icd-source + library-source, with priority
+        # (numeric-prefix encoding path). Same $SNAP + component pooling as
+        # cuda-driver-libs on the library side.
+        run_in_consumer_ns "test -f $EGL_LIB_ROOT/libs/libhost.so"
+        run_in_consumer_ns "find $EGL_LIB_ROOT -name libsquare.so" | MATCH .
+        run_in_consumer_ns "find $EGL_LIB_ROOT -name libmultiply.so" | MATCH .
+        run_in_consumer_ns "test -f $EGL_SHARE_DIR/$EGL_SNAP_ENCODED"
+        run_in_consumer_ns "test -f $EGL_SHARE_DIR/$EGL_COMP1_ENCODED"
+        run_in_consumer_ns "test -f $EGL_SHARE_DIR/$EGL_COMP2_ENCODED"
+        run_in_consumer_ns "cat $EGL_SHARE_DIR/$EGL_SNAP_ENCODED" | MATCH libhost.so
+        run_in_consumer_ns "cat $EGL_SHARE_DIR/$EGL_COMP1_ENCODED" | MATCH libsquare.so
+        run_in_consumer_ns "cat $EGL_SHARE_DIR/$EGL_COMP2_ENCODED" | MATCH libmultiply.so
+
+        # vulkan-driver-libs: icd-source + implicit-layer-source +
+        # library-source, no priority (no-prefix encoding path, two
+        # source-file subdirs sharing the same share/vulkan/ tree).
+        run_in_consumer_ns "test -f $VULKAN_LIB"
+        run_in_consumer_ns "test -f $VULKAN_ICD_SHARE_DIR/$VULKAN_ICD_ENCODED"
+        run_in_consumer_ns "test -f $VULKAN_LAYER_SHARE_DIR/$VULKAN_LAYER_ENCODED"
+        run_in_consumer_ns "cat $VULKAN_ICD_SHARE_DIR/$VULKAN_ICD_ENCODED" | MATCH libvulkanhost.so
+        run_in_consumer_ns "cat $VULKAN_LAYER_SHARE_DIR/$VULKAN_LAYER_ENCODED" | MATCH libvulkanhost.so
+
+        # gbm-driver-libs: client-driver + library-source (mountAssemblyClientDriver).
+        run_in_consumer_ns "test -f $GBM_LIB"
+        run_in_consumer_ns "test -f $GBM_SHARE"
+
+        # Redistribution to loader-scanned system locations, still inside
+        # the consumer's own mount namespace.
+        run_in_consumer_ns "test -f $EGL_REDIST_DIR/$EGL_SNAP_ENCODED"
+        run_in_consumer_ns "test -f $EGL_REDIST_DIR/$EGL_COMP1_ENCODED"
+        run_in_consumer_ns "test -f $EGL_REDIST_DIR/$EGL_COMP2_ENCODED"
+        run_in_consumer_ns "test -f $VULKAN_ICD_REDIST_DIR/$VULKAN_ICD_ENCODED"
+        run_in_consumer_ns "test -f $VULKAN_LAYER_REDIST_DIR/$VULKAN_LAYER_ENCODED"
+        run_in_consumer_ns "test -f $GBM_REDIST"
+    }
+
+    # 1. Install provider (+ components) and consumer, before any connection.
+    snap install --dangerous "$PROVIDER_SNAP"_*.snap
+    snap install --dangerous \
+        "$PROVIDER_SNAP"+"$COMP1"_*.comp \
+        "$PROVIDER_SNAP"+"$COMP2"_*.comp
+    "$TESTSTOOLS"/snaps-state install-local "$CONSUMER_SNAP"
+
+    # 2. Inside consumer's ns: nothing exists yet, no plug connected.
+    check_nothing_mounted_inside_ns
+
+    # 3. On the host: confirm no leaked state either.
+    check_host_clean_before_connect
+
+    # 4. Connect all 4 provider slots to the matching consumer plugs directly.
+    snap connect "$CONSUMER_SNAP":cuda "$PROVIDER_SNAP":cuda-driver-libs
+    snap connect "$CONSUMER_SNAP":egl "$PROVIDER_SNAP":egl-driver-libs
+    snap connect "$CONSUMER_SNAP":vulkan "$PROVIDER_SNAP":vulkan-driver-libs
+    snap connect "$CONSUMER_SNAP":gbm "$PROVIDER_SNAP":gbm-driver-libs
+
+    # 5. Inside consumer's ns, no namespace discard yet: exercises snapd's
+    #    direct snap-update-ns re-invocation path on connect.
+    check_connected_state_inside_ns
+
+    # 6. On the host: confirm isolation.
+    check_host_isolated
+
+    # 7. Discard and rebuild the consumer's mount namespace: exercises
+    #    snap-confine's bootstrap-triggered construction, the other entry
+    #    point into cmd/snap-update-ns.
+    # TODO remove after fixing problem with refreshing mount namespace
+    /usr/lib/snapd/snap-discard-ns "$CONSUMER_SNAP"
+    check_connected_state_inside_ns
+
+    # 8. Disconnect all 4 interfaces: content gone from consumer's ns, host
+    #    still clean.
+    snap disconnect "$CONSUMER_SNAP":cuda "$PROVIDER_SNAP":cuda-driver-libs
+    snap disconnect "$CONSUMER_SNAP":egl "$PROVIDER_SNAP":egl-driver-libs
+    snap disconnect "$CONSUMER_SNAP":vulkan "$PROVIDER_SNAP":vulkan-driver-libs
+    snap disconnect "$CONSUMER_SNAP":gbm "$PROVIDER_SNAP":gbm-driver-libs
+    check_nothing_mounted_inside_ns
+    check_host_isolated
+
+    # 9. Reconnect, then remove the provider snap (with components) while
+    #    still connected: verify graceful cleanup.
+    snap connect "$CONSUMER_SNAP":cuda "$PROVIDER_SNAP":cuda-driver-libs
+    snap connect "$CONSUMER_SNAP":egl "$PROVIDER_SNAP":egl-driver-libs
+    snap connect "$CONSUMER_SNAP":vulkan "$PROVIDER_SNAP":vulkan-driver-libs
+    snap connect "$CONSUMER_SNAP":gbm "$PROVIDER_SNAP":gbm-driver-libs
+    snap remove --purge "$PROVIDER_SNAP"
+    check_nothing_mounted_inside_ns
+    check_host_isolated

--- a/tests/lib/snaps/test-snapd-driver-libs/bin/sh
+++ b/tests/lib/snaps/test-snapd-driver-libs/bin/sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+PS1='$ '
+exec /bin/sh "$@"

--- a/tests/lib/snaps/test-snapd-driver-libs/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-driver-libs/meta/snap.yaml
@@ -1,0 +1,42 @@
+name: test-snapd-driver-libs
+version: '1.0'
+type: app
+summary: Consumer snap with plugs for all driver-libs interfaces
+description: |
+  A consumer snap declaring a plug for every driver-libs interface. Used to
+  exercise the direct-connection delivery model on Ubuntu Core: with the
+  driver-libs connections made, the provider's libraries become available under
+  /opt/snapd/interfaces/ via SNAP_LIBRARY_PATH and the ICD/GBM metadata is
+  redistributed to the loader-scanned system locations.
+confinement: strict
+grade: stable
+base: core26
+
+apps:
+  sh:
+    command: bin/sh
+    plugs:
+      - cuda
+      - egl
+      - gbm
+      - nvidia-video
+      - opengl
+      - opengles
+      - vulkan
+
+plugs:
+  cuda:
+    interface: cuda-driver-libs
+  egl:
+    interface: egl-driver-libs
+  gbm:
+    interface: gbm-driver-libs
+  nvidia-video:
+    interface: nvidia-video-driver-libs
+  opengl:
+    interface: opengl-driver-libs
+  opengles:
+    interface: opengles-driver-libs
+  vulkan:
+    interface: vulkan-driver-libs
+

--- a/tests/lib/snaps/test-snapd-driver-libs/meta/snap.yaml
+++ b/tests/lib/snaps/test-snapd-driver-libs/meta/snap.yaml
@@ -5,9 +5,10 @@ summary: Consumer snap with plugs for all driver-libs interfaces
 description: |
   A consumer snap declaring a plug for every driver-libs interface. Used to
   exercise the direct-connection delivery model on Ubuntu Core: with the
-  driver-libs connections made, the provider's libraries become available under
-  /opt/snapd/interfaces/ via SNAP_LIBRARY_PATH and the ICD/GBM metadata is
-  redistributed to the loader-scanned system locations.
+  driver-libs connections made, the provider's libraries and ICD/GBM metadata
+  are bind-mounted into this snap's own mount namespace under
+  /run/snapd/snap/interfaces/, and the ICD/GBM metadata is also redistributed
+  to the loader-scanned system locations.
 confinement: strict
 grade: stable
 base: core26


### PR DESCRIPTION
Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?

Alternative approach to https://github.com/canonical/snapd/pull/17338. We're following the plan outlined in https://gist.github.com/bboozzoo/ffed91e231d2098818fdc9d20fdd209c where the goal is to use the mount backend to make the libraries and metadata available within the snap's mount namespace using the following layout:

```
/opt/snapd/interfaces/
  <iface>/                              ← per interface (e.g. egl-driver-libs)
    lib/                                ← libraries (from library-source)
      <provider>_<slot>/                ← per provider+slot (e.g. pc-kernel_egl-dl)
        <idx>/                          ← per library-source dir index
          libcuda.so.1                  ← original filenames, bound from the provider
          libnvidia-glcore.so
    share/                              ← static data (from icd-source / *-layer-source)
      egl_vendor.d/                     ← ICDs exported here (encoded names)
        <encoded>.json
      vulkan/icd.d/                     ← (vulkan-driver-libs)
      vulkan/implicit_layer.d/
      gbm/                              ← (gbm-driver-libs client-driver .so)
```

The next step is to redistribute the files in this manner:
```
/opt/snapd/interfaces/<iface>/share/egl_vendor.d/<encoded>.json  →  /usr/share/glvnd/egl_vendor.d/<encoded>.json
/opt/snapd/interfaces/<iface>/share/vulkan/icd.d/<encoded>.json  →  /usr/share/vulkan/icd.d/<encoded>.json
/opt/snapd/interfaces/<iface>/share/vulkan/implicit_layer.d/…  →  /usr/share/vulkan/implicit_layer.d/…
/opt/snapd/interfaces/<iface>/share/vulkan/explicit_layer.d/… →  /usr/share/vulkan/explicit_layer.d/…
/opt/snapd/interfaces/<iface>/share/gbm/<client-driver>        →  /usr/lib/<arch>-linux-gnu/gbm/<client-driver>
```

Related: [SNAPDENG-37413](https://warthogs.atlassian.net/browse/SNAPDENG-37413)

[SNAPDENG-37413]: https://warthogs.atlassian.net/browse/SNAPDENG-37413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ