### PR TITLE
kernel: discover and set up directories found under the mounted kernel modules tree

### DIFF
--- a/kernel/kernel_drivers.go
+++ b/kernel/kernel_drivers.go
@@ -139,24 +139,59 @@ func createModulesSubtree(kMntPts MountPoints, kernelTree, kversion string, comp
 		return err
 	}
 
-	// Copy modinfo files from the snap (these might be overwritten if
-	// kernel-modules components are installed).
-	modsGlob := kMntPts.UnderCurrentPath("modules", kversion, "modules.*")
-	modFiles, err := filepath.Glob(modsGlob)
+	// Discover the content of the modules directory of the current mount
+	// once. The target mount may not exist yet (for example, during
+	// install/preseed the target is the future runtime mount), so it must
+	// not be read for discovery; only the current mount is guaranteed to be
+	// available. The discovered directory names are reused for both the
+	// current and the target symlinks (see createKernelModulesSymlinks).
+	currentMntDir := kMntPts.UnderCurrentPath("modules", kversion)
+	entries, err := os.ReadDir(currentMntDir)
 	if err != nil {
-		// Should not really happen (only possible error is ErrBadPattern)
 		return err
 	}
-	for _, orig := range modFiles {
-		target := filepath.Join(modsRoot, filepath.Base(orig))
-		if err := osutil.CopyFile(orig, target, osutil.CopyFlagDefault); err != nil {
-			return err
+
+	// Copy modinfo files (modules.*) from the snap; these might be
+	// overwritten if kernel-modules components are installed. Collect the
+	// directories found under the modules tree, to be set up as symlinks
+	// below, skipping the ones that are either reserved or not useful in
+	// the drivers tree.
+
+	modDirs := map[string]bool{
+		"kernel": true, // the default kernel drivers tree
+		"vdso":   true, // the expected vdso libs tree
+	}
+	for _, e := range entries {
+		switch {
+		case e.Type().IsRegular():
+			// Copy modprobe artifacts (modules.*).
+			if strings.HasPrefix(e.Name(), "modules.") {
+				target := filepath.Join(modsRoot, e.Name())
+				if err := osutil.CopyFile(filepath.Join(currentMntDir, e.Name()), target, osutil.CopyFlagDefault); err != nil {
+					return err
+				}
+			}
+		case e.IsDir():
+			n := e.Name()
+			switch n {
+			// Drop and log entries which would cause conflicts. We are
+			// expecting those to have raised an error during snap pack.
+			case "updates":
+				// Reserved for modules coming from kernel-modules
+				// components; do not link it back to the kernel snap.
+				logger.Debugf("skipping directory %q in the kernel modules tree, reserved for components", n)
+			case "build":
+				// Typically a symlink to the kernel source tree; not
+				// useful in the drivers tree.
+				logger.Debugf("skipping directory %q in the kernel modules tree, typically the kernel source tree", n)
+			default:
+				modDirs[n] = true
+			}
 		}
 	}
 
 	// Symbolic links to current mount of the kernel snap
-	currentMntDir := kMntPts.UnderCurrentPath("modules", kversion)
-	if err := createKernelModulesSymlinks(modsRoot, currentMntDir); err != nil {
+	if err := createKernelModulesSymlinks(modsRoot, currentMntDir, modDirs); err != nil {
 		return err
 	}
 
@@ -165,10 +200,12 @@ func createModulesSubtree(kMntPts MountPoints, kernelTree, kversion string, comp
 		return err
 	}
 
-	// Change symlinks to target ones when needed
+	// Change symlinks to target ones when needed. Reuse the directories
+	// discovered from the current mount: the target mount holds the same
+	// kernel snap content, just mounted at a different path.
 	if !kMntPts.CurrentEqualsTarget() {
 		targetMntDir := kMntPts.UnderTargetPath("modules", kversion)
-		if err := createKernelModulesSymlinks(modsRoot, targetMntDir); err != nil {
+		if err := createKernelModulesSymlinks(modsRoot, targetMntDir, modDirs); err != nil {
 			return err
 		}
 	}
@@ -176,59 +213,13 @@ func createModulesSubtree(kMntPts MountPoints, kernelTree, kversion string, comp
 	return nil
 }
 
-func createKernelModulesSymlinks(modsRoot, kMntPt string) error {
-	pathPair := func(dirname string) (linkName, to string) {
-		return filepath.Join(modsRoot, dirname), filepath.Join(kMntPt, dirname)
-	}
+func createKernelModulesSymlinks(modsRoot, kMntPt string, dirs map[string]bool) error {
+	for d := range dirs {
+		lname := filepath.Join(modsRoot, d)
+		to := filepath.Join(kMntPt, d)
 
-	setupOne := func(to, lname string) error {
-		// We might be re-creating, first remove
 		os.Remove(lname)
-		return osSymlink(to, lname)
-	}
-
-	// we are certain that the following directories are always present in the
-	// modules tree
-	expected := map[string]bool{
-		"kernel": true, // typical kernel modules tree
-		"vdso":   true, // virtual DSO
-	}
-	for d := range expected {
-		lname, to := pathPair(d)
-		if err := setupOne(to, lname); err != nil {
-			return err
-		}
-	}
-
-	disallowedNames := map[string]bool{
-		"updates": true, // conflicts with tree set up for modules from components
-		"build":   true, // typically points/contains the kernel source tree
-	}
-
-	// but also set up any additional directories that are found in the kernel tree
-	// TODO: maybe make this smarter and set them up only if *.ko are found inside?
-	entries, err := os.ReadDir(kMntPt)
-	if err != nil {
-		return err
-	}
-	for _, e := range entries {
-		// ignore top level files, those are modprobe artifacts
-		if e.Type().IsRegular() {
-			continue
-		}
-		if expected[e.Name()] {
-			// we've seen this one already
-			continue
-		}
-
-		if disallowedNames[e.Name()] {
-			logger.Noticef("skipping conflicting directory named %q in the kernel modules tree", e.Name())
-			continue
-		}
-
-		lname, to := pathPair(e.Name())
-
-		if err := setupOne(to, lname); err != nil {
+		if err := osSymlink(to, lname); err != nil {
 			return err
 		}
 	}

--- a/kernel/kernel_drivers.go
+++ b/kernel/kernel_drivers.go
@@ -170,7 +170,7 @@ func createModulesSubtree(kMntPts MountPoints, kernelTree, kversion string, comp
 	}
 	for _, e := range entries {
 		switch {
-		case e.Type().IsRegular():
+		case !e.Type().IsDir(): // files & symlinks
 			// Copy modprobe artifacts (modules.*).
 			if strings.HasPrefix(e.Name(), "modules.") {
 				target := filepath.Join(modsRoot, e.Name())

--- a/kernel/kernel_drivers.go
+++ b/kernel/kernel_drivers.go
@@ -177,12 +177,58 @@ func createModulesSubtree(kMntPts MountPoints, kernelTree, kversion string, comp
 }
 
 func createKernelModulesSymlinks(modsRoot, kMntPt string) error {
-	for _, d := range []string{"kernel", "vdso"} {
-		lname := filepath.Join(modsRoot, d)
-		to := filepath.Join(kMntPt, d)
+	pathPair := func(dirname string) (linkName, to string) {
+		return filepath.Join(modsRoot, dirname), filepath.Join(kMntPt, dirname)
+	}
+
+	setupOne := func(to, lname string) error {
 		// We might be re-creating, first remove
 		os.Remove(lname)
-		if err := osSymlink(to, lname); err != nil {
+		return osSymlink(to, lname)
+	}
+
+	// we are certain that the following directories are always present in the
+	// modules tree
+	expected := map[string]bool{
+		"kernel": true, // typical kernel modules tree
+		"vdso":   true, // virtual DSO
+	}
+	for d := range expected {
+		lname, to := pathPair(d)
+		if err := setupOne(to, lname); err != nil {
+			return err
+		}
+	}
+
+	disallowedNames := map[string]bool{
+		"updates": true, // conflicts with tree set up for modules from components
+		"build":   true, // typically points/contains the kernel source tree
+	}
+
+	// but also set up any additional directories that are found in the kernel tree
+	// TODO: maybe make this smarter and set them up only if *.ko are found inside?
+	entries, err := os.ReadDir(kMntPt)
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		// ignore top level files, those are modprobe artifacts
+		if e.Type().IsRegular() {
+			continue
+		}
+		if expected[e.Name()] {
+			// we've seen this one already
+			continue
+		}
+
+		if disallowedNames[e.Name()] {
+			logger.Noticef("skipping conflicting directory named %q in the kernel modules tree", e.Name())
+			continue
+		}
+
+		lname, to := pathPair(e.Name())
+
+		if err := setupOne(to, lname); err != nil {
 			return err
 		}
 	}

--- a/kernel/kernel_drivers.go
+++ b/kernel/kernel_drivers.go
@@ -152,10 +152,17 @@ func createModulesSubtree(kMntPts MountPoints, kernelTree, kversion string, comp
 	}
 
 	// Copy modinfo files (modules.*) from the snap; these might be
-	// overwritten if kernel-modules components are installed. Collect the
-	// directories found under the modules tree, to be set up as symlinks
-	// below, skipping the ones that are either reserved or not useful in
-	// the drivers tree.
+	// overwritten if kernel-modules components are installed (see
+	// setupModsFromComp, which runs depmod). The files are copied from the
+	// current mount only: their content is path-independent (module paths
+	// are relative to the modules directory), so there is no need to
+	// re-copy them for the target mount, which in any case may not exist
+	// yet during install/preseed. Only the symlinks are re-pointed to the
+	// target mount below, since they encode absolute mount paths.
+	//
+	// While scanning the modules tree, also collect the directories found
+	// under it, to be set up as symlinks below, skipping the ones that are
+	// either reserved or not useful in the drivers tree.
 
 	modDirs := map[string]bool{
 		"kernel": true, // the default kernel drivers tree

--- a/kernel/kernel_drivers_test.go
+++ b/kernel/kernel_drivers_test.go
@@ -353,7 +353,7 @@ func (s *kernelDriversTestSuite) TestBuildKernelDriversExtraDirsConflict(c *C) {
 	expected := []expectInode{
 		{"kernel", fs.ModeSymlink, filepath.Join(mountDir, "modules", kversion, "kernel")},
 		{"modules.dep.bin", 0, ""},
-		{"updates", fs.ModeDir, ""}, // a directory, not a symlinks going back to the mounted kernel tree
+		{"updates", fs.ModeDir, ""}, // a directory, not a symlink going back to the mounted kernel tree
 		{"vdso", fs.ModeSymlink, filepath.Join(mountDir, "modules", kversion, "vdso")},
 	}
 

--- a/kernel/kernel_drivers_test.go
+++ b/kernel/kernel_drivers_test.go
@@ -360,6 +360,109 @@ func (s *kernelDriversTestSuite) TestBuildKernelDriversExtraDirsConflict(c *C) {
 	doDirChecks(c, filepath.Join(dirs.SnapdStateDir(dirs.GlobalRootDir), "kernel", "pc-kernel", "1", "lib", "modules", kversion), expected)
 }
 
+// TestBuildKernelDriversOnlyModsWithTargetDir mirrors TestBuildKernelDriversOnlyMods
+// but for the install/preseed flow where the current mount (where the kernel
+// snap content is available now) differs from the target mount (the future
+// runtime mount, which does not exist yet). The created symlinks are expected
+// to point at the target mount and be dangling until the system boots into it.
+func (s *kernelDriversTestSuite) TestBuildKernelDriversOnlyModsWithTargetDir(c *C) {
+	mountDir := filepath.Join(dirs.RunDir, "mnt/tmp-mount")
+	kTargetDir := filepath.Join(dirs.RunDir, "mnt/pc-kernel")
+	kversion := "5.15.0-78-generic"
+	createKernelSnapFilesOnlyModules(c, kversion, mountDir)
+
+	// Build the tree should not fail
+	destDir := kernel.DriversTreeDir(dirs.GlobalRootDir, "pc-kernel", snap.R(1))
+	err := kernel.EnsureKernelDriversTree(
+		kernel.MountPoints{
+			Current: mountDir,
+			Target:  kTargetDir}, nil, destDir,
+		&kernel.KernelDriversTreeOptions{KernelInstall: true})
+	c.Assert(err, IsNil)
+
+	// check created files
+	expected := []expectInode{
+		{"kernel", fs.ModeSymlink, filepath.Join(kTargetDir, "modules", kversion, "kernel")},
+		{"modules.dep.bin", 0, ""},
+		{"updates", fs.ModeDir, ""},
+		{"vdso", fs.ModeSymlink, filepath.Join(kTargetDir, "modules", kversion, "vdso")},
+	}
+
+	doDirChecks(c, filepath.Join(dirs.SnapdStateDir(dirs.GlobalRootDir), "kernel", "pc-kernel", "1", "lib", "modules", kversion), expected)
+}
+
+// TestBuildKernelDriversExtraDirsWithModulesTargetDir mirrors
+// TestBuildKernelDriversExtraDirsWithModules for the install/preseed flow
+// where the target mount does not exist yet.
+func (s *kernelDriversTestSuite) TestBuildKernelDriversExtraDirsWithModulesTargetDir(c *C) {
+	mountDir := filepath.Join(dirs.RunDir, "mnt/tmp-mount")
+	kTargetDir := filepath.Join(dirs.RunDir, "mnt/pc-kernel")
+	kversion := "5.15.0-78-generic"
+	createKernelSnapFilesOnlyModules(c, kversion, mountDir)
+
+	extraModDir := filepath.Join(mountDir, "modules", kversion, "ubuntu")
+	c.Assert(os.MkdirAll(extraModDir, 0755), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(extraModDir, "zfs.ko"), []byte("content"), 0644), IsNil)
+
+	// Build the tree should not fail
+	destDir := kernel.DriversTreeDir(dirs.GlobalRootDir, "pc-kernel", snap.R(1))
+	err := kernel.EnsureKernelDriversTree(
+		kernel.MountPoints{
+			Current: mountDir,
+			Target:  kTargetDir}, nil, destDir,
+		&kernel.KernelDriversTreeOptions{KernelInstall: true})
+	c.Assert(err, IsNil)
+
+	// check created files
+	expected := []expectInode{
+		{"kernel", fs.ModeSymlink, filepath.Join(kTargetDir, "modules", kversion, "kernel")},
+		{"modules.dep.bin", 0, ""},
+		{"ubuntu", fs.ModeSymlink, filepath.Join(kTargetDir, "modules", kversion, "ubuntu")},
+		{"updates", fs.ModeDir, ""},
+		{"vdso", fs.ModeSymlink, filepath.Join(kTargetDir, "modules", kversion, "vdso")},
+	}
+
+	doDirChecks(c, filepath.Join(dirs.SnapdStateDir(dirs.GlobalRootDir), "kernel", "pc-kernel", "1", "lib", "modules", kversion), expected)
+}
+
+// TestBuildKernelDriversExtraDirsConflictTargetDir mirrors
+// TestBuildKernelDriversExtraDirsConflict for the install/preseed flow where
+// the target mount does not exist yet.
+func (s *kernelDriversTestSuite) TestBuildKernelDriversExtraDirsConflictTargetDir(c *C) {
+	mountDir := filepath.Join(dirs.RunDir, "mnt/tmp-mount")
+	kTargetDir := filepath.Join(dirs.RunDir, "mnt/pc-kernel")
+	kversion := "5.15.0-78-generic"
+	createKernelSnapFilesOnlyModules(c, kversion, mountDir)
+
+	// the 'updates' directory conflicts with the name used for extra drivers from components
+	extraModDir := filepath.Join(mountDir, "modules", kversion, "updates")
+	c.Assert(os.MkdirAll(extraModDir, 0755), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(extraModDir, "abc.ko"), nil, 0644), IsNil)
+
+	extraBuildDir := filepath.Join(mountDir, "modules", kversion, "build")
+	c.Assert(os.MkdirAll(extraBuildDir, 0755), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(extraBuildDir, "main.c"), nil, 0644), IsNil)
+
+	// Build the tree should not fail
+	destDir := kernel.DriversTreeDir(dirs.GlobalRootDir, "pc-kernel", snap.R(1))
+	err := kernel.EnsureKernelDriversTree(
+		kernel.MountPoints{
+			Current: mountDir,
+			Target:  kTargetDir}, nil, destDir,
+		&kernel.KernelDriversTreeOptions{KernelInstall: true})
+	c.Assert(err, IsNil)
+
+	// check created files, no symlink to 'updates', or 'build'
+	expected := []expectInode{
+		{"kernel", fs.ModeSymlink, filepath.Join(kTargetDir, "modules", kversion, "kernel")},
+		{"modules.dep.bin", 0, ""},
+		{"updates", fs.ModeDir, ""}, // a directory, not a symlink going back to the mounted kernel tree
+		{"vdso", fs.ModeSymlink, filepath.Join(kTargetDir, "modules", kversion, "vdso")},
+	}
+
+	doDirChecks(c, filepath.Join(dirs.SnapdStateDir(dirs.GlobalRootDir), "kernel", "pc-kernel", "1", "lib", "modules", kversion), expected)
+}
+
 func createKernelSnapFilesOnlyFw(c *C, kdir string) {
 	c.Assert(os.MkdirAll(kdir, 0755), IsNil)
 

--- a/kernel/kernel_drivers_test.go
+++ b/kernel/kernel_drivers_test.go
@@ -293,6 +293,45 @@ func (s *kernelDriversTestSuite) TestBuildKernelDriversOnlyMods(c *C) {
 	doDirChecks(c, filepath.Join(dirs.SnapdStateDir(dirs.GlobalRootDir), "kernel", "pc-kernel", "1", "lib", "modules", kversion), expected)
 }
 
+// TestBuildKernelDriversModinfoSymlink verifies that a modinfo file (modules.*)
+// that is a symlink in the kernel snap is still copied into the drivers tree,
+// following the symlink, just like the previous glob-based copy did.
+func (s *kernelDriversTestSuite) TestBuildKernelDriversModinfoSymlink(c *C) {
+	mountDir := filepath.Join(dirs.RunDir, "mnt/pc-kernel")
+	kversion := "5.15.0-78-generic"
+	createKernelSnapFilesOnlyModules(c, kversion, mountDir)
+
+	// Add a symlinked modinfo entry pointing at the regular modules.dep.bin.
+	modDir := filepath.Join(mountDir, "modules", kversion)
+	c.Assert(os.Symlink("modules.dep.bin", filepath.Join(modDir, "modules.alias")), IsNil)
+
+	// Build the tree should not fail
+	destDir := kernel.DriversTreeDir(dirs.GlobalRootDir, "pc-kernel", snap.R(1))
+	err := kernel.EnsureKernelDriversTree(
+		kernel.MountPoints{
+			Current: mountDir,
+			Target:  mountDir}, nil, destDir,
+		&kernel.KernelDriversTreeOptions{KernelInstall: true})
+	c.Assert(err, IsNil)
+
+	modsRoot := filepath.Join(dirs.SnapdStateDir(dirs.GlobalRootDir), "kernel", "pc-kernel", "1", "lib", "modules", kversion)
+
+	// The regular modinfo file is copied.
+	c.Check(osutil.FileExists(filepath.Join(modsRoot, "modules.dep.bin")), Equals, true)
+
+	// The symlinked modinfo file is copied too (its content is followed),
+	// rather than silently dropped because it is not a regular file.
+	aliasPath := filepath.Join(modsRoot, "modules.alias")
+	c.Check(osutil.FileExists(aliasPath), Equals, true)
+	// CopyFile follows the symlink, so the destination is a regular file
+	// with the same content as the link target.
+	aliasExists, aliasIsReg, err := osutil.RegularFileExists(aliasPath)
+	c.Assert(err, IsNil)
+	c.Check(aliasExists, Equals, true)
+	c.Check(aliasIsReg, Equals, true)
+	c.Check(aliasPath, testutil.FileEquals, []byte{})
+}
+
 func (s *kernelDriversTestSuite) TestBuildKernelDriversExtraDirsWithModules(c *C) {
 	mountDir := filepath.Join(dirs.RunDir, "mnt/pc-kernel")
 	kversion := "5.15.0-78-generic"

--- a/kernel/kernel_drivers_test.go
+++ b/kernel/kernel_drivers_test.go
@@ -164,8 +164,13 @@ type expectInode struct {
 func doDirChecks(c *C, dir string, expected []expectInode) {
 	entries, err := os.ReadDir(dir)
 	c.Assert(err, IsNil)
-	c.Assert(len(entries), Equals, len(expected))
+	c.Check(len(entries), Equals, len(expected))
 	for i, ent := range entries {
+		c.Logf("checking entry: %v", filepath.Join(dir, ent.Name()))
+		if i >= len(expected) {
+			c.Errorf("missing entry for %q", ent.Name())
+			continue
+		}
 		c.Check(ent.Name(), Equals, expected[i].file)
 		c.Check(ent.Type(), Equals, expected[i].fType)
 		if ent.Type() == fs.ModeSymlink {
@@ -277,41 +282,82 @@ func (s *kernelDriversTestSuite) TestBuildKernelDriversOnlyMods(c *C) {
 		&kernel.KernelDriversTreeOptions{KernelInstall: true})
 	c.Assert(err, IsNil)
 
-	// check created file
-	modPath := filepath.Join(dirs.SnapdStateDir(dirs.GlobalRootDir), "kernel", "pc-kernel", "1", "lib", "modules", kversion, "modules.dep.bin")
-	exists, isReg, err := osutil.RegularFileExists(modPath)
-	c.Assert(err, IsNil)
-	c.Check(exists, Equals, true)
-	c.Check(isReg, Equals, true)
+	// check created files
+	expected := []expectInode{
+		{"kernel", fs.ModeSymlink, filepath.Join(mountDir, "modules", kversion, "kernel")},
+		{"modules.dep.bin", 0, ""},
+		{"updates", fs.ModeDir, ""},
+		{"vdso", fs.ModeSymlink, filepath.Join(mountDir, "modules", kversion, "vdso")},
+	}
+
+	doDirChecks(c, filepath.Join(dirs.SnapdStateDir(dirs.GlobalRootDir), "kernel", "pc-kernel", "1", "lib", "modules", kversion), expected)
 }
 
-func (s *kernelDriversTestSuite) TestBuildKernelDriversOnlyModsWithTargetDir(c *C) {
-	mountDir := filepath.Join(dirs.RunDir, "mnt/tmp-mount")
-	kTargetDir := filepath.Join(dirs.RunDir, "mnt/pc-kernel")
+func (s *kernelDriversTestSuite) TestBuildKernelDriversExtraDirsWithModules(c *C) {
+	mountDir := filepath.Join(dirs.RunDir, "mnt/pc-kernel")
 	kversion := "5.15.0-78-generic"
 	createKernelSnapFilesOnlyModules(c, kversion, mountDir)
+
+	extraModDir := filepath.Join(mountDir, "modules", kversion, "ubuntu")
+	c.Assert(os.MkdirAll(extraModDir, 0755), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(extraModDir, "zfs.ko"), []byte("content"), 0644), IsNil)
 
 	// Build the tree should not fail
 	destDir := kernel.DriversTreeDir(dirs.GlobalRootDir, "pc-kernel", snap.R(1))
 	err := kernel.EnsureKernelDriversTree(
 		kernel.MountPoints{
 			Current: mountDir,
-			Target:  kTargetDir}, nil, destDir,
+			Target:  mountDir}, nil, destDir,
 		&kernel.KernelDriversTreeOptions{KernelInstall: true})
 	c.Assert(err, IsNil)
 
-	// check created file
-	modPath := filepath.Join(dirs.SnapdStateDir(dirs.GlobalRootDir), "kernel", "pc-kernel", "1", "lib", "modules", kversion)
-	modDepBinPath := filepath.Join(modPath, "modules.dep.bin")
-	exists, isReg, err := osutil.RegularFileExists(modDepBinPath)
+	// check created files
+	expected := []expectInode{
+		{"kernel", fs.ModeSymlink, filepath.Join(mountDir, "modules", kversion, "kernel")},
+		{"modules.dep.bin", 0, ""},
+		{"ubuntu", fs.ModeSymlink, filepath.Join(mountDir, "modules", kversion, "ubuntu")},
+		{"updates", fs.ModeDir, ""},
+		{"vdso", fs.ModeSymlink, filepath.Join(mountDir, "modules", kversion, "vdso")},
+	}
+
+	doDirChecks(c, filepath.Join(dirs.SnapdStateDir(dirs.GlobalRootDir), "kernel", "pc-kernel", "1", "lib", "modules", kversion), expected)
+
+	// and the extra module content is accessible
+	c.Check(filepath.Join(mountDir, "modules", kversion, "ubuntu", "zfs.ko"), testutil.FileEquals, []byte("content"))
+}
+
+func (s *kernelDriversTestSuite) TestBuildKernelDriversExtraDirsConflict(c *C) {
+	mountDir := filepath.Join(dirs.RunDir, "mnt/pc-kernel")
+	kversion := "5.15.0-78-generic"
+	createKernelSnapFilesOnlyModules(c, kversion, mountDir)
+
+	// the 'updates' directory conflicts with the name used for extra drivers from components
+	extraModDir := filepath.Join(mountDir, "modules", kversion, "updates")
+	c.Assert(os.MkdirAll(extraModDir, 0755), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(extraModDir, "abc.ko"), nil, 0644), IsNil)
+
+	extraBuildDir := filepath.Join(mountDir, "modules", kversion, "build")
+	c.Assert(os.MkdirAll(extraBuildDir, 0755), IsNil)
+	c.Assert(os.WriteFile(filepath.Join(extraBuildDir, "main.c"), nil, 0644), IsNil)
+
+	// Build the tree should not fail
+	destDir := kernel.DriversTreeDir(dirs.GlobalRootDir, "pc-kernel", snap.R(1))
+	err := kernel.EnsureKernelDriversTree(
+		kernel.MountPoints{
+			Current: mountDir,
+			Target:  mountDir}, nil, destDir,
+		&kernel.KernelDriversTreeOptions{KernelInstall: true})
 	c.Assert(err, IsNil)
-	c.Check(exists, Equals, true)
-	c.Check(isReg, Equals, true)
-	// Check symlinks points to final target
-	modsPath := filepath.Join(modPath, "kernel")
-	modsTarget, err := os.Readlink(modsPath)
-	c.Assert(err, IsNil)
-	c.Check(modsTarget, Equals, filepath.Join(kTargetDir, "modules", kversion, "kernel"))
+
+	// check created files, no symlink to 'updates', or 'build'
+	expected := []expectInode{
+		{"kernel", fs.ModeSymlink, filepath.Join(mountDir, "modules", kversion, "kernel")},
+		{"modules.dep.bin", 0, ""},
+		{"updates", fs.ModeDir, ""}, // a directory, not a symlinks going back to the mounted kernel tree
+		{"vdso", fs.ModeSymlink, filepath.Join(mountDir, "modules", kversion, "vdso")},
+	}
+
+	doDirChecks(c, filepath.Join(dirs.SnapdStateDir(dirs.GlobalRootDir), "kernel", "pc-kernel", "1", "lib", "modules", kversion), expected)
 }
 
 func createKernelSnapFilesOnlyFw(c *C, kdir string) {


### PR DESCRIPTION
Set up symlinks for discovered directories found under the mounted
kernel modules tree. This ensures that extra, vendor specific
directories like 'ubuntu' will be picked up.

Skip the entries that would: 1) conflict ("updates") 2) are
pointless ("build").

Related: SNAPDENG-37492