### PR TITLE
tests: new repack-gadget and repack-base tools

### DIFF
--- a/tests/lib/nested.sh
+++ b/tests/lib/nested.sh
@@ -676,17 +676,6 @@ nested_model_authority() {
     grep "authority-id:" "$model"|cut -d ' ' -f2
 }
 
-nested_ensure_ubuntu_save() {
-    local GADGET_DIR="$1"
-    shift
-    "$TESTSLIB"/ensure_ubuntu_save.py "$@" "$GADGET_DIR"/meta/gadget.yaml > /tmp/gadget-with-save.yaml
-    if [ "$(cat /tmp/gadget-with-save.yaml)" != "" ]; then
-        mv /tmp/gadget-with-save.yaml "$GADGET_DIR"/meta/gadget.yaml
-    else
-        rm -f /tmp/gadget-with-save.yaml
-    fi
-}
-
 nested_prepare_snapd() {
     if [ "$NESTED_BUILD_SNAPD_FROM_CURRENT" = "true" ]; then
         echo "Repacking snapd snap"
@@ -785,7 +774,7 @@ nested_prepare_gadget() {
     if [ "$NESTED_REPACK_GADGET_SNAP" = "true" ]; then
         if nested_is_core_ge 20; then
             # Prepare the pc gadget snap (unless provided by extra-snaps)
-            local snap_id version gadget_snap
+            local snap_id version
             version="$(nested_get_version)"
             snap_id="UqFziVZDHLSyO3TqSWgNBoAdHbLI4dAH"
 
@@ -806,32 +795,27 @@ nested_prepare_gadget() {
             snakeoil_key="$PWD/$key_name.key"
             snakeoil_cert="$PWD/$key_name.pem"
 
-            snap download --basename=pc --channel="$version/$(nested_get_gadget_channel)" pc
-            unsquashfs -d pc-gadget pc.snap
-            nested_secboot_sign_gadget pc-gadget "$snakeoil_key" "$snakeoil_cert"
+            repack_gadget_args=(
+                --gadget-branch "$version"
+                --gadget-channel "$(nested_get_gadget_channel)"
+                --output-snap "$NESTED_ASSETS_DIR/pc-repacked.snap"
+                --sign-key "$snakeoil_key"
+                --sign-cert "$snakeoil_cert"
+                --persistent-journal
+            )
             case "${NESTED_UBUNTU_SAVE:-}" in
                 add)
                     # ensure that ubuntu-save is present
-                    nested_ensure_ubuntu_save pc-gadget --add
+                    repack_gadget_args+=(--ubuntu-save add)
                     touch ubuntu-save-added
                     ;;
                 remove)
                     # ensure that ubuntu-save is removed
-                    nested_ensure_ubuntu_save pc-gadget --remove
+                    repack_gadget_args+=(--ubuntu-save remove)
                     touch ubuntu-save-removed
                     ;;
             esac
 
-            # also make logging persistent for easier debugging of
-            # test failures, otherwise we have no way to see what
-            # happened during a failed nested VM boot where we
-            # weren't able to login to a device
-            cat >> pc-gadget/meta/gadget.yaml << EOF
-defaults:
-  system:
-    journal:
-      persistent: true
-EOF
             local GADGET_EXTRA_CMDLINE=""
             if [ "$NESTED_SNAPD_DEBUG_TO_SERIAL" = "true" ]; then
                 # add snapd debug and log to serial console for extra
@@ -851,27 +835,20 @@ EOF
 
             if [ -n "$GADGET_EXTRA_CMDLINE" ]; then
                 echo "Configuring command line parameters in the gadget snap: \"console=ttyS0 $GADGET_EXTRA_CMDLINE\""
-                echo "$GADGET_EXTRA_CMDLINE" > pc-gadget/cmdline.extra
+                repack_gadget_args+=(--write-cmdline-extra "$GADGET_EXTRA_CMDLINE")
             fi
 
             if [ -n "$NESTED_UBUNTU_SEED_SIZE" ]; then
-                "$TESTSLIB"/manip_ubuntu_seed.py pc-gadget/meta/gadget.yaml "$NESTED_UBUNTU_SEED_SIZE"
+                repack_gadget_args+=(--ubuntu-seed-size "$NESTED_UBUNTU_SEED_SIZE")
             fi
 
             if [ "$NESTED_REPACK_FOR_FAKESTORE" = "true" ]; then
-                cat > pc-gadget/meta/hooks/prepare-device << EOF
-#!/bin/sh
-snapctl set device-service.url=http://10.0.2.2:11029
-EOF
-                chmod +x pc-gadget/meta/hooks/prepare-device
+                repack_gadget_args+=(--prepare-device-url http://10.0.2.2:11029)
             fi
 
-            # pack the gadget
-            snap pack pc-gadget/ "$NESTED_ASSETS_DIR"
-
-            gadget_snap=$(ls "$NESTED_ASSETS_DIR"/pc_*.snap)
-            cp "$gadget_snap" "$(nested_get_extra_snaps_path)/pc.snap"
-            rm -f "pc.snap" "pc.assert" "$snakeoil_key" "$snakeoil_cert"
+            "$TESTSTOOLS"/repack-gadget "${repack_gadget_args[@]}"
+            cp "$NESTED_ASSETS_DIR/pc-repacked.snap" "$(nested_get_extra_snaps_path)/pc.snap"
+            rm -f "$snakeoil_key" "$snakeoil_cert"
         fi
         # sign the pc gadget snap with fakestore if requested
         if [ "$NESTED_SIGN_SNAPS_FAKESTORE" = "true" ]; then
@@ -882,7 +859,8 @@ EOF
             "$TESTSTOOLS"/store-state make-snap-installable --noack --extra-decl-json "$NESTED_FAKESTORE_SNAP_DECL_PC_GADGET" "$NESTED_FAKESTORE_BLOB_DIR" "$(nested_get_extra_snaps_path)/pc.snap" "$snap_id"
         fi
         if [ -n "$TAG_FEATURES" ] && nested_is_core_18_system; then
-            snap="$(repack_gadget_w_feature_tagging_core_18 "$(nested_get_gadget_channel)" "$NESTED_ASSETS_DIR")"
+            snap="$NESTED_ASSETS_DIR/pc-repacked.snap"
+            "$TESTSTOOLS"/repack-gadget --gadget-branch 18 --gadget-channel "$(nested_get_gadget_channel)" --output-snap "$snap" --persistent-journal --tag-features-grub
             cp "$snap" "$(nested_get_extra_snaps_path)/pc.snap"
         fi
     fi
@@ -890,6 +868,9 @@ EOF
 
 nested_prepare_base() {
     if [ "$NESTED_REPACK_BASE_SNAP" = "true" ]; then
+    local base_branch base_channel
+    local -a repack_base_args
+
         if nested_is_core_16_system; then
             echo "No base snap to prepare in core 16"
             return
@@ -925,11 +906,27 @@ nested_prepare_base() {
 
         if [ ! -f "$NESTED_ASSETS_DIR/$output_name" ]; then
             echo "Repacking $snap_name snap"
-            snap download --channel="$(nested_get_base_channel)" --basename="$snap_name" "$snap_name"
-            repack_core_snap_with_tweaks "${snap_name}.snap" "new-${snap_name}.snap"
-            rm -f "$snap_name".snap "$snap_name".assert
-
-            mv "new-${snap_name}.snap" "$NESTED_ASSETS_DIR/$output_name"
+            base_branch=latest
+            base_channel="$(nested_get_base_channel)"
+            if [[ "$base_channel" = */* ]]; then
+                base_branch="${base_channel%/*}"
+                base_channel="${base_channel##*/}"
+            fi
+            repack_base_args=(
+                --base-name "$snap_name"
+                --base-branch "$base_branch"
+                --base-channel "$base_channel"
+                --output-snap "$NESTED_ASSETS_DIR/$output_name"
+                --enable-test-logging
+                --completion-file "$SPREAD_PATH/data/completion/bash/complete.sh"
+            )
+            if [ "$NESTED_REPACK_FOR_FAKESTORE" = true ]; then
+                repack_base_args+=(--store-url http://10.0.2.2:11028)
+            fi
+            if [ "${SNAPD_USE_PROXY:-}" = true ]; then
+                repack_base_args+=(--proxy-env /etc/environment)
+            fi
+            "$TESTSTOOLS"/repack-base "${repack_base_args[@]}"
         fi
         cp "$NESTED_ASSETS_DIR/$output_name" "$(nested_get_extra_snaps_path)/$output_name"
 
@@ -1089,12 +1086,13 @@ nested_create_core_vm() {
             # volumes must be manually added to the VM creation by the tests
             local BOOTVOLUME
             BOOTVOLUME=pc
-            if nested_is_core_ge 20 && [ -e pc-gadget/meta/gadget.yaml ]; then
+            gadget_snap="$(nested_get_extra_snaps_path)/pc.snap"
+            if nested_is_core_ge 20 && [ -e "$gadget_snap" ]; then
                 # this assumes core2* gadget layouts and so cannot run on uc18
                 # shellcheck disable=SC2016
-                BOOTVOLUME="$(gojq --yaml-input --raw-output '.volumes | to_entries[] | .key as $p | .value.structure[] | select(.name == "ubuntu-boot") | $p' pc-gadget/meta/gadget.yaml)"
+                BOOTVOLUME="$(unsquashfs -cat "$gadget_snap" meta/gadget.yaml | gojq --yaml-input --raw-output '.volumes | to_entries[] | .key as $p | .value.structure[] | select(.name == "ubuntu-boot") | $p')"
                 if [ -z "$BOOTVOLUME" ]; then
-                    echo "was not able to deduce the ubuntu-boot partition from gadget.yaml in pc-gadget/meta/gadget.yaml"
+                    echo "was not able to deduce the ubuntu-boot partition from gadget.yaml in $gadget_snap"
                     echo "please inspect it and make sure it looks as expected"
                     exit 1
                 fi

--- a/tests/lib/prepare.sh
+++ b/tests/lib/prepare.sh
@@ -934,58 +934,6 @@ build_snapd_snap_with_run_mode_firstboot_tweaks() {
     cp "${SNAP_CACHE}"/snapd_*.snap "${TARGET}/"
 }
 
-repack_core_snap_with_tweaks() {
-    local CORESNAP="$1"
-    local TARGET="$2"
-
-    local UNPACK_DIR
-    # TODO set up a trap to clean this up properly?
-    UNPACK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/core-unpack.XXXXXXXX")"
-    unsquashfs -no-progress -f -d "$UNPACK_DIR" "$CORESNAP"
-
-    # determine destination directory for systemd configuration files
-    # core26+ uses /usr/share/factory/writable/system-data/etc/
-    # core24 and earlier use /etc/
-    local DEST_ETC
-    if [ -e "$UNPACK_DIR/usr/share/factory/writable" ]; then
-        DEST_ETC="$UNPACK_DIR/usr/share/factory/writable/system-data/etc"
-    else
-        DEST_ETC="$UNPACK_DIR/etc"
-    fi
-
-    mkdir -p "$DEST_ETC"/systemd/journald.conf.d
-    cat <<EOF > "$DEST_ETC"/systemd/journald.conf.d/to-console.conf
-[Journal]
-ForwardToConsole=yes
-TTYPath=/dev/ttyS0
-MaxLevelConsole=debug
-EOF
-    mkdir -p "$DEST_ETC"/systemd/system/snapd.service.d
-cat <<EOF > "$DEST_ETC"/systemd/system/snapd.service.d/logging.conf
-[Service]
-Environment=SNAPD_DEBUG_HTTP=7 SNAPD_DEBUG=1 SNAPPY_TESTING=1 SNAPD_CONFIGURE_HOOK_TIMEOUT=30s
-StandardOutput=journal+console
-StandardError=journal+console
-EOF
-
-    if [ "${NESTED_REPACK_FOR_FAKESTORE-}" = "true" ]; then
-        cat <<EOF > "$DEST_ETC"/systemd/system/snapd.service.d/store.conf
-[Service]
-Environment=SNAPPY_FORCE_API_URL=http://10.0.2.2:11028
-EOF
-    fi
-
-    cp "${SPREAD_PATH}"/data/completion/bash/complete.sh "${UNPACK_DIR}"/usr/lib/snapd/complete.sh
-
-    if [ "${SNAPD_USE_PROXY:-}" = true ]; then
-        cp /etc/environment "${UNPACK_DIR}"/etc/environment
-    fi
-
-    snap pack --filename="$TARGET" "$UNPACK_DIR"
-
-    rm -rf "$UNPACK_DIR"
-}
-
 repack_kernel_snap() {
     local TARGET=$1
     local VERSION
@@ -1452,29 +1400,6 @@ EOF
     cp -avr /tmp/squashfs-root/etc/systemd/system /mnt/system-data/etc/systemd/
 }
 
-repack_gadget_w_feature_tagging_core_18() {
-    channel=$1
-    repack_dir=$2
-    snap download --basename=pc --channel="18/${channel}" pc
-    unsquashfs -d pc-gadget pc.snap
-    # UC18 boot is still driven by grub config from the gadget, so
-    # update linux cmdline entries there as well.
-    for grub_cfg in pc-gadget/grub.conf pc-gadget/grub.cfg; do
-        if [ -f "$grub_cfg" ] && ! grep -q "tag.features=1" "$grub_cfg"; then
-            sed -i 's/^\([[:space:]]*linux[[:space:]].*\)$/\1 tag.features=1/' "$grub_cfg"
-        fi
-    done
-    cat >> pc-gadget/meta/gadget.yaml << EOF
-defaults:
-  system:
-    journal:
-      persistent: true
-EOF
-    snap pack --filename=pc-repacked.snap pc-gadget 
-    mv pc-repacked.snap "$repack_dir"/pc-repacked.snap
-    echo "$repack_dir/pc-repacked.snap"
-}
-
 setup_reflash_magic() {
     # install the stuff we need
     distro_install_package kpartx busybox-static
@@ -1653,7 +1578,8 @@ EOF
             chmod 0600 pc-kernel.snap
         fi
         if [ -n "$TAG_FEATURES" ] && is_test_target_core 18; then
-            snap="$(repack_gadget_w_feature_tagging_core_18 "$GADGET_CHANNEL" "$IMAGE_HOME")"
+            snap="$IMAGE_HOME/pc-repacked.snap"
+            "$TESTSTOOLS"/repack-gadget --gadget-branch 18 --gadget-channel "$GADGET_CHANNEL" --output-snap "$snap" --persistent-journal --tag-features-grub
             EXTRA_FUNDAMENTAL="$EXTRA_FUNDAMENTAL --snap $snap"
         fi
     fi
@@ -1682,17 +1608,11 @@ EOF
 
         # also add debug command line parameters to the kernel command line via
         # the gadget in case things go side ways and we need to debug
-        case "${BRANCH}/${GADGET_CHANNEL}" in
-            26/beta)
-                # TODO_UC26RELEASE: when core26 is release we can drop edge
-                snap download --basename=pc --channel="26/edge" pc
-                ;;
-            *)
-                snap download --basename=pc --channel="${BRANCH}/${GADGET_CHANNEL}" pc
-                ;;
-        esac
-        test -e pc.snap
-        unsquashfs -d pc-gadget pc.snap
+        selected_gadget_channel="$GADGET_CHANNEL"
+        if [ "${BRANCH}/${GADGET_CHANNEL}" = 26/beta ]; then
+            # TODO_UC26RELEASE: when core26 is released we can drop edge.
+            selected_gadget_channel=edge
+        fi
         # TODO: it would be desirable when we need to do in-depth debugging of
         # UC20 runs in google to have snapd.debug=1 always on the kernel command
         # line, but we can't do this universally because the logic for the env
@@ -1703,29 +1623,30 @@ EOF
         # so for now, don't include snapd.debug=1, but eventually it would be
         # nice to have this on
 
-        cmdlinefeat=""
+        repack_gadget_args=(
+            --gadget-branch "$BRANCH"
+            --gadget-channel "$selected_gadget_channel"
+            --output-snap "$IMAGE_HOME/pc-repacked.snap"
+        )
         if [[ "$SPREAD_BACKEND" =~ openstack ]] || [[ "$SPREAD_BACKEND" =~ garden ]]; then
             if [ -n "$TAG_FEATURES" ]; then
+                repack_gadget_args+=(--persistent-journal)
                 cmdlinefeat=" tag.features=1"
-                cat >> pc-gadget/meta/gadget.yaml << EOF
-defaults:
-  system:
-    journal:
-      persistent: true
-EOF
+            else
+                cmdlinefeat=""
             fi
 
             # the default console settings for snapd aren't super useful in GCE,
             # instead it's more useful to have all console go to ttyS0 which we 
             # can read more easily than tty1 for example
             for cmd in "console=ttyS0" "dangerous" "systemd.journald.forward_to_console=1" "rd.systemd.journald.forward_to_console=1" "panic=-1$cmdlinefeat"; do
-                echo "$cmd" >> pc-gadget/cmdline.full
+                repack_gadget_args+=(--append-cmdline-full "$cmd")
             done
         else
             # but for other backends, just add the additional debugging things
             # on top of whatever the gadget currently is configured to use
-            for cmd in "dangerous" "systemd.journald.forward_to_console=1" "rd.systemd.journald.forward_to_console=1$cmdlinefeat"; do
-                echo "$cmd" >> pc-gadget/cmdline.extra
+            for cmd in "dangerous" "systemd.journald.forward_to_console=1" "rd.systemd.journald.forward_to_console=1"; do
+                repack_gadget_args+=(--append-cmdline-extra "$cmd")
             done
         fi
 
@@ -1739,9 +1660,8 @@ EOF
         SNAKEOIL_KEY="$PWD/$KEY_NAME.key"
         SNAKEOIL_CERT="$PWD/$KEY_NAME.pem"
 
-        nested_secboot_sign_gadget pc-gadget "$SNAKEOIL_KEY" "$SNAKEOIL_CERT"
-        snap pack --filename=pc-repacked.snap pc-gadget 
-        mv pc-repacked.snap $IMAGE_HOME/pc-repacked.snap
+        repack_gadget_args+=(--sign-key "$SNAKEOIL_KEY" --sign-cert "$SNAKEOIL_CERT")
+        "$TESTSTOOLS"/repack-gadget "${repack_gadget_args[@]}"
         EXTRA_FUNDAMENTAL="$EXTRA_FUNDAMENTAL --snap $IMAGE_HOME/pc-repacked.snap"
     fi
 
@@ -1774,8 +1694,6 @@ EOF
         elif is_test_target_core 26; then
             BASE=core26
         fi
-        snap download "${BASE}" --channel="$BASE_CHANNEL" --basename="${BASE}"
-
         # we want to download the specific channel referenced by $BASE_CHANNEL, 
         # but if we just seed that revision and $BASE_CHANNEL != $IMAGE_CHANNEL,
         # then immediately on booting, snapd will refresh from the revision that
@@ -1791,32 +1709,24 @@ EOF
         # * pc (to aid in debugging by modifying the kernel command line)
         # * core20 (to avoid the automatic refresh issue)
         if [ "$IMAGE_CHANNEL" != "$BASE_CHANNEL" ]; then
-            unsquashfs -d "${BASE}-snap" "${BASE}.snap"
-
-            # We setup the ntp server in case it is defined in the current env
-            # This is not needed in classic systems because the images already have ntp configured
-            if [ -n "${NTP_SERVER:-}" ]; then
-                if [ -e /etc/systemd/timesyncd.conf ]; then
-                    TARGET_TIME_CONF="$(find "${BASE}-snap" -name timesyncd.conf)"
-                    if [ -z "$TARGET_TIME_CONF" ]; then
-                        echo "File timesyncd.conf not found in core image"
-                        exit 1
-                    fi
-                    while IFS= read -r target; do
-                        cp /etc/systemd/timesyncd.conf "$target"
-                    done <<< "$TARGET_TIME_CONF"
-                fi
-                if [ -e "${BASE}-snap/usr/lib/tmpfiles.d/core-writable.conf" ]; then
-                    echo "C /etc/chrony/sources.d/ci-proxy.sources" >>"${BASE}-snap/usr/lib/tmpfiles.d/core-writable.conf"
-                    mkdir -p "${BASE}-snap/usr/share/factory/writable/system-data/etc/chrony/sources.d"
-                    echo "pool ${NTP_SERVER} iburst maxsources 1 nts prefer" "${BASE}-snap/usr/share/factory/writable/system-data/etc/chrony/sources.d/ci-proxy.sources"
-                fi
+            selected_base_branch=latest
+            selected_base_channel="$BASE_CHANNEL"
+            if [[ "$selected_base_channel" = */* ]]; then
+                selected_base_branch="${selected_base_channel%/*}"
+                selected_base_channel="${selected_base_channel##*/}"
             fi
-
-            snap pack --filename="${BASE}-repacked.snap" "${BASE}-snap"
-            rm -r "${BASE}-snap"
-            mv "${BASE}-repacked.snap" "${IMAGE_HOME}/${BASE}.snap"
-        else 
+            repack_base_args=(
+                --base-name "$BASE"
+                --base-branch "$selected_base_branch"
+                --base-channel "$selected_base_channel"
+                --output-snap "$IMAGE_HOME/${BASE}.snap"
+            )
+            if [ -n "${NTP_SERVER:-}" ]; then
+                repack_base_args+=(--ntp-server "$NTP_SERVER")
+            fi
+            "$TESTSTOOLS"/repack-base "${repack_base_args[@]}"
+        else
+            snap download "${BASE}" --channel="$BASE_CHANNEL" --basename="${BASE}"
             mv "${BASE}.snap" "${IMAGE_HOME}/${BASE}.snap"
         fi
 

--- a/tests/lib/tools/repack-base
+++ b/tests/lib/tools/repack-base
@@ -1,0 +1,184 @@
+#!/bin/bash
+
+set -eu
+
+show_help() {
+    cat <<'EOF'
+usage:
+    repack-base --base-name <name> --base-branch <branch> --base-channel <channel> --output-snap <path> [options]
+
+Options:
+    --enable-test-logging
+    --completion-file <path>
+    --proxy-env <path>
+    --store-url <url>
+    --ntp-server <address>
+EOF
+}
+
+parse_value_arg() {
+    case "$1" in
+        --base-name) BASE_NAME="$2" ;;
+        --base-branch) BASE_BRANCH="$2" ;;
+        --base-channel) BASE_CHANNEL="$2" ;;
+        --output-snap) OUTPUT_SNAP="$2" ;;
+        --completion-file) COMPLETION_FILE="$2" ;;
+        --proxy-env) PROXY_ENV="$2" ;;
+        --store-url) STORE_URL="$2" ;;
+        --ntp-server) NTP_SERVER="$2" ;;
+    esac
+}
+
+parse_args() {
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --base-name|--base-branch|--base-channel|--output-snap|--completion-file|--proxy-env|--store-url|--ntp-server)
+                if [ "$#" -lt 2 ]; then
+                    echo "repack-base: missing value for $1" >&2
+                    exit 1
+                fi
+                parse_value_arg "$1" "$2"
+                shift 2
+                ;;
+            --enable-test-logging)
+                ENABLE_TEST_LOGGING=true
+                shift
+                ;;
+            -h|--help)
+                show_help
+                exit 0
+                ;;
+            *)
+                echo "repack-base: unsupported argument: $1" >&2
+                show_help >&2
+                exit 1
+                ;;
+        esac
+    done
+}
+
+validate_args() {
+    if [ -z "$BASE_NAME" ] || [ -z "$BASE_BRANCH" ] || [ -z "$BASE_CHANNEL" ] || [ -z "$OUTPUT_SNAP" ]; then
+        echo "repack-base: --base-name, --base-branch, --base-channel and --output-snap are required" >&2
+        show_help >&2
+        exit 1
+    fi
+}
+
+base_etc_dir() {
+    local unpack_dir="$1"
+
+    if [ -e "$unpack_dir/usr/share/factory/writable" ]; then
+        printf '%s\n' "$unpack_dir/usr/share/factory/writable/system-data/etc"
+    else
+        printf '%s\n' "$unpack_dir/etc"
+    fi
+}
+
+set_test_logging() {
+    local unpack_dir="$1"
+    local destination_etc
+
+    if [ "$ENABLE_TEST_LOGGING" != true ]; then
+        return
+    fi
+    destination_etc="$(base_etc_dir "$unpack_dir")"
+    mkdir -p "$destination_etc/systemd/journald.conf.d"
+    cat > "$destination_etc/systemd/journald.conf.d/to-console.conf" <<'EOF'
+[Journal]
+ForwardToConsole=yes
+TTYPath=/dev/ttyS0
+MaxLevelConsole=debug
+EOF
+    mkdir -p "$destination_etc/systemd/system/snapd.service.d"
+    cat > "$destination_etc/systemd/system/snapd.service.d/logging.conf" <<'EOF'
+[Service]
+Environment=SNAPD_DEBUG_HTTP=7 SNAPD_DEBUG=1 SNAPPY_TESTING=1 SNAPD_CONFIGURE_HOOK_TIMEOUT=30s
+StandardOutput=journal+console
+StandardError=journal+console
+EOF
+}
+
+set_store_url() {
+    local unpack_dir="$1"
+    local destination_etc
+
+    if [ -z "$STORE_URL" ]; then
+        return
+    fi
+    destination_etc="$(base_etc_dir "$unpack_dir")"
+    mkdir -p "$destination_etc/systemd/system/snapd.service.d"
+    cat > "$destination_etc/systemd/system/snapd.service.d/store.conf" <<EOF
+[Service]
+Environment=SNAPPY_FORCE_API_URL=$STORE_URL
+EOF
+}
+
+set_ntp() {
+    local unpack_dir="$1"
+    local target_time_conf
+
+    if [ -z "$NTP_SERVER" ]; then
+        return
+    fi
+    if [ -e /etc/systemd/timesyncd.conf ]; then
+        target_time_conf="$(find "$unpack_dir" -name timesyncd.conf -print -quit)"
+        if [ -z "$target_time_conf" ]; then
+            echo "repack-base: timesyncd.conf not found in base snap" >&2
+            exit 1
+        fi
+        while IFS= read -r target_time_conf; do
+            cp /etc/systemd/timesyncd.conf "$target_time_conf"
+        done < <(find "$unpack_dir" -name timesyncd.conf)
+    fi
+    if [ -e "$unpack_dir/usr/lib/tmpfiles.d/core-writable.conf" ]; then
+        printf '%s\n' 'C /etc/chrony/sources.d/ci-proxy.sources' >> "$unpack_dir/usr/lib/tmpfiles.d/core-writable.conf"
+        mkdir -p "$unpack_dir/usr/share/factory/writable/system-data/etc/chrony/sources.d"
+        printf 'pool %s iburst maxsources 1 nts prefer\n' "$NTP_SERVER" > "$unpack_dir/usr/share/factory/writable/system-data/etc/chrony/sources.d/ci-proxy.sources"
+    fi
+}
+
+repack_base() {
+    local download_dir
+    local unpack_dir
+
+    download_dir="$(mktemp -d "${TMPDIR:-/tmp}/base-download.XXXXXXXX")"
+    unpack_dir="$(mktemp -d "${TMPDIR:-/tmp}/base-unpack.XXXXXXXX")"
+    trap 'rm -rf "$download_dir" "$unpack_dir"' EXIT
+
+    (cd "$download_dir" && snap download --basename="$BASE_NAME" --channel="${BASE_BRANCH}/${BASE_CHANNEL}" "$BASE_NAME")
+    unsquashfs -no-progress -f -d "$unpack_dir" "$download_dir/$BASE_NAME.snap"
+    set_test_logging "$unpack_dir"
+    set_store_url "$unpack_dir"
+    set_ntp "$unpack_dir"
+    if [ -n "$COMPLETION_FILE" ]; then
+        cp "$COMPLETION_FILE" "$unpack_dir/usr/lib/snapd/complete.sh"
+    fi
+    if [ -n "$PROXY_ENV" ]; then
+        cp "$PROXY_ENV" "$unpack_dir/etc/environment"
+    fi
+
+    mkdir -p "$(dirname "$OUTPUT_SNAP")"
+    snap pack --filename="$OUTPUT_SNAP" "$unpack_dir"
+    rm -rf "$download_dir" "$unpack_dir"
+    trap - EXIT
+    printf '%s\n' "$OUTPUT_SNAP"
+}
+
+main() {
+    BASE_NAME=
+    BASE_BRANCH=
+    BASE_CHANNEL=
+    OUTPUT_SNAP=
+    ENABLE_TEST_LOGGING=false
+    COMPLETION_FILE=
+    PROXY_ENV=
+    STORE_URL=
+    NTP_SERVER=
+
+    parse_args "$@"
+    validate_args
+    repack_base
+}
+
+main "$@"

