### PR TITLE
o/snapstate: apply track-redirects when planning snapd store ops

### DIFF
--- a/asserts/model.go
+++ b/asserts/model.go
@@ -706,6 +706,18 @@ func (mod *Model) Base() string {
 	return mod.HeaderString("base")
 }
 
+// BaseCoreVersion returns the version of the model's core boot base snap
+// (e.g. "core18" -> 18, "core" -> 16). An omitted base on a non-classic
+// model is treated as 16 (the core snap). It returns an error for a
+// non-core base.
+func (mod *Model) BaseCoreVersion() (int, error) {
+	base := mod.Base()
+	if !mod.Classic() && base == "" {
+		return 16, nil
+	}
+	return naming.CoreVersion(base)
+}
+
 // BaseSnap returns the details of the base snap the model uses.
 func (mod *Model) BaseSnap() *ModelSnap {
 	return mod.baseSnap

--- a/asserts/model_test.go
+++ b/asserts/model_test.go
@@ -301,6 +301,9 @@ func (mods *modelSuite) TestDecodeOK(c *C) {
 	c.Check(model.Kernel(), Equals, "baz-linux")
 	c.Check(model.KernelTrack(), Equals, "")
 	c.Check(model.Base(), Equals, "core18")
+	coreVersion, err := model.BaseCoreVersion()
+	c.Assert(err, IsNil)
+	c.Check(coreVersion, Equals, 18)
 	c.Check(model.BaseSnap(), DeepEquals, &asserts.ModelSnap{
 		Name:     "core18",
 		SnapType: "base",
@@ -351,6 +354,57 @@ func (mods *modelSuite) TestDecodeOK(c *C) {
 	c.Check(model.SystemUserAuthority(), HasLen, 0)
 	c.Check(model.SerialAuthority(), DeepEquals, []string{"brand-id1", "generic"})
 	c.Check(model.PreseedAuthority(), DeepEquals, []string{"brand-id1", "preseed-delegate"})
+}
+
+func (mods *modelSuite) TestBaseCoreVersion(c *C) {
+	for _, tc := range []struct {
+		comment string
+		encoded string
+		version int
+		err     string
+	}{
+		{
+			comment: "core18",
+			encoded: strings.Replace(modelExample, "TSLINE", mods.tsLine, 1),
+			version: 18,
+		},
+		{
+			comment: "core",
+			encoded: strings.Replace(strings.Replace(modelExample, "TSLINE", mods.tsLine, 1), "base: core18\n", "base: core\n", 1),
+			version: 16,
+		},
+		{
+			comment: "core16",
+			encoded: strings.Replace(strings.Replace(modelExample, "TSLINE", mods.tsLine, 1), "base: core18\n", "base: core16\n", 1),
+			version: 16,
+		},
+		{
+			comment: "core without base header",
+			encoded: strings.Replace(strings.Replace(modelExample, "TSLINE", mods.tsLine, 1), "base: core18\n", "", 1),
+			version: 16,
+		},
+		{
+			comment: "core20",
+			encoded: strings.Replace(strings.Replace(core20ModelExample, "TSLINE", mods.tsLine, 1), "OTHER", "", 1),
+			version: 20,
+		},
+		{
+			comment: "classic without base",
+			encoded: strings.Replace(classicModelExample, "TSLINE", mods.tsLine, 1),
+			err:     "not a core base",
+		},
+	} {
+		a, err := asserts.Decode([]byte(tc.encoded))
+		c.Assert(err, IsNil, Commentf("%s", tc.comment))
+		model := a.(*asserts.Model)
+		v, err := model.BaseCoreVersion()
+		if tc.err != "" {
+			c.Check(err, ErrorMatches, tc.err, Commentf("%s", tc.comment))
+			continue
+		}
+		c.Assert(err, IsNil, Commentf("%s", tc.comment))
+		c.Check(v, Equals, tc.version, Commentf("%s", tc.comment))
+	}
 }
 
 func (mods *modelSuite) TestDecodeStoreIsOptional(c *C) {

--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -19,6 +19,17 @@ grade: stable
 license: GPL-3.0
 confinement: strict
 
+# Empty until a UC version is onboarded. Onboarding is a yaml edit here, e.g.:
+#   track-redirects:
+#     ubuntu-core:
+#       "18":
+#         latest: "18"
+#         fips-updates: "18-fips"
+# TODO: add track-redirects to the store/review-tools snap.yaml schema;
+# passthrough only skips Snapcraft validation.
+passthrough:
+  track-redirects: {}
+
 # Note that this snap is unusual in that it has no "apps" section.
 #
 # It is started via re-exec on classic systems and via special
@@ -298,8 +309,6 @@ parts:
       fi
       # make sure to set the version we declared in pull
       ./mkversion.sh "$VERSION"
-      # SNAPD_UC_TRACKS is not shipped in distro packages.
-      go run -mod=vendor ./snap/uctrack/info >> data/info
 
       # double check the toolchain
       echo "--- go version $(go version)"

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -2017,7 +2017,7 @@ func (s *snapsSuite) TestPostSnapBadChannel(c *check.C) {
 
 func (s *snapsSuite) TestPostSnap(c *check.C) {
 	checkOpts := func(opts *snapstate.RevisionOptions) {
-		// no channel in -> no channel out
+		// no channel in the request
 		c.Check(opts.Channel, check.Equals, "")
 	}
 	summary, systemRestartImmediate := s.testPostSnap(c, "", checkOpts)
@@ -2027,11 +2027,20 @@ func (s *snapsSuite) TestPostSnap(c *check.C) {
 
 func (s *snapsSuite) TestPostSnapWithChannel(c *check.C) {
 	checkOpts := func(opts *snapstate.RevisionOptions) {
-		// channel in -> channel out
 		c.Check(opts.Channel, check.Equals, "xyzzy")
 	}
 	summary, systemRestartImmediate := s.testPostSnap(c, `"channel": "xyzzy"`, checkOpts)
 	c.Check(summary, check.Equals, `Install "foo" snap from "xyzzy" channel`)
+	c.Check(systemRestartImmediate, check.Equals, false)
+}
+
+func (s *snapsSuite) TestPostSnapWithRevision(c *check.C) {
+	checkOpts := func(opts *snapstate.RevisionOptions) {
+		c.Check(opts.Channel, check.Equals, "")
+		c.Check(opts.Revision, check.Equals, snap.R(42))
+	}
+	summary, systemRestartImmediate := s.testPostSnap(c, `"revision": 42`, checkOpts)
+	c.Check(summary, check.Equals, `Install "foo" snap`)
 	c.Check(systemRestartImmediate, check.Equals, false)
 }
 

--- a/daemon/api_themes_test.go
+++ b/daemon/api_themes_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/snapcore/snapd/daemon"
 	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/devicestate"
 	"github.com/snapcore/snapd/overlord/hookstate"
 	"github.com/snapcore/snapd/overlord/ifacestate"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -373,6 +374,10 @@ func (s *themesSuite) TestThemesCmdGet(c *C) {
 
 func (s *themesSuite) daemonWithIfaceMgr(c *C) *daemon.Daemon {
 	d := s.apiBaseSuite.daemonWithOverlordMock()
+
+	oldDeviceCtx := snapstate.DeviceCtx
+	s.AddCleanup(func() { snapstate.DeviceCtx = oldDeviceCtx })
+	snapstate.DeviceCtx = devicestate.DeviceCtx
 
 	overlord := d.Overlord()
 	st := overlord.State()

--- a/overlord/snapstate/backend_test.go
+++ b/overlord/snapstate/backend_test.go
@@ -218,6 +218,18 @@ type fakeStore struct {
 	state           *state.State
 	seenPrivacyKeys map[string]bool
 
+	// redirectChannel maps a requested action channel to RedirectChannel
+	// on the SnapActionResult. Used to test UC-track remap rejection.
+	redirectChannel map[string]string
+
+	// noUpdateOnChannel makes a refresh on that channel return
+	// ErrNoUpdateAvailable (UC-track localOnly tests).
+	noUpdateOnChannel map[string]bool
+
+	// revisionNotAvailableOnChannel makes install/download/refresh on that
+	// channel return RevisionNotAvailableError.
+	revisionNotAvailableOnChannel map[string]bool
+
 	// snapResourcesFn is called for each snap that gets returned by SnapAction,
 	// it should return the resources that the snap should have.
 	snapResourcesFn func(*snap.Info) []store.SnapResourceResult
@@ -343,6 +355,9 @@ func (f *fakeStore) snap(spec snapSpec) (*snap.Info, error) {
 
 	if spec.Name == "snap-unknown" {
 		return nil, store.ErrSnapNotFound
+	}
+	if f.revisionNotAvailableOnChannel[spec.Channel] {
+		return nil, &store.RevisionNotAvailableError{}
 	}
 
 	info := &snap.Info{
@@ -674,6 +689,13 @@ func (f *fakeStore) lookupRefresh(cand refreshCand) (*snap.Info, error) {
 		info.Version = ""
 	}
 
+	if f.noUpdateOnChannel[cand.channel] {
+		return nil, store.ErrNoUpdateAvailable
+	}
+	if f.revisionNotAvailableOnChannel[cand.channel] {
+		return nil, &store.RevisionNotAvailableError{}
+	}
+
 	if name == "outdated-consumer" {
 		info.Plugs = map[string]*snap.PlugInfo{
 			"content-plug": {
@@ -864,6 +886,9 @@ func (f *fakeStore) SnapAction(ctx context.Context, currentSnaps []*store.Curren
 			if strings.HasSuffix(snapName, "-with-default-track") && strutil.ListContains([]string{"stable", "candidate", "beta", "edge"}, a.Channel) {
 				sar.RedirectChannel = "2.0/" + a.Channel
 			}
+			if redir, ok := f.redirectChannel[a.Channel]; ok {
+				sar.RedirectChannel = redir
+			}
 			res = append(res, sar)
 			continue
 		}
@@ -917,10 +942,14 @@ func (f *fakeStore) SnapAction(ctx context.Context, currentSnaps []*store.Curren
 			info.Channel = ""
 		}
 		info.InstanceKey = instanceKey
-		res = append(res, store.SnapActionResult{
+		sar := store.SnapActionResult{
 			Info:      info,
 			Resources: f.snapResources(info),
-		})
+		}
+		if redir, ok := f.redirectChannel[a.Channel]; ok {
+			sar.RedirectChannel = redir
+		}
+		res = append(res, sar)
 	}
 
 	if len(refreshErrors)+len(installErrors)+len(downloadErrors) > 0 || len(res) == 0 {

--- a/overlord/snapstate/handlers.go
+++ b/overlord/snapstate/handlers.go
@@ -4605,7 +4605,11 @@ func (m *SnapManager) doCheckReRefresh(t *state.Task, tomb *tomb.Tomb) error {
 		}
 	}
 
-	updated, updateTss, err := reRefreshUpdateMany(tomb.Context(nil), st, snaps, nil, re.UserID, reRefreshFilter, re.Flags, chg.ID())
+	revOpts := make([]*RevisionOptions, len(snaps))
+	for i := range snaps {
+		revOpts[i] = &RevisionOptions{}
+	}
+	updated, updateTss, err := reRefreshUpdateMany(tomb.Context(nil), st, snaps, revOpts, re.UserID, reRefreshFilter, re.Flags, chg.ID())
 	if err != nil {
 		return err
 	}

--- a/overlord/snapstate/handlers_rerefresh_test.go
+++ b/overlord/snapstate/handlers_rerefresh_test.go
@@ -142,12 +142,16 @@ func (s *reRefreshSuite) TestDoCheckReRefreshNoReRefreshes(c *C) {
 
 func (s *reRefreshSuite) TestDoCheckReRefreshPassesReRefreshSetupData(c *C) {
 	var chgID string
-	defer snapstate.MockReRefreshUpdateMany(func(_ context.Context, _ *state.State, snaps []string, _ []*snapstate.RevisionOptions, userID int, _ snapstate.UpdateFilter, flags *snapstate.Flags, changeID string) ([]string, *snapstate.UpdateTaskSets, error) {
+	defer snapstate.MockReRefreshUpdateMany(func(_ context.Context, _ *state.State, snaps []string, revOpts []*snapstate.RevisionOptions, userID int, _ snapstate.UpdateFilter, flags *snapstate.Flags, changeID string) ([]string, *snapstate.UpdateTaskSets, error) {
 		c.Check(changeID, Equals, chgID)
 		expected := []string{"foo", "bar", "baz"}
 		sort.Strings(expected)
 		sort.Strings(snaps)
 		c.Check(snaps, DeepEquals, expected)
+		c.Assert(revOpts, HasLen, len(snaps))
+		for _, opts := range revOpts {
+			c.Assert(opts, NotNil)
+		}
 		c.Check(userID, Equals, 42)
 		c.Check(flags, DeepEquals, &snapstate.Flags{
 			DevMode:  true,

--- a/overlord/snapstate/snapstate.go
+++ b/overlord/snapstate/snapstate.go
@@ -726,9 +726,9 @@ func InstallPath(st *state.State, si *snap.SideInfo, path, instanceName, channel
 		RevOpts: RevisionOptions{
 			Channel: channel,
 
-			// setting the revision here makes this single-snap path install an
-			// explicit revision update. InstallPathMany intentionally does not
-			// do this, so same-revision local snaps can be handled differently
+			// setting the revision here makes this single-snap path install a
+			// by-revision update. InstallPathMany intentionally does not do
+			// this, so same-revision local snaps can be handled differently
 			// by the two API entrypoints
 			Revision: si.Revision,
 		},
@@ -858,6 +858,7 @@ func downloadTasks(
 		return nil, nil, errors.New("internal error: cannot specify revision and cohort")
 	}
 
+	// Injected default, not a caller-requested channel.
 	if revOpts.Channel == "" {
 		revOpts.Channel = "stable"
 	}
@@ -877,6 +878,18 @@ func downloadTasks(
 	}, opts)
 	if err != nil {
 		return nil, nil, err
+	}
+
+	var snapst SnapState
+	if err := Get(st, name, &snapst); err != nil && !errors.Is(err, state.ErrNoState) {
+		return nil, nil, err
+	}
+	sar, localOnly, err := maybeRedirectSnapdTrack(ctx, st, sar, &revOpts, &snapst, opts, "download")
+	if err != nil {
+		return nil, nil, err
+	}
+	if localOnly {
+		return nil, nil, errors.New("internal error: snapd track redirect of download returned no store revision")
 	}
 
 	info := sar.Info

--- a/overlord/snapstate/snapstate_install_test.go
+++ b/overlord/snapstate/snapstate_install_test.go
@@ -5104,6 +5104,102 @@ func (s *validationSetsSuite) TestInstallSnapReferencedByValidationSetWrongRevis
 	c.Assert(err, ErrorMatches, `cannot install snap "some-snap" at revision 2 without --ignore-validation, revision 3 is required by validation sets: 16/foo/bar/1`)
 }
 
+func (s *validationSetsSuite) TestInstallSnapdUCTrackPinnedRevisionNotOnMappedTrack(c *C) {
+	s.AddCleanup(release.MockOnClassic(false))
+	s.AddCleanup(snapstatetest.MockDeviceModel(ModelWithBase("core18")))
+	s.fakeStore.mutateSnapInfo = func(info *snap.Info) error {
+		if info.SnapType == snap.TypeSnapd {
+			info.TrackRedirects = uc18SnapdTracks
+		}
+		return nil
+	}
+	s.fakeStore.revisionNotAvailableOnChannel = map[string]bool{
+		"18/stable": true,
+	}
+	s.AddCleanup(func() {
+		s.fakeStore.mutateSnapInfo = nil
+		s.fakeStore.revisionNotAvailableOnChannel = nil
+	})
+
+	restore := snapstate.MockEnforcedValidationSets(func(st *state.State, extraVss ...*asserts.ValidationSet) (*snapasserts.ValidationSets, error) {
+		vs := snapasserts.NewValidationSets()
+		snapdSnap := map[string]any{
+			"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzx",
+			"name":     "snapd",
+			"presence": "required",
+			"revision": "7",
+		}
+		vsa1 := s.mockValidationSetAssert(c, "bar", "1", snapdSnap)
+		c.Assert(vs.Add(vsa1.(*asserts.ValidationSet)), IsNil)
+		return vs, nil
+	})
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	snapstate.Set(s.state, "snapd", nil)
+
+	tr := assertstate.ValidationSetTracking{
+		AccountID: "foo",
+		Name:      "bar",
+		Mode:      assertstate.Enforce,
+		Current:   1,
+	}
+	assertstate.UpdateValidationSet(s.state, &tr)
+
+	_, err := snapstate.Install(context.Background(), s.state, "snapd", &snapstate.RevisionOptions{Channel: "stable"}, 0, snapstate.Flags{})
+	c.Assert(err, ErrorMatches, `no snap revision available as specified`)
+}
+
+func (s *validationSetsSuite) TestInstallSnapdUCTrackPinnedRevisionOnMappedTrack(c *C) {
+	s.AddCleanup(release.MockOnClassic(false))
+	s.AddCleanup(snapstatetest.MockDeviceModel(ModelWithBase("core18")))
+	s.fakeStore.mutateSnapInfo = func(info *snap.Info) error {
+		if info.SnapType == snap.TypeSnapd {
+			info.TrackRedirects = uc18SnapdTracks
+		}
+		return nil
+	}
+	s.AddCleanup(func() {
+		s.fakeStore.mutateSnapInfo = nil
+	})
+
+	restore := snapstate.MockEnforcedValidationSets(func(st *state.State, extraVss ...*asserts.ValidationSet) (*snapasserts.ValidationSets, error) {
+		vs := snapasserts.NewValidationSets()
+		snapdSnap := map[string]any{
+			"id":       "yOqKhntON3vR7kwEbVPsILm7bUViPDzx",
+			"name":     "snapd",
+			"presence": "required",
+			"revision": "7",
+		}
+		vsa1 := s.mockValidationSetAssert(c, "bar", "1", snapdSnap)
+		c.Assert(vs.Add(vsa1.(*asserts.ValidationSet)), IsNil)
+		return vs, nil
+	})
+	defer restore()
+
+	s.state.Lock()
+	defer s.state.Unlock()
+	snapstate.Set(s.state, "snapd", nil)
+
+	tr := assertstate.ValidationSetTracking{
+		AccountID: "foo",
+		Name:      "bar",
+		Mode:      assertstate.Enforce,
+		Current:   1,
+	}
+	assertstate.UpdateValidationSet(s.state, &tr)
+
+	ts, err := snapstate.Install(context.Background(), s.state, "snapd", &snapstate.RevisionOptions{Channel: "stable"}, 0, snapstate.Flags{})
+	c.Assert(err, IsNil)
+	snapsup, err := snapstate.TaskSnapSetup(ts.Tasks()[0])
+	c.Assert(err, IsNil)
+	c.Check(snapsup.Channel, Equals, "18/stable")
+	c.Check(snapsup.Revision(), Equals, snap.R(7))
+	c.Check(snapdActionChannels(s.fakeBackend.ops), DeepEquals, []string{"", "18/stable"})
+	c.Check(snapdActionRevisions(s.fakeBackend.ops), DeepEquals, []snap.Revision{snap.R(7), snap.R(7)})
+}
+
 func (s *validationSetsSuite) installManySnapReferencedByValidationSet(c *C, snapOnePresence, snapOneRequiredRev, snapTwoPresence, snapTwoRequiredRev string) error {
 	restore := snapstate.MockEnforcedValidationSets(func(st *state.State, extraVss ...*asserts.ValidationSet) (*snapasserts.ValidationSets, error) {
 		vs := snapasserts.NewValidationSets()

--- a/overlord/snapstate/snapstate_update_test.go
+++ b/overlord/snapstate/snapstate_update_test.go
@@ -1248,7 +1248,6 @@ func (s *snapmgrTestSuite) testUpdateAmendRunThrough(c *C, tryMode bool, compone
 	c.Assert(snapsup, DeepEquals, snapstate.SnapSetup{
 		Channel: "channel-for-components",
 		UserID:  s.user.ID,
-
 		DownloadInfo: &snap.DownloadInfo{
 			DownloadURL: "https://some-server.com/some/path.snap",
 			Size:        5,
@@ -1528,7 +1527,6 @@ func (s *snapmgrTestSuite) testUpdateRunThrough(c *C, refreshAppAwarenessUX bool
 		Channel:   "some-channel",
 		CohortKey: "some-cohort",
 		UserID:    s.user.ID,
-
 		DownloadInfo: &snap.DownloadInfo{
 			DownloadURL: "https://some-server.com/some/path.snap",
 			Sha3_384:    "<some-hash>",
@@ -1917,7 +1915,6 @@ func (s *snapmgrTestSuite) TestParallelInstanceUpdateRunThrough(c *C) {
 	c.Assert(snapsup, DeepEquals, snapstate.SnapSetup{
 		Channel: "some-channel",
 		UserID:  s.user.ID,
-
 		DownloadInfo: &snap.DownloadInfo{
 			DownloadURL: "https://some-server.com/some/path.snap",
 			Sha3_384:    "<some-hash>",
@@ -2268,7 +2265,6 @@ func (s *snapmgrTestSuite) TestUpdateModelKernelSwitchTrackRunThrough(c *C) {
 	c.Assert(snapsup, DeepEquals, snapstate.SnapSetup{
 		Channel: "18/edge",
 		UserID:  s.user.ID,
-
 		DownloadInfo: &snap.DownloadInfo{
 			DownloadURL: "https://some-server.com/some/path.snap",
 			Sha3_384:    "<some-hash>",
@@ -15750,9 +15746,8 @@ func (s *snapmgrTestSuite) TestUpdateBackToPrevRevision(c *C) {
 	err = task.Get("snap-setup", &snapsup)
 	c.Assert(err, IsNil)
 	c.Assert(snapsup, DeepEquals, snapstate.SnapSetup{
-		Channel: channel,
-		UserID:  s.user.ID,
-
+		Channel:   channel,
+		UserID:    s.user.ID,
 		SnapPath:  filepath.Join(dirs.SnapBlobDir, fmt.Sprintf("%s_%v.snap", instanceName, prevSnapRev)),
 		SideInfo:  snapsup.SideInfo,
 		Type:      snap.TypeApp,
@@ -16429,9 +16424,8 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevision(c *C) {
 	err = task.Get("snap-setup", &snapsup)
 	c.Assert(err, IsNil)
 	c.Assert(snapsup, DeepEquals, snapstate.SnapSetup{
-		Channel: channel,
-		UserID:  s.user.ID,
-
+		Channel:   channel,
+		UserID:    s.user.ID,
 		SnapPath:  filepath.Join(dirs.SnapBlobDir, fmt.Sprintf("%s_%v.snap", snapName, prevSnapRev)),
 		SideInfo:  snapsup.SideInfo,
 		Type:      snap.TypeKernel,
@@ -16973,9 +16967,8 @@ func (s *snapmgrTestSuite) TestUpdateWithComponentsBackToPrevRevisionAddComponen
 	err = task.Get("snap-setup", &snapsup)
 	c.Assert(err, IsNil)
 	c.Assert(snapsup, DeepEquals, snapstate.SnapSetup{
-		Channel: channel,
-		UserID:  s.user.ID,
-
+		Channel:   channel,
+		UserID:    s.user.ID,
 		SnapPath:  filepath.Join(dirs.SnapBlobDir, fmt.Sprintf("%s_%v.snap", snapName, prevSnapRev)),
 		SideInfo:  snapsup.SideInfo,
 		Type:      snap.TypeKernel,
@@ -17746,9 +17739,8 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThrough(c *C, opts updateW
 	c.Assert(err, IsNil)
 
 	expectedSnapsup := snapstate.SnapSetup{
-		Channel: channel,
-		UserID:  s.user.ID,
-
+		Channel:   channel,
+		UserID:    s.user.ID,
 		SideInfo:  snapsup.SideInfo,
 		Type:      opts.snapType,
 		Version:   snapName + "Ver",
@@ -18242,9 +18234,8 @@ func (s *snapmgrTestSuite) testUpdateWithComponentsRunThroughShareComponents(c *
 	c.Assert(err, IsNil)
 
 	expectedSnapsup := snapstate.SnapSetup{
-		Channel: channel,
-		UserID:  s.user.ID,
-
+		Channel:   channel,
+		UserID:    s.user.ID,
 		SideInfo:  snapsup.SideInfo,
 		Type:      snap.TypeKernel,
 		Version:   "kernelVer",

--- a/overlord/snapstate/storehelpers.go
+++ b/overlord/snapstate/storehelpers.go
@@ -580,14 +580,29 @@ func storeUpdatePlanCore(
 	}
 
 	for _, sar := range sars {
-		up, ok := updates[sar.InstanceName()]
+		name := sar.InstanceName()
+		up, ok := updates[name]
 		if !ok {
-			return updatePlan{}, fmt.Errorf("unsolicited snap action result: %q", sar.InstanceName())
+			return updatePlan{}, fmt.Errorf("unsolicited snap action result: %q", name)
 		}
 
-		snapst, ok := allSnaps[sar.InstanceName()]
+		snapst, ok := allSnaps[name]
 		if !ok {
 			snapst = &SnapState{}
+		}
+
+		action := "install"
+		if snapst.IsInstalled() {
+			action = "refresh"
+		}
+		sar, localOnly, err := maybeRedirectSnapdTrack(ctx, st, sar, &up.RevOpts, snapst, opts, action)
+		if err != nil {
+			return updatePlan{}, err
+		}
+		updates[name] = up
+		if localOnly {
+			hasLocalRevision[name] = snapst
+			continue
 		}
 
 		currentComps, err := snapst.CurrentComponentInfos()
@@ -1003,6 +1018,51 @@ func sendOneInstallOrDownloadAction(ctx context.Context, st *state.State, action
 	}
 	if len(results) != 1 {
 		return store.SnapActionResult{}, fmt.Errorf("expected exactly one result, got %d", len(results))
+	}
+	return results[0], nil
+}
+
+// sendOneStoreAction sends a single already-built store action. The caller
+// must hold the state lock; it is released for the store round-trip.
+//
+// If forceChannel is not empty, it is set on the action after
+// completeStoreAction so a validation-set pin cannot drop the channel.
+func sendOneStoreAction(ctx context.Context, st *state.State, action *store.SnapAction, revOpts RevisionOptions, opts Options, includeResources bool, forceChannel string) (store.SnapActionResult, error) {
+	if err := completeStoreAction(action, revOpts, opts.Flags.IgnoreValidation); err != nil {
+		return store.SnapActionResult{}, err
+	}
+	if forceChannel != "" {
+		action.Channel = forceChannel
+	}
+
+	curSnaps, err := currentSnaps(st)
+	if err != nil {
+		return store.SnapActionResult{}, err
+	}
+
+	refreshOpts, err := refreshOptions(st, &store.RefreshOptions{
+		IncludeResources: includeResources,
+	})
+	if err != nil {
+		return store.SnapActionResult{}, err
+	}
+
+	user, err := userFromUserID(st, opts.UserID)
+	if err != nil {
+		return store.SnapActionResult{}, err
+	}
+
+	str := Store(st, opts.DeviceCtx)
+
+	st.Unlock()
+	results, _, err := str.SnapAction(ctx, curSnaps, []*store.SnapAction{action}, nil, user, refreshOpts)
+	st.Lock()
+
+	if err != nil {
+		return store.SnapActionResult{}, singleActionResultErr(action.InstanceName, action.Action, err)
+	}
+	if len(results) != 1 {
+		return store.SnapActionResult{}, fmt.Errorf("internal error: expected exactly one result from store, got %d", len(results))
 	}
 	return results[0], nil
 }

--- a/overlord/snapstate/target.go
+++ b/overlord/snapstate/target.go
@@ -352,6 +352,15 @@ func (s *storeInstallGoal) snap(name string) (StoreSnap, bool) {
 	return StoreSnap{}, false
 }
 
+func (s *storeInstallGoal) snapByName(name string) (*StoreSnap, bool) {
+	for i := range s.snaps {
+		if s.snaps[i].InstanceName == name {
+			return &s.snaps[i], true
+		}
+	}
+	return nil, false
+}
+
 // StoreSnap represents a snap that is to be installed from the store.
 type StoreSnap struct {
 	// InstanceName is the name of snap to install.
@@ -422,7 +431,7 @@ func (s *storeInstallGoal) toInstall(ctx context.Context, st *state.State, opts 
 
 	installs := make([]target, 0, len(results))
 	for _, r := range results {
-		sn, ok := s.snap(r.InstanceName())
+		sn, ok := s.snapByName(r.InstanceName())
 		if !ok {
 			return nil, fmt.Errorf("store returned unsolicited snap action: %s", r.InstanceName())
 		}
@@ -430,6 +439,14 @@ func (s *storeInstallGoal) toInstall(ctx context.Context, st *state.State, opts 
 		snapst, ok := allSnaps[r.InstanceName()]
 		if !ok {
 			snapst = &SnapState{}
+		}
+
+		r, localOnly, err := maybeRedirectSnapdTrack(ctx, st, r, &sn.RevOpts, snapst, opts, "install")
+		if err != nil {
+			return nil, err
+		}
+		if localOnly {
+			return nil, errors.New("internal error: snapd track redirect of uninstalled snapd returned no store revision")
 		}
 
 		target, err := targetFromActionResult(r, snapst, sn.RevOpts, sn.Components)
@@ -1705,7 +1722,7 @@ func targetFromPathSnap(update PathSnap, snapst SnapState, opts Options) (target
 			Channel:   update.RevOpts.Channel,
 			CohortKey: update.RevOpts.CohortKey,
 
-			// mirror store-backed by-revision refresh: an explicit revision should
+			// mirror store-backed by-revision refresh: a requested revision should
 			// run the full update path even if the revision is already current.
 			AlwaysUpdate: !update.RevOpts.Revision.Unset(),
 		},

--- a/overlord/snapstate/trackredirect.go
+++ b/overlord/snapstate/trackredirect.go
@@ -1,0 +1,191 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/overlord/state"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/channel"
+	"github.com/snapcore/snapd/snap/naming"
+	"github.com/snapcore/snapd/snap/trackredirect"
+	"github.com/snapcore/snapd/store"
+)
+
+// maybeRedirectSnapdTrack applies track-redirects policy after the first
+// store round-trip, which supplies snap.yaml's track-redirects map. When
+// the channel remaps, a second SnapAction fetches the revision to install,
+// refresh, or download.
+//
+// Applies to type: snapd named "snapd". Path/seed/try never call this.
+// Classic, hybrid, UC16, and an unmapped boot base pass through.
+// ErrNoTrack is refused once the boot base has a map.
+//
+// A pinned or requested revision is queried on the mapped track, not
+// taken from the first result and relabelled. localOnly means a refresh
+// found no update on the mapped track: keep the installed revision and
+// switch tracking.
+func maybeRedirectSnapdTrack(ctx context.Context, st *state.State, sar store.SnapActionResult, revOpts *RevisionOptions, snapst *SnapState, opts Options, action string) (store.SnapActionResult, bool, error) {
+	if sar.Info == nil || sar.Info.Type() != snap.TypeSnapd || sar.InstanceName() != "snapd" {
+		return sar, false, nil
+	}
+
+	deviceCtx := opts.DeviceCtx
+	if deviceCtx == nil {
+		var err error
+		deviceCtx, err = DeviceCtx(st, nil, nil)
+		if err != nil {
+			return store.SnapActionResult{}, false, err
+		}
+	}
+
+	inputChannel := revOpts.Channel
+	if inputChannel == "" {
+		if snapst.TrackingChannel != "" {
+			inputChannel = snapst.TrackingChannel
+		} else {
+			inputChannel = "stable"
+		}
+	}
+
+	key, err := trackredirect.UbuntuCoreKey(deviceCtx.Model())
+	if err != nil {
+		if errors.Is(err, trackredirect.ErrNotApplicable) {
+			return sar, false, nil
+		}
+		return store.SnapActionResult{}, false, err
+	}
+
+	mapped, err := trackredirect.Resolve(key, inputChannel, sar.Info.TrackRedirects)
+	if err != nil {
+		if errors.Is(err, trackredirect.ErrNotCovered) {
+			return sar, false, nil
+		}
+		if errors.Is(err, trackredirect.ErrNoTrack) {
+			return store.SnapActionResult{}, false, fmt.Errorf("cannot %s snapd: channel %q is not a UC track for boot base %s", action, inputChannel, key.Version)
+		}
+		return store.SnapActionResult{}, false, err
+	}
+
+	if revOpts.ValidationSets != nil {
+		pres, perr := revOpts.ValidationSets.Presence(naming.Snap("snapd"))
+		if perr != nil {
+			return store.SnapActionResult{}, false, perr
+		}
+		if !pres.Revision.Unset() && revOpts.Revision.Unset() {
+			revOpts.Revision = pres.Revision
+		}
+	}
+
+	alreadyMapped := storeChannelsEqual(inputChannel, mapped)
+	if alreadyMapped && revOpts.Revision.Unset() {
+		return sar, false, nil
+	}
+
+	switch action {
+	case "install", "refresh", "download":
+	default:
+		return store.SnapActionResult{}, false, fmt.Errorf("internal error: unexpected store action %q for snapd track redirect", action)
+	}
+
+	if !alreadyMapped {
+		logger.Noticef("remapping snapd from %q to %q to follow track-redirects", inputChannel, mapped)
+	}
+	revOpts.Channel = mapped
+
+	sa := &store.SnapAction{
+		Action:       action,
+		InstanceName: sar.InstanceName(),
+	}
+	if action == "refresh" {
+		sa.SnapID = sar.SnapID
+		if sa.SnapID == "" {
+			if si := snapst.CurrentSideInfo(); si != nil {
+				sa.SnapID = si.SnapID
+			}
+		}
+		if sa.SnapID == "" {
+			return store.SnapActionResult{}, false, errors.New("internal error: cannot refresh snapd onto a UC track without a snap id")
+		}
+	}
+
+	// completeStoreAction clears Channel when a validation set pins a
+	// revision; force the mapped channel so the store must serve it there.
+	newSAR, err := sendOneStoreAction(ctx, st, sa, *revOpts, opts, len(sar.Resources) > 0, mapped)
+	if err != nil {
+		if action == "refresh" && errors.Is(err, store.ErrNoUpdateAvailable) {
+			return store.SnapActionResult{}, true, nil
+		}
+		return store.SnapActionResult{}, false, err
+	}
+
+	if err := rejectSnapdTrackRedirect(&newSAR, mapped, action); err != nil {
+		return store.SnapActionResult{}, false, err
+	}
+	return newSAR, false, nil
+}
+
+// rejectSnapdTrackRedirect requires the store to honour the mapped track.
+// A differing track is an error. Same-track or empty RedirectChannel is OK;
+// RedirectChannel is then cleared so tracking stays the mapped channel.
+func rejectSnapdTrackRedirect(sar *store.SnapActionResult, mapped, action string) error {
+	if sar.RedirectChannel == "" {
+		return nil
+	}
+
+	mappedTrack, err := channelTrack(mapped)
+	if err != nil {
+		return err
+	}
+	redirectTrack, err := channelTrack(sar.RedirectChannel)
+	if err != nil {
+		return fmt.Errorf("cannot parse store redirect channel %q: %v", sar.RedirectChannel, err)
+	}
+	if mappedTrack != redirectTrack {
+		return fmt.Errorf("cannot %s snapd: store redirected from %q to %q", action, mapped, sar.RedirectChannel)
+	}
+
+	sar.RedirectChannel = ""
+	return nil
+}
+
+func storeChannelsEqual(a, b string) bool {
+	ca, err1 := channel.Parse(a, "-")
+	cb, err2 := channel.Parse(b, "-")
+	if err1 != nil || err2 != nil {
+		return a == b
+	}
+	return ca.String() == cb.String()
+}
+
+func channelTrack(ch string) (string, error) {
+	parsed, err := channel.ParseVerbatim(ch, "-")
+	if err != nil {
+		return "", err
+	}
+	if parsed.Track == "" {
+		return "latest", nil
+	}
+	return parsed.Track, nil
+}

--- a/overlord/snapstate/trackredirect_test.go
+++ b/overlord/snapstate/trackredirect_test.go
@@ -1,0 +1,641 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package snapstate_test
+
+import (
+	"context"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/overlord/snapstate"
+	"github.com/snapcore/snapd/overlord/snapstate/snapstatetest"
+	"github.com/snapcore/snapd/release"
+	"github.com/snapcore/snapd/snap"
+	"github.com/snapcore/snapd/snap/snaptest"
+)
+
+var uc18SnapdTracks = map[string]map[string]map[string]string{
+	"ubuntu-core": {
+		"18": {
+			"latest":       "18",
+			"fips-updates": "18-fips",
+		},
+	},
+}
+
+func (s *targetTestSuite) prepareSnapdUCTracks(c *C, model *asserts.Model, tracks map[string]map[string]map[string]string) {
+	s.AddCleanup(release.MockOnClassic(false))
+	if model != nil {
+		s.AddCleanup(snapstatetest.MockDeviceModel(model))
+	}
+	s.fakeStore.mutateSnapInfo = func(info *snap.Info) error {
+		if info.SnapType == snap.TypeSnapd {
+			info.TrackRedirects = tracks
+		}
+		return nil
+	}
+	s.AddCleanup(func() {
+		s.fakeStore.mutateSnapInfo = nil
+		s.fakeStore.redirectChannel = nil
+		s.fakeStore.noUpdateOnChannel = nil
+		s.fakeStore.revisionNotAvailableOnChannel = nil
+	})
+}
+
+const snapdUCTrackYaml = `name: snapd
+type: snapd
+version: 1.0
+`
+
+func snapdActionChannels(ops fakeOps) []string {
+	var chans []string
+	for _, op := range ops {
+		if op.op == "storesvc-snap-action:action" && op.action.InstanceName == "snapd" {
+			chans = append(chans, op.action.Channel)
+		}
+	}
+	return chans
+}
+
+func snapdActionRevisions(ops fakeOps) []snap.Revision {
+	var revs []snap.Revision
+	for _, op := range ops {
+		if op.op == "storesvc-snap-action:action" && op.action.InstanceName == "snapd" {
+			revs = append(revs, op.action.Revision)
+		}
+	}
+	return revs
+}
+
+func snapdActionCohorts(ops fakeOps) []string {
+	var keys []string
+	for _, op := range ops {
+		if op.op == "storesvc-snap-action:action" && op.action.InstanceName == "snapd" {
+			keys = append(keys, op.action.CohortKey)
+		}
+	}
+	return keys
+}
+
+func (s *targetTestSuite) TestInstallSnapdRemapsUCTrack(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "snapd", nil)
+	s.prepareSnapdUCTracks(c, ModelWithBase("core18"), uc18SnapdTracks)
+
+	goal := snapstate.StoreInstallGoal(snapstate.StoreSnap{
+		InstanceName: "snapd",
+		RevOpts: snapstate.RevisionOptions{
+			Channel: "stable",
+		},
+	})
+	info, ts, err := snapstate.InstallOne(context.Background(), s.state, goal, snapstate.Options{})
+	c.Assert(err, IsNil)
+	c.Assert(info, NotNil)
+
+	snapsup, err := snapstate.TaskSnapSetup(ts.Tasks()[0])
+	c.Assert(err, IsNil)
+	c.Check(snapsup.Channel, Equals, "18/stable")
+	c.Check(snapdActionChannels(s.fakeBackend.ops), DeepEquals, []string{"stable", "18/stable"})
+}
+
+func (s *targetTestSuite) TestInstallSnapdRemapsFipsUpdatesTrack(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "snapd", nil)
+	s.prepareSnapdUCTracks(c, ModelWithBase("core18"), uc18SnapdTracks)
+
+	goal := snapstate.StoreInstallGoal(snapstate.StoreSnap{
+		InstanceName: "snapd",
+		RevOpts: snapstate.RevisionOptions{
+			Channel: "fips-updates/stable",
+		},
+	})
+	_, ts, err := snapstate.InstallOne(context.Background(), s.state, goal, snapstate.Options{})
+	c.Assert(err, IsNil)
+
+	snapsup, err := snapstate.TaskSnapSetup(ts.Tasks()[0])
+	c.Assert(err, IsNil)
+	c.Check(snapsup.Channel, Equals, "18-fips/stable")
+	c.Check(snapdActionChannels(s.fakeBackend.ops), DeepEquals, []string{"fips-updates/stable", "18-fips/stable"})
+}
+
+func (s *targetTestSuite) TestInstallSnapdNameBasedAPIRemaps(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "snapd", nil)
+	s.prepareSnapdUCTracks(c, ModelWithBase("core18"), uc18SnapdTracks)
+
+	ts, err := snapstate.Install(context.Background(), s.state, "snapd", &snapstate.RevisionOptions{Channel: "stable"}, 0, snapstate.Flags{})
+	c.Assert(err, IsNil)
+
+	snapsup, err := snapstate.TaskSnapSetup(ts.Tasks()[0])
+	c.Assert(err, IsNil)
+	c.Check(snapsup.Channel, Equals, "18/stable")
+	c.Check(snapdActionChannels(s.fakeBackend.ops), DeepEquals, []string{"stable", "18/stable"})
+}
+
+func (s *targetTestSuite) TestInstallSnapdExplicitLatestRemaps(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "snapd", nil)
+	s.prepareSnapdUCTracks(c, ModelWithBase("core18"), uc18SnapdTracks)
+
+	goal := snapstate.StoreInstallGoal(snapstate.StoreSnap{
+		InstanceName: "snapd",
+		RevOpts: snapstate.RevisionOptions{
+			Channel: "latest/stable",
+		},
+	})
+	_, ts, err := snapstate.InstallOne(context.Background(), s.state, goal, snapstate.Options{})
+	c.Assert(err, IsNil)
+
+	snapsup, err := snapstate.TaskSnapSetup(ts.Tasks()[0])
+	c.Assert(err, IsNil)
+	c.Check(snapsup.Channel, Equals, "18/stable")
+	c.Check(snapdActionChannels(s.fakeBackend.ops), DeepEquals, []string{"latest/stable", "18/stable"})
+}
+
+func (s *targetTestSuite) TestInstallSnapdRefusesUnknownTrack(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "snapd", nil)
+	s.prepareSnapdUCTracks(c, ModelWithBase("core18"), uc18SnapdTracks)
+
+	goal := snapstate.StoreInstallGoal(snapstate.StoreSnap{
+		InstanceName: "snapd",
+		RevOpts: snapstate.RevisionOptions{
+			Channel: "20/stable",
+		},
+	})
+	_, _, err := snapstate.InstallOne(context.Background(), s.state, goal, snapstate.Options{})
+	c.Assert(err, ErrorMatches, `cannot install snapd: channel "20/stable" is not a UC track for boot base 18`)
+}
+
+func (s *targetTestSuite) TestInstallSnapdRefusesLegacyTrack(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "snapd", nil)
+	s.prepareSnapdUCTracks(c, ModelWithBase("core18"), uc18SnapdTracks)
+
+	goal := snapstate.StoreInstallGoal(snapstate.StoreSnap{
+		InstanceName: "snapd",
+		RevOpts: snapstate.RevisionOptions{
+			Channel: "2.0/stable",
+		},
+	})
+	_, _, err := snapstate.InstallOne(context.Background(), s.state, goal, snapstate.Options{})
+	c.Assert(err, ErrorMatches, `cannot install snapd: channel "2.0/stable" is not a UC track for boot base 18`)
+}
+
+func (s *targetTestSuite) TestInstallSnapdRevisionQueriesMappedTrack(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "snapd", nil)
+	s.prepareSnapdUCTracks(c, ModelWithBase("core18"), uc18SnapdTracks)
+
+	goal := snapstate.StoreInstallGoal(snapstate.StoreSnap{
+		InstanceName: "snapd",
+		RevOpts: snapstate.RevisionOptions{
+			Channel:  "stable",
+			Revision: snap.R(7),
+		},
+	})
+	_, ts, err := snapstate.InstallOne(context.Background(), s.state, goal, snapstate.Options{})
+	c.Assert(err, IsNil)
+
+	snapsup, err := snapstate.TaskSnapSetup(ts.Tasks()[0])
+	c.Assert(err, IsNil)
+	c.Check(snapsup.Channel, Equals, "18/stable")
+	c.Check(snapsup.Revision(), Equals, snap.R(7))
+	c.Check(snapdActionChannels(s.fakeBackend.ops), DeepEquals, []string{"stable", "18/stable"})
+	c.Check(snapdActionRevisions(s.fakeBackend.ops), DeepEquals, []snap.Revision{snap.R(7), snap.R(7)})
+}
+
+func (s *targetTestSuite) TestInstallSnapdRevisionNotOnMappedTrack(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "snapd", nil)
+	s.prepareSnapdUCTracks(c, ModelWithBase("core18"), uc18SnapdTracks)
+	s.fakeStore.revisionNotAvailableOnChannel = map[string]bool{
+		"18/stable": true,
+	}
+
+	goal := snapstate.StoreInstallGoal(snapstate.StoreSnap{
+		InstanceName: "snapd",
+		RevOpts: snapstate.RevisionOptions{
+			Channel:  "stable",
+			Revision: snap.R(7),
+		},
+	})
+	_, _, err := snapstate.InstallOne(context.Background(), s.state, goal, snapstate.Options{})
+	c.Assert(err, ErrorMatches, `no snap revision available as specified`)
+}
+
+func (s *targetTestSuite) TestInstallSnapdKeepsCohortOnRemap(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "snapd", nil)
+	s.prepareSnapdUCTracks(c, ModelWithBase("core18"), uc18SnapdTracks)
+
+	goal := snapstate.StoreInstallGoal(snapstate.StoreSnap{
+		InstanceName: "snapd",
+		RevOpts: snapstate.RevisionOptions{
+			Channel:   "stable",
+			CohortKey: "cohort-1",
+		},
+	})
+	_, ts, err := snapstate.InstallOne(context.Background(), s.state, goal, snapstate.Options{})
+	c.Assert(err, IsNil)
+
+	snapsup, err := snapstate.TaskSnapSetup(ts.Tasks()[0])
+	c.Assert(err, IsNil)
+	c.Check(snapsup.Channel, Equals, "18/stable")
+	c.Check(snapsup.CohortKey, Equals, "cohort-1")
+	c.Check(snapdActionCohorts(s.fakeBackend.ops), DeepEquals, []string{"cohort-1", "cohort-1"})
+}
+
+func (s *targetTestSuite) TestPathInstallSnapdDoesNotRemap(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "snapd", nil)
+	s.prepareSnapdUCTracks(c, ModelWithBase("core18"), uc18SnapdTracks)
+	path := makeTestSnap(c, snapdUCTrackYaml)
+
+	ts, err := snapstate.InstallPath(s.state, &snap.SideInfo{RealName: "snapd"}, path, "", "latest/stable", snapstate.Flags{}, nil)
+	c.Assert(err, IsNil)
+
+	snapsup, err := snapstate.TaskSnapSetup(ts.Tasks()[0])
+	c.Assert(err, IsNil)
+	c.Check(snapsup.Channel, Equals, "latest/stable")
+	c.Check(snapdActionChannels(s.fakeBackend.ops), HasLen, 0)
+}
+
+func (s *targetTestSuite) TestInstallSnapdNoRemapOnClassic(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "snapd", nil)
+	s.prepareSnapdUCTracks(c, ClassicModel(), uc18SnapdTracks)
+
+	goal := snapstate.StoreInstallGoal(snapstate.StoreSnap{
+		InstanceName: "snapd",
+		RevOpts: snapstate.RevisionOptions{
+			Channel: "stable",
+		},
+	})
+	_, ts, err := snapstate.InstallOne(context.Background(), s.state, goal, snapstate.Options{})
+	c.Assert(err, IsNil)
+
+	snapsup, err := snapstate.TaskSnapSetup(ts.Tasks()[0])
+	c.Assert(err, IsNil)
+	c.Check(snapsup.Channel, Equals, "stable")
+	c.Check(snapdActionChannels(s.fakeBackend.ops), DeepEquals, []string{"stable"})
+}
+
+func (s *targetTestSuite) TestInstallSnapdNoRemapOnHybridClassic(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "snapd", nil)
+	s.prepareSnapdUCTracks(c, MakeModelClassicWithModes("pc", nil), uc18SnapdTracks)
+
+	goal := snapstate.StoreInstallGoal(snapstate.StoreSnap{
+		InstanceName: "snapd",
+		RevOpts: snapstate.RevisionOptions{
+			Channel: "stable",
+		},
+	})
+	_, ts, err := snapstate.InstallOne(context.Background(), s.state, goal, snapstate.Options{})
+	c.Assert(err, IsNil)
+
+	snapsup, err := snapstate.TaskSnapSetup(ts.Tasks()[0])
+	c.Assert(err, IsNil)
+	c.Check(snapsup.Channel, Equals, "stable")
+	c.Check(snapdActionChannels(s.fakeBackend.ops), DeepEquals, []string{"stable"})
+}
+
+func (s *targetTestSuite) TestInstallSnapdNoRemapOnUC16(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "snapd", nil)
+	// DefaultModel is UC16 (no base).
+	s.prepareSnapdUCTracks(c, DefaultModel(), uc18SnapdTracks)
+
+	goal := snapstate.StoreInstallGoal(snapstate.StoreSnap{
+		InstanceName: "snapd",
+		RevOpts: snapstate.RevisionOptions{
+			Channel: "stable",
+		},
+	})
+	_, ts, err := snapstate.InstallOne(context.Background(), s.state, goal, snapstate.Options{})
+	c.Assert(err, IsNil)
+
+	snapsup, err := snapstate.TaskSnapSetup(ts.Tasks()[0])
+	c.Assert(err, IsNil)
+	c.Check(snapsup.Channel, Equals, "stable")
+	c.Check(snapdActionChannels(s.fakeBackend.ops), DeepEquals, []string{"stable"})
+}
+
+func (s *targetTestSuite) TestInstallSnapdNoRemapWhenMapMissing(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "snapd", nil)
+	s.prepareSnapdUCTracks(c, ModelWithBase("core18"), nil)
+
+	goal := snapstate.StoreInstallGoal(snapstate.StoreSnap{
+		InstanceName: "snapd",
+		RevOpts: snapstate.RevisionOptions{
+			Channel: "stable",
+		},
+	})
+	_, ts, err := snapstate.InstallOne(context.Background(), s.state, goal, snapstate.Options{})
+	c.Assert(err, IsNil)
+
+	snapsup, err := snapstate.TaskSnapSetup(ts.Tasks()[0])
+	c.Assert(err, IsNil)
+	c.Check(snapsup.Channel, Equals, "stable")
+	c.Check(snapdActionChannels(s.fakeBackend.ops), DeepEquals, []string{"stable"})
+}
+
+func (s *targetTestSuite) TestInstallSnapdNoRemapWhenAlreadyOnTargetTrack(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "snapd", nil)
+	s.prepareSnapdUCTracks(c, ModelWithBase("core18"), uc18SnapdTracks)
+
+	goal := snapstate.StoreInstallGoal(snapstate.StoreSnap{
+		InstanceName: "snapd",
+		RevOpts: snapstate.RevisionOptions{
+			Channel: "18/stable",
+		},
+	})
+	_, ts, err := snapstate.InstallOne(context.Background(), s.state, goal, snapstate.Options{})
+	c.Assert(err, IsNil)
+
+	snapsup, err := snapstate.TaskSnapSetup(ts.Tasks()[0])
+	c.Assert(err, IsNil)
+	c.Check(snapsup.Channel, Equals, "18/stable")
+	c.Check(snapdActionChannels(s.fakeBackend.ops), DeepEquals, []string{"18/stable"})
+}
+
+func (s *targetTestSuite) TestInstallSnapdRejectsRedirectOffMappedTrack(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "snapd", nil)
+	s.prepareSnapdUCTracks(c, ModelWithBase("core18"), uc18SnapdTracks)
+	s.fakeStore.redirectChannel = map[string]string{
+		"18/stable": "2.0/stable",
+	}
+
+	goal := snapstate.StoreInstallGoal(snapstate.StoreSnap{
+		InstanceName: "snapd",
+		RevOpts: snapstate.RevisionOptions{
+			Channel: "stable",
+		},
+	})
+	_, _, err := snapstate.InstallOne(context.Background(), s.state, goal, snapstate.Options{})
+	c.Assert(err, ErrorMatches, `cannot install snapd: store redirected from "18/stable" to "2.0/stable"`)
+}
+
+func (s *targetTestSuite) TestInstallSnapdIgnoresSameTrackRedirect(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	snapstate.Set(s.state, "snapd", nil)
+	s.prepareSnapdUCTracks(c, ModelWithBase("core18"), uc18SnapdTracks)
+	s.fakeStore.redirectChannel = map[string]string{
+		"18/stable": "18/edge",
+	}
+
+	goal := snapstate.StoreInstallGoal(snapstate.StoreSnap{
+		InstanceName: "snapd",
+		RevOpts: snapstate.RevisionOptions{
+			Channel: "stable",
+		},
+	})
+	_, ts, err := snapstate.InstallOne(context.Background(), s.state, goal, snapstate.Options{})
+	c.Assert(err, IsNil)
+
+	snapsup, err := snapstate.TaskSnapSetup(ts.Tasks()[0])
+	c.Assert(err, IsNil)
+	c.Check(snapsup.Channel, Equals, "18/stable")
+}
+
+func (s *targetTestSuite) TestUpdateSnapdRemapsUCTrack(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.prepareSnapdUCTracks(c, ModelWithBase("core18"), uc18SnapdTracks)
+	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
+		Active:          true,
+		TrackingChannel: "latest/stable",
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "snapd", SnapID: "snapd-snap-id", Revision: snap.R(1)},
+		}),
+		Current:  snap.R(1),
+		SnapType: "snapd",
+	})
+
+	goal := snapstate.StoreUpdateGoal(snapstate.StoreUpdate{
+		InstanceName: "snapd",
+		RevOpts: snapstate.RevisionOptions{
+			Channel: "stable",
+		},
+	})
+	ts, err := snapstate.UpdateOne(context.Background(), s.state, goal, nil, snapstate.Options{})
+	c.Assert(err, IsNil)
+
+	snapsup, err := snapstate.TaskSnapSetup(ts.Tasks()[0])
+	c.Assert(err, IsNil)
+	c.Check(snapsup.Channel, Equals, "18/stable")
+	c.Check(snapdActionChannels(s.fakeBackend.ops), DeepEquals, []string{"latest/stable", "18/stable"})
+}
+
+func (s *targetTestSuite) TestUpdateSnapdLocalOnlySwitchesChannel(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.prepareSnapdUCTracks(c, ModelWithBase("core18"), uc18SnapdTracks)
+	s.fakeStore.noUpdateOnChannel = map[string]bool{
+		"18/stable": true,
+	}
+
+	si := &snap.SideInfo{RealName: "snapd", SnapID: "snapd-snap-id", Revision: snap.R(1)}
+	snaptest.MockSnapCurrent(c, snapdUCTrackYaml, si)
+	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
+		Active:          true,
+		TrackingChannel: "latest/stable",
+		Sequence:        snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{si}),
+		Current:         snap.R(1),
+		SnapType:        "snapd",
+	})
+
+	goal := snapstate.StoreUpdateGoal(snapstate.StoreUpdate{
+		InstanceName: "snapd",
+		RevOpts: snapstate.RevisionOptions{
+			Channel: "stable",
+		},
+	})
+	ts, err := snapstate.UpdateOne(context.Background(), s.state, goal, nil, snapstate.Options{})
+	c.Assert(err, IsNil)
+
+	c.Check(ts.Tasks()[0].Kind(), Equals, "switch-snap-channel")
+	snapsup, err := snapstate.TaskSnapSetup(ts.Tasks()[0])
+	c.Assert(err, IsNil)
+	c.Check(snapsup.Channel, Equals, "18/stable")
+	c.Check(snapsup.Revision(), Equals, snap.R(1))
+	c.Check(snapdActionChannels(s.fakeBackend.ops), DeepEquals, []string{"latest/stable", "18/stable"})
+}
+
+func (s *targetTestSuite) TestUpdateSnapdRefusesUnknownTrack(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.prepareSnapdUCTracks(c, ModelWithBase("core18"), uc18SnapdTracks)
+	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
+		Active:          true,
+		TrackingChannel: "latest/stable",
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "snapd", SnapID: "snapd-snap-id", Revision: snap.R(1)},
+		}),
+		Current:  snap.R(1),
+		SnapType: "snapd",
+	})
+
+	goal := snapstate.StoreUpdateGoal(snapstate.StoreUpdate{
+		InstanceName: "snapd",
+		RevOpts: snapstate.RevisionOptions{
+			Channel: "20/stable",
+		},
+	})
+	_, err := snapstate.UpdateOne(context.Background(), s.state, goal, nil, snapstate.Options{})
+	c.Assert(err, ErrorMatches, `cannot refresh snapd: channel "20/stable" is not a UC track for boot base 18`)
+}
+
+func (s *targetTestSuite) TestUpdateSnapdRejectsRedirectOffMappedTrack(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.prepareSnapdUCTracks(c, ModelWithBase("core18"), uc18SnapdTracks)
+	s.fakeStore.redirectChannel = map[string]string{
+		"18/stable": "2.0/stable",
+	}
+	snapstate.Set(s.state, "snapd", &snapstate.SnapState{
+		Active:          true,
+		TrackingChannel: "latest/stable",
+		Sequence: snapstatetest.NewSequenceFromSnapSideInfos([]*snap.SideInfo{
+			{RealName: "snapd", SnapID: "snapd-snap-id", Revision: snap.R(1)},
+		}),
+		Current:  snap.R(1),
+		SnapType: "snapd",
+	})
+
+	goal := snapstate.StoreUpdateGoal(snapstate.StoreUpdate{
+		InstanceName: "snapd",
+		RevOpts: snapstate.RevisionOptions{
+			Channel: "stable",
+		},
+	})
+	_, err := snapstate.UpdateOne(context.Background(), s.state, goal, nil, snapstate.Options{})
+	c.Assert(err, ErrorMatches, `cannot refresh snapd: store redirected from "18/stable" to "2.0/stable"`)
+}
+
+func snapdActionKinds(ops fakeOps) []string {
+	var kinds []string
+	for _, op := range ops {
+		if op.op == "storesvc-snap-action:action" && op.action.InstanceName == "snapd" {
+			kinds = append(kinds, op.action.Action)
+		}
+	}
+	return kinds
+}
+
+func (s *targetTestSuite) TestDownloadSnapdRemapsUCTrack(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.prepareSnapdUCTracks(c, ModelWithBase("core18"), uc18SnapdTracks)
+
+	ts, info, err := snapstate.Download(context.Background(), s.state, "snapd", nil, c.MkDir(), snapstate.RevisionOptions{
+		Channel: "stable",
+	}, snapstate.Options{})
+	c.Assert(err, IsNil)
+	c.Assert(info, NotNil)
+
+	downloadSnap := ts.MaybeEdge(snapstate.BeginEdge)
+	c.Assert(downloadSnap, NotNil)
+	var snapsup snapstate.SnapSetup
+	c.Assert(downloadSnap.Get("snap-setup", &snapsup), IsNil)
+	c.Check(snapsup.Channel, Equals, "18/stable")
+	c.Check(snapdActionChannels(s.fakeBackend.ops), DeepEquals, []string{"stable", "18/stable"})
+	c.Check(snapdActionKinds(s.fakeBackend.ops), DeepEquals, []string{"download", "download"})
+}
+
+func (s *targetTestSuite) TestDownloadSnapdRejectsRedirectOffMappedTrack(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.prepareSnapdUCTracks(c, ModelWithBase("core18"), uc18SnapdTracks)
+	s.fakeStore.redirectChannel = map[string]string{
+		"18/stable": "2.0/stable",
+	}
+
+	_, _, err := snapstate.Download(context.Background(), s.state, "snapd", nil, c.MkDir(), snapstate.RevisionOptions{
+		Channel: "stable",
+	}, snapstate.Options{})
+	c.Assert(err, ErrorMatches, `cannot download snapd: store redirected from "18/stable" to "2.0/stable"`)
+}
+
+func (s *targetTestSuite) TestDownloadSnapdIgnoresSameTrackRedirect(c *C) {
+	s.state.Lock()
+	defer s.state.Unlock()
+
+	s.prepareSnapdUCTracks(c, ModelWithBase("core18"), uc18SnapdTracks)
+	s.fakeStore.redirectChannel = map[string]string{
+		"18/stable": "18/edge",
+	}
+
+	ts, _, err := snapstate.Download(context.Background(), s.state, "snapd", nil, c.MkDir(), snapstate.RevisionOptions{
+		Channel: "stable",
+	}, snapstate.Options{})
+	c.Assert(err, IsNil)
+
+	downloadSnap := ts.MaybeEdge(snapstate.BeginEdge)
+	c.Assert(downloadSnap, NotNil)
+	var snapsup snapstate.SnapSetup
+	c.Assert(downloadSnap.Get("snap-setup", &snapsup), IsNil)
+	c.Check(snapsup.Channel, Equals, "18/stable")
+}

--- a/overlord/snapstate/trackredirect_test.go
+++ b/overlord/snapstate/trackredirect_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/snapcore/snapd/snap/snaptest"
 )
 
-var uc18SnapdTracks = map[string]map[string]map[string]string{
+var uc18SnapdTracks = snap.TrackRedirects{
 	"ubuntu-core": {
 		"18": {
 			"latest":       "18",
@@ -41,7 +41,7 @@ var uc18SnapdTracks = map[string]map[string]map[string]string{
 	},
 }
 
-func (s *targetTestSuite) prepareSnapdUCTracks(c *C, model *asserts.Model, tracks map[string]map[string]map[string]string) {
+func (s *targetTestSuite) prepareSnapdUCTracks(c *C, model *asserts.Model, tracks snap.TrackRedirects) {
 	s.AddCleanup(release.MockOnClassic(false))
 	if model != nil {
 		s.AddCleanup(snapstatetest.MockDeviceModel(model))

--- a/snap/channel/channel.go
+++ b/snap/channel/channel.go
@@ -189,6 +189,13 @@ func (c *Channel) VerbatimTrackOnly() bool {
 	return c.Track != "" && c.Risk == "" && c.Branch == ""
 }
 
+// IsVerbatimTrackOnly reports whether s is a verbatim track-only channel name
+// (non-empty track, no risk or branch), such as "18" or "latest".
+func IsVerbatimTrackOnly(s string) bool {
+	ch, err := ParseVerbatim(s, "-")
+	return err == nil && ch.VerbatimTrackOnly()
+}
+
 // VerbatimRiskOnly returns whether the channel represents a risk only.
 func (c *Channel) VerbatimRiskOnly() bool {
 	return c.Track == "" && c.Risk != "" && c.Branch == ""

--- a/snap/channel/channel_test.go
+++ b/snap/channel/channel_test.go
@@ -167,6 +167,23 @@ func (s storeChannelSuite) TestParseVerbatim(c *C) {
 	c.Check(mustParse(c, "latest/stable/foo"), DeepEquals, ch.Clean())
 }
 
+func (s storeChannelSuite) TestIsVerbatimTrackOnly(c *C) {
+	for _, t := range []struct {
+		name string
+		ok   bool
+	}{
+		{"latest", true},
+		{"18", true},
+		{"18-fips", true},
+		{"", false},
+		{"stable", false},
+		{"18/stable", false},
+		{"18/stable/hotfix", false},
+	} {
+		c.Check(channel.IsVerbatimTrackOnly(t.name), Equals, t.ok, Commentf("%q", t.name))
+	}
+}
+
 func (s storeChannelSuite) TestClean(c *C) {
 	ch := channel.Channel{
 		Architecture: "arm64",

--- a/snap/info.go
+++ b/snap/info.go
@@ -37,7 +37,6 @@ import (
 	"github.com/snapcore/snapd/metautil"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/sys"
-	"github.com/snapcore/snapd/snap/channel"
 	"github.com/snapcore/snapd/snap/integrity"
 	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/snapdtool"
@@ -437,9 +436,10 @@ type Info struct {
 	// IntegrityData available for this snap
 	IntegrityData *IntegrityDataInfo
 
-	// TrackRedirects is the optional track-redirects map from snap.yaml.
-	// Shape: os-release ID → VERSION_ID → input-track → target-track.
-	// Nil if omitted or empty. Unknown IDs are stored and ignored at resolve time.
+	// TrackRedirects is the optional track-redirects map from snap.yaml:
+	// os-release ID → VERSION_ID → input track → target track.
+	// Nil if omitted or empty. Extra IDs in the map are unused until a
+	// matching Key is resolved.
 	TrackRedirects map[string]map[string]map[string]string
 }
 
@@ -2045,22 +2045,6 @@ func SnapdInfoFromSnapFile(snapf Container, snapType Type) (version string, flag
 		return "", nil, err
 	}
 	return snapdtool.ParseInfoFile(bytes.NewBuffer(b), fmt.Sprintf("from %s snap", snapType))
-}
-
-func validateTrackRedirects(trackRedirects map[string]map[string]map[string]string) error {
-	for osID, versions := range trackRedirects {
-		for version, redirects := range versions {
-			for input, target := range redirects {
-				if !channel.IsVerbatimTrackOnly(input) {
-					return fmt.Errorf("input track %q for %s %s is not a track-only channel", input, osID, version)
-				}
-				if !channel.IsVerbatimTrackOnly(target) {
-					return fmt.Errorf("target track %q for %s %s is not a track-only channel", target, osID, version)
-				}
-			}
-		}
-	}
-	return nil
 }
 
 // SnapdAssertionMaxFormatsFromSnapFile returns the supported assertion max

--- a/snap/info.go
+++ b/snap/info.go
@@ -2047,13 +2047,17 @@ func SnapdInfoFromSnapFile(snapf Container, snapType Type) (version string, flag
 	return snapdtool.ParseInfoFile(bytes.NewBuffer(b), fmt.Sprintf("from %s snap", snapType))
 }
 
-func validateTrackRedirectRules(osID, version string, rules map[string]string) error {
-	for input, target := range rules {
-		if !channel.IsVerbatimTrackOnly(input) {
-			return fmt.Errorf("input track %q for %s %s is not a track-only channel", input, osID, version)
-		}
-		if !channel.IsVerbatimTrackOnly(target) {
-			return fmt.Errorf("target track %q for %s %s is not a track-only channel", target, osID, version)
+func validateTrackRedirects(trackRedirects map[string]map[string]map[string]string) error {
+	for osID, versions := range trackRedirects {
+		for version, redirects := range versions {
+			for input, target := range redirects {
+				if !channel.IsVerbatimTrackOnly(input) {
+					return fmt.Errorf("input track %q for %s %s is not a track-only channel", input, osID, version)
+				}
+				if !channel.IsVerbatimTrackOnly(target) {
+					return fmt.Errorf("target track %q for %s %s is not a track-only channel", target, osID, version)
+				}
+			}
 		}
 	}
 	return nil

--- a/snap/info.go
+++ b/snap/info.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2024 Canonical Ltd
+ * Copyright (C) 2014-2026 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -37,6 +37,7 @@ import (
 	"github.com/snapcore/snapd/metautil"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/osutil/sys"
+	"github.com/snapcore/snapd/snap/channel"
 	"github.com/snapcore/snapd/snap/integrity"
 	"github.com/snapcore/snapd/snap/naming"
 	"github.com/snapcore/snapd/snapdtool"
@@ -435,6 +436,11 @@ type Info struct {
 
 	// IntegrityData available for this snap
 	IntegrityData *IntegrityDataInfo
+
+	// TrackRedirects is the optional track-redirects map from snap.yaml.
+	// Shape: os-release ID → VERSION_ID → input-track → target-track.
+	// Nil if omitted or empty. Unknown IDs are stored and ignored at resolve time.
+	TrackRedirects map[string]map[string]map[string]string
 }
 
 // StoreAccount holds information about a store account, for example of snap
@@ -2039,6 +2045,18 @@ func SnapdInfoFromSnapFile(snapf Container, snapType Type) (version string, flag
 		return "", nil, err
 	}
 	return snapdtool.ParseInfoFile(bytes.NewBuffer(b), fmt.Sprintf("from %s snap", snapType))
+}
+
+func validateTrackRedirectRules(osID, version string, rules map[string]string) error {
+	for input, target := range rules {
+		if !channel.IsVerbatimTrackOnly(input) {
+			return fmt.Errorf("input track %q for %s %s is not a track-only channel", input, osID, version)
+		}
+		if !channel.IsVerbatimTrackOnly(target) {
+			return fmt.Errorf("target track %q for %s %s is not a track-only channel", target, osID, version)
+		}
+	}
+	return nil
 }
 
 // SnapdAssertionMaxFormatsFromSnapFile returns the supported assertion max

--- a/snap/info.go
+++ b/snap/info.go
@@ -436,12 +436,14 @@ type Info struct {
 	// IntegrityData available for this snap
 	IntegrityData *IntegrityDataInfo
 
-	// TrackRedirects is the optional track-redirects map from snap.yaml:
-	// os-release ID → VERSION_ID → input track → target track.
-	// Nil if omitted or empty. Extra IDs in the map are unused until a
-	// matching Key is resolved.
-	TrackRedirects map[string]map[string]map[string]string
+	// TrackRedirects comes from snap.yaml; nil if omitted or empty.
+	TrackRedirects TrackRedirects
 }
+
+// TrackRedirects is the optional track-redirects map from snap.yaml:
+// os-release ID → VERSION_ID → input track → target track.
+// Extra IDs in the map are unused until a matching Key is resolved.
+type TrackRedirects map[string]map[string]map[string]string
 
 // StoreAccount holds information about a store account, for example of snap
 // publisher.

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -29,36 +29,36 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/snapcore/snapd/metautil"
+	"github.com/snapcore/snapd/snap/channel"
 	"github.com/snapcore/snapd/strutil"
 	"github.com/snapcore/snapd/timeout"
 )
 
 type snapYaml struct {
-	Name            string                   `yaml:"name"`
-	Version         string                   `yaml:"version"`
-	Type            Type                     `yaml:"type"`
-	Architectures   []string                 `yaml:"architectures,omitempty"`
-	Assumes         []string                 `yaml:"assumes"`
-	Title           string                   `yaml:"title"`
-	Description     string                   `yaml:"description"`
-	Summary         string                   `yaml:"summary"`
-	Provenance      string                   `yaml:"provenance"`
-	License         string                   `yaml:"license,omitempty"`
-	Epoch           Epoch                    `yaml:"epoch,omitempty"`
-	Base            string                   `yaml:"base,omitempty"`
-	Confinement     ConfinementType          `yaml:"confinement,omitempty"`
-	Grade           GradeType                `yaml:"grade,omitempty"`
-	Environment     strutil.OrderedMap       `yaml:"environment,omitempty"`
-	Plugs           map[string]any           `yaml:"plugs,omitempty"`
-	Slots           map[string]any           `yaml:"slots,omitempty"`
-	Apps            map[string]appYaml       `yaml:"apps,omitempty"`
-	Hooks           map[string]hookYaml      `yaml:"hooks,omitempty"`
-	Layout          map[string]layoutYaml    `yaml:"layout,omitempty"`
-	SystemUsernames map[string]any           `yaml:"system-usernames,omitempty"`
-	Links           map[string][]string      `yaml:"links,omitempty"`
-	Components      map[string]componentYaml `yaml:"components,omitempty"`
-	// TrackRedirects is snapd-only; Validate rejects it on other snap types.
-	TrackRedirects map[string]map[string]map[string]string `yaml:"track-redirects,omitempty"`
+	Name            string                                  `yaml:"name"`
+	Version         string                                  `yaml:"version"`
+	Type            Type                                    `yaml:"type"`
+	Architectures   []string                                `yaml:"architectures,omitempty"`
+	Assumes         []string                                `yaml:"assumes"`
+	Title           string                                  `yaml:"title"`
+	Description     string                                  `yaml:"description"`
+	Summary         string                                  `yaml:"summary"`
+	Provenance      string                                  `yaml:"provenance"`
+	License         string                                  `yaml:"license,omitempty"`
+	Epoch           Epoch                                   `yaml:"epoch,omitempty"`
+	Base            string                                  `yaml:"base,omitempty"`
+	Confinement     ConfinementType                         `yaml:"confinement,omitempty"`
+	Grade           GradeType                               `yaml:"grade,omitempty"`
+	Environment     strutil.OrderedMap                      `yaml:"environment,omitempty"`
+	Plugs           map[string]any                          `yaml:"plugs,omitempty"`
+	Slots           map[string]any                          `yaml:"slots,omitempty"`
+	Apps            map[string]appYaml                      `yaml:"apps,omitempty"`
+	Hooks           map[string]hookYaml                     `yaml:"hooks,omitempty"`
+	Layout          map[string]layoutYaml                   `yaml:"layout,omitempty"`
+	SystemUsernames map[string]any                          `yaml:"system-usernames,omitempty"`
+	Links           map[string][]string                     `yaml:"links,omitempty"`
+	Components      map[string]componentYaml                `yaml:"components,omitempty"`
+	TrackRedirects  map[string]map[string]map[string]string `yaml:"track-redirects,omitempty"`
 
 	// TypoLayouts is used to detect the use of the incorrect plural form of "layout"
 	TypoLayouts typoDetector `yaml:"layouts,omitempty"`
@@ -669,6 +669,28 @@ func setTrackRedirectsFromSnapYaml(y snapYaml, snap *Info) error {
 		return fmt.Errorf("cannot parse snap.yaml: invalid track-redirects: %v", err)
 	}
 	snap.TrackRedirects = y.TrackRedirects
+	return nil
+}
+
+func validateTrackRedirects(trackRedirects map[string]map[string]map[string]string) error {
+	for osID, versions := range trackRedirects {
+		if osID == "" {
+			return fmt.Errorf("empty os-release ID")
+		}
+		for version, redirects := range versions {
+			if version == "" {
+				return fmt.Errorf("empty version for %s", osID)
+			}
+			for input, target := range redirects {
+				if !channel.IsVerbatimTrackOnly(input) {
+					return fmt.Errorf("input track %q for %s %s is not a track-only channel", input, osID, version)
+				}
+				if !channel.IsVerbatimTrackOnly(target) {
+					return fmt.Errorf("target track %q for %s %s is not a track-only channel", target, osID, version)
+				}
+			}
+		}
+	}
 	return nil
 }
 

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2021 Canonical Ltd
+ * Copyright (C) 2014-2026 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -57,6 +57,8 @@ type snapYaml struct {
 	SystemUsernames map[string]any           `yaml:"system-usernames,omitempty"`
 	Links           map[string][]string      `yaml:"links,omitempty"`
 	Components      map[string]componentYaml `yaml:"components,omitempty"`
+	// TrackRedirects is snapd-only; Validate rejects it on other snap types.
+	TrackRedirects map[string]map[string]map[string]string `yaml:"track-redirects,omitempty"`
 
 	// TypoLayouts is used to detect the use of the incorrect plural form of "layout"
 	TypoLayouts typoDetector `yaml:"layouts,omitempty"`
@@ -249,6 +251,10 @@ func infoFromSnapYaml(yamlData []byte, strk *scopedTracker) (*Info, error) {
 	}
 
 	if err := setLinksFromSnapYaml(y, snap); err != nil {
+		return nil, err
+	}
+
+	if err := setTrackRedirectsFromSnapYaml(y, snap); err != nil {
 		return nil, err
 	}
 
@@ -652,6 +658,21 @@ func setLinksFromSnapYaml(y snapYaml, snap *Info) error {
 		}
 		snap.OriginalLinks[linksKey] = links
 	}
+	return nil
+}
+
+func setTrackRedirectsFromSnapYaml(y snapYaml, snap *Info) error {
+	if len(y.TrackRedirects) == 0 {
+		return nil
+	}
+	for osID, versions := range y.TrackRedirects {
+		for version, rules := range versions {
+			if err := validateTrackRedirectRules(osID, version, rules); err != nil {
+				return fmt.Errorf("cannot parse snap.yaml: invalid track-redirects: %v", err)
+			}
+		}
+	}
+	snap.TrackRedirects = y.TrackRedirects
 	return nil
 }
 

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -35,30 +35,30 @@ import (
 )
 
 type snapYaml struct {
-	Name            string                                  `yaml:"name"`
-	Version         string                                  `yaml:"version"`
-	Type            Type                                    `yaml:"type"`
-	Architectures   []string                                `yaml:"architectures,omitempty"`
-	Assumes         []string                                `yaml:"assumes"`
-	Title           string                                  `yaml:"title"`
-	Description     string                                  `yaml:"description"`
-	Summary         string                                  `yaml:"summary"`
-	Provenance      string                                  `yaml:"provenance"`
-	License         string                                  `yaml:"license,omitempty"`
-	Epoch           Epoch                                   `yaml:"epoch,omitempty"`
-	Base            string                                  `yaml:"base,omitempty"`
-	Confinement     ConfinementType                         `yaml:"confinement,omitempty"`
-	Grade           GradeType                               `yaml:"grade,omitempty"`
-	Environment     strutil.OrderedMap                      `yaml:"environment,omitempty"`
-	Plugs           map[string]any                          `yaml:"plugs,omitempty"`
-	Slots           map[string]any                          `yaml:"slots,omitempty"`
-	Apps            map[string]appYaml                      `yaml:"apps,omitempty"`
-	Hooks           map[string]hookYaml                     `yaml:"hooks,omitempty"`
-	Layout          map[string]layoutYaml                   `yaml:"layout,omitempty"`
-	SystemUsernames map[string]any                          `yaml:"system-usernames,omitempty"`
-	Links           map[string][]string                     `yaml:"links,omitempty"`
-	Components      map[string]componentYaml                `yaml:"components,omitempty"`
-	TrackRedirects  map[string]map[string]map[string]string `yaml:"track-redirects,omitempty"`
+	Name            string                   `yaml:"name"`
+	Version         string                   `yaml:"version"`
+	Type            Type                     `yaml:"type"`
+	Architectures   []string                 `yaml:"architectures,omitempty"`
+	Assumes         []string                 `yaml:"assumes"`
+	Title           string                   `yaml:"title"`
+	Description     string                   `yaml:"description"`
+	Summary         string                   `yaml:"summary"`
+	Provenance      string                   `yaml:"provenance"`
+	License         string                   `yaml:"license,omitempty"`
+	Epoch           Epoch                    `yaml:"epoch,omitempty"`
+	Base            string                   `yaml:"base,omitempty"`
+	Confinement     ConfinementType          `yaml:"confinement,omitempty"`
+	Grade           GradeType                `yaml:"grade,omitempty"`
+	Environment     strutil.OrderedMap       `yaml:"environment,omitempty"`
+	Plugs           map[string]any           `yaml:"plugs,omitempty"`
+	Slots           map[string]any           `yaml:"slots,omitempty"`
+	Apps            map[string]appYaml       `yaml:"apps,omitempty"`
+	Hooks           map[string]hookYaml      `yaml:"hooks,omitempty"`
+	Layout          map[string]layoutYaml    `yaml:"layout,omitempty"`
+	SystemUsernames map[string]any           `yaml:"system-usernames,omitempty"`
+	Links           map[string][]string      `yaml:"links,omitempty"`
+	Components      map[string]componentYaml `yaml:"components,omitempty"`
+	TrackRedirects  TrackRedirects           `yaml:"track-redirects,omitempty"`
 
 	// TypoLayouts is used to detect the use of the incorrect plural form of "layout"
 	TypoLayouts typoDetector `yaml:"layouts,omitempty"`
@@ -672,7 +672,7 @@ func setTrackRedirectsFromSnapYaml(y snapYaml, snap *Info) error {
 	return nil
 }
 
-func validateTrackRedirects(trackRedirects map[string]map[string]map[string]string) error {
+func validateTrackRedirects(trackRedirects TrackRedirects) error {
 	for osID, versions := range trackRedirects {
 		if osID == "" {
 			return fmt.Errorf("empty os-release ID")

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -665,12 +665,8 @@ func setTrackRedirectsFromSnapYaml(y snapYaml, snap *Info) error {
 	if len(y.TrackRedirects) == 0 {
 		return nil
 	}
-	for osID, versions := range y.TrackRedirects {
-		for version, rules := range versions {
-			if err := validateTrackRedirectRules(osID, version, rules); err != nil {
-				return fmt.Errorf("cannot parse snap.yaml: invalid track-redirects: %v", err)
-			}
-		}
+	if err := validateTrackRedirects(y.TrackRedirects); err != nil {
+		return fmt.Errorf("cannot parse snap.yaml: invalid track-redirects: %v", err)
 	}
 	snap.TrackRedirects = y.TrackRedirects
 	return nil

--- a/snap/info_snap_yaml.go
+++ b/snap/info_snap_yaml.go
@@ -681,6 +681,9 @@ func validateTrackRedirects(trackRedirects TrackRedirects) error {
 			if version == "" {
 				return fmt.Errorf("empty version for %s", osID)
 			}
+			if len(redirects) == 0 {
+				return fmt.Errorf("empty track map for %s %s", osID, version)
+			}
 			for input, target := range redirects {
 				if !channel.IsVerbatimTrackOnly(input) {
 					return fmt.Errorf("input track %q for %s %s is not a track-only channel", input, osID, version)

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2014-2021 Canonical Ltd
+ * Copyright (C) 2014-2026 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -2406,4 +2406,155 @@ components:
 `))
 	c.Assert(err.Error(), Equals, `component hooks cannot have slots`)
 	c.Assert(info, IsNil)
+}
+
+func (s *YamlSuite) TestUnmarshalTrackRedirects(c *C) {
+	info, err := snap.InfoFromSnapYaml([]byte(`
+name: snapd
+version: 1.0
+track-redirects:
+  ubuntu-core:
+    "18":
+      latest: "18"
+      fips-updates: "18-fips"
+    "20":
+      latest: "20"
+  ubuntu:
+    "22.04":
+      latest: "22.04"
+`))
+	c.Assert(err, IsNil)
+	c.Check(info.Type(), Equals, snap.TypeSnapd)
+	c.Check(info.TrackRedirects, DeepEquals, map[string]map[string]map[string]string{
+		"ubuntu-core": {
+			"18": {"latest": "18", "fips-updates": "18-fips"},
+			"20": {"latest": "20"},
+		},
+		"ubuntu": {
+			"22.04": {"latest": "22.04"},
+		},
+	})
+}
+
+func (s *YamlSuite) TestUnmarshalTrackRedirectsUnquotedVersion(c *C) {
+	info, err := snap.InfoFromSnapYaml([]byte(`
+name: snapd
+version: 1.0
+track-redirects:
+  ubuntu-core:
+    18:
+      latest: "18"
+`))
+	c.Assert(err, IsNil)
+	c.Check(info.TrackRedirects, DeepEquals, map[string]map[string]map[string]string{
+		"ubuntu-core": {
+			"18": {"latest": "18"},
+		},
+	})
+}
+
+func (s *YamlSuite) TestUnmarshalTrackRedirectsOmitted(c *C) {
+	info, err := snap.InfoFromSnapYaml([]byte(`name: snapd
+version: 1.0
+`))
+	c.Assert(err, IsNil)
+	c.Check(info.TrackRedirects, IsNil)
+}
+
+func (s *YamlSuite) TestUnmarshalTrackRedirectsEmpty(c *C) {
+	info, err := snap.InfoFromSnapYaml([]byte(`
+name: snapd
+version: 1.0
+track-redirects: {}
+`))
+	c.Assert(err, IsNil)
+	c.Check(info.TrackRedirects, IsNil)
+}
+
+func (s *YamlSuite) TestUnmarshalTrackRedirectsRejectsTwoLevelMap(c *C) {
+	_, err := snap.InfoFromSnapYaml([]byte(`
+name: snapd
+version: 1.0
+track-redirects:
+  18:
+    latest: "18"
+`))
+	c.Assert(err, ErrorMatches, "(?s)cannot parse snap.yaml: yaml: unmarshal errors:.*cannot unmarshal !!str `18` into map\\[string\\]string")
+}
+
+func (s *YamlSuite) TestUnmarshalTrackRedirectsRejectsNonTrackOnly(c *C) {
+	for _, t := range []struct {
+		yaml string
+		err  string
+	}{
+		{
+			yaml: `
+name: snapd
+version: 1.0
+track-redirects:
+  ubuntu-core:
+    "18":
+      latest: "18/stable"
+`,
+			err: `cannot parse snap.yaml: invalid track-redirects: target track "18/stable" for ubuntu-core 18 is not a track-only channel`,
+		},
+		{
+			yaml: `
+name: snapd
+version: 1.0
+track-redirects:
+  ubuntu-core:
+    "18":
+      latest: "stable"
+`,
+			err: `cannot parse snap.yaml: invalid track-redirects: target track "stable" for ubuntu-core 18 is not a track-only channel`,
+		},
+		{
+			yaml: `
+name: snapd
+version: 1.0
+track-redirects:
+  ubuntu-core:
+    "18":
+      latest/stable: "18"
+`,
+			err: `cannot parse snap.yaml: invalid track-redirects: input track "latest/stable" for ubuntu-core 18 is not a track-only channel`,
+		},
+		{
+			yaml: `
+name: snapd
+version: 1.0
+track-redirects:
+  ubuntu-core:
+    "18":
+      latest: ""
+`,
+			err: `cannot parse snap.yaml: invalid track-redirects: target track "" for ubuntu-core 18 is not a track-only channel`,
+		},
+		{
+			yaml: `
+name: snapd
+version: 1.0
+track-redirects:
+  ubuntu-core:
+    "18":
+      "": "18"
+`,
+			err: `cannot parse snap.yaml: invalid track-redirects: input track "" for ubuntu-core 18 is not a track-only channel`,
+		},
+		{
+			yaml: `
+name: snapd
+version: 1.0
+track-redirects:
+  ubuntu-core:
+    "18":
+      stable: "18"
+`,
+			err: `cannot parse snap.yaml: invalid track-redirects: input track "stable" for ubuntu-core 18 is not a track-only channel`,
+		},
+	} {
+		_, err := snap.InfoFromSnapYaml([]byte(t.yaml))
+		c.Check(err, ErrorMatches, t.err, Commentf("yaml=%s", t.yaml))
+	}
 }

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -2425,7 +2425,7 @@ track-redirects:
 `))
 	c.Assert(err, IsNil)
 	c.Check(info.Type(), Equals, snap.TypeSnapd)
-	c.Check(info.TrackRedirects, DeepEquals, map[string]map[string]map[string]string{
+	c.Check(info.TrackRedirects, DeepEquals, snap.TrackRedirects{
 		"ubuntu-core": {
 			"18": {"latest": "18", "fips-updates": "18-fips"},
 			"20": {"latest": "20"},
@@ -2446,7 +2446,7 @@ track-redirects:
       latest: "18"
 `))
 	c.Assert(err, IsNil)
-	c.Check(info.TrackRedirects, DeepEquals, map[string]map[string]map[string]string{
+	c.Check(info.TrackRedirects, DeepEquals, snap.TrackRedirects{
 		"ubuntu-core": {
 			"18": {"latest": "18"},
 		},

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -2575,6 +2575,16 @@ track-redirects:
 `,
 			err: `cannot parse snap.yaml: invalid track-redirects: empty version for ubuntu-core`,
 		},
+		{
+			yaml: `
+name: snapd
+version: 1.0
+track-redirects:
+  ubuntu-core:
+    "18": {}
+`,
+			err: `cannot parse snap.yaml: invalid track-redirects: empty track map for ubuntu-core 18`,
+		},
 	} {
 		_, err := snap.InfoFromSnapYaml([]byte(t.yaml))
 		c.Check(err, ErrorMatches, t.err, Commentf("yaml=%s", t.yaml))

--- a/snap/info_snap_yaml_test.go
+++ b/snap/info_snap_yaml_test.go
@@ -2553,6 +2553,28 @@ track-redirects:
 `,
 			err: `cannot parse snap.yaml: invalid track-redirects: input track "stable" for ubuntu-core 18 is not a track-only channel`,
 		},
+		{
+			yaml: `
+name: snapd
+version: 1.0
+track-redirects:
+  "":
+    "18":
+      latest: "18"
+`,
+			err: `cannot parse snap.yaml: invalid track-redirects: empty os-release ID`,
+		},
+		{
+			yaml: `
+name: snapd
+version: 1.0
+track-redirects:
+  ubuntu-core:
+    "":
+      latest: "18"
+`,
+			err: `cannot parse snap.yaml: invalid track-redirects: empty version for ubuntu-core`,
+		},
 	} {
 		_, err := snap.InfoFromSnapYaml([]byte(t.yaml))
 		c.Check(err, ErrorMatches, t.err, Commentf("yaml=%s", t.yaml))

--- a/snap/trackredirect/trackredirect.go
+++ b/snap/trackredirect/trackredirect.go
@@ -1,0 +1,158 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Package trackredirect implements snapd track-redirects policy from snap.yaml.
+//
+// A track-aware snapd consults this package when resolving snapd store
+// channels. Track awareness does not imply that snapd carries a populated
+// map; maps are added incrementally as LTS branches are onboarded.
+//
+// UbuntuCoreKey selects the ubuntu-core os-release ID and version from a model.
+// Resolve looks up that (or any other) key in snap.Info.TrackRedirects and
+// rewrites the channel.
+package trackredirect
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/snapcore/snapd/asserts"
+	snapchannel "github.com/snapcore/snapd/snap/channel"
+)
+
+const (
+	// UbuntuCoreID is the os-release ID for Ubuntu Core.
+	UbuntuCoreID = "ubuntu-core"
+)
+
+// Key identifies a slice of the track-redirects map: ID → version
+// (os-release ID and VERSION_ID).
+type Key struct {
+	ID      string
+	Version string
+}
+
+var (
+	// ErrNotApplicable is returned when a selector does not apply to the system.
+	ErrNotApplicable = errors.New("cannot use UC tracks")
+	// ErrNotCovered is returned when the key's ID or version is missing
+	// from the map. Callers pass through: no channel restriction applies
+	// until that version is onboarded.
+	ErrNotCovered = errors.New("cannot find track redirects")
+	// ErrNoTrack is returned when the version is covered but the input
+	// track is neither a map key nor a map value. Store callers refuse.
+	ErrNoTrack = errors.New("cannot find track redirect for input track")
+)
+
+// UbuntuCoreKey returns the track-redirects key for an Ubuntu Core model.
+// It returns ErrNotApplicable for classic, hybrid classic, and UC16.
+func UbuntuCoreKey(model *asserts.Model) (Key, error) {
+	if model == nil {
+		return Key{}, fmt.Errorf("internal error: cannot use nil model")
+	}
+
+	if model.Classic() {
+		if model.HybridClassic() {
+			return Key{}, fmt.Errorf("%w on a hybrid classic system", ErrNotApplicable)
+		}
+		return Key{}, fmt.Errorf("%w on a classic system", ErrNotApplicable)
+	}
+
+	bootBase, err := model.BaseCoreVersion()
+	if err != nil {
+		return Key{}, fmt.Errorf("internal error: cannot determine boot base: %v", err)
+	}
+	// UC16 uses the core snap as both base and snapd, so there is no
+	// separate snapd snap to apply track policy to.
+	if bootBase == 16 {
+		return Key{}, fmt.Errorf("%w: unsupported Ubuntu Core 16 model", ErrNotApplicable)
+	}
+	return Key{ID: UbuntuCoreID, Version: strconv.Itoa(bootBase)}, nil
+}
+
+// Resolve applies track-redirects policy to channel using the map slice for
+// key. On success it returns the remapped channel with the target track, the
+// original risk, and any branch dropped. On failure it returns ("", err).
+//
+// Policy errors wrap sentinels: ErrNotCovered when key.ID or key.Version
+// is missing from the map, and ErrNoTrack when the slice exists but the input
+// track is neither a transition key nor a target track. Channel parse
+// failures are plain errors. Empty ID or version is an internal error.
+//
+// Channel is the planned store channel (typically SnapSetup.Channel after
+// resolveChannel). Risk-only names are interpreted as the store does: a
+// missing track means latest, so "stable" is latest/stable. This function
+// does not inherit a tracking track; that merge must already have happened.
+func Resolve(key Key, channel string, trackRedirects map[string]map[string]map[string]string) (string, error) {
+	if key.ID == "" || key.Version == "" {
+		return "", fmt.Errorf("internal error: cannot resolve track redirects with empty key")
+	}
+
+	parsed, err := snapchannel.ParseVerbatim(channel, "-")
+	if err != nil {
+		return "", fmt.Errorf("cannot parse input channel: %v", err)
+	}
+	inputTrack := parsed.Track
+	if inputTrack == "" {
+		inputTrack = "latest"
+	}
+
+	targetTrack, err := resolveTrack(key, trackRedirects, inputTrack)
+	if err != nil {
+		return "", err
+	}
+
+	parsed.Track = targetTrack
+	parsed.Branch = ""
+	return parsed.Clean().String(), nil
+}
+
+func resolveTrack(key Key, trackRedirects map[string]map[string]map[string]string, inputTrack string) (string, error) {
+	byID, ok := trackRedirects[key.ID]
+	if !ok {
+		return "", fmt.Errorf("%w for %s %s", ErrNotCovered, key.ID, key.Version)
+	}
+	rules, ok := byID[key.Version]
+	if !ok {
+		return "", fmt.Errorf("%w for %s %s", ErrNotCovered, key.ID, key.Version)
+	}
+	targetTrack, found := lookupTrack(rules, inputTrack)
+	if !found {
+		return "", fmt.Errorf("%w %s for %s %s", ErrNoTrack, inputTrack, key.ID, key.Version)
+	}
+	return targetTrack, nil
+}
+
+// lookupTrack returns the target track for inputTrack. Keys are
+// transitions (latest → 18). If inputTrack already matches a target
+// (e.g. "18" after a previous jump), it is kept. An explicit key wins,
+// so a later onboard can remap onward ("18": "24").
+func lookupTrack(rules map[string]string, inputTrack string) (targetTrack string, found bool) {
+	if targetTrack, ok := rules[inputTrack]; ok && targetTrack != "" {
+		return targetTrack, true
+	}
+	// Already on a target track (e.g. "18" after a previous jump): keep it.
+	for _, target := range rules {
+		if target != "" && target == inputTrack {
+			return inputTrack, true
+		}
+	}
+	return "", false
+}

--- a/snap/trackredirect/trackredirect.go
+++ b/snap/trackredirect/trackredirect.go
@@ -30,6 +30,7 @@ import (
 	"strconv"
 
 	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/snap"
 	snapchannel "github.com/snapcore/snapd/snap/channel"
 )
 
@@ -94,7 +95,7 @@ func UbuntuCoreKey(model *asserts.Model) (Key, error) {
 // Risk-only names are interpreted as the store does: a missing track means
 // latest, so "stable" is latest/stable. This function does not inherit
 // SnapState tracking; resolveChannel must already have run.
-func Resolve(key Key, channel string, trackRedirects map[string]map[string]map[string]string) (string, error) {
+func Resolve(key Key, channel string, trackRedirects snap.TrackRedirects) (string, error) {
 	if key.ID == "" || key.Version == "" {
 		return "", fmt.Errorf("internal error: cannot resolve track redirects with empty key")
 	}
@@ -118,7 +119,7 @@ func Resolve(key Key, channel string, trackRedirects map[string]map[string]map[s
 	return parsed.Clean().String(), nil
 }
 
-func resolveTrack(key Key, trackRedirects map[string]map[string]map[string]string, inputTrack string) (string, error) {
+func resolveTrack(key Key, trackRedirects snap.TrackRedirects, inputTrack string) (string, error) {
 	byID, ok := trackRedirects[key.ID]
 	if !ok {
 		return "", fmt.Errorf("%w for %s %s", ErrNotCovered, key.ID, key.Version)

--- a/snap/trackredirect/trackredirect.go
+++ b/snap/trackredirect/trackredirect.go
@@ -17,15 +17,11 @@
  *
  */
 
-// Package trackredirect implements snapd track-redirects policy from snap.yaml.
+// Package trackredirect applies snap.yaml track-redirects to snapd store channels.
 //
-// A track-aware snapd consults this package when resolving snapd store
-// channels. Track awareness does not imply that snapd carries a populated
-// map; maps are added incrementally as LTS branches are onboarded.
-//
-// UbuntuCoreKey selects the ubuntu-core os-release ID and version from a model.
-// Resolve looks up that (or any other) key in snap.Info.TrackRedirects and
-// rewrites the channel.
+// UbuntuCoreKey builds a Key from an Ubuntu Core model. Resolve rewrites a
+// planned channel using snap.Info.TrackRedirects. An empty map is valid;
+// versions are onboarded incrementally.
 package trackredirect
 
 import (
@@ -42,22 +38,20 @@ const (
 	UbuntuCoreID = "ubuntu-core"
 )
 
-// Key identifies a slice of the track-redirects map: ID → version
-// (os-release ID and VERSION_ID).
+// Key selects a slice of the track-redirects map: os-release ID, then
+// VERSION_ID. UbuntuCoreKey sets Version from the model boot base (e.g. "18").
 type Key struct {
 	ID      string
 	Version string
 }
 
 var (
-	// ErrNotApplicable is returned when a selector does not apply to the system.
+	// ErrNotApplicable is returned when a Key cannot be selected for the model.
 	ErrNotApplicable = errors.New("cannot use UC tracks")
-	// ErrNotCovered is returned when the key's ID or version is missing
-	// from the map. Callers pass through: no channel restriction applies
-	// until that version is onboarded.
+	// ErrNotCovered is returned when the key's ID or version is not in the map.
 	ErrNotCovered = errors.New("cannot find track redirects")
-	// ErrNoTrack is returned when the version is covered but the input
-	// track is neither a map key nor a map value. Store callers refuse.
+	// ErrNoTrack is returned when the version is in the map but the input
+	// track is neither a key nor a value.
 	ErrNoTrack = errors.New("cannot find track redirect for input track")
 )
 
@@ -77,7 +71,7 @@ func UbuntuCoreKey(model *asserts.Model) (Key, error) {
 
 	bootBase, err := model.BaseCoreVersion()
 	if err != nil {
-		return Key{}, fmt.Errorf("internal error: cannot determine boot base: %v", err)
+		return Key{}, fmt.Errorf("cannot determine boot base: %v", err)
 	}
 	// UC16 uses the core snap as both base and snapd, so there is no
 	// separate snapd snap to apply track policy to.
@@ -87,19 +81,19 @@ func UbuntuCoreKey(model *asserts.Model) (Key, error) {
 	return Key{ID: UbuntuCoreID, Version: strconv.Itoa(bootBase)}, nil
 }
 
-// Resolve applies track-redirects policy to channel using the map slice for
-// key. On success it returns the remapped channel with the target track, the
-// original risk, and any branch dropped. On failure it returns ("", err).
+// Resolve applies track-redirects for key to channel. On success it returns
+// the remapped channel with the target track, the original risk, and any
+// branch dropped.
 //
-// Policy errors wrap sentinels: ErrNotCovered when key.ID or key.Version
-// is missing from the map, and ErrNoTrack when the slice exists but the input
-// track is neither a transition key nor a target track. Channel parse
-// failures are plain errors. Empty ID or version is an internal error.
+// Policy errors wrap ErrNotCovered when key.ID or key.Version is missing
+// from the map, and ErrNoTrack when the slice exists but the input track
+// is neither a map key nor a map value. Channel parse failures are plain
+// errors. Empty ID or version is an internal error.
 //
-// Channel is the planned store channel (typically SnapSetup.Channel after
-// resolveChannel). Risk-only names are interpreted as the store does: a
-// missing track means latest, so "stable" is latest/stable. This function
-// does not inherit a tracking track; that merge must already have happened.
+// Channel is the planned store channel (typically after resolveChannel).
+// Risk-only names are interpreted as the store does: a missing track means
+// latest, so "stable" is latest/stable. This function does not inherit
+// SnapState tracking; resolveChannel must already have run.
 func Resolve(key Key, channel string, trackRedirects map[string]map[string]map[string]string) (string, error) {
 	if key.ID == "" || key.Version == "" {
 		return "", fmt.Errorf("internal error: cannot resolve track redirects with empty key")
@@ -129,11 +123,11 @@ func resolveTrack(key Key, trackRedirects map[string]map[string]map[string]strin
 	if !ok {
 		return "", fmt.Errorf("%w for %s %s", ErrNotCovered, key.ID, key.Version)
 	}
-	rules, ok := byID[key.Version]
+	redirects, ok := byID[key.Version]
 	if !ok {
 		return "", fmt.Errorf("%w for %s %s", ErrNotCovered, key.ID, key.Version)
 	}
-	targetTrack, found := lookupTrack(rules, inputTrack)
+	targetTrack, found := lookupTrack(redirects, inputTrack)
 	if !found {
 		return "", fmt.Errorf("%w %s for %s %s", ErrNoTrack, inputTrack, key.ID, key.Version)
 	}
@@ -144,12 +138,12 @@ func resolveTrack(key Key, trackRedirects map[string]map[string]map[string]strin
 // transitions (latest → 18). If inputTrack already matches a target
 // (e.g. "18" after a previous jump), it is kept. An explicit key wins,
 // so a later onboard can remap onward ("18": "24").
-func lookupTrack(rules map[string]string, inputTrack string) (targetTrack string, found bool) {
-	if targetTrack, ok := rules[inputTrack]; ok && targetTrack != "" {
-		return targetTrack, true
+func lookupTrack(redirects map[string]string, inputTrack string) (string, bool) {
+	if target, ok := redirects[inputTrack]; ok && target != "" {
+		return target, true
 	}
 	// Already on a target track (e.g. "18" after a previous jump): keep it.
-	for _, target := range rules {
+	for _, target := range redirects {
 		if target != "" && target == inputTrack {
 			return inputTrack, true
 		}

--- a/snap/trackredirect/trackredirect_test.go
+++ b/snap/trackredirect/trackredirect_test.go
@@ -147,6 +147,12 @@ func (s *trackredirectSuite) TestUbuntuCoreKeyNilModel(c *C) {
 	c.Check(err, ErrorMatches, "internal error: cannot use nil model")
 }
 
+func (s *trackredirectSuite) TestUbuntuCoreKeyNonCoreBase(c *C) {
+	model := s.coreModel(c, "bare", "pc", "pc-kernel")
+	_, err := trackredirect.UbuntuCoreKey(model)
+	c.Check(err, ErrorMatches, "cannot determine boot base: not a core base")
+}
+
 func (s *trackredirectSuite) TestResolveUC18Remap(c *C) {
 	trackMap := trackRedirectMap(18, "18", "18-fips")
 
@@ -161,6 +167,8 @@ func (s *trackredirectSuite) TestResolveUC18Remap(c *C) {
 		{"stable", "18/stable"},
 		{"candidate", "18/candidate"},
 		{"beta", "18/beta"},
+		{"latest", "18/stable"},
+		{"edge", "18/edge"},
 		// fips-updates variant -> 18-fips track
 		{"fips-updates/stable", "18-fips/stable"},
 		{"fips-updates/candidate", "18-fips/candidate"},

--- a/snap/trackredirect/trackredirect_test.go
+++ b/snap/trackredirect/trackredirect_test.go
@@ -1,0 +1,286 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package trackredirect_test
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/assertstest"
+	"github.com/snapcore/snapd/snap/trackredirect"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type ucSuite struct {
+	brands *assertstest.SigningAccounts
+}
+
+var _ = Suite(&ucSuite{})
+
+func (s *ucSuite) SetUpTest(c *C) {
+	brandKey, _ := assertstest.GenerateKey(752)
+	store := assertstest.NewStoreStack("store", nil)
+	s.brands = assertstest.NewSigningAccounts(store)
+	s.brands.Register("my-brand", brandKey, nil)
+}
+
+func (s *ucSuite) coreModel(c *C, base, gadget, kernel string) *asserts.Model {
+	headers := map[string]any{
+		"architecture": "amd64",
+		"gadget":       gadget,
+		"kernel":       kernel,
+	}
+	if base != "" {
+		headers["base"] = base
+	}
+	return s.brands.Model("my-brand", "my-model", headers)
+}
+
+func (s *ucSuite) classicModel(c *C) *asserts.Model {
+	return s.brands.Model("my-brand", "my-model", map[string]any{
+		"architecture": "amd64",
+		"classic":      "true",
+	})
+}
+
+func (s *ucSuite) hybridClassicModel(c *C, base string) *asserts.Model {
+	return assertstest.FakeAssertion(map[string]any{
+		"type":         "model",
+		"authority-id": "my-brand",
+		"brand-id":     "my-brand",
+		"model":        "my-model",
+		"series":       "16",
+		"architecture": "amd64",
+		"classic":      "true",
+		"distribution": "ubuntu",
+		"base":         base,
+		"timestamp":    "2018-01-01T08:00:00+00:00",
+		"snaps": []any{
+			map[string]any{
+				"name": "pc-kernel",
+				"id":   "pclinuxdidididididididididididid",
+				"type": "kernel",
+			},
+			map[string]any{
+				"name": "pc",
+				"id":   "pcididididididididididididididid",
+				"type": "gadget",
+			},
+		},
+	}).(*asserts.Model)
+}
+
+func ucKey(version string) trackredirect.Key {
+	return trackredirect.Key{ID: trackredirect.UbuntuCoreID, Version: version}
+}
+
+func trackRedirectMap(bootBase int, tracks ...string) map[string]map[string]map[string]string {
+	if len(tracks) == 0 {
+		return map[string]map[string]map[string]string{}
+	}
+	rules := map[string]string{
+		"latest": tracks[0],
+	}
+	for _, track := range tracks {
+		if strings.HasSuffix(track, "-fips") {
+			rules["fips-updates"] = track
+		}
+	}
+	return map[string]map[string]map[string]string{
+		trackredirect.UbuntuCoreID: {strconv.Itoa(bootBase): rules},
+	}
+}
+
+func (s *ucSuite) TestUbuntuCoreKeyClassic(c *C) {
+	_, err := trackredirect.UbuntuCoreKey(s.classicModel(c))
+	c.Assert(err, ErrorMatches, "cannot use UC tracks on a classic system")
+	c.Check(errors.Is(err, trackredirect.ErrNotApplicable), Equals, true)
+}
+
+func (s *ucSuite) TestUbuntuCoreKeyHybridClassic(c *C) {
+	_, err := trackredirect.UbuntuCoreKey(s.hybridClassicModel(c, "core22"))
+	c.Assert(err, ErrorMatches, "cannot use UC tracks on a hybrid classic system")
+	c.Check(errors.Is(err, trackredirect.ErrNotApplicable), Equals, true)
+}
+
+func (s *ucSuite) TestUbuntuCoreKeyUC18(c *C) {
+	uc18 := s.coreModel(c, "core18", "pc=18", "pc-kernel=18")
+	key, err := trackredirect.UbuntuCoreKey(uc18)
+	c.Assert(err, IsNil)
+	c.Check(key, DeepEquals, ucKey("18"))
+}
+
+func (s *ucSuite) TestUbuntuCoreKeyUC16(c *C) {
+	for _, base := range []string{"", "core", "core16"} {
+		uc16 := s.coreModel(c, base, "pc", "pc-kernel")
+		_, err := trackredirect.UbuntuCoreKey(uc16)
+		c.Assert(err, ErrorMatches, "cannot use UC tracks: unsupported Ubuntu Core 16 model", Commentf("base %q", base))
+		c.Check(errors.Is(err, trackredirect.ErrNotApplicable), Equals, true, Commentf("base %q", base))
+	}
+}
+
+func (s *ucSuite) TestUbuntuCoreKeyNilModel(c *C) {
+	_, err := trackredirect.UbuntuCoreKey(nil)
+	c.Check(err, ErrorMatches, "internal error: cannot use nil model")
+}
+
+func (s *ucSuite) TestResolveUC18Remap(c *C) {
+	trackMap := trackRedirectMap(18, "18", "18-fips")
+
+	for _, t := range []struct {
+		channel string
+		want    string
+	}{
+		// latest variant -> 18 track, risk preserved
+		{"latest/stable", "18/stable"},
+		{"latest/candidate", "18/candidate"},
+		{"latest/beta", "18/beta"},
+		{"stable", "18/stable"},
+		{"candidate", "18/candidate"},
+		{"beta", "18/beta"},
+		// fips-updates variant -> 18-fips track
+		{"fips-updates/stable", "18-fips/stable"},
+		{"fips-updates/candidate", "18-fips/candidate"},
+	} {
+		resolved, err := trackredirect.Resolve(ucKey("18"), t.channel, trackMap)
+		c.Assert(err, IsNil, Commentf("channel %q", t.channel))
+		c.Check(resolved, Equals, t.want, Commentf("channel %q", t.channel))
+	}
+}
+
+func (s *ucSuite) TestResolveUC18Identity(c *C) {
+	trackMap := trackRedirectMap(18, "18", "18-fips")
+
+	for _, channel := range []string{
+		"18/stable",
+		"18/candidate",
+		"18-fips/stable",
+		"18-fips/beta",
+	} {
+		resolved, err := trackredirect.Resolve(ucKey("18"), channel, trackMap)
+		c.Assert(err, IsNil, Commentf("channel %q", channel))
+		c.Check(resolved, Equals, channel, Commentf("channel %q", channel))
+	}
+}
+
+func (s *ucSuite) TestResolveExplicitKeyWinsOverIdentity(c *C) {
+	// A later onboard can remap a track onward with an explicit key.
+	trackMap := map[string]map[string]map[string]string{
+		trackredirect.UbuntuCoreID: {
+			"18": {"latest": "24", "18": "24"},
+		},
+	}
+
+	resolved, err := trackredirect.Resolve(ucKey("18"), "latest/stable", trackMap)
+	c.Assert(err, IsNil)
+	c.Check(resolved, Equals, "24/stable")
+
+	resolved, err = trackredirect.Resolve(ucKey("18"), "18/stable", trackMap)
+	c.Assert(err, IsNil)
+	c.Check(resolved, Equals, "24/stable")
+
+	resolved, err = trackredirect.Resolve(ucKey("18"), "24/edge", trackMap)
+	c.Assert(err, IsNil)
+	c.Check(resolved, Equals, "24/edge")
+}
+
+func (s *ucSuite) TestResolveUncoveredVersion(c *C) {
+	// Version 22 is not covered (not in the map; 18 is onboarded).
+	trackMap := trackRedirectMap(18, "18")
+
+	for _, channel := range []string{"latest/stable", "22/stable", "stable"} {
+		_, err := trackredirect.Resolve(ucKey("22"), channel, trackMap)
+		c.Assert(err, ErrorMatches, `cannot find track redirects for ubuntu-core 22`, Commentf("channel %q", channel))
+		c.Check(errors.Is(err, trackredirect.ErrNotCovered), Equals, true, Commentf("channel %q", channel))
+	}
+}
+
+func (s *ucSuite) TestResolveEmptyMapErrors(c *C) {
+	_, err := trackredirect.Resolve(ucKey("18"), "latest/stable", map[string]map[string]map[string]string{})
+	c.Assert(err, ErrorMatches, `cannot find track redirects for ubuntu-core 18`)
+	c.Check(errors.Is(err, trackredirect.ErrNotCovered), Equals, true)
+
+	_, err = trackredirect.Resolve(ucKey("18"), "latest/stable", nil)
+	c.Assert(err, ErrorMatches, `cannot find track redirects for ubuntu-core 18`)
+	c.Check(errors.Is(err, trackredirect.ErrNotCovered), Equals, true)
+}
+
+func (s *ucSuite) TestResolveBranchDropped(c *C) {
+	resolved, err := trackredirect.Resolve(ucKey("18"), "latest/stable/mybranch", trackRedirectMap(18, "18"))
+	c.Assert(err, IsNil)
+	c.Check(resolved, Equals, "18/stable")
+}
+
+func (s *ucSuite) TestResolveErrors(c *C) {
+	trackMap := trackRedirectMap(18, "18")
+
+	_, err := trackredirect.Resolve(ucKey("18"), "foo/bar/baz/quux", trackMap)
+	c.Check(err, ErrorMatches, `cannot parse input channel: .*`)
+
+	// Unknown track on a covered version errors.
+	_, err = trackredirect.Resolve(ucKey("18"), "20/stable", trackMap)
+	c.Check(err, ErrorMatches, `cannot find track redirect for input track 20 for ubuntu-core 18`)
+	c.Check(errors.Is(err, trackredirect.ErrNoTrack), Equals, true)
+}
+
+func (s *ucSuite) TestResolveEmptyKey(c *C) {
+	_, err := trackredirect.Resolve(trackredirect.Key{}, "latest/stable", trackRedirectMap(18, "18"))
+	c.Check(err, ErrorMatches, "internal error: cannot resolve track redirects with empty key")
+
+	_, err = trackredirect.Resolve(trackredirect.Key{ID: trackredirect.UbuntuCoreID}, "latest/stable", trackRedirectMap(18, "18"))
+	c.Check(err, ErrorMatches, "internal error: cannot resolve track redirects with empty key")
+
+	_, err = trackredirect.Resolve(trackredirect.Key{Version: "18"}, "latest/stable", trackRedirectMap(18, "18"))
+	c.Check(err, ErrorMatches, "internal error: cannot resolve track redirects with empty key")
+}
+
+func (s *ucSuite) TestResolveIgnoresUnusedID(c *C) {
+	trackMap := map[string]map[string]map[string]string{
+		trackredirect.UbuntuCoreID: {
+			"18": {"latest": "18"},
+		},
+		"ubuntu": {
+			"22.04": {"latest": "22.04"},
+		},
+	}
+
+	resolved, err := trackredirect.Resolve(ucKey("18"), "latest/stable", trackMap)
+	c.Assert(err, IsNil)
+	c.Check(resolved, Equals, "18/stable")
+}
+
+func (s *ucSuite) TestResolveUbuntuID(c *C) {
+	trackMap := map[string]map[string]map[string]string{
+		"ubuntu": {
+			"22.04": {"latest": "22.04"},
+		},
+	}
+	key := trackredirect.Key{ID: "ubuntu", Version: "22.04"}
+
+	resolved, err := trackredirect.Resolve(key, "latest/stable", trackMap)
+	c.Assert(err, IsNil)
+	c.Check(resolved, Equals, "22.04/stable")
+}

--- a/snap/trackredirect/trackredirect_test.go
+++ b/snap/trackredirect/trackredirect_test.go
@@ -34,20 +34,20 @@ import (
 
 func Test(t *testing.T) { TestingT(t) }
 
-type ucSuite struct {
+type trackredirectSuite struct {
 	brands *assertstest.SigningAccounts
 }
 
-var _ = Suite(&ucSuite{})
+var _ = Suite(&trackredirectSuite{})
 
-func (s *ucSuite) SetUpTest(c *C) {
+func (s *trackredirectSuite) SetUpTest(c *C) {
 	brandKey, _ := assertstest.GenerateKey(752)
 	store := assertstest.NewStoreStack("store", nil)
 	s.brands = assertstest.NewSigningAccounts(store)
 	s.brands.Register("my-brand", brandKey, nil)
 }
 
-func (s *ucSuite) coreModel(c *C, base, gadget, kernel string) *asserts.Model {
+func (s *trackredirectSuite) coreModel(c *C, base, gadget, kernel string) *asserts.Model {
 	headers := map[string]any{
 		"architecture": "amd64",
 		"gadget":       gadget,
@@ -59,14 +59,14 @@ func (s *ucSuite) coreModel(c *C, base, gadget, kernel string) *asserts.Model {
 	return s.brands.Model("my-brand", "my-model", headers)
 }
 
-func (s *ucSuite) classicModel(c *C) *asserts.Model {
+func (s *trackredirectSuite) classicModel(c *C) *asserts.Model {
 	return s.brands.Model("my-brand", "my-model", map[string]any{
 		"architecture": "amd64",
 		"classic":      "true",
 	})
 }
 
-func (s *ucSuite) hybridClassicModel(c *C, base string) *asserts.Model {
+func (s *trackredirectSuite) hybridClassicModel(c *C, base string) *asserts.Model {
 	return assertstest.FakeAssertion(map[string]any{
 		"type":         "model",
 		"authority-id": "my-brand",
@@ -114,26 +114,26 @@ func trackRedirectMap(bootBase int, tracks ...string) map[string]map[string]map[
 	}
 }
 
-func (s *ucSuite) TestUbuntuCoreKeyClassic(c *C) {
+func (s *trackredirectSuite) TestUbuntuCoreKeyClassic(c *C) {
 	_, err := trackredirect.UbuntuCoreKey(s.classicModel(c))
 	c.Assert(err, ErrorMatches, "cannot use UC tracks on a classic system")
 	c.Check(errors.Is(err, trackredirect.ErrNotApplicable), Equals, true)
 }
 
-func (s *ucSuite) TestUbuntuCoreKeyHybridClassic(c *C) {
+func (s *trackredirectSuite) TestUbuntuCoreKeyHybridClassic(c *C) {
 	_, err := trackredirect.UbuntuCoreKey(s.hybridClassicModel(c, "core22"))
 	c.Assert(err, ErrorMatches, "cannot use UC tracks on a hybrid classic system")
 	c.Check(errors.Is(err, trackredirect.ErrNotApplicable), Equals, true)
 }
 
-func (s *ucSuite) TestUbuntuCoreKeyUC18(c *C) {
+func (s *trackredirectSuite) TestUbuntuCoreKeyUC18(c *C) {
 	uc18 := s.coreModel(c, "core18", "pc=18", "pc-kernel=18")
 	key, err := trackredirect.UbuntuCoreKey(uc18)
 	c.Assert(err, IsNil)
 	c.Check(key, DeepEquals, ucKey("18"))
 }
 
-func (s *ucSuite) TestUbuntuCoreKeyUC16(c *C) {
+func (s *trackredirectSuite) TestUbuntuCoreKeyUC16(c *C) {
 	for _, base := range []string{"", "core", "core16"} {
 		uc16 := s.coreModel(c, base, "pc", "pc-kernel")
 		_, err := trackredirect.UbuntuCoreKey(uc16)
@@ -142,12 +142,12 @@ func (s *ucSuite) TestUbuntuCoreKeyUC16(c *C) {
 	}
 }
 
-func (s *ucSuite) TestUbuntuCoreKeyNilModel(c *C) {
+func (s *trackredirectSuite) TestUbuntuCoreKeyNilModel(c *C) {
 	_, err := trackredirect.UbuntuCoreKey(nil)
 	c.Check(err, ErrorMatches, "internal error: cannot use nil model")
 }
 
-func (s *ucSuite) TestResolveUC18Remap(c *C) {
+func (s *trackredirectSuite) TestResolveUC18Remap(c *C) {
 	trackMap := trackRedirectMap(18, "18", "18-fips")
 
 	for _, t := range []struct {
@@ -171,7 +171,7 @@ func (s *ucSuite) TestResolveUC18Remap(c *C) {
 	}
 }
 
-func (s *ucSuite) TestResolveUC18Identity(c *C) {
+func (s *trackredirectSuite) TestResolveUC18Identity(c *C) {
 	trackMap := trackRedirectMap(18, "18", "18-fips")
 
 	for _, channel := range []string{
@@ -186,7 +186,7 @@ func (s *ucSuite) TestResolveUC18Identity(c *C) {
 	}
 }
 
-func (s *ucSuite) TestResolveExplicitKeyWinsOverIdentity(c *C) {
+func (s *trackredirectSuite) TestResolveExplicitKeyWinsOverIdentity(c *C) {
 	// A later onboard can remap a track onward with an explicit key.
 	trackMap := map[string]map[string]map[string]string{
 		trackredirect.UbuntuCoreID: {
@@ -207,7 +207,7 @@ func (s *ucSuite) TestResolveExplicitKeyWinsOverIdentity(c *C) {
 	c.Check(resolved, Equals, "24/edge")
 }
 
-func (s *ucSuite) TestResolveUncoveredVersion(c *C) {
+func (s *trackredirectSuite) TestResolveUncoveredVersion(c *C) {
 	// Version 22 is not covered (not in the map; 18 is onboarded).
 	trackMap := trackRedirectMap(18, "18")
 
@@ -218,7 +218,7 @@ func (s *ucSuite) TestResolveUncoveredVersion(c *C) {
 	}
 }
 
-func (s *ucSuite) TestResolveEmptyMapErrors(c *C) {
+func (s *trackredirectSuite) TestResolveEmptyMapErrors(c *C) {
 	_, err := trackredirect.Resolve(ucKey("18"), "latest/stable", map[string]map[string]map[string]string{})
 	c.Assert(err, ErrorMatches, `cannot find track redirects for ubuntu-core 18`)
 	c.Check(errors.Is(err, trackredirect.ErrNotCovered), Equals, true)
@@ -228,13 +228,13 @@ func (s *ucSuite) TestResolveEmptyMapErrors(c *C) {
 	c.Check(errors.Is(err, trackredirect.ErrNotCovered), Equals, true)
 }
 
-func (s *ucSuite) TestResolveBranchDropped(c *C) {
+func (s *trackredirectSuite) TestResolveBranchDropped(c *C) {
 	resolved, err := trackredirect.Resolve(ucKey("18"), "latest/stable/mybranch", trackRedirectMap(18, "18"))
 	c.Assert(err, IsNil)
 	c.Check(resolved, Equals, "18/stable")
 }
 
-func (s *ucSuite) TestResolveErrors(c *C) {
+func (s *trackredirectSuite) TestResolveErrors(c *C) {
 	trackMap := trackRedirectMap(18, "18")
 
 	_, err := trackredirect.Resolve(ucKey("18"), "foo/bar/baz/quux", trackMap)
@@ -246,7 +246,7 @@ func (s *ucSuite) TestResolveErrors(c *C) {
 	c.Check(errors.Is(err, trackredirect.ErrNoTrack), Equals, true)
 }
 
-func (s *ucSuite) TestResolveEmptyKey(c *C) {
+func (s *trackredirectSuite) TestResolveEmptyKey(c *C) {
 	_, err := trackredirect.Resolve(trackredirect.Key{}, "latest/stable", trackRedirectMap(18, "18"))
 	c.Check(err, ErrorMatches, "internal error: cannot resolve track redirects with empty key")
 
@@ -257,7 +257,7 @@ func (s *ucSuite) TestResolveEmptyKey(c *C) {
 	c.Check(err, ErrorMatches, "internal error: cannot resolve track redirects with empty key")
 }
 
-func (s *ucSuite) TestResolveIgnoresUnusedID(c *C) {
+func (s *trackredirectSuite) TestResolveIgnoresUnusedID(c *C) {
 	trackMap := map[string]map[string]map[string]string{
 		trackredirect.UbuntuCoreID: {
 			"18": {"latest": "18"},
@@ -272,7 +272,7 @@ func (s *ucSuite) TestResolveIgnoresUnusedID(c *C) {
 	c.Check(resolved, Equals, "18/stable")
 }
 
-func (s *ucSuite) TestResolveUbuntuID(c *C) {
+func (s *trackredirectSuite) TestResolveUbuntuID(c *C) {
 	trackMap := map[string]map[string]map[string]string{
 		"ubuntu": {
 			"22.04": {"latest": "22.04"},

--- a/snap/trackredirect/trackredirect_test.go
+++ b/snap/trackredirect/trackredirect_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/asserts/assertstest"
+	"github.com/snapcore/snapd/snap"
 	"github.com/snapcore/snapd/snap/trackredirect"
 )
 
@@ -97,20 +98,20 @@ func ucKey(version string) trackredirect.Key {
 	return trackredirect.Key{ID: trackredirect.UbuntuCoreID, Version: version}
 }
 
-func trackRedirectMap(bootBase int, tracks ...string) map[string]map[string]map[string]string {
+func trackRedirectMap(bootBase int, tracks ...string) snap.TrackRedirects {
 	if len(tracks) == 0 {
-		return map[string]map[string]map[string]string{}
+		return snap.TrackRedirects{}
 	}
-	rules := map[string]string{
+	redirects := map[string]string{
 		"latest": tracks[0],
 	}
 	for _, track := range tracks {
 		if strings.HasSuffix(track, "-fips") {
-			rules["fips-updates"] = track
+			redirects["fips-updates"] = track
 		}
 	}
-	return map[string]map[string]map[string]string{
-		trackredirect.UbuntuCoreID: {strconv.Itoa(bootBase): rules},
+	return snap.TrackRedirects{
+		trackredirect.UbuntuCoreID: {strconv.Itoa(bootBase): redirects},
 	}
 }
 
@@ -196,7 +197,7 @@ func (s *trackredirectSuite) TestResolveUC18Identity(c *C) {
 
 func (s *trackredirectSuite) TestResolveExplicitKeyWinsOverIdentity(c *C) {
 	// A later onboard can remap a track onward with an explicit key.
-	trackMap := map[string]map[string]map[string]string{
+	trackMap := snap.TrackRedirects{
 		trackredirect.UbuntuCoreID: {
 			"18": {"latest": "24", "18": "24"},
 		},
@@ -227,7 +228,7 @@ func (s *trackredirectSuite) TestResolveUncoveredVersion(c *C) {
 }
 
 func (s *trackredirectSuite) TestResolveEmptyMapErrors(c *C) {
-	_, err := trackredirect.Resolve(ucKey("18"), "latest/stable", map[string]map[string]map[string]string{})
+	_, err := trackredirect.Resolve(ucKey("18"), "latest/stable", snap.TrackRedirects{})
 	c.Assert(err, ErrorMatches, `cannot find track redirects for ubuntu-core 18`)
 	c.Check(errors.Is(err, trackredirect.ErrNotCovered), Equals, true)
 
@@ -266,7 +267,7 @@ func (s *trackredirectSuite) TestResolveEmptyKey(c *C) {
 }
 
 func (s *trackredirectSuite) TestResolveIgnoresUnusedID(c *C) {
-	trackMap := map[string]map[string]map[string]string{
+	trackMap := snap.TrackRedirects{
 		trackredirect.UbuntuCoreID: {
 			"18": {"latest": "18"},
 		},
@@ -281,7 +282,7 @@ func (s *trackredirectSuite) TestResolveIgnoresUnusedID(c *C) {
 }
 
 func (s *trackredirectSuite) TestResolveUbuntuID(c *C) {
-	trackMap := map[string]map[string]map[string]string{
+	trackMap := snap.TrackRedirects{
 		"ubuntu": {
 			"22.04": {"latest": "22.04"},
 		},

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -550,26 +550,22 @@ func Validate(info *Info) error {
 		return err
 	}
 
-	if err := validateTrackRedirects(info); err != nil {
+	if err := validateSnapdTrackRedirects(info); err != nil {
 		return err
 	}
 
 	return ValidateLayoutAll(info)
 }
 
-func validateTrackRedirects(info *Info) error {
+func validateSnapdTrackRedirects(info *Info) error {
 	if len(info.TrackRedirects) == 0 {
 		return nil
 	}
 	if info.Type() != TypeSnapd {
 		return fmt.Errorf("track-redirects is only allowed on snapd snaps")
 	}
-	for osID, versions := range info.TrackRedirects {
-		for version, rules := range versions {
-			if err := validateTrackRedirectRules(osID, version, rules); err != nil {
-				return fmt.Errorf("invalid track-redirects: %v", err)
-			}
-		}
+	if err := validateTrackRedirects(info.TrackRedirects); err != nil {
+		return fmt.Errorf("invalid track-redirects: %v", err)
 	}
 	return nil
 }

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -562,7 +562,7 @@ func validateSnapdTrackRedirects(info *Info) error {
 		return nil
 	}
 	if info.Type() != TypeSnapd {
-		return fmt.Errorf("track-redirects is only allowed on snapd snaps")
+		return fmt.Errorf("cannot specify track-redirects except on snapd snaps")
 	}
 	if err := validateTrackRedirects(info.TrackRedirects); err != nil {
 		return fmt.Errorf("invalid track-redirects: %v", err)

--- a/snap/validate.go
+++ b/snap/validate.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2022-2023 Canonical Ltd
+ * Copyright (C) 2022-2026 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -550,7 +550,28 @@ func Validate(info *Info) error {
 		return err
 	}
 
+	if err := validateTrackRedirects(info); err != nil {
+		return err
+	}
+
 	return ValidateLayoutAll(info)
+}
+
+func validateTrackRedirects(info *Info) error {
+	if len(info.TrackRedirects) == 0 {
+		return nil
+	}
+	if info.Type() != TypeSnapd {
+		return fmt.Errorf("track-redirects is only allowed on snapd snaps")
+	}
+	for osID, versions := range info.TrackRedirects {
+		for version, rules := range versions {
+			if err := validateTrackRedirectRules(osID, version, rules); err != nil {
+				return fmt.Errorf("invalid track-redirects: %v", err)
+			}
+		}
+	}
+	return nil
 }
 
 // ValidateBase validates the base field.

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -2929,7 +2929,7 @@ name: snapd
 version: 1.0
 `))
 	c.Assert(err, IsNil)
-	info.TrackRedirects = map[string]map[string]map[string]string{
+	info.TrackRedirects = TrackRedirects{
 		"ubuntu-core": {
 			"18": {"latest": "18/stable"},
 		},

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -1,7 +1,7 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 
 /*
- * Copyright (C) 2022-2023 Canonical Ltd
+ * Copyright (C) 2022-2026 Canonical Ltd
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 3 as
@@ -2885,4 +2885,54 @@ slots:
 
 	err = Validate(info)
 	c.Check(err, ErrorMatches, strings.Join(expectedErrs, "\n"))
+}
+
+func (s *ValidateSuite) TestValidateTrackRedirectsOnSnapd(c *C) {
+	info, err := InfoFromSnapYaml([]byte(`
+name: snapd
+version: 1.0
+track-redirects:
+  ubuntu-core:
+    "18":
+      latest: "18"
+`))
+	c.Assert(err, IsNil)
+	c.Check(Validate(info), IsNil)
+}
+
+func (s *ValidateSuite) TestValidateTrackRedirectsEmptyOnApp(c *C) {
+	info, err := InfoFromSnapYaml([]byte(`
+name: foo
+version: 1.0
+track-redirects: {}
+`))
+	c.Assert(err, IsNil)
+	c.Check(Validate(info), IsNil)
+}
+
+func (s *ValidateSuite) TestValidateTrackRedirectsRejectedOnApp(c *C) {
+	info, err := InfoFromSnapYaml([]byte(`
+name: foo
+version: 1.0
+track-redirects:
+  ubuntu-core:
+    "18":
+      latest: "18"
+`))
+	c.Assert(err, IsNil)
+	c.Check(Validate(info), ErrorMatches, `track-redirects is only allowed on snapd snaps`)
+}
+
+func (s *ValidateSuite) TestValidateTrackRedirectsConstructedInvalid(c *C) {
+	info, err := InfoFromSnapYaml([]byte(`
+name: snapd
+version: 1.0
+`))
+	c.Assert(err, IsNil)
+	info.TrackRedirects = map[string]map[string]map[string]string{
+		"ubuntu-core": {
+			"18": {"latest": "18/stable"},
+		},
+	}
+	c.Check(Validate(info), ErrorMatches, `invalid track-redirects: target track "18/stable" for ubuntu-core 18 is not a track-only channel`)
 }

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -2935,4 +2935,11 @@ version: 1.0
 		},
 	}
 	c.Check(Validate(info), ErrorMatches, `invalid track-redirects: target track "18/stable" for ubuntu-core 18 is not a track-only channel`)
+
+	info.TrackRedirects = TrackRedirects{
+		"ubuntu-core": {
+			"18": {},
+		},
+	}
+	c.Check(Validate(info), ErrorMatches, `invalid track-redirects: empty track map for ubuntu-core 18`)
 }

--- a/snap/validate_test.go
+++ b/snap/validate_test.go
@@ -2920,7 +2920,7 @@ track-redirects:
       latest: "18"
 `))
 	c.Assert(err, IsNil)
-	c.Check(Validate(info), ErrorMatches, `track-redirects is only allowed on snapd snaps`)
+	c.Check(Validate(info), ErrorMatches, `cannot specify track-redirects except on snapd snaps`)
 }
 
 func (s *ValidateSuite) TestValidateTrackRedirectsConstructedInvalid(c *C) {

--- a/tests/main/debs/task.yaml
+++ b/tests/main/debs/task.yaml
@@ -4,8 +4,9 @@ details: |
     When snapd is tested in Ubuntu and Debian, .deb files are created using
     the snapd code from the local branch.
 
-    This test verifies that the debs have the 'built-using' header. It also
-    checks that Apparmor & Seccomp are compiled (only in Ubuntu), and that
+    This test verifies that the debs have the 'built-using' header and that
+    Apparmor & Seccomp
+    are compiled (only in Ubuntu). It also checks that
     the snapd.session-agent.socket is properly enabled. On Ubuntu >= 26.04
     this is done via dh_installsystemduser (postinst calls deb-systemd-helper
     --user enable, creating the symlink in /etc/systemd/user/). On older

--- a/tests/main/debs/task.yaml
+++ b/tests/main/debs/task.yaml
@@ -4,9 +4,8 @@ details: |
     When snapd is tested in Ubuntu and Debian, .deb files are created using
     the snapd code from the local branch.
 
-    This test verifies that the debs have the 'built-using' header and that
-    Apparmor & Seccomp
-    are compiled (only in Ubuntu). It also checks that
+    This test verifies that the debs have the 'built-using' header. It also
+    checks that Apparmor & Seccomp are compiled (only in Ubuntu), and that
     the snapd.session-agent.socket is properly enabled. On Ubuntu >= 26.04
     this is done via dh_installsystemduser (postinst calls deb-systemd-helper
     --user enable, creating the symlink in /etc/systemd/user/). On older

--- a/tests/main/snapd-snap/task.yaml
+++ b/tests/main/snapd-snap/task.yaml
@@ -211,6 +211,10 @@ execute: |
     test -f squashfs-root/usr/lib/snapd/info
     MATCH SNAPD_ASSERTS_FORMATS < squashfs-root/usr/lib/snapd/info
 
+    echo "Check meta/snap.yaml carries track-redirects"
+    test -f squashfs-root/meta/snap.yaml
+    MATCH '^track-redirects:' < squashfs-root/meta/snap.yaml
+
     unsquashfs -ll snapd_spread-test.snap | MATCH libc.so
 
     echo "Ensure we have apparmor_parser"
@@ -218,6 +222,7 @@ execute: |
 
     echo "Ensure we can install the snapd snap"
     snap install --dangerous snapd_spread-test.snap
+    MATCH '^track-redirects:' < /snap/snapd/current/meta/snap.yaml
     cat >> snapd-cleanup.sh <<EOF
     #!/bin/sh
     if [ $(find /snap/snapd/ -maxdepth 1 -type d 2>/dev/null | wc -l) -gt 2 ]; then


### PR DESCRIPTION
Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?

Stacked on #17609 (SNAPD-37381 / UC042). Merge that first; this PR only adds store planning.

## Summary
- After the first `SnapAction` (which returns snap.yaml), apply `track-redirects` when planning snapd store install, refresh, and download.
- Remap `latest`/`stable` onto the mapped UC track; refuse foreign tracks once the boot base is in the map. Path/sideload/try/seed, classic, hybrid, UC16, and an unmapped boot base pass through.
- A pinned or requested revision is queried on the mapped track. `snap switch` is unchanged (local-only).

## Test plan
- [ ] `go test github.com/snapcore/snapd/overlord/snapstate -check.f 'TestInstallSnapdRemaps|TestUpdateSnapdRemaps|TestDownloadSnapdRemaps|TestPathInstallSnapdDoesNotRemap|TestInstallSnapdUCTrack'`
- [ ] Confirm path install of snapd does not remap
- [ ] Confirm classic/hybrid/UC16 and missing map pass through
- [ ] Confirm unknown tracks (e.g. `20`, `2.0`) are refused on a mapped boot base


Made with [Cursor](https://cursor.com)