### PR TITLE
confdb: fix unused branch checks and trim indexes

### DIFF
--- a/confdb/confdb.go
+++ b/confdb/confdb.go
@@ -1625,8 +1625,8 @@ func prunePathInValue(parts []Accessor, val any) (any, error) {
 
 		nested, ok := mapVal[parts[0].Name()]
 		if !ok {
-			// shouldn't happen since we already checked this
-			return nil, fmt.Errorf(`internal error: cannot use unmatched part %q as key in %v`, parts[0].Name(), mapVal)
+			// may happen if another path already covered this branch
+			return mapVal, nil
 		}
 
 		newValue, err := prunePathInValue(parts[1:], nested)

--- a/confdb/confdb.go
+++ b/confdb/confdb.go
@@ -843,7 +843,11 @@ func ParsePathIntoAccessors(path string, opts ParseOptions) ([]Accessor, error) 
 			if opts.ForbidIndexes {
 				return nil, fmt.Errorf("invalid subkey %q: view paths cannot have literal indexes (only index placeholders)", subkey)
 			}
-			accessors = append(accessors, newIndex(subkey[1:len(subkey)-1], part.filters))
+			index := strings.TrimLeft(subkey[1:len(subkey)-1], "0")
+			if index == "" {
+				index = "0"
+			}
+			accessors = append(accessors, newIndex(index, part.filters))
 
 		case !opts.AllowPlaceholders:
 			// user supplied paths cannot contain placeholders

--- a/confdb/confdb.go
+++ b/confdb/confdb.go
@@ -1245,6 +1245,14 @@ func byAccessor(getAccs accGetter) func(x, y int) bool {
 				return xPlaceholder
 			}
 
+			// index literals must be sorted numerically and not lexicographically
+			if xAcc.Type() == ListIndexType && yAcc.Type() == ListIndexType {
+				xNum, _ := strconv.Atoi(xAcc.Name())
+				yNum, _ := strconv.Atoi(yAcc.Name())
+
+				return xNum < yNum
+			}
+
 			return xAcc.Access() < yAcc.Access()
 		}
 

