### PR TITLE
confdb: forbid mismatched filters on paths that can read same data 

### DIFF
--- a/confdb/confdb.go
+++ b/confdb/confdb.go
@@ -606,16 +606,11 @@ func storagePathsHaveConsistentFilters(left, right []Accessor) bool {
 	}
 
 	commonLength := int(math.Min(float64(len(left)), float64(len(right))))
-	filtersEqual := true
 	for i := 0; i < commonLength; i++ {
 		leftAcc, rightAcc := left[i], right[i]
 		if !equalFieldFilters(leftAcc.FieldFilters(), rightAcc.FieldFilters()) {
-			filtersEqual = false
+			return false
 		}
-	}
-
-	if !filtersEqual {
-		return false
 	}
 
 	// if the longer path has any filters beyond its "equivalent prefix" then we

--- a/confdb/confdb.go
+++ b/confdb/confdb.go
@@ -352,7 +352,7 @@ func (s *Schema) GetViewsAffectedByPath(path []Accessor) []*View {
 
 func pathChangeAffects(modified, affected []Accessor) bool {
 	for i, affectedKey := range affected {
-		if affectedKey.Type() == IndexPlaceholderType || affectedKey.Type() == KeyPlaceholderType {
+		if isPlaceholderAccessor(affectedKey) {
 			continue
 		}
 
@@ -569,6 +569,10 @@ func newView(schema *Schema, name string, viewRules []any, paramPresence map[str
 		}
 	}
 
+	if err := checkFilteredPathConsistency(view.rules); err != nil {
+		return nil, err
+	}
+
 	return view, nil
 }
 
@@ -583,6 +587,83 @@ func getFilterParams(rule viewRule) []string {
 	}
 
 	return keys(params)
+}
+
+// checkFilteredPathConsistency checks that rules with paths covering the same
+// data have the same filters. Otherwise, requests could match both filtered and
+// unfiltered paths, resulting in an inconsistent merged value.
+func checkFilteredPathConsistency(rules []viewRule) error {
+	for i, rule := range rules {
+		for _, other := range rules[i+1:] {
+			if !storagePathsHaveConsistentFilters(rule.storage, other.storage) {
+				return fmt.Errorf("storage paths %q and %q access overlapping data with different field filters", rule.originalStorage, other.originalStorage)
+			}
+		}
+	}
+	return nil
+}
+
+func equalFieldFilters(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
+func accessorContainerType(acc Accessor) AccessorType {
+	if acc.Type() == KeyPlaceholderType {
+		return MapKeyType
+	}
+	if acc.Type() == IndexPlaceholderType {
+		return ListIndexType
+	}
+	return acc.Type()
+}
+
+func isPlaceholderAccessor(acc Accessor) bool {
+	return acc.Type() == KeyPlaceholderType || acc.Type() == IndexPlaceholderType
+}
+
+// storagePathsHaveConsistentFilters reports whether two storage paths either
+// cover distinct data or apply the same filters to the data they can both cover.
+func storagePathsHaveConsistentFilters(left, right []Accessor) bool {
+	commonLength := int(math.Min(float64(len(left)), float64(len(right))))
+	filtersEqual := true
+	for i := 0; i < commonLength; i++ {
+		leftAcc, rightAcc := left[i], right[i]
+		if accessorContainerType(leftAcc) != accessorContainerType(rightAcc) ||
+			(!isPlaceholderAccessor(leftAcc) && !isPlaceholderAccessor(rightAcc) && leftAcc.Name() != rightAcc.Name()) {
+			// The paths diverge, so any earlier filter difference applies to
+			// distinct data and does not make the paths inconsistent.
+			return true
+		}
+		if !equalFieldFilters(leftAcc.FieldFilters(), rightAcc.FieldFilters()) {
+			filtersEqual = false
+		}
+	}
+
+	if !filtersEqual {
+		return false
+	}
+
+	// if the longer path has any filters beyond its "equivalent prefix" then we
+	// need to fail, as the short one would read unfiltered data
+	longer := left
+	if len(right) > len(left) {
+		longer = right
+	}
+	for _, acc := range longer[commonLength:] {
+		if len(acc.FieldFilters()) != 0 {
+			return false
+		}
+	}
+	return true
 }
 
 // TODO:GOVERSION: use maps.Keys once on go 1.23
@@ -1239,8 +1320,8 @@ func byAccessor(getAccs accGetter) func(x, y int) bool {
 			}
 
 			// sort placeholders before literals so the latter override the former
-			xPlaceholder := xAcc.Type() == KeyPlaceholderType || xAcc.Type() == IndexPlaceholderType
-			yPlaceholder := yAcc.Type() == KeyPlaceholderType || yAcc.Type() == IndexPlaceholderType
+			xPlaceholder := isPlaceholderAccessor(xAcc)
+			yPlaceholder := isPlaceholderAccessor(yAcc)
 			if xPlaceholder != yPlaceholder {
 				return xPlaceholder
 			}

--- a/confdb/confdb.go
+++ b/confdb/confdb.go
@@ -583,8 +583,11 @@ func newView(schema *Schema, name string, viewRules []any, paramPresence map[str
 func checkFilteredPathConsistency(rules []viewRule) error {
 	for i, rule := range rules {
 		if !rule.isReadable() {
+			// TODO: take write-only rules into account once we implement filtering
+			// on write (will need to consider if rules overlap access-wise)
 			continue
 		}
+
 		for _, other := range rules[i+1:] {
 			if other.isReadable() && pathsOverlap(rule.request, other.request) &&
 				!storagePathsHaveConsistentFilters(rule.storage, other.storage) {

--- a/confdb/confdb.go
+++ b/confdb/confdb.go
@@ -576,31 +576,72 @@ func newView(schema *Schema, name string, viewRules []any, paramPresence map[str
 	return view, nil
 }
 
-func getFilterParams(rule viewRule) []string {
-	// filter duplicates
-	params := make(map[string]struct{})
-
-	for _, acc := range rule.storage {
-		for _, param := range acc.FieldFilters() {
-			params[param] = struct{}{}
-		}
-	}
-
-	return keys(params)
-}
-
-// checkFilteredPathConsistency checks that rules with paths covering the same
-// data have the same filters. Otherwise, requests could match both filtered and
-// unfiltered paths, resulting in an inconsistent merged value.
+// checkFilteredPathConsistency checks that readable rules with overlapping
+// request and storage paths have the same filters. Otherwise, requests could
+// match both filtered and unfiltered paths, resulting in an inconsistent merged
+// value.
 func checkFilteredPathConsistency(rules []viewRule) error {
 	for i, rule := range rules {
+		if !rule.isReadable() {
+			continue
+		}
 		for _, other := range rules[i+1:] {
-			if !storagePathsHaveConsistentFilters(rule.storage, other.storage) {
+			if other.isReadable() && pathsOverlap(rule.request, other.request) &&
+				!storagePathsHaveConsistentFilters(rule.storage, other.storage) {
 				return fmt.Errorf("storage paths %q and %q access overlapping data with different field filters", rule.originalStorage, other.originalStorage)
 			}
 		}
 	}
 	return nil
+}
+
+// storagePathsHaveConsistentFilters returns true if two storage paths either
+// cover distinct data or apply the same filters to the data they can both cover.
+func storagePathsHaveConsistentFilters(left, right []Accessor) bool {
+	if !pathsOverlap(left, right) {
+		return true
+	}
+
+	commonLength := int(math.Min(float64(len(left)), float64(len(right))))
+	filtersEqual := true
+	for i := 0; i < commonLength; i++ {
+		leftAcc, rightAcc := left[i], right[i]
+		if !equalFieldFilters(leftAcc.FieldFilters(), rightAcc.FieldFilters()) {
+			filtersEqual = false
+		}
+	}
+
+	if !filtersEqual {
+		return false
+	}
+
+	// if the longer path has any filters beyond its "equivalent prefix" then we
+	// need to fail, as the short one would read unfiltered data
+	longer := left
+	if len(right) > len(left) {
+		longer = right
+	}
+	for _, acc := range longer[commonLength:] {
+		if len(acc.FieldFilters()) != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// pathsOverlap reports whether two paths can cover the same data. A path that
+// is a prefix of the other overlaps it.
+func pathsOverlap[T Accessor](left, right []T) bool {
+	minLen := int(math.Min(float64(len(left)), float64(len(right))))
+	for i := 0; i < minLen; i++ {
+		leftAcc, rightAcc := left[i], right[i]
+		if accessorContainerType(leftAcc) != accessorContainerType(rightAcc) ||
+			(!isPlaceholderAccessor(leftAcc) && !isPlaceholderAccessor(rightAcc) &&
+				leftAcc.Name() != rightAcc.Name()) {
+			return false
+		}
+	}
+	return true
 }
 
 func equalFieldFilters(a, b map[string]string) bool {
@@ -630,40 +671,17 @@ func isPlaceholderAccessor(acc Accessor) bool {
 	return acc.Type() == KeyPlaceholderType || acc.Type() == IndexPlaceholderType
 }
 
-// storagePathsHaveConsistentFilters reports whether two storage paths either
-// cover distinct data or apply the same filters to the data they can both cover.
-func storagePathsHaveConsistentFilters(left, right []Accessor) bool {
-	commonLength := int(math.Min(float64(len(left)), float64(len(right))))
-	filtersEqual := true
-	for i := 0; i < commonLength; i++ {
-		leftAcc, rightAcc := left[i], right[i]
-		if accessorContainerType(leftAcc) != accessorContainerType(rightAcc) ||
-			(!isPlaceholderAccessor(leftAcc) && !isPlaceholderAccessor(rightAcc) && leftAcc.Name() != rightAcc.Name()) {
-			// The paths diverge, so any earlier filter difference applies to
-			// distinct data and does not make the paths inconsistent.
-			return true
-		}
-		if !equalFieldFilters(leftAcc.FieldFilters(), rightAcc.FieldFilters()) {
-			filtersEqual = false
+func getFilterParams(rule viewRule) []string {
+	// filter duplicates
+	params := make(map[string]struct{})
+
+	for _, acc := range rule.storage {
+		for _, param := range acc.FieldFilters() {
+			params[param] = struct{}{}
 		}
 	}
 
-	if !filtersEqual {
-		return false
-	}
-
-	// if the longer path has any filters beyond its "equivalent prefix" then we
-	// need to fail, as the short one would read unfiltered data
-	longer := left
-	if len(right) > len(left) {
-		longer = right
-	}
-	for _, acc := range longer[commonLength:] {
-		if len(acc.FieldFilters()) != 0 {
-			return false
-		}
-	}
-	return true
+	return keys(params)
 }
 
 // TODO:GOVERSION: use maps.Keys once on go 1.23

--- a/confdb/confdb_test.go
+++ b/confdb/confdb_test.go
@@ -4290,148 +4290,6 @@ func (*viewSuite) TestFieldFilterPathMismatch(c *C) {
 	c.Assert(err.Error(), Equals, `cannot define view "foo": field filters can only be applied to maps but schema at foo[{m}][.bar={bar}] expects bool`)
 }
 
-func (*viewSuite) TestOverlappingStoragePathsRequireMatchingFieldFilters(c *C) {
-	type testcase struct {
-		rules []any
-		err   string
-	}
-
-	tcs := []testcase{
-		{
-			rules: []any{
-				map[string]any{"request": "plain", "storage": "foo.bar"},
-				map[string]any{"request": "filtered", "storage": "foo.baz[.kind={kind}]"},
-			},
-		},
-		{
-			rules: []any{
-				map[string]any{"request": "filtered.{key}", "storage": "foo.{key}[.kind={kind}]"},
-				map[string]any{"request": "plain", "storage": "foo.bar"},
-			},
-			err: `storage paths "foo.{key}[.kind={kind}]" and "foo.bar" access overlapping data with different field filters`,
-		},
-		{
-			rules: []any{
-				map[string]any{"request": "filtered.{key}", "storage": "foo.{key}[.kind={kind}].name"},
-				map[string]any{"request": "plain", "storage": "foo"},
-			},
-			err: `storage paths "foo.{key}[.kind={kind}].name" and "foo" access overlapping data with different field filters`,
-		},
-		{
-			rules: []any{
-				map[string]any{"request": "filtered.{key}", "storage": "foo.{key}[.kind={kind}]"},
-				map[string]any{"request": "other.{key}", "storage": "foo.{key}[.kind={other}]"},
-			},
-			err: `storage paths "foo.{key}[.kind={kind}]" and "foo.{key}[.kind={other}]" access overlapping data with different field filters`,
-		},
-		{
-			rules: []any{
-				map[string]any{"request": "filtered", "storage": "foo[.kind={kind}].bar"},
-				map[string]any{"request": "other", "storage": "foo.bar[.kind={kind}]"},
-			},
-			err: `storage paths "foo[.kind={kind}].bar" and "foo.bar[.kind={kind}]" access overlapping data with different field filters`,
-		},
-		{
-			rules: []any{
-				map[string]any{"request": "filtered", "storage": "foo[.kind={kind}].bar"},
-				map[string]any{"request": "other", "storage": "foo[.kind={other}].baz"},
-			},
-		},
-		{
-			rules: []any{
-				map[string]any{"request": "filtered.{key}", "storage": "foo.{key}[.kind={kind}]", "access": "write"},
-				map[string]any{"request": "plain", "storage": "foo.bar", "access": "read"},
-			},
-			err: `storage paths "foo.{key}[.kind={kind}]" and "foo.bar" access overlapping data with different field filters`,
-		},
-		{
-			rules: []any{
-				map[string]any{"request": "filtered.{key}", "storage": "foo.{key}[.kind={kind}]"},
-				map[string]any{"request": "plain", "storage": "foo.bar[.kind={kind}]"},
-			},
-		},
-		{
-			rules: []any{
-				map[string]any{"request": "filtered.{key}", "storage": "foo.{key}[.kind={kind}]"},
-				map[string]any{"request": "plain", "storage": "foo.bar[.kind={kind}].baz"},
-			},
-		},
-		{
-			rules: []any{
-				map[string]any{"request": "filtered.{key}", "storage": "foo.{key}.{key}[.kind={kind}]"},
-				map[string]any{"request": "plain", "storage": "foo.bar.baz"},
-			},
-			err: `storage paths "foo.{key}.{key}[.kind={kind}]" and "foo.bar.baz" access overlapping data with different field filters`,
-		},
-		{
-			rules: []any{
-				map[string]any{"request": "filtered.{key}", "storage": "foo.{key}.{key}[.kind={kind}]"},
-				map[string]any{"request": "plain", "storage": "foo.bar.bar"},
-			},
-			err: `storage paths "foo.{key}.{key}[.kind={kind}]" and "foo.bar.bar" access overlapping data with different field filters`,
-		},
-		{
-			rules: []any{
-				map[string]any{"request": "filtered.{key}", "storage": "foo.{key}.{key}[.kind={kind}]"},
-				map[string]any{"request": "plain.{other}", "storage": "foo.{other}.{other}"},
-			},
-			err: `storage paths "foo.{key}.{key}[.kind={kind}]" and "foo.{other}.{other}" access overlapping data with different field filters`,
-		},
-		{
-			rules: []any{
-				map[string]any{"request": "filtered[{n}]", "storage": "foo[{n}][.kind={kind}]"},
-				map[string]any{"request": "plain", "storage": "foo[0]"},
-			},
-			err: `storage paths "foo[{n}][.kind={kind}]" and "foo[0]" access overlapping data with different field filters`,
-		},
-		{
-			rules: []any{
-				map[string]any{"request": "filtered", "storage": "foo[0][.kind={kind}]"},
-				map[string]any{"request": "plain", "storage": "foo[00]"},
-			},
-			err: `storage paths "foo[0][.kind={kind}]" and "foo[00]" access overlapping data with different field filters`,
-		},
-		{
-			rules: []any{
-				map[string]any{"request": "filtered.{key}", "storage": "foo.{key}[.kind={kind}]"},
-				map[string]any{"request": "list[{n}]", "storage": "foo[{n}]"},
-			},
-		},
-		{
-			rules: []any{
-				map[string]any{"request": "filtered.{key}", "storage": "foo.{key}[.kind={kind}][.type={other}]"},
-				map[string]any{"request": "plain", "storage": "foo.bar[.type={other}][.kind={kind}]"},
-			},
-		},
-		{
-			rules: []any{
-				map[string]any{"request": "filtered.{key}", "storage": "foo.{key}[.kind={kind}][.type={other}]"},
-				map[string]any{"request": "plain", "storage": "foo.bar[.kind={other}][.type={kind}]"},
-			},
-			err: `storage paths "foo.{key}[.kind={kind}][.type={other}]" and "foo.bar[.kind={other}][.type={kind}]" access overlapping data with different field filters`,
-		},
-	}
-
-	for i, tc := range tcs {
-		views := map[string]any{
-			"foo": map[string]any{
-				"parameters": map[string]any{
-					"kind":  map[string]any{},
-					"other": map[string]any{},
-				},
-				"rules": tc.rules,
-			},
-		}
-		_, err := confdb.NewSchema("acc", "confdb", views, confdb.NewJSONSchema())
-		cmt := Commentf("testcase %d/%d", i+1, len(tcs))
-		if tc.err == "" {
-			c.Assert(err, IsNil, cmt)
-		} else {
-			c.Assert(err, ErrorMatches, regexp.QuoteMeta(`cannot define view "foo": `+tc.err), cmt)
-		}
-	}
-}
-
 func (*viewSuite) TestContentStoragePathsRequireMatchingFieldFilters(c *C) {
 	views := func(parentStorage, childStorage string) map[string]any {
 		return map[string]any{
@@ -4452,6 +4310,199 @@ func (*viewSuite) TestContentStoragePathsRequireMatchingFieldFilters(c *C) {
 
 	_, err = confdb.NewSchema("acc", "confdb", views("foo[.kind={kind}]", "bar"), confdb.NewJSONSchema())
 	c.Assert(err, IsNil)
+}
+
+func (*viewSuite) TestMismatchedFiltersRejectedWhenRequestAndStoragePathsOverlap(c *C) {
+	_, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"foo": map[string]any{
+			"parameters": map[string]any{"kind": map[string]any{}},
+			"rules": []any{
+				map[string]any{
+					"request": "results.{group}.{item}",
+					"storage": "shared.{group}.{item}[.kind={kind}]",
+				},
+				map[string]any{
+					"request": "results.all.{item}",
+					"storage": "shared.all.{item}",
+				},
+			},
+		},
+	}, confdb.NewJSONSchema())
+	c.Assert(err, ErrorMatches, `cannot define view "foo": storage paths "shared.\{group\}.\{item\}\[.kind=\{kind\}\]" and "shared.all.\{item\}" access overlapping data with different field filters`)
+}
+
+func (*viewSuite) TestMismatchedFiltersAllowedWhenRequestPathsDiverge(c *C) {
+	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
+		"foo": map[string]any{
+			"parameters": map[string]any{"kind": map[string]any{}},
+			"rules": []any{
+				map[string]any{
+					"request": "results.filtered.{item}",
+					"storage": "shared.{item}[.kind={kind}]",
+				},
+				map[string]any{
+					"request": "results.all.{item}",
+					"storage": "shared.{item}",
+				},
+			},
+		},
+	}, confdb.NewJSONSchema())
+	c.Assert(err, IsNil)
+
+	bag := confdb.NewJSONDatabag()
+	err = bag.Set(parsePath(c, "shared"), map[string]any{
+		"a": map[string]any{"kind": "wanted", "value": "A"},
+		"b": map[string]any{"kind": "other", "value": "B"},
+	})
+	c.Assert(err, IsNil)
+
+	value, err := schema.View("foo").Get(bag, "results", map[string]any{"kind": "wanted"}, confdb.AdminAccess)
+	c.Assert(err, IsNil)
+	c.Assert(value, DeepEquals, map[string]any{
+		"filtered": map[string]any{
+			"a": map[string]any{"kind": "wanted", "value": "A"},
+		},
+		"all": map[string]any{
+			"a": map[string]any{"kind": "wanted", "value": "A"},
+			"b": map[string]any{"kind": "other", "value": "B"},
+		},
+	})
+}
+
+func (*viewSuite) TestFieldFilterConstraints(c *C) {
+	type testcase struct {
+		name  string
+		rules []any
+		err   string
+	}
+
+	tcs := []testcase{
+		{
+			name: "filtered child storage path overlaps unfiltered parent",
+			rules: []any{
+				map[string]any{"request": "filtered.{key}", "storage": "foo.{key}[.kind={kind}].name"},
+				map[string]any{"request": "filtered", "storage": "foo"},
+			},
+			err: `storage paths "foo.{key}[.kind={kind}].name" and "foo" access overlapping data with different field filters`,
+		},
+		{
+			name: "same storage path uses different filter parameters",
+			rules: []any{
+				map[string]any{"request": "filtered.left.{key}", "storage": "foo.{key}[.kind={kind}]"},
+				map[string]any{"request": "filtered.{key}", "storage": "foo.{key}[.kind={other}]"},
+			},
+			err: `storage paths "foo.{key}[.kind={kind}]" and "foo.{key}[.kind={other}]" access overlapping data with different field filters`,
+		},
+		{
+			name: "same storage data is filtered at different levels",
+			rules: []any{
+				map[string]any{"request": "filtered.value", "storage": "foo[.kind={kind}].bar"},
+				map[string]any{"request": "filtered", "storage": "foo.bar[.kind={kind}]"},
+			},
+			err: `storage paths "foo[.kind={kind}].bar" and "foo.bar[.kind={kind}]" access overlapping data with different field filters`,
+		},
+		{
+			name: "storage paths diverge after different filters",
+			rules: []any{
+				map[string]any{"request": "filtered", "storage": "foo[.kind={kind}].bar"},
+				map[string]any{"request": "filtered.other", "storage": "foo[.kind={other}].baz"},
+			},
+		},
+		{
+			name: "filter consistency excludes first write-only rule",
+			rules: []any{
+				map[string]any{"request": "filtered.{key}", "storage": "foo.{key}[.kind={kind}]", "access": "write"},
+				map[string]any{"request": "filtered.bar", "storage": "foo.bar", "access": "read"},
+			},
+		},
+		{
+			name: "filter consistency excludes second write-only rule",
+			rules: []any{
+				map[string]any{"request": "filtered.bar", "storage": "foo.bar", "access": "read"},
+				map[string]any{"request": "filtered.{key}", "storage": "foo.{key}[.kind={kind}]", "access": "write"},
+			},
+		},
+		{
+			name: "placeholder and literal storage paths use matching filters",
+			rules: []any{
+				map[string]any{"request": "filtered.{key}", "storage": "foo.{key}[.kind={kind}]"},
+				map[string]any{"request": "filtered.bar", "storage": "foo.bar[.kind={kind}]"},
+			},
+		},
+		{
+			name: "repeated placeholder overlaps different literal values",
+			rules: []any{
+				map[string]any{"request": "filtered.{key}", "storage": "foo.{key}.{key}[.kind={kind}]"},
+				map[string]any{"request": "filtered.bar", "storage": "foo.bar.baz"},
+			},
+			err: `storage paths "foo.{key}.{key}[.kind={kind}]" and "foo.bar.baz" access overlapping data with different field filters`,
+		},
+		{
+			name: "differently named repeated placeholders overlap",
+			rules: []any{
+				map[string]any{"request": "filtered.{key}", "storage": "foo.{key}.{key}[.kind={kind}]"},
+				map[string]any{"request": "filtered.{other}", "storage": "foo.{other}.{other}"},
+			},
+			err: `storage paths "foo.{key}.{key}[.kind={kind}]" and "foo.{other}.{other}" access overlapping data with different field filters`,
+		},
+		{
+			name: "storage index placeholder overlaps literal index",
+			rules: []any{
+				map[string]any{"request": "filtered[{n}]", "storage": "foo[{n}][.kind={kind}]"},
+				map[string]any{"request": "filtered", "storage": "foo[0]"},
+			},
+			err: `storage paths "foo[{n}][.kind={kind}]" and "foo[0]" access overlapping data with different field filters`,
+		},
+		{
+			name: "equivalent literal storage indexes overlap",
+			rules: []any{
+				map[string]any{"request": "filtered.value", "storage": "foo[0][.kind={kind}]"},
+				map[string]any{"request": "filtered", "storage": "foo[00]"},
+			},
+			err: `storage paths "foo[0][.kind={kind}]" and "foo[00]" access overlapping data with different field filters`,
+		},
+		{
+			name: "map and list storage paths do not overlap",
+			rules: []any{
+				map[string]any{"request": "result.{key}", "storage": "foo.{key}[.kind={kind}]"},
+				map[string]any{"request": "result.items[{n}]", "storage": "foo[{n}]"},
+			},
+		},
+		{
+			name: "equivalent filters can be declared in different order",
+			rules: []any{
+				map[string]any{"request": "filtered.{key}", "storage": "foo.{key}[.kind={kind}][.type={other}]"},
+				map[string]any{"request": "filtered.bar", "storage": "foo.bar[.type={other}][.kind={kind}]"},
+			},
+		},
+		{
+			name: "same filter fields use swapped parameters",
+			rules: []any{
+				map[string]any{"request": "filtered.{key}", "storage": "foo.{key}[.kind={kind}][.type={other}]"},
+				map[string]any{"request": "filtered.bar", "storage": "foo.bar[.kind={other}][.type={kind}]"},
+			},
+			err: `storage paths "foo.{key}[.kind={kind}][.type={other}]" and "foo.bar[.kind={other}][.type={kind}]" access overlapping data with different field filters`,
+		},
+	}
+
+	for i, tc := range tcs {
+		views := map[string]any{
+			"foo": map[string]any{
+				"parameters": map[string]any{
+					"kind":  map[string]any{},
+					"other": map[string]any{},
+				},
+				"rules": tc.rules,
+			},
+		}
+		_, err := confdb.NewSchema("acc", "confdb", views, confdb.NewJSONSchema())
+		cmt := Commentf("testcase %d/%d: %s", i+1, len(tcs), tc.name)
+		if tc.err == "" {
+			c.Assert(err, IsNil, cmt)
+		} else {
+			c.Assert(err, ErrorMatches, regexp.QuoteMeta(`cannot define view "foo": `+tc.err), cmt)
+		}
+	}
 }
 
 func (*viewSuite) TestFieldFilteringBasic(c *C) {

--- a/confdb/confdb_test.go
+++ b/confdb/confdb_test.go
@@ -720,7 +720,7 @@ func (s *viewSuite) TestViewCheckAllConstraintsAreUsed(c *C) {
 			},
 			rules: []any{
 				map[string]any{"request": "foo.{bar}", "storage": "foo.{bar}[.field={baz}]"},
-				map[string]any{"request": "foo.foo.{ggg}", "storage": "foo.foo.{ggg}"},
+				map[string]any{"request": "foo.foo.{ggg}", "storage": "other.foo.{ggg}"},
 				map[string]any{"request": "xyz.{bar}.abc[{pqr}]", "storage": "xyz.{bar}.abc[{pqr}][.field={uvw}]"},
 			},
 			requests:    []string{"foo", "xyz.xyz"},
@@ -4290,6 +4290,170 @@ func (*viewSuite) TestFieldFilterPathMismatch(c *C) {
 	c.Assert(err.Error(), Equals, `cannot define view "foo": field filters can only be applied to maps but schema at foo[{m}][.bar={bar}] expects bool`)
 }
 
+func (*viewSuite) TestOverlappingStoragePathsRequireMatchingFieldFilters(c *C) {
+	type testcase struct {
+		rules []any
+		err   string
+	}
+
+	tcs := []testcase{
+		{
+			rules: []any{
+				map[string]any{"request": "plain", "storage": "foo.bar"},
+				map[string]any{"request": "filtered", "storage": "foo.baz[.kind={kind}]"},
+			},
+		},
+		{
+			rules: []any{
+				map[string]any{"request": "filtered.{key}", "storage": "foo.{key}[.kind={kind}]"},
+				map[string]any{"request": "plain", "storage": "foo.bar"},
+			},
+			err: `storage paths "foo.{key}[.kind={kind}]" and "foo.bar" access overlapping data with different field filters`,
+		},
+		{
+			rules: []any{
+				map[string]any{"request": "filtered.{key}", "storage": "foo.{key}[.kind={kind}].name"},
+				map[string]any{"request": "plain", "storage": "foo"},
+			},
+			err: `storage paths "foo.{key}[.kind={kind}].name" and "foo" access overlapping data with different field filters`,
+		},
+		{
+			rules: []any{
+				map[string]any{"request": "filtered.{key}", "storage": "foo.{key}[.kind={kind}]"},
+				map[string]any{"request": "other.{key}", "storage": "foo.{key}[.kind={other}]"},
+			},
+			err: `storage paths "foo.{key}[.kind={kind}]" and "foo.{key}[.kind={other}]" access overlapping data with different field filters`,
+		},
+		{
+			rules: []any{
+				map[string]any{"request": "filtered", "storage": "foo[.kind={kind}].bar"},
+				map[string]any{"request": "other", "storage": "foo.bar[.kind={kind}]"},
+			},
+			err: `storage paths "foo[.kind={kind}].bar" and "foo.bar[.kind={kind}]" access overlapping data with different field filters`,
+		},
+		{
+			rules: []any{
+				map[string]any{"request": "filtered", "storage": "foo[.kind={kind}].bar"},
+				map[string]any{"request": "other", "storage": "foo[.kind={other}].baz"},
+			},
+		},
+		{
+			rules: []any{
+				map[string]any{"request": "filtered.{key}", "storage": "foo.{key}[.kind={kind}]", "access": "write"},
+				map[string]any{"request": "plain", "storage": "foo.bar", "access": "read"},
+			},
+			err: `storage paths "foo.{key}[.kind={kind}]" and "foo.bar" access overlapping data with different field filters`,
+		},
+		{
+			rules: []any{
+				map[string]any{"request": "filtered.{key}", "storage": "foo.{key}[.kind={kind}]"},
+				map[string]any{"request": "plain", "storage": "foo.bar[.kind={kind}]"},
+			},
+		},
+		{
+			rules: []any{
+				map[string]any{"request": "filtered.{key}", "storage": "foo.{key}[.kind={kind}]"},
+				map[string]any{"request": "plain", "storage": "foo.bar[.kind={kind}].baz"},
+			},
+		},
+		{
+			rules: []any{
+				map[string]any{"request": "filtered.{key}", "storage": "foo.{key}.{key}[.kind={kind}]"},
+				map[string]any{"request": "plain", "storage": "foo.bar.baz"},
+			},
+			err: `storage paths "foo.{key}.{key}[.kind={kind}]" and "foo.bar.baz" access overlapping data with different field filters`,
+		},
+		{
+			rules: []any{
+				map[string]any{"request": "filtered.{key}", "storage": "foo.{key}.{key}[.kind={kind}]"},
+				map[string]any{"request": "plain", "storage": "foo.bar.bar"},
+			},
+			err: `storage paths "foo.{key}.{key}[.kind={kind}]" and "foo.bar.bar" access overlapping data with different field filters`,
+		},
+		{
+			rules: []any{
+				map[string]any{"request": "filtered.{key}", "storage": "foo.{key}.{key}[.kind={kind}]"},
+				map[string]any{"request": "plain.{other}", "storage": "foo.{other}.{other}"},
+			},
+			err: `storage paths "foo.{key}.{key}[.kind={kind}]" and "foo.{other}.{other}" access overlapping data with different field filters`,
+		},
+		{
+			rules: []any{
+				map[string]any{"request": "filtered[{n}]", "storage": "foo[{n}][.kind={kind}]"},
+				map[string]any{"request": "plain", "storage": "foo[0]"},
+			},
+			err: `storage paths "foo[{n}][.kind={kind}]" and "foo[0]" access overlapping data with different field filters`,
+		},
+		{
+			rules: []any{
+				map[string]any{"request": "filtered", "storage": "foo[0][.kind={kind}]"},
+				map[string]any{"request": "plain", "storage": "foo[00]"},
+			},
+			err: `storage paths "foo[0][.kind={kind}]" and "foo[00]" access overlapping data with different field filters`,
+		},
+		{
+			rules: []any{
+				map[string]any{"request": "filtered.{key}", "storage": "foo.{key}[.kind={kind}]"},
+				map[string]any{"request": "list[{n}]", "storage": "foo[{n}]"},
+			},
+		},
+		{
+			rules: []any{
+				map[string]any{"request": "filtered.{key}", "storage": "foo.{key}[.kind={kind}][.type={other}]"},
+				map[string]any{"request": "plain", "storage": "foo.bar[.type={other}][.kind={kind}]"},
+			},
+		},
+		{
+			rules: []any{
+				map[string]any{"request": "filtered.{key}", "storage": "foo.{key}[.kind={kind}][.type={other}]"},
+				map[string]any{"request": "plain", "storage": "foo.bar[.kind={other}][.type={kind}]"},
+			},
+			err: `storage paths "foo.{key}[.kind={kind}][.type={other}]" and "foo.bar[.kind={other}][.type={kind}]" access overlapping data with different field filters`,
+		},
+	}
+
+	for i, tc := range tcs {
+		views := map[string]any{
+			"foo": map[string]any{
+				"parameters": map[string]any{
+					"kind":  map[string]any{},
+					"other": map[string]any{},
+				},
+				"rules": tc.rules,
+			},
+		}
+		_, err := confdb.NewSchema("acc", "confdb", views, confdb.NewJSONSchema())
+		cmt := Commentf("testcase %d/%d", i+1, len(tcs))
+		if tc.err == "" {
+			c.Assert(err, IsNil, cmt)
+		} else {
+			c.Assert(err, ErrorMatches, regexp.QuoteMeta(`cannot define view "foo": `+tc.err), cmt)
+		}
+	}
+}
+
+func (*viewSuite) TestContentStoragePathsRequireMatchingFieldFilters(c *C) {
+	views := func(parentStorage, childStorage string) map[string]any {
+		return map[string]any{
+			"foo": map[string]any{
+				"parameters": map[string]any{"kind": map[string]any{}},
+				"rules": []any{
+					map[string]any{
+						"request": "foo", "storage": parentStorage,
+						"content": []any{map[string]any{"storage": childStorage}},
+					},
+				},
+			},
+		}
+	}
+
+	_, err := confdb.NewSchema("acc", "confdb", views("foo", "bar[.kind={kind}]"), confdb.NewJSONSchema())
+	c.Assert(err, ErrorMatches, `cannot define view "foo": storage paths "foo" and "foo.bar\[.kind=\{kind\}\]" access overlapping data with different field filters`)
+
+	_, err = confdb.NewSchema("acc", "confdb", views("foo[.kind={kind}]", "bar"), confdb.NewJSONSchema())
+	c.Assert(err, IsNil)
+}
+
 func (*viewSuite) TestFieldFilteringBasic(c *C) {
 	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
 		"foo": map[string]any{
@@ -4352,13 +4516,19 @@ func (*viewSuite) TestFieldFilteringBasic(c *C) {
 
 func (*viewSuite) TestFieldFilteringManyLevels(c *C) {
 	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
-		"foo": map[string]any{
+		"users": map[string]any{
 			"parameters": map[string]any{
 				"age": map[string]any{},
-				"toy": map[string]any{},
 			},
 			"rules": []any{
 				map[string]any{"request": "users.{user}.{pet}", "storage": "{user}[.age={age}].{pet}"},
+			},
+		},
+		"pet-kinds": map[string]any{
+			"parameters": map[string]any{
+				"toy": map[string]any{},
+			},
+			"rules": []any{
 				map[string]any{"request": "pet-kinds.{user}.{pet}", "storage": "{user}.{pet}[.toy={toy}].kind"},
 			},
 		},
@@ -4393,7 +4563,7 @@ func (*viewSuite) TestFieldFilteringManyLevels(c *C) {
 	})
 	c.Assert(err, IsNil)
 
-	view := schema.View("foo")
+	view := schema.View("users")
 	val, err := view.Get(bag, "users", map[string]any{"age": "21"}, confdb.AdminAccess)
 	c.Assert(err, IsNil)
 	c.Assert(val, DeepEquals,
@@ -4414,6 +4584,7 @@ func (*viewSuite) TestFieldFilteringManyLevels(c *C) {
 			},
 		})
 
+	view = schema.View("pet-kinds")
 	val, err = view.Get(bag, "pet-kinds", map[string]any{"toy": "ball"}, confdb.AdminAccess)
 	c.Assert(err, IsNil)
 	c.Assert(val, DeepEquals,
@@ -4429,12 +4600,19 @@ func (*viewSuite) TestFieldFilteringManyLevels(c *C) {
 
 func (*viewSuite) TestFilteringNoData(c *C) {
 	schema, err := confdb.NewSchema("acc", "confdb", map[string]any{
-		"foo": map[string]any{
+		"top": map[string]any{
 			"parameters": map[string]any{
 				"field": map[string]any{},
 			},
 			"rules": []any{
 				map[string]any{"request": "{foo}", "storage": "{foo}[.baz={field}]"},
+			},
+		},
+		"nested": map[string]any{
+			"parameters": map[string]any{
+				"field": map[string]any{},
+			},
+			"rules": []any{
 				map[string]any{"request": "a.b.c", "storage": "a.b.c[.d={field}]"},
 			},
 		},
@@ -4443,7 +4621,7 @@ func (*viewSuite) TestFilteringNoData(c *C) {
 
 	bag := confdb.NewJSONDatabag()
 
-	view := schema.View("foo")
+	view := schema.View("top")
 	_, err = view.Get(bag, "", map[string]any{"field": "baz"}, confdb.AdminAccess)
 	c.Assert(err, testutil.ErrorIs, &confdb.NoDataError{})
 
@@ -4462,6 +4640,7 @@ func (*viewSuite) TestFilteringNoData(c *C) {
 	c.Assert(err, IsNil)
 
 	// pruning several nested levels down
+	view = schema.View("nested")
 	val, err = view.Get(bag, "a", map[string]any{"field": "not-there"}, confdb.AdminAccess)
 	c.Assert(val, IsNil)
 	c.Assert(err, testutil.ErrorIs, &confdb.NoDataError{})
@@ -5277,4 +5456,43 @@ func FuzzParsePathIntoAccessorsAllowPlaceholders(f *testing.F) {
 func FuzzParsePathIntoAccessorsAllowPlaceholdersForbidIndexes(f *testing.F) {
 	o := confdb.ParseOptions{AllowPlaceholders: true, ForbidIndexes: true}
 	fuzzHelper(f, o, "foo[.status={status}].{bar}.baz.foo[{n}][{m}]")
+}
+
+func (s *viewSuite) TestSetNestedContentWithFieldFilter(c *C) {
+	views := map[string]any{
+		"foo": map[string]any{
+			"parameters": map[string]any{"account-id": map[string]any{}},
+			"rules": []any{
+				map[string]any{"request": "sets[{n}]", "storage": "v1.sets[{n}][.account-id={account-id}]",
+					"content": []any{
+						map[string]any{"storage": "validation-set"},
+						map[string]any{"storage": "account-id"},
+						map[string]any{"storage": "snaps", "content": []any{
+							map[string]any{"storage": "name"},
+						}},
+						map[string]any{"storage": "mode"},
+					},
+				},
+			},
+		},
+	}
+	schema, err := confdb.NewSchema("acc", "foo", views, confdb.NewJSONSchema())
+	c.Assert(err, IsNil)
+
+	bag := confdb.NewJSONDatabag()
+	view := schema.View("foo")
+
+	err = view.Set(bag, "sets", []any{
+		map[string]any{"validation-set": "my-set", "account-id": "ABC123", "snaps": map[string]any{"name": "my-snap"}, "mode": "enforce"},
+		map[string]any{"validation-set": "other-set", "account-id": "FOO321", "snaps": map[string]any{"name": "snapd"}, "mode": "monitor"},
+	})
+	c.Assert(err, IsNil)
+
+	val, err := view.Get(bag, "sets", map[string]any{"account-id": "ABC123"}, confdb.AdminAccess)
+	c.Assert(err, IsNil)
+	c.Assert(val, DeepEquals, []any{map[string]any{"validation-set": "my-set", "account-id": "ABC123", "snaps": map[string]any{"name": "my-snap"}, "mode": "enforce"}})
+
+	val, err = view.Get(bag, "sets", map[string]any{"account-id": "FOO321"}, confdb.AdminAccess)
+	c.Assert(err, IsNil)
+	c.Assert(val, DeepEquals, []any{map[string]any{"validation-set": "other-set", "account-id": "FOO321", "snaps": map[string]any{"name": "snapd"}, "mode": "monitor"}})
 }


### PR DESCRIPTION
Forbid paths that can read the same data from having different filters to avoid reading the data both filtered and unfiltered, resulting in dubious semantics and an impossible merge.
Based on another branch which fixes a few things unrelated to the new constraint being proposed https://github.com/canonical/snapd/pull/17593. The relevant commit is 3caf80ed3ef0f777a78e1542818e60311bf40660