--- a/tests/lib/tools/repack-gadget
+++ b/tests/lib/tools/repack-gadget
@@ -1,0 +1,282 @@
+#!/bin/bash
+
+set -eu
+
+show_help() {
+    cat <<'EOF'
+usage:
+    repack-gadget --gadget-branch <branch> --gadget-channel <channel> --output-snap <path> [options]
+
+Options:
+    --output-assertion <path>
+    --persistent-journal
+    --tag-features-grub
+    --append-cmdline-full <arguments>
+    --append-cmdline-extra <arguments>
+    --write-cmdline-full <arguments>
+    --write-cmdline-extra <arguments>
+    --sign-key <path> --sign-cert <path>
+    --sign-grub
+    --ubuntu-save <add|remove>
+    --ubuntu-seed-size <size>
+    --prepare-device-url <url>
+EOF
+}
+
+parse_value_arg() {
+    case "$1" in
+        --gadget-branch) GADGET_BRANCH="$2" ;;
+        --gadget-channel) GADGET_CHANNEL="$2" ;;
+        --output-snap) OUTPUT_SNAP="$2" ;;
+        --output-assertion) OUTPUT_ASSERTION="$2" ;;
+        --sign-key) SIGN_KEY="$2" ;;
+        --sign-cert) SIGN_CERT="$2" ;;
+    esac
+}
+
+parse_modification_arg() {
+    case "$1" in
+        --append-cmdline-full) CMDLINE_FULL_ARGS+=("$2") ;;
+        --append-cmdline-extra) CMDLINE_EXTRA_ARGS+=("$2") ;;
+        --write-cmdline-full) WRITE_CMDLINE_FULL="$2" ;;
+        --write-cmdline-extra) WRITE_CMDLINE_EXTRA="$2" ;;
+        --ubuntu-save) UBUNTU_SAVE="$2" ;;
+        --ubuntu-seed-size) UBUNTU_SEED_SIZE="$2" ;;
+        --prepare-device-url) PREPARE_DEVICE_URL="$2" ;;
+    esac
+}
+
+parse_args() {
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --gadget-branch|--gadget-channel|--output-snap|--output-assertion|--sign-key|--sign-cert)
+                if [ "$#" -lt 2 ]; then
+                    echo "repack-gadget: missing value for $1" >&2
+                    exit 1
+                fi
+                parse_value_arg "$1" "$2"
+                shift 2
+                ;;
+            --append-cmdline-full|--append-cmdline-extra|--write-cmdline-full|--write-cmdline-extra|--ubuntu-save|--ubuntu-seed-size|--prepare-device-url)
+                if [ "$#" -lt 2 ]; then
+                    echo "repack-gadget: missing value for $1" >&2
+                    exit 1
+                fi
+                parse_modification_arg "$1" "$2"
+                shift 2
+                ;;
+            --persistent-journal)
+                PERSISTENT_JOURNAL=true
+                shift
+                ;;
+            --sign-grub)
+                SIGN_GRUB=true
+                shift
+                ;;
+            --tag-features-grub)
+                TAG_FEATURES_GRUB=true
+                shift
+                ;;
+            -h|--help)
+                show_help
+                exit 0
+                ;;
+            *)
+                echo "repack-gadget: unsupported argument: $1" >&2
+                show_help >&2
+                exit 1
+                ;;
+        esac
+    done
+}
+
+validate_args() {
+    if [ -z "$GADGET_BRANCH" ] || [ -z "$GADGET_CHANNEL" ] || [ -z "$OUTPUT_SNAP" ]; then
+        echo "repack-gadget: --gadget-branch, --gadget-channel and --output-snap are required" >&2
+        show_help >&2
+        exit 1
+    fi
+    if [ -n "$SIGN_KEY" ] && [ -z "$SIGN_CERT" ] || [ -z "$SIGN_KEY" ] && [ -n "$SIGN_CERT" ]; then
+        echo "repack-gadget: --sign-key and --sign-cert must be used together" >&2
+        exit 1
+    fi
+    case "$UBUNTU_SAVE" in
+        ""|add|remove) ;;
+        *)
+            echo "repack-gadget: --ubuntu-save must be add or remove" >&2
+            exit 1
+            ;;
+    esac
+}
+
+remove_signatures() {
+    local file="$1"
+
+    while sbverify --list "$file" | grep -q '^signature [0-9]*$'; do
+        sbattach --remove "$file"
+    done
+}
+
+sign_file() {
+    local file="$1"
+
+    remove_signatures "$file"
+    sbsign --key "$SIGN_KEY" --cert "$SIGN_CERT" --output "$file" "$file"
+}
+
+set_signatures() {
+    local unpack_dir="$1"
+    local grub_efi
+
+    if [ -z "$SIGN_KEY" ]; then
+        return
+    fi
+    if [ -f "$unpack_dir/fb.efi" ]; then
+        sign_file "$unpack_dir/fb.efi"
+    fi
+    sign_file "$unpack_dir/shim.efi.signed"
+    if [ "$SIGN_GRUB" = true ]; then
+        for grub_efi in "$unpack_dir"/grub*.efi; do
+            if [ -f "$grub_efi" ]; then
+                sign_file "$grub_efi"
+            fi
+        done
+    fi
+}
+
+set_ubuntu_save() {
+    local unpack_dir="$1"
+    local output
+
+    if [ -z "$UBUNTU_SAVE" ]; then
+        return
+    fi
+    output="$unpack_dir/gadget-with-save.yaml"
+    "$TESTSLIB_DIR/ensure_ubuntu_save.py" "--$UBUNTU_SAVE" "$unpack_dir/meta/gadget.yaml" > "$output"
+    if [ -s "$output" ]; then
+        mv "$output" "$unpack_dir/meta/gadget.yaml"
+    else
+        rm -f "$output"
+    fi
+}
+
+set_persistent_journal() {
+    local unpack_dir="$1"
+
+    if [ "$PERSISTENT_JOURNAL" != true ]; then
+        return
+    fi
+    cat >> "$unpack_dir/meta/gadget.yaml" <<'EOF'
+defaults:
+  system:
+    journal:
+      persistent: true
+EOF
+}
+
+set_grub_tag_features() {
+    local unpack_dir="$1"
+    local grub_cfg
+
+    if [ "$TAG_FEATURES_GRUB" != true ]; then
+        return
+    fi
+    for grub_cfg in "$unpack_dir/grub.conf" "$unpack_dir/grub.cfg"; do
+        if [ -f "$grub_cfg" ] && ! grep -q 'tag.features=1' "$grub_cfg"; then
+            sed -i 's/^\([[:space:]]*linux[[:space:]].*\)$/\1 tag.features=1/' "$grub_cfg"
+        fi
+    done
+}
+
+set_cmdline() {
+    local unpack_dir="$1"
+    local arguments
+
+    for arguments in "${CMDLINE_FULL_ARGS[@]}"; do
+        printf '%s\n' "$arguments" >> "$unpack_dir/cmdline.full"
+    done
+    for arguments in "${CMDLINE_EXTRA_ARGS[@]}"; do
+        printf '%s\n' "$arguments" >> "$unpack_dir/cmdline.extra"
+    done
+    if [ -n "$WRITE_CMDLINE_FULL" ]; then
+        printf '%s\n' "$WRITE_CMDLINE_FULL" > "$unpack_dir/cmdline.full"
+    fi
+    if [ -n "$WRITE_CMDLINE_EXTRA" ]; then
+        printf '%s\n' "$WRITE_CMDLINE_EXTRA" > "$unpack_dir/cmdline.extra"
+    fi
+}
+
+set_prepare_device_hook() {
+    local unpack_dir="$1"
+
+    if [ -z "$PREPARE_DEVICE_URL" ]; then
+        return
+    fi
+    mkdir -p "$unpack_dir/meta/hooks"
+    cat > "$unpack_dir/meta/hooks/prepare-device" <<EOF
+#!/bin/sh
+snapctl set device-service.url=$PREPARE_DEVICE_URL
+EOF
+    chmod +x "$unpack_dir/meta/hooks/prepare-device"
+}
+
+repack_gadget() {
+    local download_dir
+    local unpack_dir
+
+    download_dir="$(mktemp -d "${TMPDIR:-/tmp}/gadget-download.XXXXXXXX")"
+    unpack_dir="$(mktemp -d "${TMPDIR:-/tmp}/gadget-unpack.XXXXXXXX")"
+    trap 'rm -rf "$download_dir" "$unpack_dir"' EXIT
+
+    (cd "$download_dir" && snap download --basename=pc --channel="${GADGET_BRANCH}/${GADGET_CHANNEL}" pc)
+    if [ -n "$OUTPUT_ASSERTION" ]; then
+        mkdir -p "$(dirname "$OUTPUT_ASSERTION")"
+        cp "$download_dir/pc.assert" "$OUTPUT_ASSERTION"
+    fi
+    unsquashfs -no-progress -f -d "$unpack_dir" "$download_dir/pc.snap"
+    set_signatures "$unpack_dir"
+    set_ubuntu_save "$unpack_dir"
+    set_persistent_journal "$unpack_dir"
+    set_grub_tag_features "$unpack_dir"
+    set_cmdline "$unpack_dir"
+    if [ -n "$UBUNTU_SEED_SIZE" ]; then
+        "$TESTSLIB_DIR/manip_ubuntu_seed.py" "$unpack_dir/meta/gadget.yaml" "$UBUNTU_SEED_SIZE"
+    fi
+    set_prepare_device_hook "$unpack_dir"
+
+    mkdir -p "$(dirname "$OUTPUT_SNAP")"
+    snap pack --filename="$OUTPUT_SNAP" "$unpack_dir"
+    rm -rf "$download_dir" "$unpack_dir"
+    trap - EXIT
+    printf '%s\n' "$OUTPUT_SNAP"
+}
+
+main() {
+    local tools_dir
+
+    GADGET_BRANCH=
+    GADGET_CHANNEL=
+    OUTPUT_SNAP=
+    OUTPUT_ASSERTION=
+    PERSISTENT_JOURNAL=false
+    TAG_FEATURES_GRUB=false
+    CMDLINE_FULL_ARGS=()
+    CMDLINE_EXTRA_ARGS=()
+    WRITE_CMDLINE_FULL=
+    WRITE_CMDLINE_EXTRA=
+    SIGN_KEY=
+    SIGN_CERT=
+    SIGN_GRUB=false
+    UBUNTU_SAVE=
+    UBUNTU_SEED_SIZE=
+    PREPARE_DEVICE_URL=
+
+    tools_dir="$(dirname "$(readlink -f "$0")")"
+    TESTSLIB_DIR="$(dirname "$tools_dir")"
+
+    parse_args "$@"
+    validate_args
+    repack_gadget
+}
+
+main "$@"

