### PR TITLE
tests/main/snapd-snap: handle debian-sid which disallows vendored apparmor

### DIFF
--- a/tests/main/snapd-snap/task.yaml
+++ b/tests/main/snapd-snap/task.yaml
@@ -144,6 +144,8 @@ execute: |
     # shellcheck source=tests/lib/systems.sh
     . "$TESTSLIB/systems.sh"
 
+    libexecdir="$(os.paths libexec-dir)"
+
     # only run the destructive mode variant on xenial
     if ! os.query is-jammy && [ "$SNAPCRAFT_BUILD_ENVIRONMENT" = "host" ]; then
         echo "Skipping destructive mode build on non-jammy"
@@ -238,6 +240,11 @@ execute: |
     # see LP:2024637
     if grep -q /var/lib/snapd/apparmor/ /lib/apparmor/functions; then
        echo "SKIP: cannot test builtin apparmor parser until /lib/apparmor/functions stops loading the snapd profiles"
+       exit 0
+    fi
+
+    if grep -q 'SNAPD_APPARMOR_REEXEC=0' "$libexecdir"/snapd/info; then
+       echo "SKIP: apparmor reexec disabled by distro packaging"
        exit 0
     fi
 


### PR DESCRIPTION
The snapd packaging on Debian Sid disables internal apparmor which is needed by the 2nd half of the test.

Related: [SNAPDENG-37495](https://warthogs.atlassian.net/browse/SNAPDENG-37495)

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?


[SNAPDENG-37495]: https://warthogs.atlassian.net/browse/SNAPDENG-37495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

unskip:
- garden:debian-sid-64:tests/main/snapd-snap