### PR TITLE
build-aux/snap, mkversion.sh: fix missing map

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -298,8 +298,6 @@ parts:
       fi
       # make sure to set the version we declared in pull
       ./mkversion.sh "$VERSION"
-      # SNAPD_UC_TRACKS is not shipped in distro packages.
-      go run -mod=vendor ./snap/uctrack/info >> data/info
 
       # double check the toolchain
       echo "--- go version $(go version)"

--- a/mkversion.sh
+++ b/mkversion.sh
@@ -152,3 +152,8 @@ VERSION=$v
 SNAPD_APPARMOR_REEXEC=1
 ${fmts}
 EOF
+# SNAPD_UC_TRACKS is not shipped in distro packages. Snapcraft sets
+# CRAFT_PART_BUILD; write into the same file as VERSION.
+if [ -n "${CRAFT_PART_BUILD:-}" ]; then
+    (cd "$GO_GENERATE_BUILDDIR" ; go run $MOD ./snap/uctrack/info) >> "$PKG_BUILDDIR/data/info"
+fi


### PR DESCRIPTION
Fix missing UC tracks map in snapd snap.

Spread failure: the UC tracks map was not successfully added to the map from within the snapcraft.yaml:
```
echo "Check /usr/lib/snapd/info"
test -f squashfs-root/usr/lib/snapd/info
MATCH SNAPD_ASSERTS_FORMATS < squashfs-root/usr/lib/snapd/info
MATCH '^SNAPD_UC_TRACKS=' < squashfs-root/usr/lib/snapd/info
```

This was verified with local snapcraft based build.