--- a/tests/nested/manual/core20-boot-config-update/task.yaml
+++ b/tests/nested/manual/core20-boot-config-update/task.yaml
@@ -37,33 +37,31 @@ prepare: |
   rm -rf snapd-snap
 
   if [ "$VARIANT" != "no-gadget" ]; then
-    echo "Grab and prepare the gadget snap"
-    version=$(tests.nested show version)
-    snap download --basename=pc --channel="$version/edge" pc
-    unsquashfs -d pc-gadget pc.snap
-
-    echo "Sign the shim binary"
     KEY_NAME=$(tests.nested download snakeoil-key)
     SNAKEOIL_KEY="$PWD/$KEY_NAME.key"
     SNAKEOIL_CERT="$PWD/$KEY_NAME.pem"
-    tests.nested secboot-sign gadget pc-gadget "$SNAKEOIL_KEY" "$SNAKEOIL_CERT"
-
+    version=$(tests.nested show version)
+    gadget_args=(
+      --gadget-branch "$version"
+      --gadget-channel edge
+      --output-snap "$(tests.nested get extra-snaps-path)/pc.snap"
+      --sign-key "$SNAKEOIL_KEY"
+      --sign-cert "$SNAKEOIL_CERT"
+    )
     case "$VARIANT" in
       gadget-extra)
