### PR TITLE
asserts: export assertion base and consistency checker

### DIFF
--- a/asserts/account.go
+++ b/asserts/account.go
@@ -68,8 +68,8 @@ func (acc *Account) Timestamp() time.Time {
 	return acc.timestamp
 }
 
-// Implement further consistency checks.
-func (acc *Account) checkConsistency(db RODatabase, acck *AccountKey) error {
+// CheckConsistency performs further checks using the assertion database.
+func (acc *Account) CheckConsistency(db RODatabase, acck *AccountKey) error {
 	if !db.IsTrustedAccount(acc.AuthorityID()) {
 		return fmt.Errorf("account assertion for %q is not signed by a directly trusted authority: %s", acc.AccountID(), acc.AuthorityID())
 	}
@@ -77,7 +77,7 @@ func (acc *Account) checkConsistency(db RODatabase, acck *AccountKey) error {
 }
 
 // expected interface is implemented
-var _ consistencyChecker = (*Account)(nil)
+var _ ConsistencyChecker = (*Account)(nil)
 
 func assembleAccount(assert assertionBase) (Assertion, error) {
 	_, err := checkNotEmptyString(assert.headers, "display-name")

--- a/asserts/account.go
+++ b/asserts/account.go
@@ -33,7 +33,7 @@ var (
 // Account holds an account assertion, which ties a name for an account
 // to its identifier and provides the authority's confidence in the name's validity.
 type Account struct {
-	assertionBase
+	AssertionBase
 	validation string
 	timestamp  time.Time
 }
@@ -79,7 +79,7 @@ func (acc *Account) CheckConsistency(db RODatabase, acck *AccountKey) error {
 // expected interface is implemented
 var _ ConsistencyChecker = (*Account)(nil)
 
-func assembleAccount(assert assertionBase) (Assertion, error) {
+func assembleAccount(assert AssertionBase) (Assertion, error) {
 	_, err := checkNotEmptyString(assert.headers, "display-name")
 	if err != nil {
 		return nil, err
@@ -108,7 +108,7 @@ func assembleAccount(assert assertionBase) (Assertion, error) {
 	}
 
 	return &Account{
-		assertionBase: assert,
+		AssertionBase: assert,
 		validation:    validation,
 		timestamp:     timestamp,
 	}, nil

--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -175,8 +175,8 @@ func checkPublicKey(ab *assertionBase, keyIDName string) (PublicKey, error) {
 	return pubKey, nil
 }
 
-// Implement further consistency checks.
-func (ak *AccountKey) checkConsistency(db RODatabase, acck *AccountKey) error {
+// CheckConsistency performs further checks using the assertion database.
+func (ak *AccountKey) CheckConsistency(db RODatabase, acck *AccountKey) error {
 	if !db.IsTrustedAccount(ak.AuthorityID()) {
 		return fmt.Errorf("account-key assertion for %q is not signed by a directly trusted authority: %s", ak.AccountID(), ak.AuthorityID())
 	}
@@ -214,7 +214,7 @@ func (ak *AccountKey) checkConsistency(db RODatabase, acck *AccountKey) error {
 }
 
 // expected interface is implemented
-var _ consistencyChecker = (*AccountKey)(nil)
+var _ ConsistencyChecker = (*AccountKey)(nil)
 
 // Prerequisites returns references to this account-key's prerequisite assertions.
 func (ak *AccountKey) Prerequisites() []*Ref {
@@ -355,8 +355,8 @@ func (akr *AccountKeyRequest) signKey(db RODatabase) (PublicKey, error) {
 	return akr.pubKey, nil
 }
 
-// Implement further consistency checks.
-func (akr *AccountKeyRequest) checkConsistency(db RODatabase, acck *AccountKey) error {
+// CheckConsistency performs further checks using the assertion database.
+func (akr *AccountKeyRequest) CheckConsistency(db RODatabase, acck *AccountKey) error {
 	_, err := db.Find(AccountType, map[string]string{
 		"account-id": akr.AccountID(),
 	})
@@ -371,7 +371,7 @@ func (akr *AccountKeyRequest) checkConsistency(db RODatabase, acck *AccountKey) 
 
 // expected interfaces are implemented
 var (
-	_ consistencyChecker = (*AccountKeyRequest)(nil)
+	_ ConsistencyChecker = (*AccountKeyRequest)(nil)
 	_ customSigner       = (*AccountKeyRequest)(nil)
 )
 

--- a/asserts/account_key.go
+++ b/asserts/account_key.go
@@ -31,7 +31,7 @@ var validAccountKeyName = regexp.MustCompile(`^(?:[a-z0-9]+-?)*[a-z](?:-?[a-z0-9
 // AccountKey holds an account-key assertion, asserting a public key
 // belonging to the account.
 type AccountKey struct {
-	assertionBase
+	AssertionBase
 	sinceUntil
 	constraintMatchers []attrMatcher
 	pubKey             PublicKey
@@ -160,7 +160,7 @@ func (ak *AccountKey) canSign(a Assertion) bool {
 	return ak.matchAgainstConstraints(a.Headers())
 }
 
-func checkPublicKey(ab *assertionBase, keyIDName string) (PublicKey, error) {
+func checkPublicKey(ab *AssertionBase, keyIDName string) (PublicKey, error) {
 	pubKey, err := DecodePublicKey(ab.Body())
 	if err != nil {
 		return nil, err
@@ -223,7 +223,7 @@ func (ak *AccountKey) Prerequisites() []*Ref {
 	}
 }
 
-func assembleAccountKey(assert assertionBase) (Assertion, error) {
+func assembleAccountKey(assert AssertionBase) (Assertion, error) {
 	_, err := checkNotEmptyString(assert.headers, "account-id")
 	if err != nil {
 		return nil, err
@@ -258,7 +258,7 @@ func assembleAccountKey(assert assertionBase) (Assertion, error) {
 
 	// ignore extra headers for future compatibility
 	return &AccountKey{
-		assertionBase:      assert,
+		AssertionBase:      assert,
 		sinceUntil:         *sinceUntil,
 		constraintMatchers: matchers,
 		pubKey:             pubk,
@@ -320,7 +320,7 @@ func accountKeyFormatAnalyze(headers map[string]any, body []byte) (formatnum int
 
 // AccountKeyRequest holds an account-key-request assertion, which is a self-signed request to prove that the requester holds the private key and wishes to create an account-key assertion for it.
 type AccountKeyRequest struct {
-	assertionBase
+	AssertionBase
 	sinceUntil
 	pubKey PublicKey
 }
@@ -382,7 +382,7 @@ func (akr *AccountKeyRequest) Prerequisites() []*Ref {
 	}
 }
 
-func assembleAccountKeyRequest(assert assertionBase) (Assertion, error) {
+func assembleAccountKeyRequest(assert AssertionBase) (Assertion, error) {
 	_, err := checkNotEmptyString(assert.headers, "account-id")
 	if err != nil {
 		return nil, err
@@ -408,7 +408,7 @@ func assembleAccountKeyRequest(assert assertionBase) (Assertion, error) {
 
 	// ignore extra headers for future compatibility
 	return &AccountKeyRequest{
-		assertionBase: assert,
+		AssertionBase: assert,
 		sinceUntil:    *sinceUntil,
 		pubKey:        pubk,
 	}, nil

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -73,7 +73,7 @@ type AssertionType struct {
 	// forming types.
 	OptionalPrimaryKeyDefaults map[string]string
 
-	assembler func(assert assertionBase) (Assertion, error)
+	assembler func(assert AssertionBase) (Assertion, error)
 	flags     typeFlags
 }
 
@@ -588,8 +588,8 @@ type customSigner interface {
 // MediaType is the media type for encoded assertions on the wire.
 const MediaType = "application/x.ubuntu.assertion"
 
-// assertionBase is the concrete base to hold representation data for actual assertions.
-type assertionBase struct {
+// AssertionBase holds the common representation shared by assertion types.
+type AssertionBase struct {
 	headers map[string]any
 	body    []byte
 	// parsed format iteration
@@ -602,46 +602,41 @@ type assertionBase struct {
 	signature []byte
 }
 
-// AssertionBase provides the generic assertion behavior for concrete
-// assertion types. External assertion implementations should embed the value
-// passed to their Assembler.
-type AssertionBase = assertionBase
-
 // HeaderString retrieves the string value of header with name or ""
-func (ab *assertionBase) HeaderString(name string) string {
+func (ab *AssertionBase) HeaderString(name string) string {
 	s, _ := ab.headers[name].(string)
 	return s
 }
 
 // Type returns the assertion type.
-func (ab *assertionBase) Type() *AssertionType {
+func (ab *AssertionBase) Type() *AssertionType {
 	return Type(ab.HeaderString("type"))
 }
 
 // Format returns the assertion format iteration.
-func (ab *assertionBase) Format() int {
+func (ab *AssertionBase) Format() int {
 	return ab.format
 }
 
 // SupportedFormat returns whether the assertion uses a supported
 // format iteration. If false the assertion might have been only
 // partially parsed.
-func (ab *assertionBase) SupportedFormat() bool {
+func (ab *AssertionBase) SupportedFormat() bool {
 	return ab.format <= maxSupportedFormat[ab.HeaderString("type")]
 }
 
 // Revision returns the assertion revision.
-func (ab *assertionBase) Revision() int {
+func (ab *AssertionBase) Revision() int {
 	return ab.revision
 }
 
 // AuthorityID returns the authority-id a.k.a the authority responsible for the assertion.
-func (ab *assertionBase) AuthorityID() string {
+func (ab *AssertionBase) AuthorityID() string {
 	return ab.HeaderString("authority-id")
 }
 
 // Header returns the value of an header by name.
-func (ab *assertionBase) Header(name string) any {
+func (ab *AssertionBase) Header(name string) any {
 	v := ab.headers[name]
 	if v == nil {
 		return nil
@@ -650,32 +645,32 @@ func (ab *assertionBase) Header(name string) any {
 }
 
 // Headers returns the complete headers.
-func (ab *assertionBase) Headers() map[string]any {
+func (ab *AssertionBase) Headers() map[string]any {
 	return copyHeaders(ab.headers)
 }
 
 // Body returns the body of the assertion.
-func (ab *assertionBase) Body() []byte {
+func (ab *AssertionBase) Body() []byte {
 	return ab.body
 }
 
 // Signature returns the signed content and its unprocessed signature.
-func (ab *assertionBase) Signature() (content, signature []byte) {
+func (ab *AssertionBase) Signature() (content, signature []byte) {
 	return ab.content, ab.signature
 }
 
 // SignKeyID returns the key id for the key that signed this assertion.
-func (ab *assertionBase) SignKeyID() string {
+func (ab *AssertionBase) SignKeyID() string {
 	return ab.HeaderString("sign-key-sha3-384")
 }
 
 // Prerequisites returns references to the prerequisite assertions for the validity of this one.
-func (ab *assertionBase) Prerequisites() []*Ref {
+func (ab *AssertionBase) Prerequisites() []*Ref {
 	return nil
 }
 
 // Ref returns a reference representing this assertion.
-func (ab *assertionBase) Ref() *Ref {
+func (ab *AssertionBase) Ref() *Ref {
 	assertType := ab.Type()
 	primKey := make([]string, len(assertType.PrimaryKey))
 	for i, name := range assertType.PrimaryKey {
@@ -688,12 +683,12 @@ func (ab *assertionBase) Ref() *Ref {
 }
 
 // At returns an AtRevision referencing this assertion at its revision.
-func (ab *assertionBase) At() *AtRevision {
+func (ab *AssertionBase) At() *AtRevision {
 	return &AtRevision{Ref: *ab.Ref(), Revision: ab.Revision()}
 }
 
 // expected interface is implemented
-var _ Assertion = (*assertionBase)(nil)
+var _ Assertion = (*AssertionBase)(nil)
 
 // Decode parses a serialized assertion.
 //
@@ -1118,7 +1113,7 @@ func assemble(headers map[string]any, body, content, signature []byte) (Assertio
 		return nil, fmt.Errorf("empty assertion signature")
 	}
 
-	assert, err := assertType.assembler(assertionBase{
+	assert, err := assertType.assembler(AssertionBase{
 		headers:   headers,
 		body:      body,
 		format:    formatnum,
@@ -1286,7 +1281,7 @@ func assembleAndSign(assertType *AssertionType, headers map[string]any, body []b
 	// be 'cat' friendly, add a ignored newline to the signature which is the last part of the encoded assertion
 	signature = append(signature, '\n')
 
-	assert, err := assertType.assembler(assertionBase{
+	assert, err := assertType.assembler(AssertionBase{
 		headers:   finalHeaders,
 		body:      finalBody,
 		format:    formatnum,

--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -602,6 +602,11 @@ type assertionBase struct {
 	signature []byte
 }
 
+// AssertionBase provides the generic assertion behavior for concrete
+// assertion types. External assertion implementations should embed the value
+// passed to their Assembler.
+type AssertionBase = assertionBase
+
 // HeaderString retrieves the string value of header with name or ""
 func (ab *assertionBase) HeaderString(name string) string {
 	s, _ := ab.headers[name].(string)

--- a/asserts/base_declaration.go
+++ b/asserts/base_declaration.go
@@ -57,8 +57,8 @@ func (basedcl *BaseDeclaration) SlotRule(interfaceName string) *SlotRule {
 	return basedcl.slotRules[interfaceName]
 }
 
-// Implement further consistency checks.
-func (basedcl *BaseDeclaration) checkConsistency(db RODatabase, acck *AccountKey) error {
+// CheckConsistency performs further checks using the assertion database.
+func (basedcl *BaseDeclaration) CheckConsistency(db RODatabase, acck *AccountKey) error {
 	if !db.IsTrustedAccount(basedcl.AuthorityID()) {
 		return fmt.Errorf("base-declaration assertion for series %s is not signed by a directly trusted authority: %s", basedcl.Series(), basedcl.AuthorityID())
 	}
@@ -66,7 +66,7 @@ func (basedcl *BaseDeclaration) checkConsistency(db RODatabase, acck *AccountKey
 }
 
 // expected interface is implemented
-var _ consistencyChecker = (*BaseDeclaration)(nil)
+var _ ConsistencyChecker = (*BaseDeclaration)(nil)
 
 func assembleBaseDeclaration(assert assertionBase) (Assertion, error) {
 	var plugRules map[string]*PlugRule

--- a/asserts/base_declaration.go
+++ b/asserts/base_declaration.go
@@ -29,7 +29,7 @@ import (
 // BaseDeclaration holds a base-declaration assertion, declaring the policies
 // (to start with interface ones) applying to all snaps of a series.
 type BaseDeclaration struct {
-	assertionBase
+	AssertionBase
 	plugRules map[string]*PlugRule
 	slotRules map[string]*SlotRule
 	timestamp time.Time
@@ -68,7 +68,7 @@ func (basedcl *BaseDeclaration) CheckConsistency(db RODatabase, acck *AccountKey
 // expected interface is implemented
 var _ ConsistencyChecker = (*BaseDeclaration)(nil)
 
-func assembleBaseDeclaration(assert assertionBase) (Assertion, error) {
+func assembleBaseDeclaration(assert AssertionBase) (Assertion, error) {
 	var plugRules map[string]*PlugRule
 	plugs, err := checkMap(assert.headers, "plugs")
 	if err != nil {
@@ -105,7 +105,7 @@ func assembleBaseDeclaration(assert assertionBase) (Assertion, error) {
 	}
 
 	return &BaseDeclaration{
-		assertionBase: assert,
+		AssertionBase: assert,
 		plugRules:     plugRules,
 		slotRules:     slotRules,
 		timestamp:     timestamp,

--- a/asserts/builtin.go
+++ b/asserts/builtin.go
@@ -104,7 +104,7 @@ func assembleBuiltinAssertion(assertType *AssertionType, headerBytes, body []byt
 		content = append(content, body...)
 	}
 
-	a, err := assertType.assembler(assertionBase{
+	a, err := assertType.assembler(AssertionBase{
 		headers:   h,
 		body:      body,
 		revision:  revision,

--- a/asserts/cluster.go
+++ b/asserts/cluster.go
@@ -31,7 +31,7 @@ import (
 // Cluster holds a cluster assertion, which describes a cluster of devices and
 // their organization into subclusters.
 type Cluster struct {
-	assertionBase
+	AssertionBase
 	seq         int
 	devices     []ClusterDevice
 	subclusters []Subcluster
@@ -300,7 +300,7 @@ func validateClusterDeviceIDs(devices []ClusterDevice, subclusters []Subcluster)
 	return nil
 }
 
-func assembleCluster(assert assertionBase) (Assertion, error) {
+func assembleCluster(assert AssertionBase) (Assertion, error) {
 	seq, err := checkSequence(assert.headers, "sequence")
 	if err != nil {
 		return nil, err
@@ -331,7 +331,7 @@ func assembleCluster(assert assertionBase) (Assertion, error) {
 	}
 
 	return &Cluster{
-		assertionBase: assert,
+		AssertionBase: assert,
 		seq:           seq,
 		devices:       devices,
 		subclusters:   subclusters,

--- a/asserts/confdb.go
+++ b/asserts/confdb.go
@@ -32,7 +32,7 @@ import (
 // account of access views and a storage schema for a set of related
 // configuration options under the purview of the account.
 type ConfdbSchema struct {
-	assertionBase
+	AssertionBase
 
 	schema    *confdb.Schema
 	timestamp time.Time
@@ -54,7 +54,7 @@ func (ar *ConfdbSchema) Schema() *confdb.Schema {
 	return ar.schema
 }
 
-func assembleConfdbSchema(assert assertionBase) (Assertion, error) {
+func assembleConfdbSchema(assert AssertionBase) (Assertion, error) {
 	authorityID := assert.AuthorityID()
 	accountID := assert.HeaderString("account-id")
 	if accountID == "system" {
@@ -108,7 +108,7 @@ func assembleConfdbSchema(assert assertionBase) (Assertion, error) {
 	}
 
 	return &ConfdbSchema{
-		assertionBase: assert,
+		AssertionBase: assert,
 		schema:        confdbSchema,
 		timestamp:     timestamp,
 	}, nil
@@ -117,7 +117,7 @@ func assembleConfdbSchema(assert assertionBase) (Assertion, error) {
 // ConfdbControl holds a confdb-control assertion, which holds lists of
 // views delegated by the device to operators.
 type ConfdbControl struct {
-	assertionBase
+	AssertionBase
 
 	control *confdb.Control
 }
@@ -177,7 +177,7 @@ func (cc *ConfdbControl) Control() confdb.Control {
 
 // assembleConfdbControl creates a new confdb-control assertion after validating
 // all required fields and constraints.
-func assembleConfdbControl(assert assertionBase) (Assertion, error) {
+func assembleConfdbControl(assert AssertionBase) (Assertion, error) {
 	_, err := checkStringMatches(assert.headers, "brand-id", validAccountID)
 	if err != nil {
 		return nil, err
@@ -203,7 +203,7 @@ func assembleConfdbControl(assert assertionBase) (Assertion, error) {
 	}
 
 	return &ConfdbControl{
-		assertionBase: assert,
+		AssertionBase: assert,
 		control:       cc,
 	}, nil
 }

--- a/asserts/database.go
+++ b/asserts/database.go
@@ -834,17 +834,16 @@ func CheckTimestampVsSigningKeyValidity(assert Assertion, signingKey *AccountKey
 	return nil
 }
 
-// A consistencyChecker performs further checks based on the full
-// assertion database knowledge and its own signing key.
-type consistencyChecker interface {
-	checkConsistency(roDB RODatabase, signingKey *AccountKey) error
+// A ConsistencyChecker performs further checks based on the full assertion
+// database knowledge and its own signing key.
+type ConsistencyChecker interface {
+	CheckConsistency(roDB RODatabase, signingKey *AccountKey) error
 }
 
 // CheckCrossConsistency verifies that the assertion is consistent with the other statements in the database.
 func CheckCrossConsistency(assert Assertion, signingKey *AccountKey, roDB RODatabase, checkTimeEarliest, checkTimeLatest time.Time) error {
-	// see if the assertion requires further checks
-	if checker, ok := assert.(consistencyChecker); ok {
-		return checker.checkConsistency(roDB, signingKey)
+	if checker, ok := assert.(ConsistencyChecker); ok {
+		return checker.CheckConsistency(roDB, signingKey)
 	}
 	return nil
 }

--- a/asserts/export_test.go
+++ b/asserts/export_test.go
@@ -63,7 +63,7 @@ func NewDecoderStressed(r io.Reader, bufSize, maxHeadersSize, maxBodySize, maxSi
 
 func BootstrapAccountForTest(authorityID string) *Account {
 	return &Account{
-		assertionBase: assertionBase{
+		AssertionBase: AssertionBase{
 			headers: map[string]any{
 				"type":         "account",
 				"authority-id": authorityID,
@@ -81,7 +81,7 @@ func MakeAccountKeyForTest(authorityID string, openPGPPubKey PublicKey, since ti
 
 func MakeAccountKeyForTestWithUntil(authorityID string, openPGPPubKey PublicKey, since, until time.Time, validYears int) *AccountKey {
 	return &AccountKey{
-		assertionBase: assertionBase{
+		AssertionBase: AssertionBase{
 			headers: map[string]any{
 				"type":                "account-key",
 				"authority-id":        authorityID,
@@ -118,10 +118,10 @@ func MockTimeNow(t time.Time) (restore func()) {
 // define test assertion types to use in the tests
 
 type TestOnly struct {
-	assertionBase
+	AssertionBase
 }
 
-func assembleTestOnly(assert assertionBase) (Assertion, error) {
+func assembleTestOnly(assert AssertionBase) (Assertion, error) {
 	// for testing error cases
 	if _, err := checkIntWithDefault(assert.headers, "count", 0); err != nil {
 		return nil, err
@@ -132,10 +132,10 @@ func assembleTestOnly(assert assertionBase) (Assertion, error) {
 var TestOnlyType = &AssertionType{"test-only", []string{"primary-key"}, nil, assembleTestOnly, 0}
 
 type TestOnly2 struct {
-	assertionBase
+	AssertionBase
 }
 
-func assembleTestOnly2(assert assertionBase) (Assertion, error) {
+func assembleTestOnly2(assert AssertionBase) (Assertion, error) {
 	return &TestOnly2{assert}, nil
 }
 
@@ -144,7 +144,7 @@ var TestOnly2Type = &AssertionType{"test-only-2", []string{"pk1", "pk2"}, nil, a
 // TestOnlyDecl is a test-only assertion that mimics snap-declaration
 // relations with other assertions.
 type TestOnlyDecl struct {
-	assertionBase
+	AssertionBase
 }
 
 func (dcl *TestOnlyDecl) ID() string {
@@ -161,7 +161,7 @@ func (dcl *TestOnlyDecl) Prerequisites() []*Ref {
 	}
 }
 
-func assembleTestOnlyDecl(assert assertionBase) (Assertion, error) {
+func assembleTestOnlyDecl(assert AssertionBase) (Assertion, error) {
 	return &TestOnlyDecl{assert}, nil
 }
 
@@ -170,7 +170,7 @@ var TestOnlyDeclType = &AssertionType{"test-only-decl", []string{"id"}, nil, ass
 // TestOnlyRev is a test-only assertion that mimics snap-revision
 // relations with other assertions.
 type TestOnlyRev struct {
-	assertionBase
+	AssertionBase
 }
 
 func (rev *TestOnlyRev) H() string {
@@ -192,7 +192,7 @@ func (rev *TestOnlyRev) Prerequisites() []*Ref {
 	}
 }
 
-func assembleTestOnlyRev(assert assertionBase) (Assertion, error) {
+func assembleTestOnlyRev(assert AssertionBase) (Assertion, error) {
 	return &TestOnlyRev{assert}, nil
 }
 
@@ -200,7 +200,7 @@ var TestOnlyRevType = &AssertionType{"test-only-rev", []string{"h"}, nil, assemb
 
 // TestOnlySeq is a test-only assertion that is sequence-forming.
 type TestOnlySeq struct {
-	assertionBase
+	AssertionBase
 	seq int
 }
 
@@ -212,13 +212,13 @@ func (seq *TestOnlySeq) Sequence() int {
 	return seq.seq
 }
 
-func assembleTestOnlySeq(assert assertionBase) (Assertion, error) {
+func assembleTestOnlySeq(assert AssertionBase) (Assertion, error) {
 	seq, err := checkSequence(assert.headers, "sequence")
 	if err != nil {
 		return nil, err
 	}
 	return &TestOnlySeq{
-		assertionBase: assert,
+		AssertionBase: assert,
 		seq:           seq,
 	}, nil
 }
@@ -226,10 +226,10 @@ func assembleTestOnlySeq(assert assertionBase) (Assertion, error) {
 var TestOnlySeqType = &AssertionType{"test-only-seq", []string{"n", "sequence"}, nil, assembleTestOnlySeq, sequenceForming}
 
 type TestOnlyNoAuthority struct {
-	assertionBase
+	AssertionBase
 }
 
-func assembleTestOnlyNoAuthority(assert assertionBase) (Assertion, error) {
+func assembleTestOnlyNoAuthority(assert AssertionBase) (Assertion, error) {
 	if _, err := checkNotEmptyString(assert.headers, "hdr"); err != nil {
 		return nil, err
 	}
@@ -239,10 +239,10 @@ func assembleTestOnlyNoAuthority(assert assertionBase) (Assertion, error) {
 var TestOnlyNoAuthorityType = &AssertionType{"test-only-no-authority", nil, nil, assembleTestOnlyNoAuthority, noAuthority}
 
 type TestOnlyNoAuthorityPK struct {
-	assertionBase
+	AssertionBase
 }
 
-func assembleTestOnlyNoAuthorityPK(assert assertionBase) (Assertion, error) {
+func assembleTestOnlyNoAuthorityPK(assert AssertionBase) (Assertion, error) {
 	return &TestOnlyNoAuthorityPK{assert}, nil
 }
 

--- a/asserts/hardware_identity.go
+++ b/asserts/hardware_identity.go
@@ -37,7 +37,7 @@ import (
 // HardwareIdentity holds a hardware identity assertion, which is a statement
 // that verifies the identity of a physical piece of hardware
 type HardwareIdentity struct {
-	assertionBase
+	AssertionBase
 
 	hardwareIDKeySha3384 string
 	hardwareKey          crypto.PublicKey
@@ -79,7 +79,7 @@ func (h *HardwareIdentity) HardwareIDKeySha3384() string {
 	return h.hardwareIDKeySha3384
 }
 
-func assembleHardwareIdentity(assert assertionBase) (Assertion, error) {
+func assembleHardwareIdentity(assert AssertionBase) (Assertion, error) {
 	issuerID, err := checkStringMatches(assert.headers, "issuer-id", validAccountID)
 	if err != nil {
 		return nil, err
@@ -128,7 +128,7 @@ func assembleHardwareIdentity(assert assertionBase) (Assertion, error) {
 	}
 
 	return &HardwareIdentity{
-		assertionBase:        assert,
+		AssertionBase:        assert,
 		hardwareIDKeySha3384: hardwareIDKeySha3384,
 		hardwareKey:          pubKey,
 	}, nil

--- a/asserts/messages.go
+++ b/asserts/messages.go
@@ -71,7 +71,7 @@ func newDeviceIDFromString(rawID string) (DeviceID, error) {
 
 // RequestMessage represents a request message assertion used to trigger actions on snapd.
 type RequestMessage struct {
-	assertionBase
+	AssertionBase
 
 	id     string
 	seqNum int
@@ -124,7 +124,7 @@ func (req *RequestMessage) ValidUntil() time.Time {
 	return req.until
 }
 
-func assembleRequestMessage(assert assertionBase) (Assertion, error) {
+func assembleRequestMessage(assert AssertionBase) (Assertion, error) {
 	accountID := assert.HeaderString("account-id")
 	if !validAccountID.MatchString(accountID) {
 		return nil, fmt.Errorf("invalid account id: %s", accountID)
@@ -165,7 +165,7 @@ func assembleRequestMessage(assert assertionBase) (Assertion, error) {
 	}
 
 	return &RequestMessage{
-		assertionBase: assert,
+		AssertionBase: assert,
 		id:            id,
 		seqNum:        seqNum,
 		devices:       deviceIDs,
@@ -281,7 +281,7 @@ func newMessageStatus(status string) (MessageStatus, error) {
 // for every processed request-message. It contains the processing outcome
 // and any payload data in the assertion body.
 type ResponseMessage struct {
-	assertionBase
+	AssertionBase
 
 	id     string
 	seqNum int
@@ -318,7 +318,7 @@ func (res *ResponseMessage) Device() DeviceID {
 	return res.device
 }
 
-func assembleResponseMessage(assert assertionBase) (Assertion, error) {
+func assembleResponseMessage(assert AssertionBase) (Assertion, error) {
 	accountID := assert.HeaderString("account-id")
 	if !validAccountID.MatchString(accountID) {
 		return nil, fmt.Errorf("invalid account id: %s", accountID)
@@ -345,7 +345,7 @@ func assembleResponseMessage(assert assertionBase) (Assertion, error) {
 	}
 
 	return &ResponseMessage{
-		assertionBase: assert,
+		AssertionBase: assert,
 		id:            id,
 		seqNum:        seqNum,
 		device:        deviceID,

--- a/asserts/model.go
+++ b/asserts/model.go
@@ -781,14 +781,14 @@ func (mod *Model) Timestamp() time.Time {
 	return mod.timestamp
 }
 
-// Implement further consistency checks.
-func (mod *Model) checkConsistency(db RODatabase, acck *AccountKey) error {
+// CheckConsistency performs further checks using the assertion database.
+func (mod *Model) CheckConsistency(db RODatabase, acck *AccountKey) error {
 	// TODO: double check trust level of authority depending on class and possibly allowed-modes
 	return nil
 }
 
 // expected interface is implemented
-var _ consistencyChecker = (*Model)(nil)
+var _ ConsistencyChecker = (*Model)(nil)
 
 // limit model to only lowercase for now
 var validModel = regexp.MustCompile("^[a-zA-Z0-9](?:-?[a-zA-Z0-9])*$")

--- a/asserts/model.go
+++ b/asserts/model.go
@@ -573,7 +573,7 @@ func (mvs *ModelValidationSet) AtSequence() *AtSequence {
 // Model holds a model assertion, which is a statement by a brand
 // about the properties of a device model.
 type Model struct {
-	assertionBase
+	AssertionBase
 	classic bool
 
 	baseSnap   *ModelSnap
@@ -981,7 +981,7 @@ var (
 	validDistribution = regexp.MustCompile(`^[a-z0-9._-]*$`)
 )
 
-func assembleModel(assert assertionBase) (Assertion, error) {
+func assembleModel(assert AssertionBase) (Assertion, error) {
 	err := checkAuthorityMatchesBrand(&assert)
 	if err != nil {
 		return nil, err
@@ -1208,7 +1208,7 @@ func assembleModel(assert assertionBase) (Assertion, error) {
 
 	// ignore extra headers and non-empty body for future compatibility
 	return &Model{
-		assertionBase:              assert,
+		AssertionBase:              assert,
 		classic:                    classic,
 		baseSnap:                   modSnaps.base,
 		gadgetSnap:                 modSnaps.gadget,

--- a/asserts/preseed.go
+++ b/asserts/preseed.go
@@ -71,7 +71,7 @@ func (s *PreseedSnap) ID() string {
 // Preseed holds preseed assertion, which is a statement about system-label,
 // model, set of snaps and preseed artifact used for preseeding of UC20 system.
 type Preseed struct {
-	assertionBase
+	AssertionBase
 	snaps     []*PreseedSnap
 	timestamp time.Time
 }
@@ -269,7 +269,7 @@ func checkPreseedSnaps(snapList any) ([]*PreseedSnap, error) {
 	return snaps, nil
 }
 
-func assemblePreseed(assert assertionBase) (Assertion, error) {
+func assemblePreseed(assert AssertionBase) (Assertion, error) {
 	// because the authority-id and model-id can differ (as per the model),
 	// authority-id should be validated against allowed IDs when the preseed
 	// blob is being checked
@@ -303,7 +303,7 @@ func assemblePreseed(assert assertionBase) (Assertion, error) {
 		return nil, err
 	}
 	return &Preseed{
-		assertionBase: assert,
+		AssertionBase: assert,
 		snaps:         snaps,
 		timestamp:     timestamp,
 	}, nil

--- a/asserts/repair.go
+++ b/asserts/repair.go
@@ -111,8 +111,8 @@ func (r *Repair) Timestamp() time.Time {
 	return r.timestamp
 }
 
-// Implement further consistency checks.
-func (r *Repair) checkConsistency(db RODatabase, acck *AccountKey) error {
+// CheckConsistency performs further checks using the assertion database.
+func (r *Repair) CheckConsistency(db RODatabase, acck *AccountKey) error {
 	// Do the cross-checks when this assertion is actually used,
 	// i.e. in the future repair code
 
@@ -120,7 +120,7 @@ func (r *Repair) checkConsistency(db RODatabase, acck *AccountKey) error {
 }
 
 // expected interface is implemented
-var _ consistencyChecker = (*Repair)(nil)
+var _ ConsistencyChecker = (*Repair)(nil)
 
 func assembleRepair(assert assertionBase) (Assertion, error) {
 	err := checkAuthorityMatchesBrand(&assert)

--- a/asserts/repair.go
+++ b/asserts/repair.go
@@ -32,7 +32,7 @@ import (
 // code to fixup broken systems. It can be limited by series and models, as well
 // as by bases and modes.
 type Repair struct {
-	assertionBase
+	AssertionBase
 
 	series        []string
 	architectures []string
@@ -122,7 +122,7 @@ func (r *Repair) CheckConsistency(db RODatabase, acck *AccountKey) error {
 // expected interface is implemented
 var _ ConsistencyChecker = (*Repair)(nil)
 
-func assembleRepair(assert assertionBase) (Assertion, error) {
+func assembleRepair(assert AssertionBase) (Assertion, error) {
 	err := checkAuthorityMatchesBrand(&assert)
 	if err != nil {
 		return nil, err
@@ -205,7 +205,7 @@ func assembleRepair(assert assertionBase) (Assertion, error) {
 	}
 
 	return &Repair{
-		assertionBase: assert,
+		AssertionBase: assert,
 		series:        series,
 		architectures: architectures,
 		models:        models,

--- a/asserts/serial_asserts.go
+++ b/asserts/serial_asserts.go
@@ -80,7 +80,8 @@ func (ser *Serial) Timestamp() time.Time {
 	return ser.timestamp
 }
 
-func (ser *Serial) checkConsistency(db RODatabase, acck *AccountKey) error {
+// CheckConsistency performs further checks using the assertion database.
+func (ser *Serial) CheckConsistency(db RODatabase, acck *AccountKey) error {
 	if ser.AuthorityID() != ser.BrandID() {
 		// serial authority and brand do not match, check the model
 		a, err := db.Find(ModelType, map[string]string{

--- a/asserts/serial_asserts.go
+++ b/asserts/serial_asserts.go
@@ -40,7 +40,7 @@ var (
 // Serial holds a serial assertion, which is a statement binding a
 // device identity with the device public key.
 type Serial struct {
-	assertionBase
+	AssertionBase
 	timestamp time.Time
 	pubKey    PublicKey
 }
@@ -99,7 +99,7 @@ func (ser *Serial) CheckConsistency(db RODatabase, acck *AccountKey) error {
 	return nil
 }
 
-func assembleSerial(assert assertionBase) (Assertion, error) {
+func assembleSerial(assert AssertionBase) (Assertion, error) {
 	// brand-id and authority-id can diverge if the model allows
 	// for it via serial-authority, check for brand-id well-formedness
 	_, err := checkStringMatches(assert.headers, "brand-id", validAccountID)
@@ -135,7 +135,7 @@ func assembleSerial(assert assertionBase) (Assertion, error) {
 
 	// ignore extra headers and non-empty body for future compatibility
 	return &Serial{
-		assertionBase: assert,
+		AssertionBase: assert,
 		timestamp:     timestamp,
 		pubKey:        pubKey,
 	}, nil
@@ -143,7 +143,7 @@ func assembleSerial(assert assertionBase) (Assertion, error) {
 
 // SerialRequest holds a serial-request assertion, which is a self-signed request to obtain a full device identity bound to the device public key.
 type SerialRequest struct {
-	assertionBase
+	AssertionBase
 	pubKey PublicKey
 }
 
@@ -172,7 +172,7 @@ func (sreq *SerialRequest) DeviceKey() PublicKey {
 	return sreq.pubKey
 }
 
-func assembleSerialRequest(assert assertionBase) (Assertion, error) {
+func assembleSerialRequest(assert AssertionBase) (Assertion, error) {
 	_, err := checkNotEmptyString(assert.headers, "brand-id")
 	if err != nil {
 		return nil, err
@@ -208,14 +208,14 @@ func assembleSerialRequest(assert assertionBase) (Assertion, error) {
 
 	// ignore extra headers and non-empty body for future compatibility
 	return &SerialRequest{
-		assertionBase: assert,
+		AssertionBase: assert,
 		pubKey:        pubKey,
 	}, nil
 }
 
 // DeviceSessionRequest holds a device-session-request assertion, which is a request wrapping a store-provided nonce to start a session by a device signed with its key.
 type DeviceSessionRequest struct {
-	assertionBase
+	AssertionBase
 	timestamp time.Time
 }
 
@@ -246,7 +246,7 @@ func (req *DeviceSessionRequest) Timestamp() time.Time {
 	return req.timestamp
 }
 
-func assembleDeviceSessionRequest(assert assertionBase) (Assertion, error) {
+func assembleDeviceSessionRequest(assert AssertionBase) (Assertion, error) {
 	_, err := checkModel(assert.headers)
 	if err != nil {
 		return nil, err
@@ -264,7 +264,7 @@ func assembleDeviceSessionRequest(assert assertionBase) (Assertion, error) {
 
 	// ignore extra headers and non-empty body for future compatibility
 	return &DeviceSessionRequest{
-		assertionBase: assert,
+		AssertionBase: assert,
 		timestamp:     timestamp,
 	}, nil
 }

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -116,8 +116,8 @@ func (snapdcl *SnapDeclaration) RevisionAuthority(provenance string) []*Revision
 	return res
 }
 
-// Implement further consistency checks.
-func (snapdcl *SnapDeclaration) checkConsistency(db RODatabase, acck *AccountKey) error {
+// CheckConsistency performs further checks using the assertion database.
+func (snapdcl *SnapDeclaration) CheckConsistency(db RODatabase, acck *AccountKey) error {
 	if !db.IsTrustedAccount(snapdcl.AuthorityID()) {
 		return fmt.Errorf("snap-declaration assertion for %q (id %q) is not signed by a directly trusted authority: %s", snapdcl.SnapName(), snapdcl.SnapID(), snapdcl.AuthorityID())
 	}
@@ -135,7 +135,7 @@ func (snapdcl *SnapDeclaration) checkConsistency(db RODatabase, acck *AccountKey
 }
 
 // expected interface is implemented
-var _ consistencyChecker = (*SnapDeclaration)(nil)
+var _ ConsistencyChecker = (*SnapDeclaration)(nil)
 
 // Prerequisites returns references to this snap-declaration's prerequisite assertions.
 func (snapdcl *SnapDeclaration) Prerequisites() []*Ref {
@@ -656,8 +656,8 @@ func (snaprev *SnapRevision) SnapIntegrityData() []IntegrityData {
 	return snaprev.snapIntegrityData
 }
 
-// Implement further consistency checks.
-func (snaprev *SnapRevision) checkConsistency(db RODatabase, acck *AccountKey) error {
+// CheckConsistency performs further checks using the assertion database.
+func (snaprev *SnapRevision) CheckConsistency(db RODatabase, acck *AccountKey) error {
 	otherProvenance := snaprev.Provenance() != naming.DefaultProvenance
 	if !otherProvenance && !db.IsTrustedAccount(snaprev.AuthorityID()) {
 		// delegating global-upload revisions is not allowed
@@ -704,7 +704,7 @@ func (snaprev *SnapRevision) checkConsistency(db RODatabase, acck *AccountKey) e
 }
 
 // expected interface is implemented
-var _ consistencyChecker = (*SnapRevision)(nil)
+var _ ConsistencyChecker = (*SnapRevision)(nil)
 
 // Prerequisites returns references to this snap-revision's prerequisite assertions.
 func (snaprev *SnapRevision) Prerequisites() []*Ref {
@@ -914,8 +914,8 @@ func (validation *Validation) Timestamp() time.Time {
 	return validation.timestamp
 }
 
-// Implement further consistency checks.
-func (validation *Validation) checkConsistency(db RODatabase, acck *AccountKey) error {
+// CheckConsistency performs further checks using the assertion database.
+func (validation *Validation) CheckConsistency(db RODatabase, acck *AccountKey) error {
 	_, err := db.Find(SnapDeclarationType, map[string]string{
 		"series":  validation.Series(),
 		"snap-id": validation.ApprovedSnapID(),
@@ -946,7 +946,7 @@ func (validation *Validation) checkConsistency(db RODatabase, acck *AccountKey) 
 }
 
 // expected interface is implemented
-var _ consistencyChecker = (*Validation)(nil)
+var _ ConsistencyChecker = (*Validation)(nil)
 
 // Prerequisites returns references to this validation's prerequisite assertions.
 func (validation *Validation) Prerequisites() []*Ref {
@@ -1008,7 +1008,8 @@ func (snapdev *SnapDeveloper) PublisherID() string {
 	return snapdev.HeaderString("publisher-id")
 }
 
-func (snapdev *SnapDeveloper) checkConsistency(db RODatabase, acck *AccountKey) error {
+// CheckConsistency performs further checks using the assertion database.
+func (snapdev *SnapDeveloper) CheckConsistency(db RODatabase, acck *AccountKey) error {
 	// Check authority is the publisher or trusted.
 	authorityID := snapdev.AuthorityID()
 	publisherID := snapdev.PublisherID()
@@ -1058,7 +1059,7 @@ func (snapdev *SnapDeveloper) checkConsistency(db RODatabase, acck *AccountKey) 
 }
 
 // expected interface is implemented
-var _ consistencyChecker = (*SnapDeveloper)(nil)
+var _ ConsistencyChecker = (*SnapDeveloper)(nil)
 
 // Prerequisites returns references to this snap-developer's prerequisite assertions.
 func (snapdev *SnapDeveloper) Prerequisites() []*Ref {

--- a/asserts/snap_asserts.go
+++ b/asserts/snap_asserts.go
@@ -40,7 +40,7 @@ import (
 // snap binding its identifying snap-id to a name, asserting its
 // publisher and its other properties.
 type SnapDeclaration struct {
-	assertionBase
+	AssertionBase
 	refreshControl      []string
 	plugRules           map[string]*PlugRule
 	slotRules           map[string]*SlotRule
@@ -281,7 +281,7 @@ func checkAliases(headers map[string]any) (map[string]string, error) {
 	return aliasMap, nil
 }
 
-func assembleSnapDeclaration(assert assertionBase) (Assertion, error) {
+func assembleSnapDeclaration(assert AssertionBase) (Assertion, error) {
 	_, err := checkExistsString(assert.headers, "snap-name")
 	if err != nil {
 		return nil, err
@@ -409,7 +409,7 @@ func assembleSnapDeclaration(assert assertionBase) (Assertion, error) {
 	}
 
 	return &SnapDeclaration{
-		assertionBase:       assert,
+		AssertionBase:       assert,
 		refreshControl:      refControl,
 		plugRules:           plugRules,
 		slotRules:           slotRules,
@@ -539,7 +539,7 @@ func SnapFileSHA3_384(snapPath string) (digest string, size uint64, err error) {
 // SnapBuild holds a snap-build assertion, asserting the properties of a snap
 // at the time it was built by the developer.
 type SnapBuild struct {
-	assertionBase
+	AssertionBase
 	size      uint64
 	timestamp time.Time
 }
@@ -569,7 +569,7 @@ func (snapbld *SnapBuild) Timestamp() time.Time {
 	return snapbld.timestamp
 }
 
-func assembleSnapBuild(assert assertionBase) (Assertion, error) {
+func assembleSnapBuild(assert AssertionBase) (Assertion, error) {
 	_, err := checkDigest(assert.headers, "snap-sha3-384", crypto.SHA3_384)
 	if err != nil {
 		return nil, err
@@ -596,7 +596,7 @@ func assembleSnapBuild(assert assertionBase) (Assertion, error) {
 	}
 	// ignore extra headers and non-empty body for future compatibility
 	return &SnapBuild{
-		assertionBase: assert,
+		AssertionBase: assert,
 		size:          size,
 		timestamp:     timestamp,
 	}, nil
@@ -606,7 +606,7 @@ func assembleSnapBuild(assert assertionBase) (Assertion, error) {
 // store acknowledging the receipt of a build of a snap and labeling it with a
 // snap revision.
 type SnapRevision struct {
-	assertionBase
+	AssertionBase
 	snapSize     uint64
 	snapRevision int
 	timestamp    time.Time
@@ -823,7 +823,7 @@ func checkSnapIntegrity(headers map[string]any) ([]IntegrityData, error) {
 	return snapIntegrityDataList, nil
 }
 
-func assembleSnapRevision(assert assertionBase) (Assertion, error) {
+func assembleSnapRevision(assert AssertionBase) (Assertion, error) {
 	_, err := checkDigest(assert.headers, "snap-sha3-384", crypto.SHA3_384)
 	if err != nil {
 		return nil, err
@@ -865,7 +865,7 @@ func assembleSnapRevision(assert assertionBase) (Assertion, error) {
 	}
 
 	return &SnapRevision{
-		assertionBase:     assert,
+		AssertionBase:     assert,
 		snapSize:          snapSize,
 		snapRevision:      snapRevision,
 		timestamp:         timestamp,
@@ -878,7 +878,7 @@ func assembleSnapRevision(assert assertionBase) (Assertion, error) {
 // the series, meaning updating to that revision of approved-snap-id
 // has been approved by the owner of the gating snap with snap-id.
 type Validation struct {
-	assertionBase
+	AssertionBase
 	revoked              bool
 	timestamp            time.Time
 	approvedSnapRevision int
@@ -956,7 +956,7 @@ func (validation *Validation) Prerequisites() []*Ref {
 	}
 }
 
-func assembleValidation(assert assertionBase) (Assertion, error) {
+func assembleValidation(assert AssertionBase) (Assertion, error) {
 	approvedSnapRevision, err := checkSnapRevisionWhat(assert.headers, "approved-snap-revision", "header")
 	if err != nil {
 		return nil, err
@@ -973,7 +973,7 @@ func assembleValidation(assert assertionBase) (Assertion, error) {
 	}
 
 	return &Validation{
-		assertionBase:        assert,
+		AssertionBase:        assert,
 		revoked:              revoked,
 		timestamp:            timestamp,
 		approvedSnapRevision: approvedSnapRevision,
@@ -994,7 +994,7 @@ type dateRange struct {
 // snap-developer for the current publisher (the snap-declaration publisher-id)
 // is relevant to a device.
 type SnapDeveloper struct {
-	assertionBase
+	AssertionBase
 	developerRanges map[string][]*dateRange
 }
 
@@ -1082,14 +1082,14 @@ func (snapdev *SnapDeveloper) Prerequisites() []*Ref {
 	return refs
 }
 
-func assembleSnapDeveloper(assert assertionBase) (Assertion, error) {
+func assembleSnapDeveloper(assert AssertionBase) (Assertion, error) {
 	developerRanges, err := checkDevelopers(assert.headers)
 	if err != nil {
 		return nil, err
 	}
 
 	return &SnapDeveloper{
-		assertionBase:   assert,
+		AssertionBase:   assert,
 		developerRanges: developerRanges,
 	}, nil
 }

--- a/asserts/snap_resource_asserts.go
+++ b/asserts/snap_resource_asserts.go
@@ -87,8 +87,8 @@ func (resrev *SnapResourceRevision) ResourceIntegrityData() []IntegrityData {
 	return resrev.resourceIntegrityData
 }
 
-// Implement further consistency checks.
-func (resrev *SnapResourceRevision) checkConsistency(db RODatabase, acck *AccountKey) error {
+// CheckConsistency performs further checks using the assertion database.
+func (resrev *SnapResourceRevision) CheckConsistency(db RODatabase, acck *AccountKey) error {
 	otherProvenance := resrev.Provenance() != naming.DefaultProvenance
 	if !otherProvenance && !db.IsTrustedAccount(resrev.AuthorityID()) {
 		// delegating global-upload revisions is not allowed
@@ -134,7 +134,7 @@ func (resrev *SnapResourceRevision) checkConsistency(db RODatabase, acck *Accoun
 }
 
 // expected interface is implemented
-var _ consistencyChecker = (*SnapResourceRevision)(nil)
+var _ ConsistencyChecker = (*SnapResourceRevision)(nil)
 
 // Prerequisites returns references to this snap-resource-revision's prerequisite assertions.
 func (resrev *SnapResourceRevision) Prerequisites() []*Ref {
@@ -252,8 +252,8 @@ func (respair *SnapResourcePair) Timestamp() time.Time {
 	return respair.timestamp
 }
 
-// Implement further consistency checks.
-func (respair *SnapResourcePair) checkConsistency(db RODatabase, acck *AccountKey) error {
+// CheckConsistency performs further checks using the assertion database.
+func (respair *SnapResourcePair) CheckConsistency(db RODatabase, acck *AccountKey) error {
 	otherProvenance := respair.Provenance() != naming.DefaultProvenance
 	if !otherProvenance && !db.IsTrustedAccount(respair.AuthorityID()) {
 		// delegating global-upload revisions is not allowed
@@ -300,7 +300,7 @@ func (respair *SnapResourcePair) checkConsistency(db RODatabase, acck *AccountKe
 }
 
 // expected interface is implemented
-var _ consistencyChecker = (*SnapResourcePair)(nil)
+var _ ConsistencyChecker = (*SnapResourcePair)(nil)
 
 // Prerequisites returns references to this snap-resource-pair's prerequisite assertions.
 func (respair *SnapResourcePair) Prerequisites() []*Ref {

--- a/asserts/snap_resource_asserts.go
+++ b/asserts/snap_resource_asserts.go
@@ -33,7 +33,7 @@ import (
 // statement by the store acknowledging the receipt of data for a resource of a
 // snap and labeling it with a resource revision.
 type SnapResourceRevision struct {
-	assertionBase
+	AssertionBase
 	resourceSize     uint64
 	resourceRevision int
 	timestamp        time.Time
@@ -156,7 +156,7 @@ func checkResourceName(headers map[string]any) error {
 	return nil
 }
 
-func assembleSnapResourceRevision(assert assertionBase) (Assertion, error) {
+func assembleSnapResourceRevision(assert AssertionBase) (Assertion, error) {
 	if err := checkResourceName(assert.headers); err != nil {
 		return nil, err
 	}
@@ -197,7 +197,7 @@ func assembleSnapResourceRevision(assert assertionBase) (Assertion, error) {
 	}
 
 	return &SnapResourceRevision{
-		assertionBase:         assert,
+		AssertionBase:         assert,
 		resourceSize:          resourceSize,
 		resourceRevision:      resourceRevision,
 		timestamp:             timestamp,
@@ -210,7 +210,7 @@ func assembleSnapResourceRevision(assert assertionBase) (Assertion, error) {
 // that the given snap resource revision can work with the given
 // snap revision.
 type SnapResourcePair struct {
-	assertionBase
+	AssertionBase
 	resourceRevision int
 	snapRevision     int
 	timestamp        time.Time
@@ -309,7 +309,7 @@ func (respair *SnapResourcePair) Prerequisites() []*Ref {
 	}
 }
 
-func assembleSnapResourcePair(assert assertionBase) (Assertion, error) {
+func assembleSnapResourcePair(assert AssertionBase) (Assertion, error) {
 	if err := checkResourceName(assert.headers); err != nil {
 		return nil, err
 	}
@@ -340,7 +340,7 @@ func assembleSnapResourcePair(assert assertionBase) (Assertion, error) {
 	}
 
 	return &SnapResourcePair{
-		assertionBase:    assert,
+		AssertionBase:    assert,
 		resourceRevision: resourceRevision,
 		snapRevision:     snapRevision,
 		timestamp:        timestamp,

--- a/asserts/store_asserts.go
+++ b/asserts/store_asserts.go
@@ -66,7 +66,8 @@ func (store *Store) Timestamp() time.Time {
 	return store.timestamp
 }
 
-func (store *Store) checkConsistency(db RODatabase, acck *AccountKey) error {
+// CheckConsistency performs further checks using the assertion database.
+func (store *Store) CheckConsistency(db RODatabase, acck *AccountKey) error {
 	// Will be applied to a system's snapd or influence snapd
 	// policy decisions (via friendly-stores) so must be signed by a trusted
 	// authority!

--- a/asserts/store_asserts.go
+++ b/asserts/store_asserts.go
@@ -29,7 +29,7 @@ import (
 // Store holds a store assertion, defining the configuration needed to connect
 // a device to the store or relative to a non-default store.
 type Store struct {
-	assertionBase
+	AssertionBase
 	url            *url.URL
 	friendlyStores []string
 	timestamp      time.Time
@@ -129,7 +129,7 @@ func checkStoreURL(headers map[string]any) (*url.URL, error) {
 	return u, nil
 }
 
-func assembleStore(assert assertionBase) (Assertion, error) {
+func assembleStore(assert AssertionBase) (Assertion, error) {
 	_, err := checkNotEmptyString(assert.headers, "operator-id")
 	if err != nil {
 		return nil, err
@@ -156,7 +156,7 @@ func assembleStore(assert assertionBase) (Assertion, error) {
 	}
 
 	return &Store{
-		assertionBase:  assert,
+		AssertionBase:  assert,
 		url:            url,
 		friendlyStores: friendlyStores,
 		timestamp:      timestamp,

--- a/asserts/system_user.go
+++ b/asserts/system_user.go
@@ -130,16 +130,16 @@ func (su *SystemUser) ValidAt(when time.Time) bool {
 	return valid
 }
 
-// Implement further consistency checks.
-func (su *SystemUser) checkConsistency(db RODatabase, acck *AccountKey) error {
+// CheckConsistency performs further checks using the assertion database.
+func (su *SystemUser) CheckConsistency(db RODatabase, acck *AccountKey) error {
 	// Do the cross-checks when this assertion is actually used,
-	// i.e. in the create-user code. See also Model.checkConsitency
+	// i.e. in the create-user code. See also Model.CheckConsistency.
 
 	return nil
 }
 
 // expected interface is implemented
-var _ consistencyChecker = (*SystemUser)(nil)
+var _ ConsistencyChecker = (*SystemUser)(nil)
 
 type shadow struct {
 	ID     string

--- a/asserts/system_user.go
+++ b/asserts/system_user.go
@@ -34,7 +34,7 @@ var validSystemUserUsernames = regexp.MustCompile(`^[a-z0-9][-a-z0-9._]*$`)
 // SystemUser holds a system-user assertion which allows creating local
 // system users.
 type SystemUser struct {
-	assertionBase
+	AssertionBase
 	series     []string
 	models     []string
 	serials    []string
@@ -231,7 +231,7 @@ func checkHashedPassword(headers map[string]any, name string) (string, error) {
 	return pw, nil
 }
 
-func checkSystemUserPresence(assert assertionBase) (string, error) {
+func checkSystemUserPresence(assert AssertionBase) (string, error) {
 	str, err := checkOptionalString(assert.headers, "user-presence")
 	if err != nil || str == "" {
 		return "", err
@@ -246,7 +246,7 @@ func checkSystemUserPresence(assert assertionBase) (string, error) {
 	return str, nil
 }
 
-func assembleSystemUser(assert assertionBase) (Assertion, error) {
+func assembleSystemUser(assert AssertionBase) (Assertion, error) {
 	// brand-id here can be different from authority-id,
 	// the code using the assertion must use the policy set
 	// by the model assertion system-user-authority header
@@ -321,7 +321,7 @@ func assembleSystemUser(assert assertionBase) (Assertion, error) {
 	}
 
 	return &SystemUser{
-		assertionBase:       assert,
+		AssertionBase:       assert,
 		series:              series,
 		models:              models,
 		serials:             serials,

--- a/asserts/validation_set.go
+++ b/asserts/validation_set.go
@@ -258,7 +258,7 @@ func checkValidationSetSnaps(snapList any) ([]*ValidationSetSnap, error) {
 // well together). validation-sets are organized in sequences under a
 // name.
 type ValidationSet struct {
-	assertionBase
+	AssertionBase
 
 	seq int
 
@@ -322,7 +322,7 @@ var (
 	validValidationSetName = regexp.MustCompile("^[a-z0-9](?:-?[a-z0-9])*$")
 )
 
-func assembleValidationSet(assert assertionBase) (Assertion, error) {
+func assembleValidationSet(assert AssertionBase) (Assertion, error) {
 	authorityID := assert.AuthorityID()
 	accountID := assert.HeaderString("account-id")
 	if accountID != authorityID {
@@ -354,7 +354,7 @@ func assembleValidationSet(assert assertionBase) (Assertion, error) {
 	}
 
 	return &ValidationSet{
-		assertionBase: assert,
+		AssertionBase: assert,
 		seq:           seq,
 		snaps:         snaps,
 		timestamp:     timestamp,


### PR DESCRIPTION
## Summary

Export the assertion extension points needed by assertion types implemented outside the `asserts` package.

This change:

- renames `assertionBase` to `AssertionBase` while keeping its representation fields private;
- exports `ConsistencyChecker`;
- updates the existing assertion types to implement the exported consistency method.

## Motivation

An externally implemented assertion needs to reuse the common `Assertion` behavior and may need to perform checks against other assertions in a database. Both extension points are currently private to the `asserts` package.

This is the foundation for #17573, which uses these APIs to construct and register external assertion types.