### PR TITLE
tests: remove incorrect backend usage in spread tests

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -1253,7 +1253,7 @@ restore-each: |
 suites:
     tests/lib/tools/suite/:
         summary: Tests for tests/lib/tools tools
-        backends: [openstsack, qemu, garden]
+        backends: [openstack, qemu, garden]
         prepare-each: |
             tests.invariant set snap-mount-dir "$(os.paths snap-mount-dir)"
             "$TESTSLIB"/prepare-restore.sh --prepare-suite-each-minimal-no-snaps

--- a/tests/main/snapd-state/task.yaml
+++ b/tests/main/snapd-state/task.yaml
@@ -6,7 +6,7 @@ details: |
 
     This test verifies the different functionalities provided by such tool.
 
-backends: [google, qemu, openstack]
+backends: [qemu, openstack]
 
 prepare: |
     snap install test-snapd-tools


### PR DESCRIPTION
These error were found using the new spread checks for backends