-        echo 'snapd.debug=1 hello from test' > pc-gadget/cmdline.extra
-        echo "${NESTED_EXTRA_CMDLINE}" >>pc-gadget/cmdline.extra
+        gadget_args+=(--write-cmdline-extra "$(printf '%s\n%s' 'snapd.debug=1 hello from test' "$NESTED_EXTRA_CMDLINE")")
         ;;
       gadget-full)
         # keep the console so that we have useful debug logs
-        echo 'snapd.debug=1 console=ttyS0,115200n8 full hello from test' > pc-gadget/cmdline.full
-        echo "${NESTED_EXTRA_CMDLINE}" >>pc-gadget/cmdline.full
+        gadget_args+=(--write-cmdline-full "$(printf '%s\n%s' 'snapd.debug=1 console=ttyS0,115200n8 full hello from test' "$NESTED_EXTRA_CMDLINE")")
         ;;
       *)
         echo "unexpected variant $VARIANT, fix the test"
         exit 1
         ;;
     esac
-    snap pack pc-gadget/ "$(tests.nested get extra-snaps-path)"
+    "$TESTSTOOLS"/repack-gadget "${gadget_args[@]}"
   fi
 
   tests.nested build-image core

--- a/tests/nested/manual/core20-custom-kernel-commandline/task.yaml
+++ b/tests/nested/manual/core20-custom-kernel-commandline/task.yaml
@@ -15,33 +15,34 @@ prepare: |
     SNAKEOIL_KEY="$PWD/$KEY_NAME.key"
     SNAKEOIL_CERT="$PWD/$KEY_NAME.pem"
 
