### PR TITLE
interfaces/builtin: add comment about docker interface peer label

### DIFF
--- a/interfaces/builtin/docker.go
+++ b/interfaces/builtin/docker.go
@@ -41,6 +41,11 @@ const dockerConnectedPlugAppArmor = `
 
 # Allow talking to the docker daemon
 /{,var/}run/docker.sock rw,
+
+# Do not in the future use peer=(label=unconfined), because we want snaps with
+# docker plugs to be able to communicate with the docker daemon running on the
+# system regardless of whether docker happens to be running unconfined or as a
+# snap.
 `
 
 const dockerConnectedPlugSecComp = `


### PR DESCRIPTION
Add a comment to the `docker` interface indicating that developers should not in the future use `peer=(label=unconfined)` in the AppArmor rules. We want snaps with `docker` plugs to be able to communicate with the Docker daemon running on the system regardless of whether the latter happens to be the `docker` snap or an unconfined installation.
