### PR TITLE
o/s/tasktest: add assertions that operate on selections

### DIFF
--- a/overlord/snapstate/tasktest/assertions.go
+++ b/overlord/snapstate/tasktest/assertions.go
@@ -25,10 +25,11 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 )
 
-// AssertSequenced checks that the given Selections form a sequence in the task
-// graph. Every task in each Selection must transitively precede every task in
-// the following Selection. Task ordering within a Selection is not considered.
-func AssertSequenced(selections ...Selection) error {
+// AssertOrdered checks that the given Selections are ordered in the task
+// graph as specified by their argument order. Every task in each Selection
+// must transitively precede every task in the next Selection. Task ordering
+// within a Selection is not considered.
+func AssertOrdered(selections ...Selection) error {
 	if err := validateNonEmpty(selections...); err != nil {
 		return err
 	}
@@ -47,9 +48,9 @@ func AssertSequenced(selections ...Selection) error {
 	return nil
 }
 
-// AssertNotSequenced checks that no task in first transitively precedes any
-// task in second.
-func AssertNotSequenced(first, second Selection) error {
+// AssertNotOrdered checks that no task in first transitively precedes any task
+// in second. Task ordering within a Selection is not considered.
+func AssertNotOrdered(first, second Selection) error {
 	if err := validateNonEmpty(first, second); err != nil {
 		return err
 	}

--- a/overlord/snapstate/tasktest/assertions.go
+++ b/overlord/snapstate/tasktest/assertions.go
@@ -1,0 +1,169 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package tasktest
+
+import (
+	"fmt"
+
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+// AssertSequenced checks that the given Selections form a sequence in the task
+// graph. Every task in each Selection must transitively precede every task in
+// the following Selection. Task ordering within a Selection is not considered.
+func AssertSequenced(selections ...Selection) error {
+	if err := validateNonEmpty(selections...); err != nil {
+		return err
+	}
+
+	for i := 0; i+1 < len(selections); i++ {
+		before := selections[i]
+		after := selections[i+1]
+		for _, beforeTask := range before.selected {
+			for _, afterTask := range after.selected {
+				if !before.reachability[beforeTask][afterTask] {
+					return fmt.Errorf("task %s (%s) is not sequenced before task %s (%s)", beforeTask.ID(), beforeTask.Kind(), afterTask.ID(), afterTask.Kind())
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// AssertNotSequenced checks that no task in first transitively precedes any
+// task in second.
+func AssertNotSequenced(first, second Selection) error {
+	if err := validateNonEmpty(first, second); err != nil {
+		return err
+	}
+
+	for _, firstTask := range first.selected {
+		for _, secondTask := range second.selected {
+			if first.reachability[firstTask][secondTask] {
+				return fmt.Errorf("task %s (%s) is sequenced before task %s (%s)", firstTask.ID(), firstTask.Kind(), secondTask.ID(), secondTask.Kind())
+			}
+		}
+	}
+	return nil
+}
+
+// AssertLaneSuperset checks that the lanes of every task in superset contain
+// all the lanes of every task in subset.
+//
+// This verifies that a failure of any task in superset includes every task in
+// subset in its transactional rollback scope. The reverse is not necessarily
+// true, as tasks in superset may belong to additional lanes.
+func AssertLaneSuperset(withSupersetOfLanes, withSubsetOfLanes Selection) error {
+	if err := validateNonEmpty(withSupersetOfLanes, withSubsetOfLanes); err != nil {
+		return err
+	}
+
+	for _, supersetTask := range withSupersetOfLanes.selected {
+		supersetLanes := laneSet(supersetTask)
+		for _, subsetTask := range withSubsetOfLanes.selected {
+			for _, lane := range subsetTask.Lanes() {
+				if !supersetLanes[lane] {
+					return fmt.Errorf("task %s (%s) with lanes %v is not a lane superset of task %s (%s) with lanes %v", supersetTask.ID(), supersetTask.Kind(), supersetTask.Lanes(), subsetTask.ID(), subsetTask.Kind(), subsetTask.Lanes())
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// AssertDoesNotShareLane checks that no task in first shares a lane with any
+// task in second.
+//
+// This verifies that the two Selections are in independent transactional
+// failure domains. A failure in one does not cause tasks in the other to be
+// aborted or undone through shared lane membership, though task dependencies
+// may still propagate the failure.
+func AssertDoesNotShareLane(first, second Selection) error {
+	if err := validateNonEmpty(first, second); err != nil {
+		return err
+	}
+
+	for _, firstTask := range first.selected {
+		firstLanes := laneSet(firstTask)
+		for _, secondTask := range second.selected {
+			for _, lane := range secondTask.Lanes() {
+				if firstLanes[lane] {
+					return fmt.Errorf("task %s (%s) and task %s (%s) share lane %d", firstTask.ID(), firstTask.Kind(), secondTask.ID(), secondTask.Kind(), lane)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// AssertSameLanes checks that all tasks in the given Selections have exactly
+// the same set of lanes.
+//
+// This verifies that the tasks have the same transactional failure domain and
+// are included in the same rollback scope when any of them fails.
+func AssertSameLanes(selections ...Selection) error {
+	if err := validateNonEmpty(selections...); err != nil {
+		return err
+	}
+
+	var reference *state.Task
+	var referenceLanes map[int]bool
+	for _, selection := range selections {
+		for _, task := range selection.selected {
+			if reference == nil {
+				reference = task
+				referenceLanes = laneSet(task)
+				continue
+			}
+
+			taskLanes := laneSet(task)
+			same := len(taskLanes) == len(referenceLanes)
+			if same {
+				for lane := range referenceLanes {
+					if !taskLanes[lane] {
+						same = false
+						break
+					}
+				}
+			}
+			if !same {
+				return fmt.Errorf("task %s (%s) has lanes %v, expected the same lanes as task %s (%s) with lanes %v", task.ID(), task.Kind(), task.Lanes(), reference.ID(), reference.Kind(), reference.Lanes())
+			}
+		}
+	}
+	return nil
+}
+
+func laneSet(task *state.Task) map[int]bool {
+	lanes := make(map[int]bool, len(task.Lanes()))
+	for _, lane := range task.Lanes() {
+		lanes[lane] = true
+	}
+	return lanes
+}
+
+func validateNonEmpty(selections ...Selection) error {
+	for i, selection := range selections {
+		if len(selection.selected) == 0 {
+			return fmt.Errorf("selection %d is empty", i+1)
+		}
+	}
+	return nil
+}

--- a/overlord/snapstate/tasktest/assertions_test.go
+++ b/overlord/snapstate/tasktest/assertions_test.go
@@ -45,7 +45,7 @@ func (s *assertionsSuite) TestAssertSequenced(c *C) {
 	tail.WaitFor(right)
 	selection := tasktest.NewSelection([]*state.Task{root, left, right, tail})
 
-	c.Check(tasktest.AssertSequenced(
+	c.Check(tasktest.AssertOrdered(
 		selection.Select(tasktest.Kind("root")),
 		selection.Select(tasktest.Kind("middle").All()),
 		selection.Select(tasktest.Kind("tail")),
@@ -67,7 +67,7 @@ func (s *assertionsSuite) TestAssertSequencedMissingDependency(c *C) {
 	before := tasktest.NewSelection([]*state.Task{first, second})
 	after := tasktest.NewSelection([]*state.Task{third, fourth})
 
-	c.Check(tasktest.AssertSequenced(before, after), ErrorMatches, `task 2 \(second\) is not sequenced before task 4 \(fourth\)`)
+	c.Check(tasktest.AssertOrdered(before, after), ErrorMatches, `task 2 \(second\) is not sequenced before task 4 \(fourth\)`)
 }
 
 func (s *assertionsSuite) TestAssertNotSequenced(c *C) {
@@ -82,7 +82,7 @@ func (s *assertionsSuite) TestAssertNotSequenced(c *C) {
 	later := tasktest.NewSelection([]*state.Task{second})
 	others := tasktest.NewSelection([]*state.Task{first, unrelated})
 
-	c.Check(tasktest.AssertNotSequenced(later, others), IsNil)
+	c.Check(tasktest.AssertNotOrdered(later, others), IsNil)
 }
 
 func (s *assertionsSuite) TestAssertNotSequencedHasDependency(c *C) {
@@ -100,7 +100,7 @@ func (s *assertionsSuite) TestAssertNotSequencedHasDependency(c *C) {
 	before := tasktest.NewSelection([]*state.Task{first, second})
 	after := tasktest.NewSelection([]*state.Task{third, fourth})
 
-	c.Check(tasktest.AssertNotSequenced(before, after), ErrorMatches, `task 2 \(second\) is sequenced before task 4 \(fourth\)`)
+	c.Check(tasktest.AssertNotOrdered(before, after), ErrorMatches, `task 2 \(second\) is sequenced before task 4 \(fourth\)`)
 }
 
 func (s *assertionsSuite) TestAssertLaneSuperset(c *C) {
@@ -256,8 +256,8 @@ func (s *assertionsSuite) TestAssertionsCheckEmptySets(c *C) {
 	selection := tasktest.NewSelection([]*state.Task{task})
 	empty := tasktest.NewSelection(nil)
 
-	c.Check(tasktest.AssertSequenced(selection, empty), ErrorMatches, "selection 2 is empty")
-	c.Check(tasktest.AssertNotSequenced(selection, empty), ErrorMatches, "selection 2 is empty")
+	c.Check(tasktest.AssertOrdered(selection, empty), ErrorMatches, "selection 2 is empty")
+	c.Check(tasktest.AssertNotOrdered(selection, empty), ErrorMatches, "selection 2 is empty")
 	c.Check(tasktest.AssertLaneSuperset(selection, empty), ErrorMatches, "selection 2 is empty")
 	c.Check(tasktest.AssertDoesNotShareLane(selection, empty), ErrorMatches, "selection 2 is empty")
 	c.Check(tasktest.AssertSameLanes(selection, empty), ErrorMatches, "selection 2 is empty")

--- a/overlord/snapstate/tasktest/assertions_test.go
+++ b/overlord/snapstate/tasktest/assertions_test.go
@@ -1,0 +1,264 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2026 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package tasktest_test
+
+import (
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/overlord/snapstate/tasktest"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+type assertionsSuite struct{}
+
+var _ = Suite(&assertionsSuite{})
+
+func (s *assertionsSuite) TestAssertSequenced(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	root := st.NewTask("root", "...")
+	left := st.NewTask("middle", "...")
+	right := st.NewTask("middle", "...")
+	tail := st.NewTask("tail", "...")
+	left.WaitFor(root)
+	right.WaitFor(root)
+	tail.WaitFor(left)
+	tail.WaitFor(right)
+	selection := tasktest.NewSelection([]*state.Task{root, left, right, tail})
+
+	c.Check(tasktest.AssertSequenced(
+		selection.Select(tasktest.Kind("root")),
+		selection.Select(tasktest.Kind("middle").All()),
+		selection.Select(tasktest.Kind("tail")),
+	), IsNil)
+}
+
+func (s *assertionsSuite) TestAssertSequencedMissingDependency(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	first := st.NewTask("first", "...")
+	second := st.NewTask("second", "...")
+	third := st.NewTask("third", "...")
+	fourth := st.NewTask("fourth", "...")
+	third.WaitFor(first)
+	third.WaitFor(second)
+	fourth.WaitFor(first)
+	before := tasktest.NewSelection([]*state.Task{first, second})
+	after := tasktest.NewSelection([]*state.Task{third, fourth})
+
+	c.Check(tasktest.AssertSequenced(before, after), ErrorMatches, `task 2 \(second\) is not sequenced before task 4 \(fourth\)`)
+}
+
+func (s *assertionsSuite) TestAssertNotSequenced(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	first := st.NewTask("first", "...")
+	second := st.NewTask("second", "...")
+	unrelated := st.NewTask("unrelated", "...")
+	second.WaitFor(first)
+	later := tasktest.NewSelection([]*state.Task{second})
+	others := tasktest.NewSelection([]*state.Task{first, unrelated})
+
+	c.Check(tasktest.AssertNotSequenced(later, others), IsNil)
+}
+
+func (s *assertionsSuite) TestAssertNotSequencedHasDependency(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	first := st.NewTask("first", "...")
+	second := st.NewTask("second", "...")
+	third := st.NewTask("third", "...")
+	fourth := st.NewTask("fourth", "...")
+	middle := st.NewTask("middle", "...")
+	middle.WaitFor(second)
+	fourth.WaitFor(middle)
+	before := tasktest.NewSelection([]*state.Task{first, second})
+	after := tasktest.NewSelection([]*state.Task{third, fourth})
+
+	c.Check(tasktest.AssertNotSequenced(before, after), ErrorMatches, `task 2 \(second\) is sequenced before task 4 \(fourth\)`)
+}
+
+func (s *assertionsSuite) TestAssertLaneSuperset(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	first := st.NewTask("first", "...")
+	first.JoinLane(1)
+	first.JoinLane(2)
+	second := st.NewTask("second", "...")
+	second.JoinLane(2)
+	second.JoinLane(1)
+	second.JoinLane(1)
+	third := st.NewTask("third", "...")
+	third.JoinLane(1)
+	fourth := st.NewTask("fourth", "...")
+	fourth.JoinLane(2)
+	fourth.JoinLane(1)
+	superset := tasktest.NewSelection([]*state.Task{first, second})
+	subset := tasktest.NewSelection([]*state.Task{third, fourth})
+
+	c.Check(tasktest.AssertLaneSuperset(superset, subset), IsNil)
+}
+
+func (s *assertionsSuite) TestAssertLaneSupersetMissingLane(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	first := st.NewTask("first", "...")
+	first.JoinLane(1)
+	first.JoinLane(2)
+	second := st.NewTask("second", "...")
+	second.JoinLane(1)
+	third := st.NewTask("third", "...")
+	third.JoinLane(1)
+	fourth := st.NewTask("fourth", "...")
+	fourth.JoinLane(1)
+	fourth.JoinLane(2)
+	superset := tasktest.NewSelection([]*state.Task{first, second})
+	subset := tasktest.NewSelection([]*state.Task{third, fourth})
+
+	c.Check(tasktest.AssertLaneSuperset(superset, subset), ErrorMatches, `task 2 \(second\) with lanes \[1\] is not a lane superset of task 4 \(fourth\) with lanes \[1 2\]`)
+}
+
+func (s *assertionsSuite) TestAssertDoesNotShareLane(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	first := st.NewTask("first", "...")
+	first.JoinLane(1)
+	first.JoinLane(2)
+	second := st.NewTask("second", "...")
+	second.JoinLane(2)
+	third := st.NewTask("third", "...")
+	third.JoinLane(3)
+	fourth := st.NewTask("fourth", "...")
+	fourth.JoinLane(3)
+	fourth.JoinLane(4)
+	left := tasktest.NewSelection([]*state.Task{first, second})
+	right := tasktest.NewSelection([]*state.Task{third, fourth})
+
+	c.Check(tasktest.AssertDoesNotShareLane(left, right), IsNil)
+}
+
+func (s *assertionsSuite) TestAssertDoesNotShareLaneSharedLane(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	first := st.NewTask("first", "...")
+	first.JoinLane(1)
+	second := st.NewTask("second", "...")
+	second.JoinLane(2)
+	third := st.NewTask("third", "...")
+	third.JoinLane(3)
+	fourth := st.NewTask("fourth", "...")
+	fourth.JoinLane(4)
+	fourth.JoinLane(2)
+	left := tasktest.NewSelection([]*state.Task{first, second})
+	right := tasktest.NewSelection([]*state.Task{third, fourth})
+
+	c.Check(tasktest.AssertDoesNotShareLane(left, right), ErrorMatches, `task 2 \(second\) and task 4 \(fourth\) share lane 2`)
+}
+
+func (s *assertionsSuite) TestAssertSameLanes(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	first := st.NewTask("first", "...")
+	first.JoinLane(1)
+	first.JoinLane(2)
+	second := st.NewTask("second", "...")
+	second.JoinLane(2)
+	second.JoinLane(1)
+	second.JoinLane(1)
+	third := st.NewTask("third", "...")
+	third.JoinLane(1)
+	third.JoinLane(2)
+	selection := tasktest.NewSelection([]*state.Task{first, second, third})
+	begin := selection.Select(tasktest.Kind("first"))
+
+	c.Check(tasktest.AssertSameLanes(begin, selection.Select(tasktest.Kind("second")), selection.Select(tasktest.Kind("third"))), IsNil)
+}
+
+func (s *assertionsSuite) TestAssertSameLanesDifferentSize(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	first := st.NewTask("first", "...")
+	first.JoinLane(1)
+	second := st.NewTask("second", "...")
+	second.JoinLane(1)
+	second.JoinLane(2)
+	selection := tasktest.NewSelection([]*state.Task{first, second})
+
+	c.Check(tasktest.AssertSameLanes(selection), ErrorMatches, `task 2 \(second\) has lanes \[1 2\], expected the same lanes as task 1 \(first\) with lanes \[1\]`)
+}
+
+func (s *assertionsSuite) TestAssertSameLanesDifferentMembership(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	first := st.NewTask("first", "...")
+	first.JoinLane(1)
+	first.JoinLane(2)
+	second := st.NewTask("second", "...")
+	second.JoinLane(1)
+	second.JoinLane(2)
+	third := st.NewTask("third", "...")
+	third.JoinLane(1)
+	third.JoinLane(3)
+	selection := tasktest.NewSelection([]*state.Task{first, second, third})
+
+	c.Check(tasktest.AssertSameLanes(
+		selection.Select(tasktest.Kind("first")),
+		selection.Select(tasktest.Kind("second")),
+		selection.Select(tasktest.Kind("third")),
+	), ErrorMatches, `task 3 \(third\) has lanes \[1 3\], expected the same lanes as task 1 \(first\) with lanes \[1 2\]`)
+}
+
+func (s *assertionsSuite) TestAssertionsCheckEmptySets(c *C) {
+	st := state.New(nil)
+	st.Lock()
+	defer st.Unlock()
+
+	task := st.NewTask("task", "...")
+	selection := tasktest.NewSelection([]*state.Task{task})
+	empty := tasktest.NewSelection(nil)
+
+	c.Check(tasktest.AssertSequenced(selection, empty), ErrorMatches, "selection 2 is empty")
+	c.Check(tasktest.AssertNotSequenced(selection, empty), ErrorMatches, "selection 2 is empty")
+	c.Check(tasktest.AssertLaneSuperset(selection, empty), ErrorMatches, "selection 2 is empty")
+	c.Check(tasktest.AssertDoesNotShareLane(selection, empty), ErrorMatches, "selection 2 is empty")
+	c.Check(tasktest.AssertSameLanes(selection, empty), ErrorMatches, "selection 2 is empty")
+}


### PR DESCRIPTION
Adds a set of assertions that can be used with the `tasktest.Selection` type. Intended to be used in tests.