-    echo "Grab and prepare the gadget snap"
     VERSION="$(tests.nested show version)"
-    snap download --basename=pc --channel="$VERSION/edge" pc
-    unsquashfs -d pc-gadget pc.snap
+    gadget_args=(
+        --gadget-branch "$VERSION"
+        --gadget-channel edge
+        --sign-key "$SNAKEOIL_KEY"
+        --sign-cert "$SNAKEOIL_CERT"
+    )
+    "$TESTSTOOLS"/repack-gadget "${gadget_args[@]}" \
+        --output-snap "$(tests.nested get extra-snaps-path)/pc_1.snap" \
+        --write-cmdline-extra 'snapd.debug=1 hello from test'
+    "$TESTSTOOLS"/repack-gadget "${gadget_args[@]}" \
+        --output-snap pc-gadget-cmdline-extra-updated.snap \
+        --write-cmdline-extra 'snapd.debug=1 updated hello from test'
 
-    echo "Sign the shim binary"
-    tests.nested secboot-sign gadget pc-gadget "$SNAKEOIL_KEY" "$SNAKEOIL_CERT"
-
-    echo 'snapd.debug=1 hello from test' > pc-gadget/cmdline.extra
-    snap pack pc-gadget/ "$(tests.nested get extra-snaps-path)"
-
-    echo 'snapd.debug=1 updated hello from test' > pc-gadget/cmdline.extra
-    snap pack pc-gadget --filename=pc-gadget-cmdline-extra-updated.snap
-
-    rm pc-gadget/cmdline.extra
     # keep the console so that we get some logging
