### PR TITLE
revert: build-aux/snap, mkversion.sh: fix missing map

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -298,6 +298,8 @@ parts:
       fi
       # make sure to set the version we declared in pull
       ./mkversion.sh "$VERSION"
+      # SNAPD_UC_TRACKS is not shipped in distro packages.
+      go run -mod=vendor ./snap/uctrack/info >> data/info
 
       # double check the toolchain
       echo "--- go version $(go version)"

--- a/mkversion.sh
+++ b/mkversion.sh
@@ -152,8 +152,3 @@ VERSION=$v
 SNAPD_APPARMOR_REEXEC=1
 ${fmts}
 EOF
-# SNAPD_UC_TRACKS is not shipped in distro packages. Snapcraft sets
-# CRAFT_PART_BUILD; write into the same file as VERSION.
-if [ -n "${CRAFT_PART_BUILD:-}" ]; then
-    (cd "$GO_GENERATE_BUILDDIR" ; go run $MOD ./snap/uctrack/info) >> "$PKG_BUILDDIR/data/info"
-fi


### PR DESCRIPTION
Reverts canonical/snapd#17604

This fix is part of the approach in https://github.com/canonical/snapd/pull/17509 that should be abandoned. So this PR also needs to be abandoned.