### PR TITLE
tests: remove google backend from spread.yaml

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -1253,7 +1253,7 @@ restore-each: |
 suites:
     tests/lib/tools/suite/:
         summary: Tests for tests/lib/tools tools
-        backends: [google, qemu, garden]
+        backends: [openstsack, qemu, garden]
         prepare-each: |
             tests.invariant set snap-mount-dir "$(os.paths snap-mount-dir)"
             "$TESTSLIB"/prepare-restore.sh --prepare-suite-each-minimal-no-snaps


### PR DESCRIPTION
Google was added in the backends section of tests/lib/tools/suite/

This is causing a segmentation fault in spread.
