### PR TITLE
overlord/devicestate/handlers_reprovision.go: fix reprovision failure cleanup

### DIFF
--- a/overlord/devicestate/handlers_reprovision.go
+++ b/overlord/devicestate/handlers_reprovision.go
@@ -160,7 +160,7 @@ func (m *DeviceManager) doReprovision(t *state.Task, _ *tomb.Tomb) error {
 		for _, disk := range []string{dataDisk.DevPath(), saveDisk.DevPath()} {
 			platformKeyslots, err := secbootListContainerUnlockKeyNames(disk)
 			if err != nil {
-				logger.Debugf("cannot list keyslots on %s, ignoring disk.", disk)
+				logger.Debugf("cannot list keyslots on %s, ignoring disk: %v", disk, err)
 				continue
 			}
 			hasPlatformKeyslot := map[string]bool{}
@@ -182,10 +182,10 @@ func (m *DeviceManager) doReprovision(t *state.Task, _ *tomb.Tomb) error {
 				if hasPlatformKeyslot[rename.old] && hasPlatformKeyslot[rename.new] {
 					nv, err := secbootGetPCRHandleFromToken(disk, rename.new)
 					if err != nil {
-						logger.Debugf("cannot read nv index for %s on %s", rename.new, disk)
+						logger.Debugf("cannot read nv index for %s on %s: %v", rename.new, disk, err)
 					} else if (nv != 0) && !removedNvIndices[nv] {
 						if err := secbootReleasePCRResourceHandle(nv); err != nil {
-							logger.Debugf("cannot release nv index for %s on %s", rename.new, disk)
+							logger.Debugf("cannot release nv index for %s on %s: %v", rename.new, disk, err)
 						} else {
 							removedNvIndices[nv] = true
 						}
@@ -203,26 +203,26 @@ func (m *DeviceManager) doReprovision(t *state.Task, _ *tomb.Tomb) error {
 					continue
 				}
 				if err := secbootDeleteContainerKey(disk, rename.new); err != nil {
-					logger.Debugf("cannot remove %s on %s", rename.new, disk)
+					logger.Debugf("cannot remove %s on %s: %v", rename.new, disk, err)
 				}
 				if err := secbootRenameContainerKey(disk, rename.old, rename.new); err != nil {
-					logger.Debugf("cannot rename %s to %s on %s", rename.old, rename.new, disk)
+					logger.Debugf("cannot rename %s to %s on %s: %v", rename.old, rename.new, disk, err)
 				}
 			}
 		}
 		if err := secbootDeleteContainerKey(dataDisk.DevPath(), "bootstrap-key"); err != nil {
-			logger.Debugf("cannot delete bootstrap-key on %s", dataDisk.DevPath())
+			logger.Debugf("cannot delete bootstrap-key on %s: %v", dataDisk.DevPath(), err)
 		}
 		if err := secbootDeleteContainerKey(saveDisk.DevPath(), "bootstrap-key"); err != nil {
-			logger.Debugf("cannot delete bootstrap-key on %s", saveDisk.DevPath())
+			logger.Debugf("cannot delete bootstrap-key on %s: %v", saveDisk.DevPath(), err)
 		}
 
 		// The last clean up
 		if err := secbootDeleteContainerKey(saveDisk.DevPath(), "default"); err != nil {
-			logger.Debugf("could remove default on %s", saveDisk.DevPath())
+			logger.Debugf("could not remove default on %s: %v", saveDisk.DevPath(), err)
 		}
 		if err := secbootRenameContainerKey(saveDisk.DevPath(), "snapd-reprovision-default", "default"); err != nil {
-			logger.Debugf("cannot rename snapd-reprovision-default to default on %s", saveDisk.DevPath())
+			logger.Debugf("cannot rename snapd-reprovision-default to default on %s: %v", saveDisk.DevPath(), err)
 		}
 	}
 
@@ -244,6 +244,7 @@ func (m *DeviceManager) doReprovision(t *state.Task, _ *tomb.Tomb) error {
 			// For example we could store a digest of the plainkey's primary key, and if it matches, we could
 			// just jump to after step 6.
 			if oldKeyMatches {
+				logger.Debugf("detected previous reprovision attempt was unsuccessful, reverting.")
 				// We must have been restarted in the middle, before step 6.
 				// The backed up keys are the correct ones, we need to cancel that previous
 				// attempt and then go back to expected name.

--- a/overlord/devicestate/handlers_reprovision.go
+++ b/overlord/devicestate/handlers_reprovision.go
@@ -217,12 +217,27 @@ func (m *DeviceManager) doReprovision(t *state.Task, _ *tomb.Tomb) error {
 			logger.Debugf("cannot delete bootstrap-key on %s: %v", saveDisk.DevPath(), err)
 		}
 
-		// The last clean up
-		if err := secbootDeleteContainerKey(saveDisk.DevPath(), "default"); err != nil {
-			logger.Debugf("could not remove default on %s: %v", saveDisk.DevPath(), err)
+		savePlatformKeyslots, err := secbootListContainerUnlockKeyNames(saveDisk.DevPath())
+		if err != nil {
+			logger.Debugf("cannot list keyslots on %s, ignoring disk: %v", saveDisk.DevPath(), err)
+			return
 		}
-		if err := secbootRenameContainerKey(saveDisk.DevPath(), "snapd-reprovision-default", "default"); err != nil {
-			logger.Debugf("cannot rename snapd-reprovision-default to default on %s: %v", saveDisk.DevPath(), err)
+		for _, k := range savePlatformKeyslots {
+			if k == "snapd-reprovision-default" {
+				// The last clean up. The reason we want to do it last is because this is the key
+				// we will use to detect incomplete reprovision. It is important to do that
+				// cleanup when re executing reprovision, since all "new" are wrong and must
+				// be removed before we try to do step 1 (rename existing key slots). But those
+				// "new" keys are wrong only if the "snapd-reprovision-default" of save matches
+				// the protector key file.
+				if err := secbootDeleteContainerKey(saveDisk.DevPath(), "default"); err != nil {
+					logger.Debugf("could not remove default on %s: %v", saveDisk.DevPath(), err)
+				}
+				if err := secbootRenameContainerKey(saveDisk.DevPath(), "snapd-reprovision-default", "default"); err != nil {
+					logger.Debugf("cannot rename snapd-reprovision-default to default on %s: %v", saveDisk.DevPath(), err)
+				}
+				break
+			}
 		}
 	}
 

--- a/overlord/devicestate/running_system_test.go
+++ b/overlord/devicestate/running_system_test.go
@@ -2239,3 +2239,85 @@ func (s *handlersReprovisionSuite) TestReprovisionCreateChangeOtherFDETaskRunnin
 	c.Check(confictError.Message, Equals, "FDE change in progress, no other FDE changes allowed until this is done")
 	c.Check(confictError.ChangeID, Equals, conflictChg.ID())
 }
+
+func (s *handlersReprovisionSuite) testDoReprovisionRenameFailure(c *C, failedDisk, failedKey string) {
+	st := s.state
+	st.Lock()
+	defer st.Unlock()
+
+	s.setupModel(c)
+
+	t := st.NewTask("fde-reprovision", "reprovision test")
+
+	defer devicestate.MockFdestateGetRecoveryKey(func(st *state.State, keyID string) (keys.RecoveryKey, error) {
+		c.Check(keyID, Equals, "key-id")
+		return keys.RecoveryKey{1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4}, nil
+	})()
+	preinstallCheckContext := &secboot.PreinstallCheckContext{}
+	st.Cache(devicestate.ReprovisionSetupDataKey{}, devicestate.MakeReprovisionSetupData("key-id", preinstallCheckContext))
+
+	defer devicestate.MockSecbootGetPCRHandleFromToken(func(disk string, name string) (uint32, error) {
+		// Because this test will not reach further than renaming, no new key will be created,
+		// only renamed. So we will never remove new keys, thus never remove PCR handles.
+		c.Errorf("unexpected call")
+		return 0, fmt.Errorf("unexpected call")
+	})()
+
+	defer devicestate.MockSecbootReleasePCRResourceHandle(func(nv uint32) error {
+		// Because this test will not reach further than renaming, no new key will be created,
+		// only renamed. So we will never remove new keys, thus never remove PCR handles.
+		c.Errorf("unexpected call")
+		return fmt.Errorf("unexpected call")
+	})()
+
+	// This the same implementation as in SetupTest + injected error
+	defer devicestate.MockSecbootRenameContainerKey(func(disk string, from string, to string) error {
+		var diskKeys *mockContainer
+
+		if from == failedKey && disk == failedDisk {
+			return fmt.Errorf("injected error")
+		}
+
+		switch disk {
+		case "/dev/data":
+			diskKeys = s.dataKeys
+		case "/dev/save":
+			diskKeys = s.saveKeys
+		default:
+			c.Errorf("unexpected disk")
+			return fmt.Errorf("unexpected disk")
+		}
+
+		if _, hadKey := diskKeys.keys[to]; hadKey {
+			return fmt.Errorf("key already exists")
+		}
+
+		key, hasKey := diskKeys.keys[from]
+		if !hasKey {
+			return fmt.Errorf("key did not exist")
+		}
+
+		diskKeys.keys[to] = key
+		delete(diskKeys.keys, from)
+
+		return nil
+	})()
+
+	err := func() error {
+		st.Unlock()
+		defer st.Lock()
+		return devicestate.DoReprovision(s.mgr, t)
+	}()
+	c.Assert(err, ErrorMatches, "injected error")
+	s.verifyRollback(c)
+}
+
+func (s *handlersReprovisionSuite) TestDoReprovisionRenameFailureEarly(c *C) {
+	// Failure on first rename
+	s.testDoReprovisionRenameFailure(c, "/dev/data", "default")
+}
+
+func (s *handlersReprovisionSuite) TestDoReprovisionRenameFailureLate(c *C) {
+	// Failure late
+	s.testDoReprovisionRenameFailure(c, "/dev/save", "default-fallback")
+}


### PR DESCRIPTION
We were removing the "default" key on save disk when the backed up key does not exist. This happens when initial backing of keys fails and kicks the revert.

This was found during https://github.com/canonical/snapd/pull/17577