### PR TITLE
tests/main: fix broken logging in classic-snap-confine-unix-inheritance

### DIFF
--- a/tests/main/classic-snap-confine-unix-inheritance/test-snapd-classic-launcher/bin/run
+++ b/tests/main/classic-snap-confine-unix-inheritance/test-snapd-classic-launcher/bin/run
@@ -23,8 +23,7 @@ def main() -> None:
                 sys.stdout.buffer.write(data)
                 sys.stdout.buffer.flush()
         except Exception as exc:
-            println("exception: {}".format(exc), file=os.stderr)
-            pass
+            print("exception: {}".format(exc), file=sys.stderr)
         finally:
             s1.close()
 


### PR DESCRIPTION
Noticed this failing on one of my PRs:

```
File "/snap/test-snapd-classic-launcher/x1/bin/run", line 26, in drain
println("exception: {}".format(exc), file=os.stderr)
NameError: name 'println' is not defined
```

The code was calling `println` which doesn't exist in Python, and passed `file=os.stderr`, but `stderr` is an attribute of `sys`, not `os`.