### PR TITLE
o/devicestate, o/fdestate: mock out hitting real system dbus and fix memfdesecret call in tests

### DIFF
--- a/overlord/devicestate/devicestate_systems_test.go
+++ b/overlord/devicestate/devicestate_systems_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/snapcore/snapd/gadget"
 	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/osutil"
+	"github.com/snapcore/snapd/osutil/keyboard"
 	"github.com/snapcore/snapd/overlord/assertstate"
 	"github.com/snapcore/snapd/overlord/assertstate/assertstatetest"
 	"github.com/snapcore/snapd/overlord/auth"
@@ -1646,6 +1647,10 @@ func (s *deviceMgrSystemsCreateSuite) TestDeviceManagerEnsureTriedRecoverySystem
 	restore = devicestate.SetBootOkRanForCurrentBootID(s.mgr, true)
 	defer restore()
 	devicestate.SetBootRevisionsUpdated(s.mgr, true)
+	restore = devicestate.MockKeyboardCurrentXKBConfig(func() (*keyboard.XKBConfig, error) {
+		return &keyboard.XKBConfig{}, nil
+	})
+	defer restore()
 
 	s.state.Lock()
 	defer s.state.Unlock()

--- a/overlord/fdestate/backend/secret_state_test.go
+++ b/overlord/fdestate/backend/secret_state_test.go
@@ -29,6 +29,7 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/osutil/sys"
 	"github.com/snapcore/snapd/overlord/fdestate/backend"
 	"github.com/snapcore/snapd/strutil"
 	"github.com/snapcore/snapd/systemd/fdstore"
@@ -156,7 +157,7 @@ func (s *secretStateSuite) memfdSecret(flags int) (int, error) {
 		return 0, s.failOn["memfd-secret"]
 	}
 
-	return unix.MemfdSecret(flags)
+	return sys.MemfdSecret(flags)
 }
 
 func (s *secretStateSuite) memfdCreate(name string, flags int) (int, error) {


### PR DESCRIPTION
In launchpad builds on resolute and stonking, the unit tests were talking to the real dbus
```
FAIL: devicestate_systems_test.go:1643: deviceMgrSystemsCreateSuite.TestDeviceManagerEnsureTriedRecoverySystemHybridClassic

devicestate_systems_test.go:1720:
    c.Assert(err, IsNil)
... value *devicestate.ensureError = &devicestate.ensureError{errs:[]error{(*net.OpError)(0x286c448068c0)}} ("devicemgr: dial unix /var/run/dbus/system_bus_socket: connect: no such file or directory")

OOPS: 747 passed, 1 FAILED
--- FAIL: TestDeviceManager (152.68s)
FAIL
FAIL    github.com/snapcore/snapd/overlord/devicestate    152.913s
```

To test the fix, I ran the unit tests with dbus pointing to a dummy
```
sudo --preserve-env=PATH,GOROOT,GOPATH,GOMODCACHE,GOCACHE,GO_BUILD_TAGS,SNAPD_DEBUG,GO_TEST_RACE,SKIP_COVERAGE   unshare --net --mount --propagation private -- bash -c '
    ip link set lo up
    mkdir -p /run/dbus
    mount -t tmpfs -o size=1m,mode=755 tmpfs /run/dbus
    export DBUS_SYSTEM_BUS_ADDRESS=unix:path=/run/dbus/system_bus_socket
    runuser -u "$1" -- ./run-checks --unit
  ' -- "$USER"
```