-    cat <<'EOF' > pc-gadget/cmdline.full
+    cmdline_full=$(cat <<'EOF'
     snapd.debug=1
     # keep the console
     console=ttyS0
     full hello from
     test
     EOF
-    snap pack pc-gadget --filename=pc-gadget-cmdline-full.snap
-
-    rm pc-gadget/cmdline.full
-    snap pack pc-gadget --filename=pc-gadget-cmdline-none.snap
+    )
+    "$TESTSTOOLS"/repack-gadget "${gadget_args[@]}" \
+        --output-snap pc-gadget-cmdline-full.snap \
+        --write-cmdline-full "$cmdline_full"
+    "$TESTSTOOLS"/repack-gadget "${gadget_args[@]}" \
+        --output-snap pc-gadget-cmdline-none.snap
 
     tests.nested build-image core
     tests.nested create-vm core

--- a/tests/nested/manual/fde-on-classic/task.yaml
+++ b/tests/nested/manual/fde-on-classic/task.yaml
@@ -162,9 +162,17 @@ execute: |
   # precondition, the coreXX is not a local version
   remote.exec snap list "core${VERSION}" | NOMATCH " x1 "
   # create modified coreXX
-  unsquashfs -d corebase "$CACHE_D"/core"${VERSION}"_*.snap
-  touch corebase/empty-file
-  snap pack --filename=corebase-new.snap corebase
+    base_branch=latest
+    base_channel="$(nested_get_base_channel)"
+    if [[ "$base_channel" = */* ]]; then
+      base_branch="${base_channel%/*}"
+      base_channel="${base_channel##*/}"
+    fi
+    "$TESTSTOOLS"/repack-base \
+      --base-name "core${VERSION}" \
+      --base-branch "$base_branch" \
+      --base-channel "$base_channel" \
+      --output-snap corebase-new.snap
   remote.push "corebase-new.snap"
   # install and validate it is now a local version
   remote.exec sudo snap install --dangerous "corebase-new.snap"

--- a/tests/nested/manual/hybrid-fde-all-key-databases/task.yaml
+++ b/tests/nested/manual/hybrid-fde-all-key-databases/task.yaml
@@ -44,23 +44,20 @@ prepare: |
 
   version="$(nested_get_version)"
 
-  # Retrieve the gadget
-  snap download --basename=pc --channel="$version/edge" pc
-  # the fakestore needs the assertion
-  snap ack pc.assert
-  # keep original blob just so we can find the assertion later
-  cp pc.snap pc.snap.orig
-
-  # New modified gadget
-  unsquashfs -d pc-gadget pc.snap
-  echo 'console=ttyS0 systemd.journald.forward_to_console=1' > pc-gadget/cmdline.extra
-
-  echo "Sign the shim binary"
   KEY_NAME=$(tests.nested download snakeoil-key)
   SNAKEOIL_KEY="$PWD/$KEY_NAME.key"
   SNAKEOIL_CERT="$PWD/$KEY_NAME.pem"
-  tests.nested secboot-sign gadget pc-gadget "$SNAKEOIL_KEY" "$SNAKEOIL_CERT"
-  snap pack --filename=pc.snap pc-gadget/
+  "$TESTSTOOLS"/repack-gadget \
+    --gadget-branch "$version" \
+    --gadget-channel edge \
+    --output-snap "$PWD/pc.snap" \
+    --output-assertion "$PWD/pc.assert" \
+    --write-cmdline-extra 'console=ttyS0 systemd.journald.forward_to_console=1' \
+    --sign-key "$SNAKEOIL_KEY" \
+    --sign-cert "$SNAKEOIL_CERT"
+
+  # the fakestore needs the assertion
+  snap ack pc.assert
 
   # Retrieve kernel
   snap download --basename=pc-kernel-from-store --channel="$version/${KERNEL_CHANNEL}" pc-kernel

--- a/tests/nested/manual/muinstaller-oldbasenewkernel/task.yaml
+++ b/tests/nested/manual/muinstaller-oldbasenewkernel/task.yaml
@@ -44,22 +44,20 @@ execute: |
   core_version=22
   kernel_version="$(nested_get_version)"
 
-  # Retrieve the gadget
-  snap download --basename=pc --channel="$core_version/edge" pc
-  # the fakestore needs the assertion
-  snap ack pc.assert
-  # keep original blob just so we can find the assertion later
-  cp pc.snap pc.snap.orig
-
-  # New modified gadget
-  unsquashfs -d pc-gadget pc.snap
-  echo 'console=ttyS0 systemd.journald.forward_to_console=1' > pc-gadget/cmdline.extra
-  echo "Sign the shim binary"
   KEY_NAME=$(tests.nested download snakeoil-key)
   SNAKEOIL_KEY="$PWD/$KEY_NAME.key"
   SNAKEOIL_CERT="$PWD/$KEY_NAME.pem"
-  tests.nested secboot-sign gadget pc-gadget "$SNAKEOIL_KEY" "$SNAKEOIL_CERT"
-  snap pack --filename=pc.snap pc-gadget/
+  "$TESTSTOOLS"/repack-gadget \
+    --gadget-branch "$core_version" \
+    --gadget-channel edge \
+    --output-snap "$PWD/pc.snap" \
+    --output-assertion "$PWD/pc.assert" \
+    --write-cmdline-extra 'console=ttyS0 systemd.journald.forward_to_console=1' \
+    --sign-key "$SNAKEOIL_KEY" \
+    --sign-cert "$SNAKEOIL_CERT"
+
+  # the fakestore needs the assertion
+  snap ack pc.assert
 
   # Retrieve kernel
   snap download --basename=pc-kernel-from-store --channel="$kernel_version/edge" pc-kernel

--- a/tests/nested/manual/remodel-uc-to-next-version-fakestore/task.yaml
+++ b/tests/nested/manual/remodel-uc-to-next-version-fakestore/task.yaml
@@ -58,11 +58,18 @@ prepare: |
 
   mv pc-kernel-modified.snap updates/pc-kernel-22.snap
 
-  snap download --channel="latest/edge" --basename="original-core22" "core22"
-  # shellcheck source=tests/lib/prepare.sh
-  . "$TESTSLIB/prepare.sh"
-  repack_core_snap_with_tweaks original-core22.snap updates/core22.snap
-  rm -f original-core22.{snap,assert}
+  repack_base_args=(
+    --base-name core22
+    --base-branch latest
+    --base-channel edge
+    --output-snap updates/core22.snap
+    --enable-test-logging
+    --completion-file "$SPREAD_PATH/data/completion/bash/complete.sh"
+  )
+  if [ "${SNAPD_USE_PROXY:-}" = true ]; then
+    repack_base_args+=(--proxy-env /etc/environment)
+  fi
+  "$TESTSTOOLS"/repack-base "${repack_base_args[@]}"
 
   snap download --channel="22/edge" --basename="original-pc-22" "pc"
   unsquashfs -d pc original-pc-22.snap

--- a/tests/nested/manual/uc-update-command-line-secure/task.yaml
+++ b/tests/nested/manual/uc-update-command-line-secure/task.yaml
@@ -13,23 +13,27 @@ prepare: |
   VERSION="$(tests.nested show version)"
   case "${VERSION}" in
     26)
