### PR TITLE
tests: add parallel instances test inside of lxd

### DIFF
--- a/tests/main/parallel-install-lxd/task.yaml
+++ b/tests/main/parallel-install-lxd/task.yaml
@@ -1,0 +1,427 @@
+summary: Test parallel instances of snaps inside LXD containers
+
+details: |
+    Verify that parallel instances work correctly when snapd runs inside an
+    LXD container.
+
+systems: 
+    - ubuntu-20.04*
+    - ubuntu-22.04*
+    - ubuntu-24.04*
+    - ubuntu-26.04*
+    - ubuntu-26.10*
+
+skip:
+    - reason: No need to test when the snapd pkg is from the repository and reexec is disabled
+      if: |
+       [ "$SNAP_REEXEC" = "0" ] && tests.info is-snapd-from-archive
+
+prepare: |
+    echo "Pack test snaps for use inside the LXD container"
+    snap pack "$TESTSLIB/snaps/test-snapd-sh" --filename test-snapd-sh.snap
+    snap pack "$TESTSLIB/snaps/test-snapd-service" --filename test-snapd-service.snap
+    tests.cleanup defer rm -f test-snapd-sh.snap test-snapd-service.snap
+
+    snap pack "$TESTSLIB/snaps/test-snapd-classic-confinement" \
+        --filename test-snapd-classic-confinement.snap
+    tests.cleanup defer rm -f test-snapd-classic-confinement.snap
+
+    snap pack "$TESTSLIB/snaps/aliases" --filename aliases.snap
+    snap pack "$TESTSLIB/snaps/test-snapd-content-plug" --filename test-snapd-content-plug.snap
+    snap pack "$TESTSLIB/snaps/test-snapd-content-slot" --filename test-snapd-content-slot.snap
+    snap pack "$TESTSLIB/snaps/test-snapd-layout" --filename test-snapd-layout.snap
+    tests.cleanup defer rm -f aliases.snap test-snapd-content-plug.snap \
+        test-snapd-content-slot.snap test-snapd-layout.snap
+
+    "$TESTSTOOLS"/lxd-state prepare-snap
+    "$TESTSTOOLS"/lxd-state launch --name my-ubuntu
+
+    echo "Wait for container to be fully up"
+    retry --wait 1 -n 10 sh -c "lxd.lxc exec my-ubuntu -- systemctl --wait is-system-running | grep -Eq '^(running|degraded)$'"
+
+    echo "Install the snapd being tested into the container"
+    if [ "$SNAP_REEXEC" = "0" ]; then
+        lxd.lxc exec my-ubuntu -- mkdir -p "$GOHOME"
+        lxd.lxc file push --quiet "$GOHOME"/snapd_*.deb "my-ubuntu/$GOHOME/"
+        lxd.lxc exec my-ubuntu -- apt-get update
+        lxd.lxc exec my-ubuntu -- apt-get install -y "$GOHOME"/snapd_*.deb
+    else
+        snapd_snap="$(find "$SNAPD_WORK_DIR/snapd_snap" -name 'snapd_*.snap')"
+        lxd.lxc file push --quiet "$snapd_snap" "my-ubuntu/root/snapd.snap"
+        lxd.lxc exec my-ubuntu -- snap install --dangerous /root/snapd.snap
+    fi
+
+    echo "Wait for snapd to finish seeding"
+    retry --wait 1 -n 30 sh -c "lxd.lxc exec my-ubuntu -- snap wait system seed.loaded" || true
+
+    echo "Enable parallel instances feature"
+    lxd.lxc exec my-ubuntu -- snap set system experimental.parallel-instances=true
+
+    echo "Push test snaps into the container"
+    lxd.lxc file push --quiet test-snapd-sh.snap "my-ubuntu/root/"
+    lxd.lxc file push --quiet test-snapd-service.snap "my-ubuntu/root/"
+    lxd.lxc file push --quiet test-snapd-classic-confinement.snap "my-ubuntu/root/"
+    lxd.lxc file push --quiet aliases.snap "my-ubuntu/root/"
+    lxd.lxc file push --quiet test-snapd-content-plug.snap "my-ubuntu/root/"
+    lxd.lxc file push --quiet test-snapd-content-slot.snap "my-ubuntu/root/"
+    lxd.lxc file push --quiet test-snapd-layout.snap "my-ubuntu/root/"
+
+    echo "Set up dbus user session for snap user-level execution"
+    lxd.lxc exec my-ubuntu -- apt-get update
+    lxd.lxc exec my-ubuntu -- apt-get install -y dbus-user-session
+    lxd.lxc exec my-ubuntu -- su -l ubuntu -c "systemctl --user enable dbus.socket" || true
+
+restore: |
+    lxd.lxc stop my-ubuntu --force || true
+    lxd.lxc delete my-ubuntu || true
+    snap remove --purge lxd || true
+    "$TESTSTOOLS"/lxd-state undo-mount-changes
+
+    # stop user dbus if it was started by refresh-app-awareness
+    systemctl --user stop dbus.service || true
+
+    # clean up test output files
+    rm -f snap_foo_env.txt snap_env.txt classic_bar_env.txt
+
+execute: |
+    # -------------------------------------------------------------------
+    # Basic parallel instance install, run, and isolation
+    # -------------------------------------------------------------------
+    echo "=== Basic install, execution, and isolation ==="
+
+    echo "Verify a parallel instance can be installed without the base instance present"
+    lxd.lxc exec my-ubuntu -- snap install --dangerous /root/test-snapd-sh.snap \
+        --name test-snapd-sh_foo
+    lxd.lxc exec my-ubuntu -- snap list | MATCH 'test-snapd-sh_foo '
+    lxd.lxc exec my-ubuntu -- su -l ubuntu -c \
+        "test-snapd-sh_foo.sh -c 'echo standalone-instance'" | MATCH standalone-instance
+
+    echo "Verify the standalone instance can write to SNAP_DATA"
+    #shellcheck disable=SC2016
+    lxd.lxc exec my-ubuntu -- test-snapd-sh_foo.sh -c \
+        'echo standalone-data > $SNAP_DATA/standalone-file'
+    lxd.lxc exec my-ubuntu -- cat /var/snap/test-snapd-sh_foo/current/standalone-file \
+        | MATCH standalone-data
+
+    lxd.lxc exec my-ubuntu -- sh -c '! test -e /var/snap/test-snapd-sh/current'
+
+    echo "Remove the standalone parallel instance"
+    lxd.lxc exec my-ubuntu -- snap remove --purge test-snapd-sh_foo
+    lxd.lxc exec my-ubuntu -- sh -c 'snap list' | NOMATCH test-snapd-sh_foo
+
+    lxd.lxc exec my-ubuntu -- snap install --dangerous /root/test-snapd-sh.snap
+    lxd.lxc exec my-ubuntu -- snap install --dangerous /root/test-snapd-sh.snap \
+        --name test-snapd-sh_foo
+
+    echo "Verify both instances appear in snap list"
+    lxd.lxc exec my-ubuntu -- snap list | MATCH 'test-snapd-sh '
+    lxd.lxc exec my-ubuntu -- snap list | MATCH 'test-snapd-sh_foo '
+
+    echo "Verify both can run as regular user"
+    lxd.lxc exec my-ubuntu -- su -l ubuntu -c \
+        "test-snapd-sh.sh -c 'echo regular-instance'" | MATCH regular-instance
+    lxd.lxc exec my-ubuntu -- su -l ubuntu -c \
+        "test-snapd-sh_foo.sh -c 'echo parallel-instance'" | MATCH parallel-instance
+
+    echo "Verify environment variable isolation"
+    lxd.lxc exec my-ubuntu -- su -l ubuntu -c \
+        "test-snapd-sh_foo.sh -c env" > snap_foo_env.txt
+    MATCH 'SNAP_INSTANCE_NAME=test-snapd-sh_foo' < snap_foo_env.txt
+    MATCH 'SNAP_NAME=test-snapd-sh'              < snap_foo_env.txt
+    MATCH 'SNAP_INSTANCE_KEY=foo'                < snap_foo_env.txt
+    MATCH 'SNAP_USER_DATA=/home/ubuntu/snap/test-snapd-sh_foo/' < snap_foo_env.txt
+    MATCH 'SNAP_USER_COMMON=/home/ubuntu/snap/test-snapd-sh_foo/common' < snap_foo_env.txt
+
+    lxd.lxc exec my-ubuntu -- su -l ubuntu -c \
+        "test-snapd-sh.sh -c env" > snap_env.txt
+    MATCH 'SNAP_INSTANCE_NAME=test-snapd-sh'     < snap_env.txt
+    MATCH 'SNAP_INSTANCE_KEY=$'                  < snap_env.txt
+    MATCH 'SNAP_USER_DATA=/home/ubuntu/snap/test-snapd-sh/' < snap_env.txt
+
+    echo "Verify /var/snap data directory separation"
+    lxd.lxc exec my-ubuntu -- test -d /var/snap/test-snapd-sh
+    lxd.lxc exec my-ubuntu -- test -d /var/snap/test-snapd-sh_foo
+
+    echo "Verify /snap mount directory separation"
+    lxd.lxc exec my-ubuntu -- test -d /snap/test-snapd-sh
+    lxd.lxc exec my-ubuntu -- test -d /snap/test-snapd-sh_foo
+
+    echo "Verify data writes are isolated (SNAP_USER_COMMON)"
+    lxd.lxc exec my-ubuntu -- su -l ubuntu -c \
+        "test-snapd-sh_foo.sh -c 'echo instance-data > \$SNAP_USER_COMMON/write-test'"
+    lxd.lxc exec my-ubuntu -- cat /home/ubuntu/snap/test-snapd-sh_foo/common/write-test \
+        | MATCH instance-data
+    # Non-instance does not see the instance's data
+    lxd.lxc exec my-ubuntu -- sh -c '! test -f /home/ubuntu/snap/test-snapd-sh/common/write-test'
+
+    echo "Verify data writes are isolated (SNAP_USER_DATA)"
+    lxd.lxc exec my-ubuntu -- su -l ubuntu -c \
+        "test-snapd-sh_foo.sh -c 'echo hello-instance > \$SNAP_USER_DATA/instance-file'"
+    lxd.lxc exec my-ubuntu -- cat /home/ubuntu/snap/test-snapd-sh_foo/current/instance-file \
+        | MATCH hello-instance
+    lxd.lxc exec my-ubuntu -- sh -c '! test -f /home/ubuntu/snap/test-snapd-sh/current/instance-file'
+
+    # -------------------------------------------------------------------
+    # Strict confinement mount namespace
+    # -------------------------------------------------------------------
+    echo "=== Strict confinement mount namespace ==="
+
+    echo "Verify SNAP env var points to non-instance name inside the snap"
+    lxd.lxc exec my-ubuntu -- su -l ubuntu -c \
+        "test-snapd-sh_foo.sh -c 'echo \$SNAP'" | MATCH '/snap/test-snapd-sh/'
+
+    echo "Verify SNAP_DATA maps instance dir to non-instance name"
+    lxd.lxc exec my-ubuntu -- su -l ubuntu -c \
+        "test-snapd-sh_foo.sh -c 'echo \$SNAP_DATA'" | MATCH '^/var/snap/test-snapd-sh/'
+
+    echo "Verify SNAP_COMMON maps instance dir to non-instance name"
+    lxd.lxc exec my-ubuntu -- su -l ubuntu -c \
+        "test-snapd-sh_foo.sh -c 'echo \$SNAP_COMMON'" | MATCH '^/var/snap/test-snapd-sh/common$'
+
+    echo "Verify the mount namespace mask works: instance sees non-instance paths"
+    lxd.lxc exec my-ubuntu -- su -l ubuntu -c \
+        "test-snapd-sh_foo.sh -c 'ls \$SNAP'" | MATCH bin
+
+    # -------------------------------------------------------------------
+    # Classic confinement parallel instances
+    # -------------------------------------------------------------------
+    echo "=== Category 3: Classic confinement parallel instances ==="
+
+    # Ensure /snap is accessible for classic confinement
+    lxd.lxc exec my-ubuntu -- sh -c 'test -d /snap || ln -sf /var/lib/snapd/snap /snap'
+
+    lxd.lxc exec my-ubuntu -- snap install --dangerous --classic \
+        /root/test-snapd-classic-confinement.snap
+    lxd.lxc exec my-ubuntu -- snap install --dangerous --classic \
+        /root/test-snapd-classic-confinement.snap --name test-snapd-classic-confinement_bar
+
+    echo "Verify classic parallel instances can run"
+    lxd.lxc exec my-ubuntu -- su -l ubuntu -c \
+        "test-snapd-classic-confinement_bar.sh -c 'echo classic-bar'" | MATCH classic-bar
+
+    echo "Verify classic instance mounts mask the instance key"
+    lxd.lxc exec my-ubuntu -- su -l ubuntu -c \
+        "test-snapd-classic-confinement_bar.sh -c 'echo \$SNAP'" \
+        | MATCH '^/snap/test-snapd-classic-confinement/'
+
+    echo "Verify classic instance env vars"
+    lxd.lxc exec my-ubuntu -- su -l ubuntu -c \
+        "test-snapd-classic-confinement_bar.sh -c env" > classic_bar_env.txt
+    MATCH 'SNAP_INSTANCE_NAME=test-snapd-classic-confinement_bar' < classic_bar_env.txt
+    MATCH 'SNAP_INSTANCE_KEY=bar'                                  < classic_bar_env.txt
+
+    echo "Verify classic data isolation"
+    #shellcheck disable=SC2016
+    lxd.lxc exec my-ubuntu -- \
+        test-snapd-classic-confinement_bar.sh -c 'echo bar-data > $SNAP_DATA/cf'
+    lxd.lxc exec my-ubuntu -- cat /var/snap/test-snapd-classic-confinement_bar/x1/cf \
+        | MATCH bar-data
+    lxd.lxc exec my-ubuntu -- sh -c \
+        '! test -f /var/snap/test-snapd-classic-confinement/x1/cf'
+
+    echo "Verify classic instance can also write to user-accessible directories"
+    lxd.lxc exec my-ubuntu -- su -l ubuntu -c \
+        "test-snapd-classic-confinement_bar.sh -c 'echo user-data > \$SNAP_USER_DATA/cf'"
+    lxd.lxc exec my-ubuntu -- cat \
+        /home/ubuntu/snap/test-snapd-classic-confinement_bar/x1/cf | MATCH user-data
+    lxd.lxc exec my-ubuntu -- sh -c \
+        '! test -f /home/ubuntu/snap/test-snapd-classic-confinement/x1/cf'
+
+    echo "Clean up classic instances"
+    lxd.lxc exec my-ubuntu -- snap remove --purge test-snapd-classic-confinement
+    lxd.lxc exec my-ubuntu -- snap remove --purge test-snapd-classic-confinement_bar
+    rm -f classic_bar_env.txt
+
+    # -------------------------------------------------------------------
+    # Services with parallel instances
+    # -------------------------------------------------------------------
+    echo "=== Services with parallel instances ==="
+
+    lxd.lxc exec my-ubuntu -- snap install --dangerous /root/test-snapd-service.snap
+    lxd.lxc exec my-ubuntu -- snap install --dangerous /root/test-snapd-service.snap \
+        --name test-snapd-service_foo
+
+    echo "Verify per-instance systemd service units exist"
+    lxd.lxc exec my-ubuntu -- test -f \
+        /etc/systemd/system/snap.test-snapd-service.test-snapd-service.service
+    lxd.lxc exec my-ubuntu -- test -f \
+        /etc/systemd/system/snap.test-snapd-service_foo.test-snapd-service.service
+
+    echo "Verify both instances' services are active"
+    lxd.lxc exec my-ubuntu -- systemctl is-active \
+        snap.test-snapd-service.test-snapd-service.service | MATCH '^active$'
+    lxd.lxc exec my-ubuntu -- systemctl is-active \
+        snap.test-snapd-service_foo.test-snapd-service.service | MATCH '^active$'
+
+    echo "Verify snapctl can stop one instance without affecting the other"
+    lxd.lxc exec my-ubuntu -- snap run --shell test-snapd-service_foo -c \
+        "snapctl stop test-snapd-service_foo.test-snapd-service"
+    lxd.lxc exec my-ubuntu -- systemctl is-active \
+        snap.test-snapd-service_foo.test-snapd-service.service | MATCH '^inactive$'
+    lxd.lxc exec my-ubuntu -- systemctl is-active \
+        snap.test-snapd-service.test-snapd-service.service | MATCH '^active$'
+
+    echo "Start the stopped service back"
+    lxd.lxc exec my-ubuntu -- snap run --shell test-snapd-service_foo -c \
+        "snapctl start test-snapd-service_foo.test-snapd-service"
+    lxd.lxc exec my-ubuntu -- systemctl is-active \
+        snap.test-snapd-service_foo.test-snapd-service.service | MATCH '^active$'
+
+    echo "Install a third instance for cross-instance service testing"
+    lxd.lxc exec my-ubuntu -- snap install --dangerous /root/test-snapd-service.snap \
+        --name test-snapd-service_bar
+
+    echo "Verify snap name is silently remapped to instance key"
+    # When test-snapd-service_foo issues "snapctl restart test-snapd-service.other-service",
+    # it gets silently remapped to restart test-snapd-service_foo.other-service instead.
+    # Verify by checking the non-instance service was NOT restarted.
+    lxd.lxc exec my-ubuntu -- snap start test-snapd-service.test-snapd-other-service
+    lxd.lxc exec my-ubuntu -- systemctl is-active \
+        snap.test-snapd-service.test-snapd-other-service.service | MATCH '^active$'
+    svc_ts_start=$(lxd.lxc exec my-ubuntu -- systemctl show \
+        --property=ExecMainStartTimestampMonotonic \
+        snap.test-snapd-service.test-snapd-other-service.service | cut -d= -f2)
+    lxd.lxc exec my-ubuntu -- snap run --shell test-snapd-service_foo -c \
+        "snapctl restart test-snapd-service.test-snapd-other-service"
+    svc_ts_after=$(lxd.lxc exec my-ubuntu -- systemctl show \
+        --property=ExecMainStartTimestampMonotonic \
+        snap.test-snapd-service.test-snapd-other-service.service | cut -d= -f2)
+    # non-instance service was NOT restarted (silently remapped to instance)
+    test "$svc_ts_start" = "$svc_ts_after"
+
+    echo "Verify explicit cross-instance service name is rejected"
+    lxd.lxc exec my-ubuntu -- snap run --shell test-snapd-service_foo -c \
+        "snapctl restart test-snapd-service_bar.test-snapd-other-service" 2>&1 \
+        | MATCH 'unexpected snap instance key'
+    lxd.lxc exec my-ubuntu -- snap remove --purge test-snapd-service_bar || true
+
+    echo "Clean up service instances"
+    lxd.lxc exec my-ubuntu -- snap remove --purge test-snapd-service || true
+    lxd.lxc exec my-ubuntu -- snap remove --purge test-snapd-service_foo || true
+
+    # -------------------------------------------------------------------
+    # Mount unit generation verification
+    # -------------------------------------------------------------------
+    echo "=== Mount unit generation ==="
+
+    echo "Install a parallel instance to verify its mount unit gets a container.conf override"
+    lxd.lxc exec my-ubuntu -- snap install --dangerous /root/test-snapd-sh.snap \
+        --name test-snapd-sh_foo
+
+    echo "Verify snapd-generator created a container.conf override for the instance mount unit"
+    lxd.lxc exec my-ubuntu -- find /var/run/systemd/generator/ -name container.conf \
+        | MATCH 'snap-test\\x2dsnapd\\x2dsh_foo-.*mount\.d/container\.conf'
+
+
+    # -------------------------------------------------------------------
+    # Aliases with parallel instances
+    # -------------------------------------------------------------------
+    echo "=== Aliases with parallel instances ==="
+
+    lxd.lxc exec my-ubuntu -- snap install --dangerous /root/aliases.snap
+    lxd.lxc exec my-ubuntu -- snap install --dangerous /root/aliases.snap --name aliases_foo
+
+    echo "Create a manual alias for each instance"
+    lxd.lxc exec my-ubuntu -- snap alias aliases.cmd1 alias1
+    lxd.lxc exec my-ubuntu -- snap alias aliases_foo.cmd1 alias1_foo
+
+    echo "Creating the same alias name for both instances must conflict"
+    lxd.lxc exec my-ubuntu -- sh -c '! snap alias aliases_foo.cmd2 alias1'
+
+    echo "Verify snap aliases lists both aliases mapped to the correct instance"
+    lxd.lxc exec my-ubuntu -- snap aliases | MATCH 'aliases\.cmd1 +alias1 +manual'
+    lxd.lxc exec my-ubuntu -- snap aliases | MATCH 'aliases_foo\.cmd1 +alias1_foo +manual'
+
+    echo "Verify each alias resolves to the correct instance's command"
+    #shellcheck disable=SC2016
+    lxd.lxc exec my-ubuntu -- sh -c 'test "$(readlink /snap/bin/alias1)" = "aliases.cmd1"'
+    #shellcheck disable=SC2016
+    lxd.lxc exec my-ubuntu -- sh -c 'test "$(readlink /snap/bin/alias1_foo)" = "aliases_foo.cmd1"'
+
+    echo "Removing the original snap only removes its own alias"
+    lxd.lxc exec my-ubuntu -- snap remove --purge aliases
+    lxd.lxc exec my-ubuntu -- snap aliases | MATCH 'aliases_foo\.cmd1 +alias1_foo +manual'
+    lxd.lxc exec my-ubuntu -- sh -c 'snap aliases | grep "aliases\.cmd1" && exit 1 || true'
+    lxd.lxc exec my-ubuntu -- alias1_foo | MATCH "ok command 1"
+
+    echo "Clean up the remaining aliases_foo instance"
+    lxd.lxc exec my-ubuntu -- snap remove --purge aliases_foo
+
+    # -------------------------------------------------------------------
+    # Content interface between parallel instances
+    # -------------------------------------------------------------------
+    echo "=== Content interface between parallel instances ==="
+
+    echo "Install plug and slot snaps as parallel instances"
+    lxd.lxc exec my-ubuntu -- snap install --dangerous /root/test-snapd-content-plug.snap \
+        --name test-snapd-content-plug_foo
+    lxd.lxc exec my-ubuntu -- snap install --dangerous /root/test-snapd-content-slot.snap \
+        --name test-snapd-content-slot_foo
+
+    echo "The content is not readable until the plug is connected to the slot"
+    lxd.lxc exec my-ubuntu -- sh -c \
+        '! test-snapd-content-plug_foo.content-plug 2>/dev/null | grep -q "Some shared content"'
+
+    echo "Connect the content interface between the two instances"
+    lxd.lxc exec my-ubuntu -- snap connect \
+        test-snapd-content-plug_foo:shared-content-plug \
+        test-snapd-content-slot_foo:shared-content-slot
+
+    echo "Verify the plug instance can now read the shared content from the slot instance"
+    lxd.lxc exec my-ubuntu -- test-snapd-content-plug_foo.content-plug | MATCH "Some shared content"
+
+    echo "Clean up content interface instances"
+    lxd.lxc exec my-ubuntu -- snap remove --purge test-snapd-content-plug_foo
+    lxd.lxc exec my-ubuntu -- snap remove --purge test-snapd-content-slot_foo
+
+    # -------------------------------------------------------------------
+    # Layouts with parallel instances
+    # -------------------------------------------------------------------
+    echo "=== Layouts with parallel instances ==="
+
+    echo "Install the layout snap as a parallel instance"
+    lxd.lxc exec my-ubuntu -- snap install --dangerous /root/test-snapd-layout.snap \
+        --name test-snapd-layout_foo
+
+    echo "Verify layout declarations are honored for the instance"
+    lxd.lxc exec my-ubuntu -- test-snapd-layout_foo.sh -c 'test -d /etc/demo'
+    lxd.lxc exec my-ubuntu -- test-snapd-layout_foo.sh -c 'test -f /etc/demo.conf'
+
+    echo "Verify writes through the layout land in the instance's own data directory"
+    lxd.lxc exec my-ubuntu -- test-snapd-layout_foo.sh -c \
+        'echo layout-data > /etc/demo/instance-file'
+    lxd.lxc exec my-ubuntu -- cat /var/snap/test-snapd-layout_foo/common/etc/demo/instance-file \
+        | MATCH layout-data
+
+    echo "Clean up the layout instance"
+    lxd.lxc exec my-ubuntu -- snap remove --purge test-snapd-layout_foo
+
+    # -------------------------------------------------------------------
+    # Removal and cleanup
+    # -------------------------------------------------------------------
+    echo "=== Removal and cleanup ==="
+
+    echo "Remove the parallel instance while non-instance is still present"
+    lxd.lxc exec my-ubuntu -- snap remove --purge test-snapd-sh_foo
+
+    echo "Non-instance snap still runs after instance removal"
+    lxd.lxc exec my-ubuntu -- su -l ubuntu -c \
+        "test-snapd-sh.sh -c 'echo still-here'" | MATCH still-here
+
+    echo "Parallel instance removed from snap list"
+    lxd.lxc exec my-ubuntu -- snap list | MATCH 'test-snapd-sh '
+    lxd.lxc exec my-ubuntu -- sh -c 'snap list | grep test-snapd-sh_foo && exit 1 || true'
+
+    echo "Install a new parallel instance with a different key"
+    lxd.lxc exec my-ubuntu -- snap install --dangerous /root/test-snapd-sh.snap \
+        --name test-snapd-sh_baz
+
+    echo "Now remove the non-instance snap"
+    lxd.lxc exec my-ubuntu -- snap remove --purge test-snapd-sh
+
+    echo "Parallel instance still runs after non-instance removal"
+    lxd.lxc exec my-ubuntu -- su -l ubuntu -c \
+        "test-snapd-sh_baz.sh -c 'echo still-here-baz'" | MATCH still-here-baz
+
+    echo "Remove remaining instance"
+    lxd.lxc exec my-ubuntu -- snap remove --purge test-snapd-sh_baz


### PR DESCRIPTION
As part of the audit work, we decided on a spread test to ensure parallel installs continue to work inside of lxd containers

https://warthogs.atlassian.net/browse/SNAPDENG-37107