### PR TITLE
data/systemd: fix network request issue during LXD container stopping

### DIFF
--- a/data/systemd/snapd.service.in
+++ b/data/systemd/snapd.service.in
@@ -1,5 +1,6 @@
 [Unit]
 Description=Snap Daemon
+After=network.target
 After=snapd.socket
 After=time-set.target
 After=snapd.mounts.target


### PR DESCRIPTION
From SNAPDENG-37449 and https://bugs.launchpad.net/snapd/+bug/2165972

A user encountered a delayed stopping of LXD containers, specifically relating to workshop. The default containers work fine, but workshop modified containers disable cloud-init, which removes an implicit dependency that `snapd.service` has on `network.target`. This causes the Ensure loop that refreshes the snap catalog to fail and enter a retry loop, causing a 20sec delay for snapd to stop, preventing the container from closing normally. By adding the dependency `After=network.target` for, this ensures the inverse for stopping.

```
Baseline: takes around 4s, consistently

real    0m4.127s
user    0m0.072s
sys     0m0.031s

real    0m4.107s
user    0m0.084s
sys     0m0.034s

real    0m4.112s
user    0m0.100s
sys     0m0.038s

real    0m4.148s
user    0m0.091s
sys     0m0.034s

Bug: sometimes takes more than 20s

real    0m4.064s
user    0m0.080s
sys     0m0.038s

real    0m23.147s
user    0m0.116s
sys     0m0.050s

real    0m22.311s
user    0m0.086s
sys     0m0.034s

real    0m22.759s
user    0m0.076s
sys     0m0.035s

real    0m4.136s
user    0m0.116s
sys     0m0.042s

real    0m4.161s
user    0m0.148s
sys     0m0.053s

real    0m4.111s
user    0m0.112s
sys     0m0.046s

real    0m22.597s
user    0m0.082s
sys     0m0.029s

Candidate snap: /home/robert/Projects/snapd_2.77+g131.499ba60-dirty_amd64.snap
2026-09-10T14:12:30Z INFO Waiting for automatic snapd restart...
snapd 2.77+g131.499ba60-dirty installed

real    0m4.258s
user    0m0.168s
sys     0m0.048s

real    0m4.247s
user    0m0.166s
sys     0m0.046s

real    0m4.235s
user    0m0.155s
sys     0m0.052s

real    0m4.226s
user    0m0.135s
sys     0m0.069s
```