-      CHANNEL="${VERSION}/edge"
+      GADGET_CHANNEL=edge
     ;;
     *)
-      CHANNEL="${VERSION}/stable"
+      GADGET_CHANNEL=stable
     ;;
   esac
-  snap download --basename=pc --channel="${CHANNEL}" pc
-  unsquashfs -d pc pc.snap
   KEY_NAME=$(tests.nested download snakeoil-key)
   SNAKEOIL_KEY="$PWD/$KEY_NAME.key"
   SNAKEOIL_CERT="$PWD/$KEY_NAME.pem"
-  tests.nested secboot-sign file pc/shim.efi.signed "$SNAKEOIL_KEY" "$SNAKEOIL_CERT"
-  tests.nested secboot-sign file pc/grubx64.efi "$SNAKEOIL_KEY" "$SNAKEOIL_CERT"
-  snap pack pc "$(tests.nested get extra-snaps-path)"
-
-  echo "some_useless_parameter" >>pc/cmdline.extra
-  snap pack pc --filename=pc_2.snap
+  gadget_args=(
+    --gadget-branch "$VERSION"
+    --gadget-channel "$GADGET_CHANNEL"
+    --sign-key "$SNAKEOIL_KEY"
+    --sign-cert "$SNAKEOIL_CERT"
+    --sign-grub
+  )
+  "$TESTSTOOLS"/repack-gadget "${gadget_args[@]}" \
+    --output-snap "$(tests.nested get extra-snaps-path)/pc_1.snap"
+  "$TESTSTOOLS"/repack-gadget "${gadget_args[@]}" \
+    --output-snap pc_2.snap \
+    --append-cmdline-extra some_useless_parameter
 
   tests.nested build-image core
   tests.nested create-vm core


