### PR TITLE
build-aux/snap: remove uctrack data generation that was not correctly reverted

### DIFF
--- a/build-aux/snap/snapcraft.yaml
+++ b/build-aux/snap/snapcraft.yaml
@@ -298,8 +298,6 @@ parts:
       fi
       # make sure to set the version we declared in pull
       ./mkversion.sh "$VERSION"
-      # SNAPD_UC_TRACKS is not shipped in distro packages.
-      go run -mod=vendor ./snap/uctrack/info >> data/info
 
       # double check the toolchain
       echo "--- go version $(go version)"


### PR DESCRIPTION
Fix broken revert: https://github.com/canonical/snapd/pull/17612 - also revert snapcraft entry.
