### PR TITLE
o/s/tasktest: add task selections and queries

### DIFF
--- a/overlord/snapstate/tasktest/tasktest.go
+++ b/overlord/snapstate/tasktest/tasktest.go
@@ -1,0 +1,342 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package tasktest
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+// ErrNoMatches is returned when a task query matches no tasks.
+var ErrNoMatches = errors.New("task query matched no tasks")
+
+// Selection represents a fixed selection set of tasks. A root Selection will be
+// created by a caller with an initial set of tasks. Each child Selection is a
+// subset of that root Selection.
+type Selection struct {
+	// selected is the set of tasks currently represented by this Selection.
+	selected []*state.Task
+
+	// universe is the full set of tasks from which the root Selection was
+	// created.
+	universe []*state.Task
+	// cache carries universe-derived data shared by the root Selection and all
+	// of its subsets. Cached data must not depend on the currently selected
+	// tasks.
+	cache map[any]any
+	// reachability maps each task to the tasks that transitively depend on it.
+	reachability map[*state.Task]map[*state.Task]bool
+}
+
+// NewSelection creates a new root Selection.
+func NewSelection(tasks []*state.Task) Selection {
+	tasks = append([]*state.Task(nil), tasks...)
+	return Selection{
+		selected:     tasks,
+		universe:     tasks,
+		cache:        make(map[any]any),
+		reachability: reachability(tasks),
+	}
+}
+
+// reachability returns a mapping of each task to the tasks that transitively
+// depend on it.
+func reachability(tasks []*state.Task) map[*state.Task]map[*state.Task]bool {
+	table := make(map[*state.Task]map[*state.Task]bool, len(tasks))
+	for _, task := range tasks {
+		reachable := make(map[*state.Task]bool)
+		stack := append([]*state.Task(nil), task.HaltTasks()...)
+		for len(stack) != 0 {
+			next := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			if next == task {
+				panic(fmt.Sprintf("dependency cycle involving task %s (%s)", task.ID(), task.Kind()))
+			}
+			if reachable[next] {
+				continue
+			}
+
+			reachable[next] = true
+			stack = append(stack, next.HaltTasks()...)
+		}
+		table[task] = reachable
+	}
+	return table
+}
+
+// Filter returns a new Selection containing the tasks for which predicate
+// returns true. The new Selection shares the same universe, cache, and
+// reachability table as the original Selection.
+func (s Selection) Filter(predicate func(*state.Task) (bool, error)) (Selection, error) {
+	selected := make([]*state.Task, 0, len(s.selected))
+	for _, task := range s.selected {
+		matches, err := predicate(task)
+		if err != nil {
+			return Selection{}, err
+		}
+		if matches {
+			selected = append(selected, task)
+		}
+	}
+
+	return Selection{
+		selected:     selected,
+		universe:     s.universe,
+		cache:        s.cache,
+		reachability: s.reachability,
+	}, nil
+}
+
+// Tasks returns the tasks that this Selection represents.
+func (s Selection) Tasks() []*state.Task {
+	return append([]*state.Task(nil), s.selected...)
+}
+
+// Querier is the interface that enables a type to narrow a Selection via
+// Selection.Select and Selection.SelectErr.
+type Querier interface {
+	// Query returns a Selection that is a subset of the given Selection. The
+	// concrete type that implements Querier should carry data that is used to
+	// filter the tasks in the given Selection.
+	Query(Selection) (Selection, error)
+}
+
+// Select wraps Selection.SelectErr and panics if an error is returned.
+func (s Selection) Select(query Querier) Selection {
+	selection, err := s.SelectErr(query)
+	if err != nil {
+		panic(err)
+	}
+	return selection
+}
+
+// SelectErr applies a Querier to this Selection.
+func (s Selection) SelectErr(query Querier) (Selection, error) {
+	return query.Query(s)
+}
+
+// Heads returns the subset of tasks in this Selection that are not blocked by
+// any other tasks in this Selection.
+func (s Selection) Heads() Selection {
+	heads, err := s.Filter(func(candidate *state.Task) (bool, error) {
+		for _, other := range s.selected {
+			if s.reachability[other][candidate] {
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+	if err != nil {
+		panic(fmt.Sprintf("infallible call failed: %v", err))
+	}
+	return heads
+}
+
+// Tails returns the subset of tasks in this Selection that do not block any
+// other tasks in this Selection.
+func (s Selection) Tails() Selection {
+	tails, err := s.Filter(func(candidate *state.Task) (bool, error) {
+		for _, other := range s.selected {
+			if s.reachability[candidate][other] {
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+	if err != nil {
+		panic(fmt.Sprintf("infallible call failed: %v", err))
+	}
+	return tails
+}
+
+// Predecessors returns the subset of tasks in this Selection that block at
+// least one task in the given Selection.
+func (s Selection) Predecessors(of Selection) Selection {
+	predecessors, err := s.Filter(func(candidate *state.Task) (bool, error) {
+		for _, task := range of.selected {
+			if s.reachability[candidate][task] {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		panic(fmt.Sprintf("infallible call failed: %v", err))
+	}
+	return predecessors
+}
+
+// Successors returns the subset of tasks in this Selection that are blocked by
+// at least one task in the given Selection.
+func (s Selection) Successors(of Selection) Selection {
+	successors, err := s.Filter(func(candidate *state.Task) (bool, error) {
+		for _, task := range of.selected {
+			if of.reachability[task][candidate] {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		panic(fmt.Sprintf("infallible call failed: %v", err))
+	}
+	return successors
+}
+
+// TaskQuery is an implementation of Querier that enables selecting a set of tasks
+// based on generic properties of the task itself.
+type TaskQuery struct {
+	// Kind is the kind of tasks that are matched by this query.
+	Kind string
+	// Fields contains the fields that must be carried by tasks that match this
+	// query. Explicitly nil fields must be absent.
+	Fields map[string]any
+	// Cardinality defines how many tasks this query should match. A cardinality
+	// of zero indicates that exactly one task should be matched. A cardinality
+	// of -1 indicates that any non-zero number of tasks should be matched.
+	Cardinality int
+}
+
+// Kind creates a TaskQuery that matches tasks of the given kind.
+func Kind(kind string) TaskQuery {
+	return TaskQuery{Kind: kind}
+}
+
+// WithField limits the query to tasks whose given field matches the expected
+// value. A nil value only matches tasks that do not have the field.
+func (q TaskQuery) WithField(field string, expected any) TaskQuery {
+	fields := make(map[string]any, len(q.Fields)+1)
+	for f, value := range q.Fields {
+		fields[f] = value
+	}
+	fields[field] = expected
+	q.Fields = fields
+
+	return q
+}
+
+// TaskCount returns a query that expects the given number of matching tasks.
+func (q TaskQuery) TaskCount(count int) TaskQuery {
+	q.Cardinality = count
+	return q
+}
+
+// All returns a query that accepts any non-zero number of matching tasks.
+func (q TaskQuery) All() TaskQuery {
+	q.Cardinality = -1
+	return q
+}
+
+// Query returns a subset of the tasks in the given Selection that match this
+// TaskQuery.
+//
+// Returns ErrNoMatches if the query does not match any tasks in the Selection.
+func (q TaskQuery) Query(selection Selection) (Selection, error) {
+	if q.Cardinality < -1 {
+		return Selection{}, fmt.Errorf("invalid task query cardinality %d", q.Cardinality)
+	}
+
+	// send fields through a JSON round trip to ensure that comparisons work on
+	// all types
+	fields, err := normalizeFields(q.Fields)
+	if err != nil {
+		return Selection{}, err
+	}
+
+	matches, err := selection.Filter(func(task *state.Task) (bool, error) {
+		if q.Kind != "" && task.Kind() != q.Kind {
+			return false, nil
+		}
+
+		for field, expected := range fields {
+			if expected == nil {
+				if task.Has(field) {
+					return false, nil
+				}
+				continue
+			}
+
+			if !task.Has(field) {
+				return false, nil
+			}
+
+			expectedType := reflect.TypeOf(expected)
+			actual := reflect.New(expectedType)
+			if err := task.Get(field, actual.Interface()); err != nil {
+				return false, fmt.Errorf("cannot read field %q of task %s (%s) as %v", field, task.ID(), task.Kind(), expectedType)
+			}
+
+			if !reflect.DeepEqual(actual.Elem().Interface(), expected) {
+				return false, nil
+			}
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		return Selection{}, err
+	}
+
+	if len(matches.selected) == 0 {
+		return Selection{}, ErrNoMatches
+	}
+
+	// by default, we treat an unset cardinality as expecting exactly one task.
+	cardinality := q.Cardinality
+	if cardinality == 0 {
+		cardinality = 1
+	}
+
+	// cardinality of -1 implies any non-zero number of tasks is expected
+	if cardinality != -1 && len(matches.selected) != cardinality {
+		return Selection{}, fmt.Errorf("task query matched %d tasks, expected %d", len(matches.selected), cardinality)
+	}
+
+	return matches, nil
+}
+
+// normalizeFields returns a copy of inputs with values normalized through a
+// JSON round trip, as task fields are when stored in state.
+func normalizeFields(inputs map[string]any) (map[string]any, error) {
+	fields := make(map[string]any, len(inputs))
+	for field, expected := range inputs {
+		if expected == nil {
+			fields[field] = nil
+			continue
+		}
+
+		data, err := json.Marshal(expected)
+		if err != nil {
+			return nil, err
+		}
+
+		normalized := reflect.New(reflect.TypeOf(expected))
+		if err := json.Unmarshal(data, normalized.Interface()); err != nil {
+			return nil, err
+		}
+
+		fields[field] = normalized.Elem().Interface()
+	}
+	return fields, nil
+}

--- a/overlord/snapstate/tasktest/tasktest_test.go
+++ b/overlord/snapstate/tasktest/tasktest_test.go
@@ -1,0 +1,323 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package tasktest_test
+
+import (
+	"testing"
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/overlord/snapstate/tasktest"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+type selectionSuite struct{}
+
+var _ = Suite(&selectionSuite{})
+
+func Test(t *testing.T) { TestingT(t) }
+
+func (s *selectionSuite) TestSelectionTasks(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	first := st.NewTask("first", "...")
+	second := st.NewTask("second", "...")
+	input := []*state.Task{first, second}
+
+	selection := tasktest.NewSelection(input)
+
+	c.Check(selection.Tasks(), DeepEquals, input)
+}
+
+func (s *selectionSuite) TestSelectionFilter(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	first := st.NewTask("keep", "...")
+	second := st.NewTask("drop", "...")
+	third := st.NewTask("keep", "...")
+	selection := tasktest.NewSelection([]*state.Task{first, second, third})
+
+	filtered, err := selection.Filter(func(task *state.Task) (bool, error) {
+		return task.Kind() == "keep", nil
+	})
+	c.Assert(err, IsNil)
+	c.Check(filtered.Tasks(), DeepEquals, []*state.Task{first, third})
+}
+
+func (s *selectionSuite) TestSelectionHeadsAndTails(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	first := st.NewTask("first", "...")
+	second := st.NewTask("second", "...")
+	third := st.NewTask("third", "...")
+	unrelated := st.NewTask("unrelated", "...")
+	second.WaitFor(first)
+	third.WaitFor(second)
+
+	selection := tasktest.NewSelection([]*state.Task{third, unrelated, first, second})
+	c.Check(selection.Heads().Tasks(), DeepEquals, []*state.Task{unrelated, first})
+	c.Check(selection.Tails().Tasks(), DeepEquals, []*state.Task{third, unrelated})
+
+	// dependencies through tasks outside the selection still count.
+	endpoints, err := selection.Filter(func(task *state.Task) (bool, error) {
+		return task == first || task == third, nil
+	})
+	c.Assert(err, IsNil)
+	c.Check(endpoints.Heads().Tasks(), DeepEquals, []*state.Task{first})
+	c.Check(endpoints.Tails().Tasks(), DeepEquals, []*state.Task{third})
+
+	// a selected task can be both a head and a tail despite external dependencies.
+	middle := selection.Select(tasktest.Kind("second"))
+	c.Check(middle.Heads().Tasks(), DeepEquals, []*state.Task{second})
+	c.Check(middle.Tails().Tasks(), DeepEquals, []*state.Task{second})
+}
+
+func (s *selectionSuite) TestSelectionCycle(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	first := st.NewTask("first", "...")
+	second := st.NewTask("second", "...")
+	first.WaitFor(second)
+	second.WaitFor(first)
+
+	c.Check(func() {
+		tasktest.NewSelection([]*state.Task{first, second})
+	}, PanicMatches, `dependency cycle involving task 1 \(first\)`)
+}
+
+func (s *selectionSuite) TestSelectionPredecessors(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	first := st.NewTask("first", "...")
+	second := st.NewTask("second", "...")
+	third := st.NewTask("third", "...")
+	fourth := st.NewTask("fourth", "...")
+	unrelated := st.NewTask("unrelated", "...")
+	second.WaitFor(first)
+	third.WaitFor(second)
+	third.WaitFor(first)
+	fourth.WaitFor(third)
+
+	selection := tasktest.NewSelection([]*state.Task{fourth, second, unrelated, third, first})
+	target := tasktest.NewSelection([]*state.Task{third})
+
+	c.Check(selection.Predecessors(target).Tasks(), DeepEquals, []*state.Task{second, first})
+}
+
+func (s *selectionSuite) TestSelectionSuccessors(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	first := st.NewTask("first", "...")
+	second := st.NewTask("second", "...")
+	third := st.NewTask("third", "...")
+	fourth := st.NewTask("fourth", "...")
+	unrelated := st.NewTask("unrelated", "...")
+	second.WaitFor(first)
+	third.WaitFor(second)
+	fourth.WaitFor(third)
+
+	selection := tasktest.NewSelection([]*state.Task{fourth, second, unrelated, third, first})
+	source := tasktest.NewSelection([]*state.Task{second})
+	c.Check(selection.Successors(source).Tasks(), DeepEquals, []*state.Task{fourth, third})
+
+	sources := tasktest.NewSelection([]*state.Task{unrelated, second})
+	c.Check(selection.Successors(sources).Tasks(), DeepEquals, []*state.Task{fourth, third})
+
+	limited := tasktest.NewSelection([]*state.Task{fourth, unrelated})
+	c.Check(limited.Successors(source).Tasks(), DeepEquals, []*state.Task{fourth})
+}
+
+type taskQuerySuite struct{}
+
+var _ = Suite(&taskQuerySuite{})
+
+func (s *taskQuerySuite) TestKind(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	first := st.NewTask("match", "...")
+	second := st.NewTask("other", "...")
+	selection := tasktest.NewSelection([]*state.Task{first, second})
+
+	selected := selection.Select(tasktest.Kind("match"))
+	c.Check(selected.Tasks(), DeepEquals, []*state.Task{first})
+}
+
+func (s *taskQuerySuite) TestWithField(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	first := st.NewTask("task", "...")
+	first.Set("channel", "stable")
+	first.Set("enabled", true)
+
+	second := st.NewTask("task", "...")
+	second.Set("channel", "candidate")
+	second.Set("enabled", true)
+
+	third := st.NewTask("task", "...")
+	third.Set("channel", "stable")
+
+	selection := tasktest.NewSelection([]*state.Task{first, second, third})
+
+	query := tasktest.Kind("task").WithField("channel", "stable")
+	c.Check(selection.Select(query.WithField("enabled", true)).Tasks(), DeepEquals, []*state.Task{first})
+	c.Check(selection.Select(query.WithField("enabled", nil)).Tasks(), DeepEquals, []*state.Task{third})
+	c.Check(query.Fields, DeepEquals, map[string]any{"channel": "stable"})
+	c.Check(selection.Select(query.All()).Tasks(), DeepEquals, []*state.Task{first, third})
+}
+
+func (s *taskQuerySuite) TestWithTimeField(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	task := st.NewTask("task", "...")
+
+	// storing a time.Time as JSON removes its monotonic clock data. this test
+	// ensures that the query properly handles data that has been mutated during
+	// JSON serialization.
+	lastRefreshTime := time.Now()
+	task.Set("old-last-refresh-time", lastRefreshTime)
+
+	selection := tasktest.NewSelection([]*state.Task{task})
+
+	selected := selection.Select(tasktest.Kind("task").WithField("old-last-refresh-time", lastRefreshTime))
+	c.Check(selected.Tasks(), DeepEquals, []*state.Task{task})
+}
+
+func (s *taskQuerySuite) TestAbsentField(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	withoutField := st.NewTask("task", "...")
+
+	withField := st.NewTask("task", "...")
+	withField.Set("marker", true)
+
+	selection := tasktest.NewSelection([]*state.Task{withoutField, withField})
+
+	selected := selection.Select(tasktest.Kind("task").WithField("marker", nil))
+	c.Check(selected.Tasks(), DeepEquals, []*state.Task{withoutField})
+}
+
+func (s *taskQuerySuite) TestDefaultCardinality(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	first := st.NewTask("match", "...")
+	second := st.NewTask("match", "...")
+	selection := tasktest.NewSelection([]*state.Task{first, second})
+
+	_, err := selection.SelectErr(tasktest.TaskQuery{})
+	c.Check(err, ErrorMatches, "task query matched 2 tasks, expected 1")
+}
+
+func (s *taskQuerySuite) TestTaskCount(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	first := st.NewTask("match", "...")
+	second := st.NewTask("match", "...")
+	third := st.NewTask("other", "...")
+	selection := tasktest.NewSelection([]*state.Task{first, second, third})
+
+	selected := selection.Select(tasktest.Kind("match").TaskCount(2))
+	c.Check(selected.Tasks(), DeepEquals, []*state.Task{first, second})
+
+	_, err := selection.SelectErr(tasktest.Kind("match").TaskCount(3))
+	c.Check(err, ErrorMatches, "task query matched 2 tasks, expected 3")
+}
+
+func (s *taskQuerySuite) TestAll(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	first := st.NewTask("match", "...")
+	second := st.NewTask("match", "...")
+	selection := tasktest.NewSelection([]*state.Task{first, second})
+
+	selected := selection.Select(tasktest.Kind("match").All())
+	c.Check(selected.Tasks(), DeepEquals, []*state.Task{first, second})
+}
+
+func (s *taskQuerySuite) TestNoMatches(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	task := st.NewTask("other", "...")
+	selection := tasktest.NewSelection([]*state.Task{task})
+
+	for _, query := range []tasktest.TaskQuery{
+		tasktest.Kind("match"),
+		tasktest.Kind("match").All(),
+		tasktest.Kind("match").TaskCount(2),
+	} {
+		_, err := selection.SelectErr(query)
+		c.Check(err, Equals, tasktest.ErrNoMatches)
+	}
+}
+
+func (s *taskQuerySuite) TestTaskCountInvalid(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	task := st.NewTask("match", "...")
+	selection := tasktest.NewSelection([]*state.Task{task})
+
+	_, err := selection.SelectErr(tasktest.Kind("match").TaskCount(-2))
+	c.Check(err, ErrorMatches, "invalid task query cardinality -2")
+}
+
+func (s *taskQuerySuite) TestFieldDecodeError(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	task := st.NewTask("task", "...")
+	task.Set("field", "value")
+	selection := tasktest.NewSelection([]*state.Task{task})
+
+	_, err := selection.SelectErr(tasktest.TaskQuery{
+		Fields: map[string]any{"field": 1},
+	})
+	c.Check(err, ErrorMatches, `cannot read field "field" of task 1 \(task\) as int`)
+}


### PR DESCRIPTION
Split out from https://github.com/canonical/snapd/pull/17562. This contains the first layer, which enables querying tasks based on generic qualities about tasks themselves.