--- a/confdb/confdb.go
+++ b/confdb/confdb.go
@@ -1162,7 +1162,7 @@ func (v *View) Set(databag Databag, request string, value any) error {
 	sort.Slice(matches, byAccessor(getAccs))
 
 	var expandedMatches []expandedMatch
-	suffixes := make(map[string]struct{}, len(matches))
+	suffixes := make([]string, 0, len(matches))
 	for _, match := range matches {
 		pathValuePairs, err := getValuesThroughPaths(match.storagePath, match.unmatchedSuffix, value)
 		if err != nil {
@@ -1187,9 +1187,10 @@ func (v *View) Set(databag Databag, request string, value any) error {
 		// store the suffix in a map so we deduplicate them before checking if the
 		// value is used in its entirety
 		suffixPath := JoinAccessors(match.unmatchedSuffix)
-		suffixes[suffixPath] = struct{}{}
+		suffixes = append(suffixes, suffixPath)
 	}
 
+	sort.Strings(suffixes)
 	// check if value is entirely used. If not, we fail so this is consistent
 	// with doing the same write individually (one branch at a time)
 	if err := checkForUnusedBranches(value, suffixes); err != nil {
@@ -1509,11 +1510,19 @@ func replaceAccessorWith(path []Accessor, keyName string, accType AccessorType, 
 }
 
 // checkForUnusedBranches checks that the value is entirely covered by the paths.
-func checkForUnusedBranches(value any, paths map[string]struct{}) error {
+func checkForUnusedBranches(value any, paths []string) error {
 	// prune each path from the value. If anything is left at the end, the paths
-	// don't collectively cover the entire value
+	// don't collectively cover the entire value and we should error so the user
+	// isn't later surprised that some of they set isn't there
+
 	copyValue := deepCopy(value)
-	for path := range paths {
+	for i, path := range paths {
+		if i > 0 && path == paths[i-1] {
+			// we don't strictly need to do this since a repeated path would just
+			// no-op, but this is cheap and saves time
+			continue
+		}
+
 		var err error
 		var pathParts []Accessor
 

--- a/confdb/confdb_test.go
+++ b/confdb/confdb_test.go
@@ -4249,6 +4249,12 @@ func (*viewSuite) TestParsePathsWithFieldFilters(c *C) {
 	}
 }
 
+func (*viewSuite) TestParsePathNormalizesListIndexes(c *C) {
+	accessors, err := confdb.ParsePathIntoAccessors("foo[000][01]", confdb.ParseOptions{})
+	c.Assert(err, IsNil)
+	c.Check(confdb.JoinAccessors(accessors), Equals, "foo[0][1]")
+}
+
 func (*viewSuite) TestFieldFilterPathMismatch(c *C) {
 	_, err := confdb.NewSchema("acc", "confdb", map[string]any{
 		"foo": map[string]any{
@@ -5218,6 +5224,13 @@ func fuzzHelper(f *testing.F, o confdb.ParseOptions, seed string) {
 		expected := subkeyOnlyReg.FindAllString(s, -1)
 		if len(accessors) == len(expected) {
 			for i, e := range expected {
+				if accessors[i].Type() == confdb.ListIndexType {
+					index := strings.TrimLeft(e[1:len(e)-1], "0")
+					if index == "" {
+						index = "0"
+					}
+					e = "[" + index + "]"
+				}
 				if accessors[i].Access() != e {
 					t.Errorf("unexpected type of accessor %T with name %s for element %s", accessors[i].Type(), accessors[i].Name(), e)
 				}

--- a/confdb/confdb_test.go
+++ b/confdb/confdb_test.go
@@ -2744,6 +2744,27 @@ func (s *viewSuite) TestViewSetErrorIfValueContainsUnusedParts(c *C) {
 	}
 }
 
+func (s *viewSuite) TestSetPathChecksValueCoveredByMultipleBranches(c *C) {
+	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"foo": map[string]any{
+			"rules": []any{
+				map[string]any{"request": "foo.bar", "storage": "foo.bar"},
+				map[string]any{"request": "foo.bar.baz", "storage": "foo.bar.baz"},
+				map[string]any{"request": "foo.other", "storage": "foo.other"},
+			},
+		},
+	}, confdb.NewJSONSchema())
+	c.Assert(err, IsNil)
+
+	view := schema.View("foo")
+	bag := confdb.NewJSONDatabag()
+	err = view.Set(bag, "foo", map[string]any{
+		"bar":   map[string]any{"baz": "value"},
+		"other": "value",
+	})
+	c.Assert(err, IsNil)
+}
+
 func (*viewSuite) TestViewSummaryWrongType(c *C) {
 	for _, val := range []any{
 		1,

--- a/confdb/confdb_test.go
+++ b/confdb/confdb_test.go
@@ -4551,6 +4551,29 @@ func (*viewSuite) TestListFiltering(c *C) {
 	c.Assert(err, testutil.ErrorIs, &confdb.NoDataError{})
 }
 
+func (*viewSuite) TestSetListIndexesInNumericOrder(c *C) {
+	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"foo": map[string]any{
+			"rules": []any{
+				map[string]any{
+					"request": "settings[{n}]",
+					"storage": "items[{n}]",
+				},
+			},
+		},
+	}, confdb.NewJSONSchema())
+	c.Assert(err, IsNil)
+
+	bag := confdb.NewJSONDatabag()
+	view := schema.View("foo")
+
+	// has 11 elements so we test that settings[10] sorts after settings[9]
+	// (i.e., they're not lexicographically sorted)
+	value := []any{"A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K"}
+	err = view.Set(bag, "settings", value)
+	c.Assert(err, IsNil)
+}
+
 func (*viewSuite) TestFieldFilteringNotString(c *C) {
 	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
 		"foo": map[string]any{


### PR DESCRIPTION
We check that values passed into Set are completely used by the paths of rules the write matched to. If they're not, we reject the write to prevent people from thinking they're writing something which turns out to be discarded. The check was not taking into account previous paths
covering a particular branch of the value which this commit fixes.
This also trims list indexes so we don't store values as "001". I considered parsing the value into an int but it just adds more code converting it back into strings in various places so I opted against it.