### PR DESCRIPTION
This is the second step in order to start managing some dependencies by a tool. In order to achieve that, I continue by moving all the gadget and base repacking to new tools which in the future will be able to reuse previously repacked dependencies.

Centralize the download, modification, and packing of base and gadget snaps. Support the common logging, store, NTP, command-line, signing, partition, and prepare-device changes used when creating test images.

Migrate prepare, nested, remodel, hybrid, and secure-boot tests to use the new tools, removing duplicated unpack and repack logic.

Cyclomatic complexity of repack tools in the following tables. We added a requirement to have complexity <= 10 in all the functions used by nested tests.

**repack-gadget**

Function | CCN
-- | --
parse_args | 10
parse_modification_arg | 8
parse_value_arg | 7
set_signatures | 6
set_cmdline | 5
validate_args | 4
set_grub_tag_features | 4
repack_gadget | 3
set_ubuntu_save | 3
remove_signatures | 2
set_persistent_journal | 2
set_prepare_device_hook | 2
show_help | 1
sign_file | 1
main | 1

**repack-base**

Function | CCN
-- | --
parse_value_arg | 9
parse_args | 6
set_ntp | 6
repack_base | 3
validate_args | 2
base_etc_dir | 2
set_test_logging | 2
set_store_url | 2
show_help | 1
main | 1
